### PR TITLE
Mangle type kernel names with clang's mangler

### DIFF
--- a/tests/device_compilation_tests.cpp
+++ b/tests/device_compilation_tests.cpp
@@ -338,5 +338,28 @@ BOOST_AUTO_TEST_CASE(optional_lambda_naming) {
 }
 #endif
 
+template <class ...>
+struct VariadicKernelTP {};
+
+template <auto ...>
+struct VariadicKernelNTTP {};
+
+BOOST_AUTO_TEST_CASE(variadic_kernel_name) {
+    cl::sycl::queue queue;
+    cl::sycl::buffer<size_t, 1> buf(1);
+    {
+      queue.submit([&](cl::sycl::handler& cgh) {
+          auto acc = buf.get_access<cl::sycl::access::mode::discard_write>(cgh);
+          cgh.parallel_for<VariadicKernelTP<int, bool, char>>(cl::sycl::range<1>(1), [=](cl::sycl::item<1>) {});
+      });
+    }
+    {
+      queue.submit([&](cl::sycl::handler& cgh) {
+          auto acc = buf.get_access<cl::sycl::access::mode::discard_write>(cgh);
+          cgh.parallel_for<VariadicKernelNTTP<1, true, 'a'>>(cl::sycl::range<1>(1), [=](cl::sycl::item<1>) {});
+      });
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END() // NOTE: Make sure not to add anything below this line
 


### PR DESCRIPTION
This is an alternative approach to #377 (handling variadic templates in kernel name generation).
If compatibility with previously created kernel names is not a concern, I suspect this would be a much more robust approach.