### PR TITLE
[SYCL 2020] Add deduction guide for id, range, buffer, multi_ptr

### DIFF
--- a/include/hipSYCL/sycl/buffer.hpp
+++ b/include/hipSYCL/sycl/buffer.hpp
@@ -674,6 +674,23 @@ private:
   std::shared_ptr<detail::buffer_impl> _impl;
 };
 
+// Deduction guides
+template <class InputIterator, class AllocatorT>
+buffer(InputIterator, InputIterator, AllocatorT, const property_list & = {}) 
+-> buffer<typename std::iterator_traits<InputIterator>::value_type, 1, AllocatorT>;
+
+template <class InputIterator>
+buffer(InputIterator, InputIterator, const property_list & = {}) 
+-> buffer<typename std::iterator_traits<InputIterator>::value_type, 1>; 
+
+template <class T, int dimensions, class AllocatorT>
+buffer(const T *, const range<dimensions> &, AllocatorT, const property_list & = {})
+-> buffer<T, dimensions, AllocatorT>;
+
+template <class T, int dimensions>
+buffer(const T *, const range<dimensions> &, const property_list & = {}) 
+-> buffer<T, dimensions>;
+
 namespace detail::accessor {
 
 template<class AccessorType, class BufferType, int Dim>

--- a/include/hipSYCL/sycl/libkernel/id.hpp
+++ b/include/hipSYCL/sycl/libkernel/id.hpp
@@ -249,6 +249,11 @@ private:
   detail::device_array<std::size_t, dimensions> _data;
 };
 
+// Deduction guides
+id(size_t) -> id<1>;
+id(size_t, size_t) -> id<2>;
+id(size_t, size_t, size_t) -> id<3>;
+
 namespace detail {
 namespace id{
 

--- a/include/hipSYCL/sycl/libkernel/multi_ptr.hpp
+++ b/include/hipSYCL/sycl/libkernel/multi_ptr.hpp
@@ -498,6 +498,19 @@ using constant_ptr = multi_ptr<ElementType, access::address_space::constant_spac
 template <typename ElementType>
 using private_ptr = multi_ptr<ElementType, access::address_space::private_space>;
 
+// Deduction guides
+template <int dimensions, access::mode Mode, access::placeholder isPlaceholder, class T>
+multi_ptr( accessor<T, dimensions, Mode, access::target::global_buffer, isPlaceholder>)
+-> multi_ptr<T, access::address_space::global_space>;
+
+template <int dimensions, access::mode Mode, access::placeholder isPlaceholder, class T>
+multi_ptr(accessor<T, dimensions, Mode, access::target::constant_buffer, isPlaceholder>)
+-> multi_ptr<T, access::address_space::constant_space>;
+
+template <int dimensions, access::mode Mode, access::placeholder isPlaceholder, class T>
+multi_ptr(accessor<T, dimensions, Mode, access::target::local, isPlaceholder>)
+-> multi_ptr<T, access::address_space::local_space>;
+
 } // namespace sycl
 } // namespace hipsycl
 

--- a/include/hipSYCL/sycl/libkernel/range.hpp
+++ b/include/hipSYCL/sycl/libkernel/range.hpp
@@ -233,6 +233,11 @@ private:
 
 };
 
+// deduction guides
+range(size_t) -> range<1>;
+range(size_t, size_t) -> range<2>;
+range(size_t, size_t, size_t) -> range<3>;
+
 namespace detail {
 namespace range {
 


### PR DESCRIPTION
Add deduction guides for `id`, `range`, `buffer`, `multi_ptr`.

`vec` deduction guides need a bit more work.

Closes #364

Passes all CPU and CUDA tests: https://github.com/hipSYCL/hipSYCL-ci-bot/actions/runs/385685477