### PR TITLE
fix potential race in worker_thread::halt()

### DIFF
--- a/src/runtime/generic/async_worker.cpp
+++ b/src/runtime/generic/async_worker.cpp
@@ -29,6 +29,7 @@
 #include "hipSYCL/common/debug.hpp"
 
 #include <cassert>
+#include <mutex>
 
 namespace hipsycl {
 namespace rt {
@@ -64,9 +65,11 @@ void worker_thread::halt()
 {
   wait();
 
-  _continue = false;
-  _condition_wait.notify_one();
-
+  {
+    std::unique_lock<std::mutex> lock(_mutex);
+    _continue = false;
+    _condition_wait.notify_one();
+  }
   if(_worker_thread.joinable())
     _worker_thread.join();
 }


### PR DESCRIPTION
Fix a potential race condition when shutting down the background worker thread of the runtime. I'm not sure if this has much practical relevance as it would only affect the runtime shutting down, but with this, the unit tests run with a clean tsan log