### PR TITLE
Added cmake integration to examples, and tests

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,10 +1,21 @@
 project(hipsycl-examples)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/../cmake)
-
-find_package(hipSYCL CONFIG REQUIRED)
-
-if(NOT CMAKE_BUILD_TYPE)
+if(HIPSYCL_INSTALL_DIR)
+  # We make sure that we don't override an already set hipSYCL_DIR variable
+  if (hipSYCL_DIR)
+    message(FATAL_ERROR "Please only use HIPSYCL_INSTALL_DIR or hipSYCL_DIR")
+  endif() 
+  set(hipSYCL_DIR ${HIPSYCL_INSTALL_DIR}/lib/cmake)
+  # We don't set the PATHS var here since we don't want to find something other than the user intends to.
+  find_package(hipSYCL CONFIG REQUIRED)
+else()
+  # The user might have set hipSYCL_DIR or some other var manually,
+  # therefore we first try to find hipSYCL with default settings 
+  find_package(hipSYCL CONFIG)
+  # If found in the previous step nothing will be searched here
+  find_package(hipSYCL CONFIG PATHS /opt/hipSYCL/lib/cmake/ REQUIRED)
+endif()
+message(STATUS "Found hipSYCL in ${hipSYCL_DIR}")if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,13 +3,22 @@ cmake_minimum_required(VERSION 3.5)
 
 find_package(Boost COMPONENTS unit_test_framework REQUIRED)
 
-find_program(SYCLCC NAMES syclcc-clang CACHE STRING)
-if(SYCLCC MATCHES SYCLCC-NOTFOUND)
-  message(SEND_ERROR "hipSYCL syclcc-clang compiler not found, exiting.")
-  return()
+if(HIPSYCL_INSTALL_DIR)
+  # We make sure that we don't override an already set hipSYCL_DIR variable
+  if (hipSYCL_DIR)
+    message(FATAL_ERROR "Please only use HIPSYCL_INSTALL_DIR or hipSYCL_DIR")
+  endif() 
+  set(hipSYCL_DIR ${HIPSYCL_INSTALL_DIR}/lib/cmake)
+  # We don't set the PATHS var here since we don't want to find something other than the user intends to.
+  find_package(hipSYCL CONFIG REQUIRED)
+else()
+  # The user might have set hipSYCL_DIR or some other var manually,
+  # therefore we first try to find hipSYCL with default settings 
+  find_package(hipSYCL CONFIG)
+  # If found in the previous step nothing will be searched here
+  find_package(hipSYCL CONFIG PATHS /opt/hipSYCL/lib/cmake/ REQUIRED)
 endif()
-
-set(CMAKE_CXX_COMPILER ${SYCLCC})
+message(STATUS "Found hipSYCL in ${hipSYCL_DIR}")
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -40,17 +49,21 @@ endif()
 cmake_policy(SET CMP0005 NEW)
 add_definitions(-DHIPSYCL_DEBUG_LEVEL=${HIPSYCL_DEBUG_LEVEL})
 
-add_subdirectory(platform_api)
 
 add_executable(device_compilation_tests device_compilation_tests.cpp)
+add_sycl_to_target(TARGET device_compilation_tests SOURCES device_compilation_tests.cpp)
 target_include_directories(device_compilation_tests PRIVATE ${Boost_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(device_compilation_tests PRIVATE ${Boost_LIBRARIES})
 
 add_executable(unit_tests unit_tests.cpp)
+add_sycl_to_target(TARGET unit_tests SOURCES unit_tests.cpp)
 target_include_directories(unit_tests PRIVATE ${Boost_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(unit_tests PRIVATE ${Boost_LIBRARIES})
 
 add_executable(math_unit_tests math_unit_tests.cpp)
+add_sycl_to_target(TARGET math_unit_tests SOURCES math_unit_tests.cpp)
 target_include_directories(math_unit_tests PRIVATE ${Boost_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(math_unit_tests PRIVATE ${Boost_LIBRARIES})
 
+
+add_subdirectory(platform_api)

--- a/tests/platform_api/CMakeLists.txt
+++ b/tests/platform_api/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_executable(platform_api api_test.cpp)
+add_sycl_to_target(TARGET platform_api SOURCES api_test.cpp)


### PR DESCRIPTION
This PR makes the example and test projects use the hipSYCL CMake integration. It is checked in the default installation directory of the hipSYCL package in case CMake fails to find it.