### PR TITLE
Add float and double overloads for stream class

### DIFF
--- a/include/hipSYCL/sycl/libkernel/stream.hpp
+++ b/include/hipSYCL/sycl/libkernel/stream.hpp
@@ -181,6 +181,16 @@ inline const stream& operator<<(const stream& os, const char* v) {
   printf("%s", v); return os;
 }
 
+HIPSYCL_KERNEL_TARGET
+inline const stream& operator<<(const stream& os, float v){
+  printf("%f", v); return os;
+}
+
+HIPSYCL_KERNEL_TARGET
+inline const stream& operator<<(const stream& os, double v){
+  printf("%f", v); return os;
+}
+
 template<class T>
 HIPSYCL_KERNEL_TARGET
 const stream& operator<<(const stream& os, T* v) {


### PR DESCRIPTION
Adds missing overloads for `stream::operator<<`

Fixes #359