### PR TITLE
Fix several memory access bugs detecting using address sanitizer

### DIFF
--- a/include/hipSYCL/sycl/handler.hpp
+++ b/include/hipSYCL/sycl/handler.hpp
@@ -638,7 +638,7 @@ private:
     : _ctx{ctx}, _handler{handler},
       _execution_hints{hints} {}
   
-  const context& _ctx;
+  const context _ctx;
   detail::local_memory_allocator _local_mem_allocator;
   async_handler _handler;
 

--- a/tests/sycl/item.cpp
+++ b/tests/sycl/item.cpp
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(item_api, _dimensions, test_dimensions::type) {
             auto id3 = item.get_id();
             if(d >= 1) id3[0] = item.get_id(0);
             if(d >= 2) id3[1] = item.get_id(1);
-            if(d == 3) id3[3] = item.get_id(2);
+            if(d == 3) id3[2] = item.get_id(2);
             acc3[item] = id3;
           }
         });
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(item_api, _dimensions, test_dimensions::type) {
             auto id3 = item.get_id();
             if(d >= 1) id3[0] = item.get_id(0);
             if(d >= 2) id3[1] = item.get_id(1);
-            if(d == 3) id3[3] = item.get_id(2);
+            if(d == 3) id3[2] = item.get_id(2);
             acc3[item] = id3;
           }
         });


### PR DESCRIPTION
* typo in unit tests causing invalid access to `item` element
* illegal access to `context` object in USM operations after it has vanished from stack caused by reference to temporary object