### PR TITLE
Fix typo in return type of nd_item::get_group_range(size_t)

### DIFF
--- a/include/hipSYCL/sycl/libkernel/nd_item.hpp
+++ b/include/hipSYCL/sycl/libkernel/nd_item.hpp
@@ -248,7 +248,7 @@ struct nd_item
   }
 
   HIPSYCL_KERNEL_TARGET
-  range<dimensions> get_group_range(int dimension) const
+  size_t get_group_range(int dimension) const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
     return detail::get_grid_size<dimensions>(dimension);


### PR DESCRIPTION
Fixes the return type of `nd_item::get_group_range()`. Issue was reported in #380.