### PR TITLE
 Added safer patterns to the install scripts

### DIFF
--- a/install/scripts/install-cuda.sh
+++ b/install/scripts/install-cuda.sh
@@ -1,4 +1,4 @@
-export INSTALL_PREFIX=${INSTALL_PREFIX:-/opt/hipSYCL}
+export HIPSYCL_INSTALL_PREFIX=${HIPSYCL_INSTALL_PREFIX:-/opt/hipSYCL}
 
 CUDA_INSTALLER_FILENAME=cuda_10.0.130_410.48_linux
 
@@ -7,4 +7,4 @@ cd /tmp
 if [ ! -f $CUDA_INSTALLER_FILENAME ]; then
   wget https://developer.nvidia.com/compute/cuda/10.0/Prod/local_installers/$CUDA_INSTALLER_FILENAME
 fi
-sh $CUDA_INSTALLER_FILENAME --override --silent --toolkit --toolkitpath $INSTALL_PREFIX/cuda
+sh $CUDA_INSTALLER_FILENAME --override --silent --toolkit --toolkitpath $HIPSYCL_INSTALL_PREFIX/cuda

--- a/install/scripts/install-llvm.sh
+++ b/install/scripts/install-llvm.sh
@@ -8,19 +8,30 @@ HIPSYCL_PKG_LLVM_VERSION=${HIPSYCL_PKG_LLVM_VERSION_MAJOR}.${HIPSYCL_PKG_LLVM_VE
 
 
 HIPSYCL_PKG_LLVM_REPO_BRANCH=${HIPSYCL_PKG_LLVM_REPO_BRANCH:-release/9.x}
-export INSTALL_PREFIX=${INSTALL_PREFIX:-/opt/hipSYCL}
+export HIPSYCL_INSTALL_PREFIX=${INSTALL_PREFIX:-/opt/hipSYCL}
+HIPSYCL_LLVM_BUILD_DIR=${HIPSYCL_LLVM_BUILD_DIR:-$HOME/git/llvm-vanilla}
+
 
 set -e
-BUILD_DIR=$HOME/git/llvm-vanilla
-rm -rf $BUILD_DIR
+if [ -d "$HIPSYCL_LLVM_BUILD_DIR" ]; then
+       read -p  "The build directory already exists, do you want to use $HIPSYCL_LLVM_BUILD_DIR anyways?[y]" -n 1 -r
+       echo 
+       if [[ $REPLY =~ ^[Yy]$ ]]; then
+              echo "Using the exisiting directory"
+       else
+              echo "Please specify a different directory, exiting"
+              [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1
+       fi
+else
 
 echo "Cloning LLVM $HIPSYCL_PKG_LLVM_REPO_BRANCH"
-git clone -b $HIPSYCL_PKG_LLVM_REPO_BRANCH https://github.com/llvm/llvm-project $BUILD_DIR
+git clone -b $HIPSYCL_PKG_LLVM_REPO_BRANCH https://github.com/llvm/llvm-project $HIPSYCL_LLVM_BUILD_DIR
+fi
 
 case $HIPSYCL_PKG_LLVM_VERSION in
 	9.0.1)
 		echo "Applying patch on $HIPSYCL_PKG_LLVM_VERSION"
-		sed -i 's/CHECK_SIZE_AND_OFFSET(ipc_perm, mode);//g' $BUILD_DIR/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+		sed -i 's/CHECK_SIZE_AND_OFFSET(ipc_perm, mode);//g' $HIPSYCL_LLVM_BUILD_DIR/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
 		;;
 esac
 
@@ -28,19 +39,19 @@ esac
 export CC=${HIPSYCL_BASE_CC:-clang}
 export CXX=${HIPSYCL_BASE_CXX:-clang++}
 export BUILD_TYPE=Release
-export LLVM_INSTALL_PREFIX=$INSTALL_PREFIX/llvm
+export HIPSYCL_LLVM_INSTALL_PREFIX=$INSTALL_PREFIX/llvm
 export TARGETS_TO_BUILD="AMDGPU;NVPTX;X86"
 export NUMTHREADS=`nproc`
 
-CMAKE_OPTIONS="-DLLVM_ENABLE_PROJECTS=clang;compiler-rt;lld;openmp -DOPENMP_ENABLE_LIBOMPTARGET=OFF -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$LLVM_INSTALL_PREFIX -DLLVM_ENABLE_ASSERTIONS=OFF -DLLVM_TARGETS_TO_BUILD=$TARGETS_TO_BUILD -DCLANG_ANALYZER_ENABLE_Z3_SOLVER=0 -DLLVM_INCLUDE_BENCHMARKS=0 -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_RPATH=$INSTALL_PREFIX/lib -DLLVM_ENABLE_OCAMLDOC=OFF -DLLVM_ENABLE_BINDINGS=OFF -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON -DLLVM_ENABLE_DUMP=ON"
+CMAKE_OPTIONS="-DLLVM_ENABLE_PROJECTS=clang;compiler-rt;lld;openmp -DOPENMP_ENABLE_LIBOMPTARGET=OFF -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_HIPSYCL_INSTALL_PREFIX=$LLVM_INSTALL_PREFIX -DLLVM_ENABLE_ASSERTIONS=OFF -DLLVM_TARGETS_TO_BUILD=$TARGETS_TO_BUILD -DCLANG_ANALYZER_ENABLE_Z3_SOLVER=0 -DLLVM_INCLUDE_BENCHMARKS=0 -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_RPATH=$INSTALL_PREFIX/lib -DLLVM_ENABLE_OCAMLDOC=OFF -DLLVM_ENABLE_BINDINGS=OFF -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON -DLLVM_ENABLE_DUMP=ON"
 
-mkdir -p $BUILD_DIR/build
-cd $BUILD_DIR/build
-cmake $CMAKE_OPTIONS $BUILD_DIR/llvm
+mkdir -p $HIPSYCL_LLVM_BUILD_DIR/build
+cd $HIPSYCL_LLVM_BUILD_DIR/build
+cmake $CMAKE_OPTIONS $HIPSYCL_LLVM_BUILD_DIR/llvm
 make -j $NUMTHREADS
 make install
-cp -p $BUILD_DIR/build/bin/llvm-lit   $LLVM_INSTALL_PREFIX/bin/llvm-lit
-cp -p $BUILD_DIR/build/bin/FileCheck  $LLVM_INSTALL_PREFIX/bin/FileCheck
-cp -p $BUILD_DIR/build/bin/count      $LLVM_INSTALL_PREFIX/bin/count
-cp -p $BUILD_DIR/build/bin/not        $LLVM_INSTALL_PREFIX/bin/not
-cp -p $BUILD_DIR/build/bin/yaml-bench $LLVM_INSTALL_PREFIX/yaml-bench
+cp -p $HIPSYCL_LLVM_BUILD_DIR/build/bin/llvm-lit   $HIPSYCL_LLVM_INSTALL_PREFIX/bin/llvm-lit
+cp -p $HIPSYCL_LLVM_BUILD_DIR/build/bin/FileCheck  $HIPSYCL_LLVM_INSTALL_PREFIX/bin/FileCheck
+cp -p $HIPSYCL_LLVM_BUILD_DIR/build/bin/count      $HIPSYCL_LLVM_INSTALL_PREFIX/bin/count
+cp -p $HIPSYCL_LLVM_BUILD_DIR/build/bin/not        $HIPSYCL_LLVM_INSTALL_PREFIX/bin/not
+cp -p $HIPSYCL_LLVM_BUILD_DIR/build/bin/yaml-bench $HIPSYCL_LLVM_INSTALL_PREFIX/yaml-bench

--- a/install/scripts/install-rocm.sh
+++ b/install/scripts/install-rocm.sh
@@ -1,44 +1,55 @@
-export INSTALL_PREFIX=${INSTALL_PREFIX:-/opt/hipSYCL}
+export HIPSYCL_INSTALL_PREFIX=${HIPSYCL_INSTALL_PREFIX:-/opt/hipSYCL}
 
 HIPSYCL_PKG_AOMP_RELEASE=${HIPSYCL_PKG_AOMP_VERSION:-0.7-7}
 HIPSYCL_PKG_AOMP_TAG=${HIPSYCL_PKG_AOMP_TAG:-rel_${HIPSYCL_PKG_AOMP_RELEASE}}
 
 set -e
-BUILD_DIR=$HOME/git/aomp
-rm -rf $BUILD_DIR
+HIPSYCL_ROCM_BUILD_DIR=${HIPSYCL_ROCM_BUILD_DIR:-$HOME/git/aomp}
 
-#git clone -b hipsycl-0.8 https://github.com/illuhad/aomp $BUILD_DIR/aomp
-git clone -b $HIPSYCL_PKG_AOMP_TAG https://github.com/ROCm-Developer-Tools/aomp $BUILD_DIR/aomp
-
-cd $BUILD_DIR/aomp/bin
 export CC=${HIPSYCL_BASE_CC:-clang}
 export CXX=${HIPSYCL_BASE_CXX:-clang++}
 export SUDO=${SUDO:-"disable"}
-export AOMP=$INSTALL_PREFIX/rocm
+export AOMP=$HIPSYCL_INSTALL_PREFIX/rocm
 export BUILD_TYPE=Release
 #export NVPTXGPUS=60,61,62,70
 #export AOMP_BUILD_HIPSYCL_ESSENTIAL=1
 export AOMP_BUILD_HIP=1
-export CUDA=${CUDA:-$INSTALL_PREFIX/cuda}
+export CUDA=${CUDA:-$HIPSYCL_INSTALL_PREFIX/cuda}
 #export AOMP_BUILD_CUDA=1
 
+if [ -d "$HIPSYCL_ROCM_BUILD_DIR" ]; then
+       read -p  "The build directory already exists, do you want to use $HIPSYCL_ROCM_BUILD_DIR anyways?[y]" -n 1 -r
+       echo 
+       if [[ $REPLY =~ ^[Yy]$ ]]; then
+              echo "Using the exisiting directory"
+       else
+              echo "Please specify a different directory, exiting"
+              [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1
+       fi
+else
+echo "Cloning aomp"
+git clone -b $HIPSYCL_PKG_AOMP_TAG https://github.com/ROCm-Developer-Tools/aomp $HIPSYCL_ROCM_BUILD_DIR/aomp
+cd $HIPSYCL_ROCM_BUILD_DIR/aomp/bin
 ./clone_aomp.sh
+fi
 
+
+cd $HIPSYCL_ROCM_BUILD_DIR/aomp/bin
 case $HIPSYCL_PKG_AOMP_RELEASE in
 	0.7-7)
-    sed -i 's/openmp pgmath flang flang_runtime//g' $BUILD_DIR/aomp/bin/build_aomp.sh
-    sed -i 's/exit 1//g' $BUILD_DIR/aomp/bin/build_hcc.sh
+    sed -i 's/openmp pgmath flang flang_runtime//g' $HIPSYCL_ROCM_BUILD_DIR/aomp/bin/build_aomp.sh
+    sed -i 's/exit 1//g' $HIPSYCL_ROCM_BUILD_DIR/aomp/bin/build_hcc.sh
     # This aomp patch to support HIP in conjunction with OpenMP breaks HIP clang printf,
     # so we remove it
-    sed -i 's/patch -p1 < $thisdir\/hip.patch//g' $BUILD_DIR/aomp/bin/build_hip.sh
+    sed -i 's/patch -p1 < $thisdir\/hip.patch//g' $HIPSYCL_ROCM_BUILD_DIR/aomp/bin/build_hip.sh
 
     # Remove problematic -Werror compilation arguments
-    sed -i 's/ -Werror//g' $BUILD_DIR/aomp-extras/hostcall/lib/CMakeLists.txt
-    sed -i 's/ -Werror//g' $BUILD_DIR/rocr-runtime/src/CMakeLists.txt
+    sed -i 's/ -Werror//g' $HIPSYCL_ROCM_BUILD_DIR/aomp-extras/hostcall/lib/CMakeLists.txt
+    sed -i 's/ -Werror//g' $HIPSYCL_ROCM_BUILD_DIR/rocr-runtime/src/CMakeLists.txt
 
     # Remove for compatibility with glibc 2.31
-    sed -i 's/CHECK_SIZE_AND_OFFSET(ipc_perm, mode);//g' $BUILD_DIR/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
-    sed -i 's/CHECK_SIZE_AND_OFFSET(ipc_perm, mode);//g' $BUILD_DIR/hcc/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+    sed -i 's/CHECK_SIZE_AND_OFFSET(ipc_perm, mode);//g' $HIPSYCL_ROCM_BUILD_DIR/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+    sed -i 's/CHECK_SIZE_AND_OFFSET(ipc_perm, mode);//g' $HIPSYCL_ROCM_BUILD_DIR/hcc/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
   ;;
 esac
 ./build_aomp.sh


### PR DESCRIPTION
This PR should fix issues #334  and #333 

#333 
* install scripts the `INSTALL_PREFIX` varibale has been changed to `HIPSYCL_INSTALL_PREFIX`
* The `BUILD_DIR` variable has been renamed to `HIPSYCL_BUILD_DIR` in the `install-hipsycl.sh` and to `HIPSYCL_<ROCM/LLVM>_BUILD` for the other two files. This distinction should prevent confusion when building multiple componenets. 

#334 
The `rm -rf ` has been removed from all the scipts. Now if the install directory is present the user is asked if they want to use the directory if the user does not want to use that director the script exits, otherwise, a correct clone of the given software is assumed and the script proceeds with configuration. 
