### PR TITLE
[SYCL 2020][USM] Add USM queue shortcuts, memcpy, memset, fill, prefetch, mem_advise stub, test cases

### DIFF
--- a/include/hipSYCL/runtime/cuda/cuda_queue.hpp
+++ b/include/hipSYCL/runtime/cuda/cuda_queue.hpp
@@ -56,7 +56,8 @@ public:
 
   virtual result submit_memcpy(const memcpy_operation&) override;
   virtual result submit_kernel(const kernel_operation&) override;
-  virtual result submit_prefetch(const prefetch_operation&) override;
+  virtual result submit_prefetch(const prefetch_operation &) override;
+  virtual result submit_memset(const memset_operation&) override;
   
   /// Causes the queue to wait until an event on another queue has occured.
   /// the other queue must be from the same backend

--- a/include/hipSYCL/runtime/dag_builder.hpp
+++ b/include/hipSYCL/runtime/dag_builder.hpp
@@ -63,8 +63,11 @@ public:
                         const requirements_list& requirements,
                         const execution_hints& hints = {});
   dag_node_ptr add_prefetch(std::unique_ptr<operation> op,
-                            const requirements_list& requirements,
-                            const execution_hints& hints = {});
+                            const requirements_list &requirements,
+                            const execution_hints &hints = {});
+  dag_node_ptr add_memset(std::unique_ptr<operation> op,
+                          const requirements_list &requirements,
+                          const execution_hints &hints = {});
   dag_node_ptr
   add_explicit_mem_requirement(std::unique_ptr<operation> req,
                                const requirements_list &requirements,

--- a/include/hipSYCL/runtime/hip/hip_queue.hpp
+++ b/include/hipSYCL/runtime/hip/hip_queue.hpp
@@ -50,7 +50,8 @@ public:
 
   virtual result submit_memcpy(const memcpy_operation&) override;
   virtual result submit_kernel(const kernel_operation&) override;
-  virtual result submit_prefetch(const prefetch_operation&) override;
+  virtual result submit_prefetch(const prefetch_operation &) override;
+  virtual result submit_memset(const memset_operation&) override;
   
   /// Causes the queue to wait until an event on another queue has occured.
   /// the other queue must be from the same backend

--- a/include/hipSYCL/runtime/omp/omp_queue.hpp
+++ b/include/hipSYCL/runtime/omp/omp_queue.hpp
@@ -47,7 +47,8 @@ public:
 
   virtual result submit_memcpy(const memcpy_operation&) override;
   virtual result submit_kernel(const kernel_operation&) override;
-  virtual result submit_prefetch(const prefetch_operation&) override;
+  virtual result submit_prefetch(const prefetch_operation &) override;
+  virtual result submit_memset(const memset_operation&) override;
   
   /// Causes the queue to wait until an event on another queue has occured.
   /// the other queue must be from the same backend

--- a/include/hipSYCL/sycl/handler.hpp
+++ b/include/hipSYCL/sycl/handler.hpp
@@ -34,11 +34,14 @@
 
 #include "exception.hpp"
 #include "access.hpp"
+#include "context.hpp"
 #include "libkernel/backend.hpp"
 #include "device.hpp"
 #include "event.hpp"
 #include "types.hpp"
+#include "usm_query.hpp"
 #include "libkernel/accessor.hpp"
+#include "libkernel/builtin_kernels.hpp"
 #include "libkernel/id.hpp"
 #include "libkernel/range.hpp"
 #include "libkernel/nd_range.hpp"
@@ -63,9 +66,8 @@ namespace sycl {
 
 class queue;
 
-class handler
-{
-  friend class sycl::queue;
+class handler {
+  friend class queue;
 public:
   ~handler()
   {
@@ -333,35 +335,125 @@ public:
     static_assert(tgt != access::target::host_image,
                   "host_image targets are unsupported");
 
-    // Use a function object instead of lambda to avoid
-    // requiring a unique kernel name for each fill call
-    // TODO: hipSYCL rt currently does not have a dedicated operation
-    // for fills - implement for the ability to implement fill using
-    // backend functionality instead of a kernel
-    class fill_kernel
-    {
-    public:
-      fill_kernel(accessor<T, dim, mode, tgt> dest,
-                  const T& src)
-      : _dest{dest}, _src{src}
-      {}
-
-      void operator()(sycl::id<dim> tid)
-      {
-        _dest[tid] = _src;
-      }
-
-    private:
-      accessor<T, dim, mode, tgt> _dest;
-      T _src;
-    };
 
     this->submit_kernel<class _unnamed_kernel, rt::kernel_type::basic_parallel_for>(
         dest.get_offset(), dest.get_range(),
         dest.get_range() /*local range unused for basic pf*/,
-        fill_kernel{dest, src});
+        detail::kernels::fill_kernel{dest, src});
   }
 
+  // ------ USM functions ------
+
+  void memcpy(void *dest, const void *src, std::size_t num_bytes) {
+
+    rt::dag_build_guard build{rt::application::dag()};
+
+    if(!_execution_hints.has_hint<rt::hints::bind_to_device>())
+      throw invalid_parameter_error{"handler: explicit memcpy() is unsupported "
+                                    "for queues not bound to devices"};
+
+    rt::device_id queue_dev =
+        _execution_hints.get_hint<rt::hints::bind_to_device>()->get_device_id();
+  
+
+    auto determine_ptr_device = [&, this](const void *ptr) {
+      usm::alloc alloc_type = get_pointer_type(ptr, _ctx);
+      // For shared allocations, be optimistic and assume that data is
+      // already on target device
+      if (alloc_type == usm::alloc::shared)
+        return queue_dev;
+
+      if (alloc_type == usm::alloc::host ||
+          alloc_type == usm::alloc::unknown)
+        return detail::get_host_device();
+
+      if(alloc_type == usm::alloc::device)
+        // we are dealing with a device allocation
+        return detail::extract_rt_device(get_pointer_device(src, _ctx));
+    };
+
+    rt::device_id src_dev = determine_ptr_device(src);
+    rt::device_id dest_dev = determine_ptr_device(dest);
+    
+    rt::memory_location source_location{
+        src_dev, extract_ptr(src), rt::id<3>{},
+        rt::embed_in_range3(range<1>{num_bytes}), 1};
+
+    rt::memory_location dest_location{
+        dest_dev, extract_ptr(dest), rt::id<3>{},
+        rt::embed_in_range3(range<1>{num_bytes}), 1};
+    
+    auto op = rt::make_operation<rt::memcpy_operation>(
+        source_location, dest_location, rt::embed_in_range3(range<1>{num_bytes}));
+
+    rt::dag_node_ptr node = build.builder()->add_memcpy(
+        std::move(op), _requirements, _execution_hints);
+
+    _command_group_nodes.push_back(node);
+  }
+
+
+  template <class T> void fill(void *ptr, const T &pattern, std::size_t count) {
+    // For special cases we can map this to a potentially more low-level memset
+    if (sizeof(T) == 1) {
+      unsigned char val = *reinterpret_cast<const unsigned char*>(&pattern);
+      
+      memset(ptr, static_cast<int>(val), count);
+    } else {
+      T *typed_ptr = static_cast<T *>(ptr);
+
+      if (!_execution_hints.has_hint<rt::hints::bind_to_device>())
+        throw invalid_parameter_error{"handler: USM fill() is unsupported "
+                                      "for queues not bound to devices"};
+
+      this->submit_kernel<class _unnamed_kernel,
+                          rt::kernel_type::basic_parallel_for>(
+          sycl::id<1>{}, sycl::range<1>{count},
+          sycl::range<1>{count} /*local range unused for basic pf*/,
+          detail::kernels::fill_kernel_usm{typed_ptr, pattern});
+    }
+  }
+
+  void memset(void *ptr, int value, std::size_t num_bytes) {
+   
+    rt::dag_build_guard build{rt::application::dag()};
+
+    if(!_execution_hints.has_hint<rt::hints::bind_to_device>())
+      throw invalid_parameter_error{"handler: explicit memset() is unsupported "
+                                    "for queues not bound to devices"};
+
+    auto op = rt::make_operation<rt::memset_operation>(
+        ptr, static_cast<unsigned char>(value), num_bytes);
+
+    rt::dag_node_ptr node = build.builder()->add_memcpy(
+        std::move(op), _requirements, _execution_hints);
+
+    _command_group_nodes.push_back(node);
+  }
+
+  void prefetch(const void *ptr, std::size_t num_bytes) {
+
+    rt::dag_build_guard build{rt::application::dag()};
+
+    if(!_execution_hints.has_hint<rt::hints::bind_to_device>())
+      throw invalid_parameter_error{"handler: explicit prefetch() is unsupported "
+                                    "for queues not bound to devices"};
+
+    auto op = rt::make_operation<rt::prefetch_operation>(
+        ptr, num_bytes);
+
+    rt::dag_node_ptr node = build.builder()->add_prefetch(
+        std::move(op), _requirements, _execution_hints);
+
+    _command_group_nodes.push_back(node);
+  }
+
+  void mem_advise(const void *addr, std::size_t num_bytes, int advice) {
+    throw feature_not_supported{"mem_advise() is not yet supported"};
+  }
+
+
+  
   detail::local_memory_allocator& get_local_memory_allocator()
   {
     return _local_mem_allocator;
@@ -517,10 +609,12 @@ private:
   const std::vector<rt::dag_node_ptr>& get_cg_nodes() const
   { return _command_group_nodes; }
 
-  // defined in queue.hpp
-  handler(const queue& q, async_handler handler, const rt::execution_hints& hints);
-
-  const queue* _queue;
+  handler(const context &ctx, async_handler handler,
+                 const rt::execution_hints &hints)
+    : _ctx{ctx}, _handler{handler},
+      _execution_hints{hints} {}
+  
+  const context& _ctx;
   detail::local_memory_allocator _local_mem_allocator;
   async_handler _handler;
 

--- a/include/hipSYCL/sycl/handler.hpp
+++ b/include/hipSYCL/sycl/handler.hpp
@@ -369,7 +369,7 @@ public:
 
       if(alloc_type == usm::alloc::device)
         // we are dealing with a device allocation
-        return detail::extract_rt_device(get_pointer_device(src, _ctx));
+        return detail::extract_rt_device(get_pointer_device(ptr, _ctx));
     };
 
     rt::device_id src_dev = determine_ptr_device(src);

--- a/include/hipSYCL/sycl/handler.hpp
+++ b/include/hipSYCL/sycl/handler.hpp
@@ -370,6 +370,8 @@ public:
       if(alloc_type == usm::alloc::device)
         // we are dealing with a device allocation
         return detail::extract_rt_device(get_pointer_device(ptr, _ctx));
+      
+      throw invalid_parameter_error{"Invalid allocation type"};
     };
 
     rt::device_id src_dev = determine_ptr_device(src);

--- a/include/hipSYCL/sycl/libkernel/detail/local_memory_allocator.hpp
+++ b/include/hipSYCL/sycl/libkernel/detail/local_memory_allocator.hpp
@@ -49,7 +49,7 @@ public:
   using smallest_type = int;
 
   // ToDo: Query max shared memory of device and check when allocating
-  local_memory_allocator(const device&)
+  local_memory_allocator()
     : _num_allocated_bytes{0}
   {}
 

--- a/include/hipSYCL/sycl/queue.hpp
+++ b/include/hipSYCL/sycl/queue.hpp
@@ -224,7 +224,7 @@ public:
   event submit(T cgf) {
     std::lock_guard<std::mutex> lock{*_lock};
 
-    handler cgh{*this, _handler, _default_hints};
+    handler cgh{get_context(), _handler, _default_hints};
     
     this->get_hooks()->run_all(cgh);
 
@@ -280,6 +280,262 @@ public:
 
   friend bool operator!=(const queue& lhs, const queue& rhs)
   { return !(lhs == rhs); }
+
+  // ---- Queue shortcuts ------
+
+  template <typename KernelName = class _unnamed_kernel, typename KernelType>
+  event single_task(const KernelType &KernelFunc) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.single_task<KernelName>(KernelFunc);
+    });
+  }
+
+  template <typename KernelName = class _unnamed_kernel, typename KernelType>
+  event single_task(event dependency, const KernelType &KernelFunc) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dependency);
+      cgh.single_task<KernelName>(KernelFunc);
+    });
+  }
+
+  template <typename KernelName = class _unnamed_kernel, typename KernelType>
+  event single_task(const std::vector<event> &dependencies,
+                    const KernelType &KernelFunc) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dependencies);
+      cgh.single_task<KernelName>(KernelFunc);
+    });
+  }
+
+  template <typename KernelName = class _unnamed_kernel, typename KernelType,
+            int Dims>
+  event parallel_for(range<Dims> NumWorkItems, const KernelType &kernel) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.parallel_for<KernelName>(NumWorkItems, kernel);
+    });
+  }
+
+  template <typename KernelName = class _unnamed_kernel, typename KernelType,
+            int Dims>
+  event parallel_for(range<Dims> NumWorkItems, event dependency,
+                     const KernelType &kernel) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dependency);
+      cgh.parallel_for<KernelName>(NumWorkItems, kernel);
+    });
+  }
+
+  template <typename KernelName = class _unnamed_kernel, typename KernelType,
+            int Dims>
+  event parallel_for(range<Dims> NumWorkItems,
+                     const std::vector<event> &dependencies,
+                     const KernelType &kernel) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dependencies);
+      cgh.parallel_for<KernelName>(NumWorkItems, kernel);
+    });
+  }
+
+  template <typename KernelName = class _unnamed_kernel, typename KernelType,
+            int Dims>
+  event parallel_for(range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
+                     const KernelType &KernelFunc) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.parallel_for<KernelName>(NumWorkItems, WorkItemOffset, KernelFunc);
+    });
+  }
+
+  template <typename KernelName = class _unnamed_kernel, typename KernelType,
+            int Dims>
+  event parallel_for(range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
+                     event dependency, const KernelType &KernelFunc) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dependency);
+      cgh.parallel_for<KernelName>(NumWorkItems, WorkItemOffset, KernelFunc);
+    });
+  }
+
+  template <typename KernelName = class _unnamed_kernel, typename KernelType,
+            int Dims>
+  event parallel_for(range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
+                     const std::vector<event> &dependencies,
+                     const KernelType &KernelFunc) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dependencies);
+      cgh.parallel_for<KernelName>(NumWorkItems, WorkItemOffset, KernelFunc);
+    });
+  }
+
+  template <typename KernelName = class _unnamed_kernel, typename KernelType,
+            int Dims>
+  event parallel_for(nd_range<Dims> ExecutionRange,
+                     const KernelType &KernelFunc) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.parallel_for<KernelName>(ExecutionRange, KernelFunc);
+    });
+  }
+
+  template <typename KernelName = class _unnamed_kernel, typename KernelType,
+            int Dims>
+  event parallel_for(nd_range<Dims> ExecutionRange, event dependency,
+                     const KernelType &KernelFunc) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dependency);
+      cgh.parallel_for<KernelName>(ExecutionRange, KernelFunc);
+    });
+  }
+
+  template <typename KernelName = class _unnamed_kernel, typename KernelType,
+            int Dims>
+  event parallel_for(nd_range<Dims> ExecutionRange,
+                     const std::vector<event> &dependencies,
+                     const KernelType &KernelFunc) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dependencies);
+      cgh.parallel_for<KernelName>(ExecutionRange, KernelFunc);
+    });
+  }
+
+  template <typename KernelName = class _unnamed_kernel,
+            typename KernelFunctionType, int dimensions>
+  void parallel(range<dimensions> numWorkGroups,
+                range<dimensions> workGroupSize, KernelFunctionType f) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.parallel<KernelName>(numWorkGroups, workGroupSize, f);
+    });
+  }
+
+  template <typename KernelName = class _unnamed_kernel,
+            typename KernelFunctionType, int dimensions>
+  void parallel(range<dimensions> numWorkGroups,
+                range<dimensions> workGroupSize, event dependency,
+                KernelFunctionType f) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dependency);
+      cgh.parallel<KernelName>(numWorkGroups, workGroupSize, f);
+    });
+  }
+
+  template <typename KernelName = class _unnamed_kernel,
+            typename KernelFunctionType, int dimensions>
+  void parallel(range<dimensions> numWorkGroups,
+                range<dimensions> workGroupSize,
+                const std::vector<event> &dependencies, KernelFunctionType f) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dependencies);
+      cgh.parallel<KernelName>(numWorkGroups, workGroupSize, f);
+    });
+  }
+  
+  event memcpy(void *dest, const void *src, std::size_t num_bytes) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.memcpy(dest, src, num_bytes);
+    });
+  }
+
+  event memcpy(void *dest, const void *src, std::size_t num_bytes,
+               event dependency) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dependency);
+      cgh.memcpy(dest, src, num_bytes);
+    });
+  }
+
+  event memcpy(void *dest, const void *src, std::size_t num_bytes,
+               const std::vector<event> &dependencies) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dependencies);
+      cgh.memcpy(dest, src, num_bytes);
+    });
+  }
+
+  event memset(void *ptr, int value, std::size_t num_bytes) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.memset(ptr, value, num_bytes);
+    });
+  }
+
+  event memset(void *ptr, int value, std::size_t num_bytes, event dependency) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dependency);
+      cgh.memset(ptr, value, num_bytes);
+    });
+  }
+
+  event memset(void *ptr, int value, std::size_t num_bytes,
+               const std::vector<event> &dependencies) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dependencies);
+      cgh.memset(ptr, value, num_bytes);
+    });
+  }
+
+  template <class T>
+  event fill(void *ptr, const T &pattern, std::size_t count) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.fill(ptr, pattern, count);
+    });
+  }
+
+  template <class T>
+  event fill(void *ptr, const T &pattern, std::size_t count, event dependency) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dependency);
+      cgh.fill(ptr, pattern, count);
+    });
+  }
+
+  template <class T>
+  event fill(void *ptr, const T &pattern, std::size_t count,
+             const std::vector<event> &dependencies) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dependencies);
+      cgh.fill(ptr, pattern, count);
+    });
+  }
+
+  event prefetch(const void *ptr, std::size_t num_bytes) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.prefetch(ptr, num_bytes);
+    });
+  }
+
+  event prefetch(const void *ptr, std::size_t num_bytes, event dependency) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dependency);
+      cgh.prefetch(ptr, num_bytes);
+    });
+  }
+
+  event prefetch(const void *ptr, std::size_t num_bytes,
+                 const std::vector<event> &dependencies) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dependencies);
+      cgh.prefetch(ptr, num_bytes);
+    });
+  }
+
+  event mem_advise(const void *addr, std::size_t num_bytes, int advice) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.mem_advise(addr, num_bytes, advice);
+    });
+  }
+
+  event mem_advise(const void *addr, std::size_t num_bytes, int advice,
+                   event dependency) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dependency);
+      cgh.mem_advise(addr, num_bytes, advice);
+    });
+  }
+
+  event mem_advise(const void *addr, std::size_t num_bytes, int advice,
+                   const std::vector<event> &dependencies) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dependencies);
+      cgh.mem_advise(addr, num_bytes, advice);
+    });
+  }
 
 private:
   template <class Cgf>
@@ -370,14 +626,6 @@ HIPSYCL_SPECIALIZE_GET_INFO(queue, reference_count)
 {
   return 1;
 }
-
-
-
-inline handler::handler(const queue &q, async_handler handler,
-                 const rt::execution_hints &hints)
-    : _queue{&q}, _local_mem_allocator{q.get_device()}, _handler{handler},
-      _execution_hints{hints} {}
-
 
 namespace detail{
 

--- a/include/hipSYCL/sycl/usm.hpp
+++ b/include/hipSYCL/sycl/usm.hpp
@@ -36,6 +36,7 @@
 #include "device.hpp"
 #include "queue.hpp"
 #include "exception.hpp"
+#include "usm_query.hpp"
 
 #include "hipSYCL/common/debug.hpp"
 #include "hipSYCL/glue/error.hpp"
@@ -46,106 +47,6 @@
 namespace hipsycl {
 namespace sycl {
 
-namespace detail {
-
-
-inline rt::backend_id select_usm_backend(const context &ctx) {
-  const rt::unique_device_list &devs = detail::extract_context_devices(ctx);
-
-  if (devs.get_num_backends() == 0)
-    throw memory_allocation_error{
-        "USM: No backends to carry out USM memory management are present in "
-        "the context!"};
-
-
-  std::size_t num_host_backends =
-      devs.get_num_backends(rt::hardware_platform::cpu);
-
-  assert(devs.get_num_backends() >= num_host_backends);
-  std::size_t num_device_backends = devs.get_num_backends() - num_host_backends;
-
-  rt::backend_id selected_backend;
-
-  // Logic is simple: Prefer device backends if available over host backends.
-  if (num_device_backends > 0) {
-    if (num_device_backends > 1) {
-      HIPSYCL_DEBUG_WARNING
-          << "USM backend selection: Context contains multiple device "
-             "backends. "
-             "Using the first device backend as GUESS for USM memory "
-             "management. This might go TERRIBLY WRONG if you are not using "
-             "this backend for your kernels! "
-             "You are encouraged to better specify which backends you want to "
-             "target."
-          << std::endl;
-    }
-    auto backend_it = devs.find_first_backend([](rt::backend_id b) {
-      return rt::application::get_backend(b).get_hardware_platform() !=
-             rt::hardware_platform::cpu;
-    });
-    assert(backend_it != devs.backends_end());
-    selected_backend = *backend_it;
-
-  } else if (num_host_backends > 0) {
-    if (num_host_backends > 1) {
-      HIPSYCL_DEBUG_WARNING
-          << "USM backend selection: Context did not contain any device "
-             "backends, but multiple host backends. Using first host backend "
-             "(which should be fine as long as you run only on the host), but "
-             "you are encouraged to better specify which backend you wish to "
-             "carry out USM memory management"
-          << std::endl;
-    }
-    auto backend_it = devs.find_first_backend([](rt::backend_id b) {
-      return rt::application::get_backend(b).get_hardware_platform() ==
-             rt::hardware_platform::cpu;
-    });
-    assert(backend_it != devs.backends_end());
-    selected_backend = *backend_it;
-  }
-  
-  return selected_backend;
-}
-
-inline rt::backend_allocator *select_usm_allocator(const context &ctx) {
-  rt::backend_id selected_backend = select_usm_backend(ctx);
-
-  rt::backend &backend_object = rt::application::get_backend(selected_backend);
-
-  if (backend_object.get_hardware_manager()->get_num_devices() == 0)
-    throw memory_allocation_error{"USM: Context has no devices on which "
-                                  "requested operation could be carried out"};
-
-  return backend_object.get_allocator(
-      rt::device_id{backend_object.get_backend_descriptor(), 0});
-}
-
-inline rt::backend_allocator *select_usm_allocator(const context &ctx,
-                                                   const device &dev) {
-  rt::backend_id selected_backend = select_usm_backend(ctx);
-
-  rt::backend &backend_object = rt::application::get_backend(selected_backend);
-  rt::device_id d = detail::extract_rt_device(dev);
-  
-  if(d.get_backend() == selected_backend)
-    return backend_object.get_allocator(detail::extract_rt_device(dev));
-  else
-    return backend_object.get_allocator(
-        rt::device_id{d.get_full_backend_descriptor(), 0});
-}
-
-inline rt::backend_allocator *select_device_allocator(const device &dev) {
-  rt::device_id d = detail::extract_rt_device(dev);
-
-  rt::backend& backend_object = rt::application::get_backend(d.get_backend());
-  return backend_object.get_allocator(d);
-}
-
-}
-
-namespace usm {
-enum class alloc { host, device, shared, unknown };
-}
 
 // Explicit USM
 
@@ -357,47 +258,6 @@ void free(T *ptr, sycl::queue &q) {
   free(static_cast<void*>(ptr), q.get_context());
 }
 
-inline usm::alloc get_pointer_type(const void *ptr, const context &ctx) {
-  rt::pointer_info info;
-  rt::result res = detail::select_usm_allocator(ctx)->query_pointer(ptr, info);
-
-  if (!res.is_success())
-    return usm::alloc::unknown;
-
-  if (info.is_from_host_backend || info.is_optimized_host)
-    return usm::alloc::host;
-  else if (info.is_usm)
-    return usm::alloc::shared;
-  else
-    return usm::alloc::device;
-}
-
-inline sycl::device get_pointer_device(const void *ptr, const context &ctx) {
-  rt::pointer_info info;
-  rt::result res = detail::select_usm_allocator(ctx)->query_pointer(ptr, info);
-
-  if (!res.is_success())
-    std::rethrow_exception(glue::throw_result(res));
-
-  if (info.is_from_host_backend){
-    // TODO Spec says to return *the* host device, but it might be better
-    // to return a device from the actual host backend used
-    // (we might want to have multiple host devices/backends in the future)
-    return detail::get_host_device();
-  }
-  else if (info.is_optimized_host) {
-    // Return first (non-host?) device from context
-    const rt::unique_device_list &devs = detail::extract_context_devices(ctx);
-
-    auto device_iterator =
-        devs.find_first_device([](rt::device_id d) { return !d.is_host(); });
-
-    assert(device_iterator != devs.devices_end());
-    return device{*device_iterator};
-  }
-  else
-    return device{info.dev};
-}
 
 
 template <typename T, usm::alloc AllocKind, std::size_t Alignment = 0>

--- a/include/hipSYCL/sycl/usm.hpp
+++ b/include/hipSYCL/sycl/usm.hpp
@@ -248,18 +248,6 @@ inline void free(void *ptr, const sycl::queue &q) {
   free(ptr, q.get_context());
 }
 
-// Not in the SYCL 2020 provisional spec, but probably simple oversight
-template <class T> void free(T *ptr, sycl::context &context) {
-  free(static_cast<void*>(ptr), context);
-}
-
-template<class T>
-void free(T *ptr, sycl::queue &q) {
-  free(static_cast<void*>(ptr), q.get_context());
-}
-
-
-
 template <typename T, usm::alloc AllocKind, std::size_t Alignment = 0>
 class usm_allocator {
 public:

--- a/include/hipSYCL/sycl/usm_query.hpp
+++ b/include/hipSYCL/sycl/usm_query.hpp
@@ -1,0 +1,192 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2020 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "context.hpp"
+#include "device.hpp"
+#include "exception.hpp"
+
+#include "hipSYCL/common/debug.hpp"
+#include "hipSYCL/glue/error.hpp"
+#include "hipSYCL/runtime/application.hpp"
+#include "hipSYCL/runtime/backend.hpp"
+#include "hipSYCL/runtime/allocator.hpp"
+
+#ifndef HIPSYCL_USM_QUERY_HPP
+#define HIPSYCL_USM_QUERY_HPP
+
+namespace hipsycl {
+namespace sycl {
+
+
+namespace detail {
+
+
+inline rt::backend_id select_usm_backend(const context &ctx) {
+  const rt::unique_device_list &devs = detail::extract_context_devices(ctx);
+
+  if (devs.get_num_backends() == 0)
+    throw memory_allocation_error{
+        "USM: No backends to carry out USM memory management are present in "
+        "the context!"};
+
+
+  std::size_t num_host_backends =
+      devs.get_num_backends(rt::hardware_platform::cpu);
+
+  assert(devs.get_num_backends() >= num_host_backends);
+  std::size_t num_device_backends = devs.get_num_backends() - num_host_backends;
+
+  rt::backend_id selected_backend;
+
+  // Logic is simple: Prefer device backends if available over host backends.
+  if (num_device_backends > 0) {
+    if (num_device_backends > 1) {
+      HIPSYCL_DEBUG_WARNING
+          << "USM backend selection: Context contains multiple device "
+             "backends. "
+             "Using the first device backend as GUESS for USM memory "
+             "management. This might go TERRIBLY WRONG if you are not using "
+             "this backend for your kernels! "
+             "You are encouraged to better specify which backends you want to "
+             "target."
+          << std::endl;
+    }
+    auto backend_it = devs.find_first_backend([](rt::backend_id b) {
+      return rt::application::get_backend(b).get_hardware_platform() !=
+             rt::hardware_platform::cpu;
+    });
+    assert(backend_it != devs.backends_end());
+    selected_backend = *backend_it;
+
+  } else if (num_host_backends > 0) {
+    if (num_host_backends > 1) {
+      HIPSYCL_DEBUG_WARNING
+          << "USM backend selection: Context did not contain any device "
+             "backends, but multiple host backends. Using first host backend "
+             "(which should be fine as long as you run only on the host), but "
+             "you are encouraged to better specify which backend you wish to "
+             "carry out USM memory management"
+          << std::endl;
+    }
+    auto backend_it = devs.find_first_backend([](rt::backend_id b) {
+      return rt::application::get_backend(b).get_hardware_platform() ==
+             rt::hardware_platform::cpu;
+    });
+    assert(backend_it != devs.backends_end());
+    selected_backend = *backend_it;
+  }
+  
+  return selected_backend;
+}
+
+inline rt::backend_allocator *select_usm_allocator(const context &ctx) {
+  rt::backend_id selected_backend = select_usm_backend(ctx);
+
+  rt::backend &backend_object = rt::application::get_backend(selected_backend);
+
+  if (backend_object.get_hardware_manager()->get_num_devices() == 0)
+    throw memory_allocation_error{"USM: Context has no devices on which "
+                                  "requested operation could be carried out"};
+
+  return backend_object.get_allocator(
+      rt::device_id{backend_object.get_backend_descriptor(), 0});
+}
+
+inline rt::backend_allocator *select_usm_allocator(const context &ctx,
+                                                   const device &dev) {
+  rt::backend_id selected_backend = select_usm_backend(ctx);
+
+  rt::backend &backend_object = rt::application::get_backend(selected_backend);
+  rt::device_id d = detail::extract_rt_device(dev);
+  
+  if(d.get_backend() == selected_backend)
+    return backend_object.get_allocator(detail::extract_rt_device(dev));
+  else
+    return backend_object.get_allocator(
+        rt::device_id{d.get_full_backend_descriptor(), 0});
+}
+
+inline rt::backend_allocator *select_device_allocator(const device &dev) {
+  rt::device_id d = detail::extract_rt_device(dev);
+
+  rt::backend& backend_object = rt::application::get_backend(d.get_backend());
+  return backend_object.get_allocator(d);
+}
+
+}
+
+namespace usm {
+enum class alloc { host, device, shared, unknown };
+}
+
+
+inline usm::alloc get_pointer_type(const void *ptr, const context &ctx) {
+  rt::pointer_info info;
+  rt::result res = detail::select_usm_allocator(ctx)->query_pointer(ptr, info);
+
+  if (!res.is_success())
+    return usm::alloc::unknown;
+
+  if (info.is_from_host_backend || info.is_optimized_host)
+    return usm::alloc::host;
+  else if (info.is_usm)
+    return usm::alloc::shared;
+  else
+    return usm::alloc::device;
+}
+
+inline sycl::device get_pointer_device(const void *ptr, const context &ctx) {
+  rt::pointer_info info;
+  rt::result res = detail::select_usm_allocator(ctx)->query_pointer(ptr, info);
+
+  if (!res.is_success())
+    std::rethrow_exception(glue::throw_result(res));
+
+  if (info.is_from_host_backend){
+    // TODO Spec says to return *the* host device, but it might be better
+    // to return a device from the actual host backend used
+    // (we might want to have multiple host devices/backends in the future)
+    return detail::get_host_device();
+  }
+  else if (info.is_optimized_host) {
+    // Return first (non-host?) device from context
+    const rt::unique_device_list &devs = detail::extract_context_devices(ctx);
+
+    auto device_iterator =
+        devs.find_first_device([](rt::device_id d) { return !d.is_host(); });
+
+    assert(device_iterator != devs.devices_end());
+    return device{*device_iterator};
+  }
+  else
+    return device{info.dev};
+}
+
+}
+} // namespace hipsycl
+
+#endif

--- a/include/hipSYCL/sycl/usm_query.hpp
+++ b/include/hipSYCL/sycl/usm_query.hpp
@@ -34,6 +34,7 @@
 #include "hipSYCL/runtime/application.hpp"
 #include "hipSYCL/runtime/backend.hpp"
 #include "hipSYCL/runtime/allocator.hpp"
+#include <exception>
 
 #ifndef HIPSYCL_USM_QUERY_HPP
 #define HIPSYCL_USM_QUERY_HPP

--- a/src/runtime/cuda/cuda_queue.cpp
+++ b/src/runtime/cuda/cuda_queue.cpp
@@ -234,8 +234,29 @@ result cuda_queue::submit_kernel(const kernel_operation &op) {
   return make_success();
 }
 
-result cuda_queue::submit_prefetch(const prefetch_operation&) {
-  assert(false && "Unimplemented");
+result cuda_queue::submit_prefetch(const prefetch_operation& op) {
+
+  cudaError_t err = cudaMemPrefetchAsync(op.get_pointer(), op.get_num_bytes(),
+                                         _dev.get_id(), get_stream());
+
+  if (err != cudaSuccess) {
+    return make_error(__hipsycl_here(),
+                      error_info{"cuda_queue: cudaMemPrefetchAsync() failed",
+                                 error_code{"CUDA", err}});
+  }
+  return make_success();
+}
+
+result cuda_queue::submit_memset(const memset_operation &op) {
+  
+  cudaError_t err = cudaMemsetAsync(op.get_pointer(), op.get_pattern(),
+                                    op.get_num_bytes(), get_stream());
+
+  if (err != cudaSuccess) {
+    return make_error(__hipsycl_here(),
+                      error_info{"cuda_queue: cudaMemsetAsync() failed",
+                                 error_code{"CUDA", err}});
+  }
 
   return make_success();
 }

--- a/src/runtime/dag_builder.cpp
+++ b/src/runtime/dag_builder.cpp
@@ -185,6 +185,14 @@ dag_node_ptr dag_builder::add_prefetch(std::unique_ptr<operation> op,
   return add_command_group(std::move(op), requirements, hints);
 }
 
+dag_node_ptr dag_builder::add_memset(std::unique_ptr<operation> op,
+                                      const requirements_list& requirements,
+                                      const execution_hints& hints)
+{
+  assert_is<memset_operation>(op.get());
+  return add_command_group(std::move(op), requirements, hints);
+}
+
 dag_node_ptr dag_builder::add_explicit_mem_requirement(
     std::unique_ptr<operation> req,
     const requirements_list &requirements, const execution_hints &hints)

--- a/src/runtime/hip/hip_queue.cpp
+++ b/src/runtime/hip/hip_queue.cpp
@@ -233,8 +233,36 @@ result hip_queue::submit_kernel(const kernel_operation &op) {
   return make_success();
 }
 
-result hip_queue::submit_prefetch(const prefetch_operation&) {
-  assert(false && "Unimplemented");
+result hip_queue::submit_prefetch(const prefetch_operation& op) {
+  // HIP does not yet support prefetching functions
+  HIPSYCL_DEBUG_WARNING << "Ignoring prefetch request because HIP does not yet "
+                           "support prefetching memory."
+                        << std::endl;
+
+  hipError_t err = hipSuccess;
+  
+  //hipError_t err = hipMemPrefetchAsync(op.get_pointer(), op.get_num_bytes(),
+  //                                     _dev.get_id(), get_stream());
+
+  if (err != hipSuccess) {
+    return make_error(__hipsycl_here(),
+                      error_info{"hip_queue: hipMemPrefetchAsync() failed",
+                                 error_code{"HIP", err}});
+  }
+
+  return make_success();
+}
+
+result hip_queue::submit_memset(const memset_operation &op) {
+
+  hipError_t err = hipMemsetAsync(op.get_pointer(), op.get_pattern(),
+                                  op.get_num_bytes(), get_stream());
+
+  if (err != hipSuccess) {
+    return make_error(__hipsycl_here(),
+                      error_info{"cuda_queue: hipMemsetAsync() failed",
+                                 error_code{"HIP", err}});
+  }
 
   return make_success();
 }

--- a/src/runtime/hip/hip_queue.cpp
+++ b/src/runtime/hip/hip_queue.cpp
@@ -260,7 +260,7 @@ result hip_queue::submit_memset(const memset_operation &op) {
 
   if (err != hipSuccess) {
     return make_error(__hipsycl_here(),
-                      error_info{"cuda_queue: hipMemsetAsync() failed",
+                      error_info{"hip_queue: hipMemsetAsync() failed",
                                  error_code{"HIP", err}});
   }
 

--- a/src/runtime/multi_queue_executor.cpp
+++ b/src/runtime/multi_queue_executor.cpp
@@ -60,6 +60,10 @@ public:
     return _queue->submit_prefetch(*op);
   }
 
+  virtual result dispatch_memset(memset_operation *op) final override {
+    return _queue->submit_memset(*op);
+  }
+
 private:
   inorder_queue* _queue;
 };

--- a/src/runtime/omp/omp_queue.cpp
+++ b/src/runtime/omp/omp_queue.cpp
@@ -215,7 +215,27 @@ result omp_queue::submit_prefetch(const prefetch_operation &) {
   // backend here)
   return make_success();
 }
+
+result omp_queue::submit_memset(const memset_operation & op) {
+  void *ptr = op.get_pointer();
+  std::size_t bytes = op.get_num_bytes();
+  int pattern = op.get_pattern();
   
+  if (!ptr) {
+    return register_error(
+        __hipsycl_here(),
+        error_info{
+            "omp_queue: submit_memset(): Invalid argument, pointer is null."});
+  }
+
+  _worker([=]() {
+    memset(ptr, pattern, bytes);
+  });
+
+  return make_success();
+    
+}
+
   /// Causes the queue to wait until an event on another queue has occured.
   /// the other queue must be from the same backend
 result omp_queue::submit_queue_wait_for(std::shared_ptr<dag_node_event> evt) {

--- a/src/runtime/operations.cpp
+++ b/src/runtime/operations.cpp
@@ -59,7 +59,7 @@ kernel_operation::get_launcher() const
 { return _launcher; }
 
 const std::vector<memory_requirement*>& 
-kernel_operation::get_requirements() const
+kernel_operation::get_memory_requirements() const
 { return _requirements; }
 
 

--- a/src/runtime/serialization/serialization.cpp
+++ b/src/runtime/serialization/serialization.cpp
@@ -123,6 +123,17 @@ void memcpy_operation::dump(std::ostream &ostr, int indentation) const {
   ostr << _num_elements;
 }
 
+void prefetch_operation::dump(std::ostream& ostr, int indentation) const {
+  ostr << get_indentation(indentation);
+  ostr << "Prefetch: " << _num_bytes << " bytes from " << _ptr;
+}
+
+void memset_operation::dump(std::ostream &ostr, int indentation) const {
+  ostr << get_indentation(indentation);
+  ostr << "Memset: @" << _ptr << " " << _num_bytes << " bytes of value "
+       << get_pattern();
+}
+
 void memory_location::dump(std::ostream &ostr) const {
   _dev.dump(ostr);
   ostr << " #" << _element_size << " " << _offset << "+" << _allocation_shape;

--- a/tests/sycl/usm.cpp
+++ b/tests/sycl/usm.cpp
@@ -25,6 +25,8 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <exception>
+#include <vector>
 
 #include "sycl_test_suite.hpp"
 #include <boost/test/unit_test_suite.hpp>
@@ -171,33 +173,234 @@ BOOST_AUTO_TEST_CASE(in_order_queue) {
   BOOST_CHECK(evt3.get_wait_list()[0] == evt2);
 }
 
-BOOST_AUTO_TEST_CASE(shared_allocations) {
+BOOST_AUTO_TEST_CASE(allocations_in_kernels) {
   sycl::queue q{sycl::property_list{sycl::property::queue::in_order{}}};
 
   std::size_t test_size = 4096;
   int *shared_allocation = sycl::malloc_shared<int>(test_size, q);
-
-  q.single_task([=]() {
+  int *explicit_allocation = sycl::malloc_device<int>(test_size, q);
+  int *mapped_host_allocation = sycl::malloc_host<int>(test_size, q);
+  
+  q.single_task<class usm_alloc_single_task>([=]() {
     for (int i = 0; i < test_size; ++i) {
       shared_allocation[i] = i;
+      explicit_allocation[i] = i;
+      mapped_host_allocation[i] = i;
     }
   });
 
-  q.parallel_for(sycl::range<1>{test_size},
-                 [=](sycl::id<1> idx) { shared_allocation[idx.get(0)] += 1; });
+  q.parallel_for<class usm_alloc_pf>(sycl::range<1>{test_size},
+                                     [=](sycl::id<1> idx) {
+                                       shared_allocation[idx.get(0)] += 1;
+                                       explicit_allocation[idx.get(0)] += 1;
+                                       mapped_host_allocation[idx.get(0)] += 1;
+                                     });
 
-  q.parallel_for(
+  q.parallel_for<class usm_alloc_ndrange_pf>(
       sycl::nd_range<1>{sycl::range<1>{test_size}, sycl::range<1>{128}},
-      [=](sycl::id<1> idx) { shared_allocation[idx.get(0)] += 1; });
+      [=](sycl::nd_item<1> idx) {
+        shared_allocation[idx.get_global_id(0)] += 1;
+        explicit_allocation[idx.get_global_id(0)] += 1;
+        mapped_host_allocation[idx.get_global_id(0)] += 1;
+      });
+
+  std::vector<int> host_explicit_allocation(test_size);
+  q.memcpy(host_explicit_allocation.data(), explicit_allocation,
+           test_size * sizeof(int));
+  q.wait();
+
+  for (int i = 0; i < test_size; ++i){
+    BOOST_TEST(shared_allocation[i] == i + 2);
+    BOOST_TEST(host_explicit_allocation[i] == i + 2);
+    BOOST_TEST(mapped_host_allocation[i] == i + 2);
+  }
+
+  sycl::free(shared_allocation, q);
+  sycl::free(explicit_allocation, q);
+  sycl::free(mapped_host_allocation, q);
+}
+BOOST_AUTO_TEST_CASE(memcpy) {
+  sycl::queue q{sycl::property_list{sycl::property::queue::in_order{}}};
+
+  std::size_t test_size = 4096;
+  std::vector<int> initial_data(test_size);
+
+  for (std::size_t i = 0; i < initial_data.size(); ++i)
+    initial_data[i] = i;
+
+  auto test_device_host_copies = [&](int *dev_ptr) {
+    std::vector<int> host_data(test_size);
+    q.memcpy(dev_ptr, initial_data.data(), sizeof(int) * test_size);
+    q.memcpy(host_data.data(), dev_ptr, sizeof(int) * test_size);
+
+    q.wait();
+
+    for (std::size_t i = 0; i < test_size; ++i) {
+      BOOST_TEST(host_data[i] == initial_data[i]);
+    }
+  };
+
+
+  // memcpy host->explicit device
+  // memcpy explicit device->host
+  {
+    int *device_mem = sycl::malloc_device<int>(test_size, q);
+    test_device_host_copies(device_mem);
+    sycl::free(device_mem, q);
+  }
+  // memcpy host->shared
+  // memcpy shared->host
+  {
+    int *shared_mem = sycl::malloc_shared<int>(test_size, q);
+    test_device_host_copies(shared_mem);
+    sycl::free(shared_mem, q);
+  }
+
+  // memcpy device->shared
+  // memcpy shared->device
+  {
+    int *device_mem = sycl::malloc_device<int>(test_size, q);
+    int *shared_mem = sycl::malloc_shared<int>(test_size, q);
+
+    q.memcpy(device_mem, initial_data.data(), sizeof(int) * test_size);
+    q.memcpy(shared_mem, device_mem, sizeof(int) * test_size);
+
+    q.wait();
+
+    for (std::size_t i = 0; i < test_size; ++i)
+      BOOST_TEST(shared_mem[i] == initial_data[i]);
+
+    int *device_mem2 = sycl::malloc_device<int>(test_size, q);
+    std::vector<int> host_data(test_size);
+
+    q.memcpy(device_mem2, shared_mem, sizeof(int) * test_size);
+    q.memcpy(host_data.data(), device_mem2, sizeof(int) * test_size);
+
+    q.wait();
+
+    for (std::size_t i = 0; i < test_size; ++i)
+      BOOST_TEST(host_data[i] == initial_data[i]);
+    
+    sycl::free(device_mem, q);
+    sycl::free(device_mem2, q);
+    sycl::free(shared_mem, q);
+  }
+
+  // memcpy host->host
+  {
+    int *host_mem = sycl::malloc_host<int>(test_size, q);
+    int *host_mem2 = sycl::malloc_host<int>(test_size, q);
+
+    for (std::size_t i = 0; i < test_size; ++i)
+      host_mem[i] = initial_data[i];
+
+    q.memcpy(host_mem2, host_mem, sizeof(int) * test_size);
+    q.wait();
+
+    for (std::size_t i = 0; i < test_size; ++i)
+      BOOST_TEST(host_mem2[i] == initial_data[i]);
+
+    sycl::free(host_mem, q);
+    sycl::free(host_mem2, q);
+  }
+
+  // memcpy device->device
+  {
+    int *device_mem = sycl::malloc_device<int>(test_size, q);
+    int *device_mem2 = sycl::malloc_device<int>(test_size, q);
+    std::vector<int> host_data(test_size);
+    
+    q.memcpy(device_mem, initial_data.data(), test_size * sizeof(int));
+    q.memcpy(device_mem2, device_mem, test_size * sizeof(int));
+    q.memcpy(host_data.data(), device_mem2, test_size * sizeof(int));
+    q.wait();
+
+    for (std::size_t i = 0; i < test_size; ++i)
+      BOOST_TEST(host_data[i] == initial_data[i]);
+
+    sycl::free(device_mem,  q);
+    sycl::free(device_mem2, q);
+  }
+  // memcpy shared->shared
+  {
+    int *shared_mem = sycl::malloc_shared<int>(test_size, q);
+    int *shared_mem2 = sycl::malloc_shared<int>(test_size, q);
+
+    for (std::size_t i = 0; i < test_size; ++i)
+      shared_mem[i] = initial_data[i];
+
+    q.memcpy(shared_mem2, shared_mem, sizeof(int) * test_size);
+    q.wait();
+
+    for (std::size_t i = 0; i < test_size; ++i)
+      BOOST_TEST(shared_mem2[i] == initial_data[i]);
+
+    sycl::free(shared_mem, q);
+    sycl::free(shared_mem2, q);
+  }
+}
+BOOST_AUTO_TEST_CASE(usm_fill) {
+  sycl::queue q{sycl::property_list{sycl::property::queue::in_order{}}};
+
+  std::size_t test_size = 4096;
+  int* shared_mem = sycl::malloc_shared<int>(test_size, q);
+  for (int i = 0; i < test_size; ++i)
+    shared_mem[i] = 0;
+
+  int fill_value = 1234567890;
+  q.fill(shared_mem+1, fill_value, test_size-2);
+  q.wait();
+
+  for (int i = 0; i < test_size; ++i) {
+    if (i == 0 || i == test_size - 1)
+      BOOST_TEST(shared_mem[i] == 0);
+    else
+      BOOST_TEST(shared_mem[i] == fill_value);
+  }
+
+  sycl::free(shared_mem, q);
+}
+BOOST_AUTO_TEST_CASE(memset) {
+  sycl::queue q{sycl::property_list{sycl::property::queue::in_order{}}};
+
+  std::size_t test_size = 4096;
+  unsigned char *mem = sycl::malloc_device<unsigned char>(test_size, q);
+
+  q.memset(mem, 0, test_size);
+  q.memset(mem + 1, 12, test_size - 2);
+  std::vector<unsigned char> host_mem(test_size);
+  q.memcpy(host_mem.data(), mem, test_size);
 
   q.wait();
 
-  for (int i = 0; i < test_size; ++i)
-    BOOST_TEST(shared_allocation[i] == i + 2);
+  for (int i = 0; i < test_size; ++i) {
+    if (i == 0 || i == test_size - 1)
+      BOOST_TEST(host_mem[i] == 0);
+    else
+      BOOST_TEST(host_mem[i] == 12);
+  }
 
-  sycl::free(shared_allocation, q);
+  sycl::free(mem, q);
 }
+BOOST_AUTO_TEST_CASE(prefetch) {
+  sycl::queue q{sycl::property_list{sycl::property::queue::in_order{}}};
 
+  std::size_t test_size = 4096;
+  int *shared_mem = sycl::malloc_shared<int>(test_size, q);
 
+  for (std::size_t i = 0; i < test_size; ++i)
+    shared_mem[i] = i;
+
+  q.prefetch(shared_mem, test_size * sizeof(int));
+  q.parallel_for<class usm_prefetch_test_kernel>(
+      sycl::range<1>{test_size},
+      [=](sycl::id<1> idx) { shared_mem[idx.get(0)] += 1; });
+  
+  q.wait();
+  for (std::size_t i = 0; i < test_size; ++i)
+    BOOST_TEST(shared_mem[i] == i + 1);
+  
+  sycl::free(shared_mem, q);
+}
 BOOST_AUTO_TEST_SUITE_END() // NOTE: Make sure not to add anything below this
                             // line


### PR DESCRIPTION
* Add USM queue shortcuts (e.g. `queue::parallel_for`)
* Add `handler::memcpy`
* Add `handler::memset`
* Add USM `handler::fill`
* Add `handler::prefetch`
* Add test cases for all of the above
* Add `mem_advise` (stub only, see caveats below)

Testing results:
* CPU backend passes all tests
* CUDA backend passes all tests
* HIP backend passes all tests, except memset (see below)

Caveats:
* All the plumbing for `prefetch` on HIP is there, but the actual call to `hipMemPrefetchAsync()` is commented out because this function does not yet exist in HIP - likely because HIP doesn't have proper unified memory, so prefetching doesn't make sense.
* It seems `hipMemsetAsync()` does weird things causing the `memset()` tests to fail on HIP. This is probably a bug in HIP/ROCm. Since I'm using an older ROCm, it's possible that this is already fixed - needs more investigation.
* `mem_advise()` is currently only implemented as a stub that throws an exception when actually used.  
   * The reason this is a bit more complicated is because the CUDA model doesn't have an async variant for this. This means to get async `mem_advise` semantics in SYCL we need to launch a host task that then executes `cudaMemAdvise()`. For this we would first need to implement host tasks, which we don't have yet.
   * Additionally, HIP doesn't have a `hipMemAdvise()` at all - probably because of a similar reasoning as the missing `hipMemPrefetchAsync()`
   * On CPU it's not needed because shared allocations on the CPU backend are trivial.
