### PR TITLE
clang plugin: Adjust parallel_for_workgroup kernel identification

### DIFF
--- a/include/hipSYCL/compiler/Frontend.hpp
+++ b/include/hipSYCL/compiler/Frontend.hpp
@@ -419,7 +419,7 @@ private:
       return;
 
     if(f->getQualifiedNameAsString() 
-        == "hipsycl::glue::hip_dispatch::parallel_for_workgroup")
+        == "hipsycl::glue::hiplike_dispatch::parallel_for_workgroup")
     {
       clang::FunctionDecl* Kernel = 
         this->getKernelFromHierarchicalParallelFor(f);


### PR DESCRIPTION
Adjusts detection of hierarchical parallel for kernels to account for recent changes to the qualified name of the kernel invoker.
This makes hipSYCL correctly allocate work group memory in CUDA/HIP shared memory again.

Closes #284

Passes all CPU and CUDA tests: https://github.com/hipSYCL/hipSYCL-ci-bot/actions/runs/385516751