### PR TITLE
[SYCL2020] changed vector get_count(), get_size() to static constexpr

### DIFF
--- a/include/hipSYCL/sycl/libkernel/detail/vec_swizzle.hpp
+++ b/include/hipSYCL/sycl/libkernel/detail/vec_swizzle.hpp
@@ -184,11 +184,11 @@ public:
   { return _swizzled_access.get_vector().template get<0>(); }
 
   HIPSYCL_UNIVERSAL_TARGET
-  size_t get_count() const
+  static constexpr int get_count()
   { return N; }
 
   HIPSYCL_UNIVERSAL_TARGET
-  size_t get_size() const
+  static constexpr size_t get_size()
   { return get_count() * sizeof(T); }
 
   // ToDo

--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -254,11 +254,11 @@ public:
   { return _impl.template get<0>(); }
 
   HIPSYCL_UNIVERSAL_TARGET
-  size_t get_count() const
+  static constexpr int get_count()
   { return numElements; }
 
   HIPSYCL_UNIVERSAL_TARGET
-  size_t get_size() const
+  static constexpr size_t get_size()
   { return numElements * sizeof (dataT); }
 
   // ToDo


### PR DESCRIPTION
According to current SYCL2020 specification (p. 294) the functions should be `static constexpr` instead of `const`.

The functions are not used in hipSYCL, so no other changes were necessary. I didn't add a deprecated alias, since the name is the same.