### PR TITLE
Mark item::operator[] const, fix tests

### DIFF
--- a/include/hipSYCL/sycl/libkernel/item.hpp
+++ b/include/hipSYCL/sycl/libkernel/item.hpp
@@ -73,7 +73,7 @@ struct item_base
     return this->global_id[dimension];
   }
 
-  HIPSYCL_KERNEL_TARGET size_t operator[](int dimension)
+  HIPSYCL_KERNEL_TARGET size_t operator[](int dimension) const
   {
     return this->global_id[dimension];
   }

--- a/tests/sycl/item.cpp
+++ b/tests/sycl/item.cpp
@@ -60,17 +60,17 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(item_api, _dimensions, test_dimensions::type) {
             acc1[item] = item.get_id();
           }
           {
-            auto id2 = item.get_id();
+            s::id<d> id2;
             if(d >= 1) id2[0] = item.get_id(0);
             if(d >= 2) id2[1] = item.get_id(1);
             if(d == 3) id2[2] = item.get_id(2);
             acc2[item] = id2;
           }
           {
-            auto id3 = item.get_id();
-            if(d >= 1) id3[0] = item.get_id(0);
-            if(d >= 2) id3[1] = item.get_id(1);
-            if(d == 3) id3[2] = item.get_id(2);
+            s::id<d> id3;
+            if(d >= 1) id3[0] = item[0];
+            if(d >= 2) id3[1] = item[1];
+            if(d == 3) id3[2] = item[2];
             acc3[item] = id3;
           }
         });
@@ -111,17 +111,17 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(item_api, _dimensions, test_dimensions::type) {
             acc1[item] = item.get_id();
           }
           {
-            auto id2 = item.get_id();
+            s::id<d> id2;
             if(d >= 1) id2[0] = item.get_id(0);
             if(d >= 2) id2[1] = item.get_id(1);
             if(d == 3) id2[2] = item.get_id(2);
             acc2[item] = id2;
           }
           {
-            auto id3 = item.get_id();
-            if(d >= 1) id3[0] = item.get_id(0);
-            if(d >= 2) id3[1] = item.get_id(1);
-            if(d == 3) id3[2] = item.get_id(2);
+            s::id<d> id3;
+            if(d >= 1) id3[0] = item[0];
+            if(d >= 2) id3[1] = item[1];
+            if(d == 3) id3[2] = item[2];
             acc3[item] = id3;
           }
         });


### PR DESCRIPTION
As revealed by #338 there were some issues with the item tests. While fixing the tests to actually use `operator[]`, I noticed that it wasn't marked as const, so I fixed that as well!