### PR TITLE
Fix missing data transfers for buffers initialized from const pointers

### DIFF
--- a/include/hipSYCL/sycl/buffer.hpp
+++ b/include/hipSYCL/sycl/buffer.hpp
@@ -547,8 +547,15 @@ private:
     assert(_impl);
     auto host_device = detail::get_host_device();
     preallocate_host_buffer();
+
     std::memcpy(_impl->data->get_memory(host_device), data,
                 sizeof(T) * _range.size());
+    // Mark the modified range current so that the runtime
+    // knows that it needs to transfer this data if it is
+    // accessed on device
+    _impl->data->mark_range_current(host_device,
+                                    rt::embed_in_id3(sycl::id<3>{}),
+                                    rt::embed_in_range3(get_range()));
   }
 
   void init_policies_from_properties_or_default(default_policies dpol)


### PR DESCRIPTION
When initializing a buffer from a const pointer, the `data_range` is constructed and an empty host allocation is created. This allocation is then filled with a `memcpy`. However, the runtime was not informed that the data inside the buffer has been modified, which causes it to not emit data transfers when the buffer is accessed on device.

This PR fixes the issue by manually marking the modified data range as current.

@9prady9 this should resolve our problem - with this the example code prints the expected output for me.