### PR TITLE
Allow simultaneous compilation with OpenMP and CUDA backends

### DIFF
--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -659,9 +659,6 @@ class compiler:
 
     if "hip" in self._targets and "cuda" in self._targets:
       raise RuntimeError("CUDA and HIP cannot be targeted simultaneously")
-    # clang bug prevents clang -x cuda -fopenmp from working
-    if "omp" in self._targets and "cuda" in self._targets:
-      raise RuntimeError("CUDA and OpenMP cannot be targeted simultaneously")
 
     self._backends = []
 


### PR DESCRIPTION
`syclcc` has previously not allowed simultaneous compilation with OpenMP and CUDA backends because a clang bug prevented this from working. @fodinabor reports that this is fixed in clang, so we should allow it.