### PR TITLE
Don't raise error when no CUDA/HIP devices are present

### DIFF
--- a/src/runtime/cuda/cuda_hardware_manager.cpp
+++ b/src/runtime/cuda/cuda_hardware_manager.cpp
@@ -41,7 +41,10 @@ cuda_hardware_manager::cuda_hardware_manager(hardware_platform hw_platform)
   int num_devices = 0;
 
   auto err = cudaGetDeviceCount(&num_devices);
-  if (err != cudaSuccess) {
+  if(err == cudaErrorNoDevice)
+    num_devices = 0;
+  
+  if (err != cudaSuccess && err != cudaErrorNoDevice) {
     register_error(
         __hipsycl_here(),
         error_info{"cuda_hardware_manager: Could not obtain number of devices",

--- a/src/runtime/hip/hip_hardware_manager.cpp
+++ b/src/runtime/hip/hip_hardware_manager.cpp
@@ -40,7 +40,10 @@ hip_hardware_manager::hip_hardware_manager(hardware_platform hw_platform)
   int num_devices = 0;
 
   auto err = hipGetDeviceCount(&num_devices);
-  if (err != hipSuccess) {
+  if(err == hipErrorNoDevice)
+    num_devices = 0;
+  
+  if (err != hipSuccess && err != hipErrorNoDevice) {
     register_error(
         __hipsycl_here(),
         error_info{"hip_hardware_manager: Could not obtain number of devices",


### PR DESCRIPTION
Don't raise an error if `cuda/hipGetDeviceCount` fails with `cuda/hipErrorNoDevice`.

In this case, the device list should simply be empty. Additionally, raising errors when the runtime is starting up can lead to deadlocks since the errors will try to register themselves with the runtime (which is not fully there yet at this point).
This issue should however probably be solved at a more fundamental level in the future.