### PR TITLE
USM pointer query: Take into account that CUDA 11 returns cudaMemoryTypeUnregistered for host memory

### DIFF
--- a/src/runtime/cuda/cuda_allocator.cpp
+++ b/src/runtime/cuda/cuda_allocator.cpp
@@ -136,11 +136,21 @@ result cuda_allocator::query_pointer(const void *ptr, pointer_info &out) const {
                      error_code{"CUDA", err}});
   }
 
+  // CUDA 11+ return cudaMemoryTypeUnregistered and cudaSuccess
+  // for unknown host pointers
+  if (attribs.type == cudaMemoryTypeUnregistered) {
+    return make_error(
+          __hipsycl_here(),
+          error_info{"cuda_allocator: query_pointer(): pointer is unknown by backend",
+                     error_code{"CUDA", err},
+                     error_type::invalid_parameter_error});
+  }
+
   out.dev = rt::device_id{_backend_descriptor, attribs.device};
   out.is_from_host_backend = false;
   out.is_optimized_host = attribs.type == cudaMemoryTypeHost;
   out.is_usm = attribs.type == cudaMemoryTypeManaged;
-
+  
   return make_success();
 }
 

--- a/tests/sycl/usm.cpp
+++ b/tests/sycl/usm.cpp
@@ -50,7 +50,9 @@ BOOST_AUTO_TEST_CASE(allocation_functions) {
   int *shared_ptr = sycl::malloc_shared<int>(count, q);
   int *aligned_shared_ptr =
       sycl::aligned_alloc_shared<int>(sizeof(int), count, q);
-
+  std::vector<int> unregistered_data(100);
+  
+  
   BOOST_TEST(device_mem_ptr != nullptr);
   BOOST_TEST(aligned_device_mem_ptr != nullptr);
   BOOST_TEST(host_ptr != nullptr);
@@ -70,6 +72,7 @@ BOOST_AUTO_TEST_CASE(allocation_functions) {
     verify_allocation_type(aligned_host_ptr, sycl::usm::alloc::host);
     verify_allocation_type(shared_ptr, sycl::usm::alloc::host);
     verify_allocation_type(aligned_shared_ptr, sycl::usm::alloc::host);
+    verify_allocation_type(unregistered_data.data(), sycl::usm::alloc::host);
   }
   else {
     verify_allocation_type(device_mem_ptr, sycl::usm::alloc::device);
@@ -78,6 +81,7 @@ BOOST_AUTO_TEST_CASE(allocation_functions) {
     verify_allocation_type(aligned_host_ptr, sycl::usm::alloc::host);
     verify_allocation_type(shared_ptr, sycl::usm::alloc::shared);
     verify_allocation_type(aligned_shared_ptr, sycl::usm::alloc::shared);
+    verify_allocation_type(unregistered_data.data(), sycl::usm::alloc::unknown);
   }
 
   auto verify_device = [&](void *ptr) {


### PR DESCRIPTION
The logic in the USM function `get_pointer_type` has relied on the backend allocator returning an error when the pointer was not allocated by this backend. In that case, `get_pointer_type()` should return `usm::alloc::unknown`.

However, starting with CUDA 11 the call to `cudaPointerGetAttributes()` succeeds and `cudaMemoryTypeUnregistered` is returned.

This causes `get_pointer_type` to be unable to return `usm::alloc::unknown`, which in turn causes USM `memcpy()` to identify input pointers as being on the device if they are actually unregistered host pointers. In the end, this makes the `cuda_queue` submit a `memcpy` with the wrong `cudaMemcpyKind`.

This PR fixes the issue by returning an error in the `cuda_allocator` for an unregistered pointer.

Also added a test case for pointer queries w.r.t unregistered host memory.

Resolves #326 