### PR TITLE
Resolve warnings when compiling with -Wall

### DIFF
--- a/include/hipSYCL/compiler/Frontend.hpp
+++ b/include/hipSYCL/compiler/Frontend.hpp
@@ -473,7 +473,7 @@ private:
           }
         }
       }
-      else if(auto C = clang::dyn_cast<clang::CompoundStmt>(*S))
+      else if(clang::dyn_cast<clang::CompoundStmt>(*S))
       {
         storeLocalVariablesInLocalMemory(*S, F);
       }

--- a/include/hipSYCL/runtime/dag_node.hpp
+++ b/include/hipSYCL/runtime/dag_node.hpp
@@ -100,13 +100,13 @@ private:
   device_id _assigned_device;
   backend_executor *_assigned_executor;
   std::size_t _assigned_execution_lane;
-  bool _is_virtual;
 
   std::shared_ptr<dag_node_event> _event;
   std::unique_ptr<operation> _operation;
 
   std::atomic<bool> _is_submitted;
   mutable std::atomic<bool> _is_complete;
+  bool _is_virtual;
   std::atomic<bool> _is_cancelled;
 
   std::size_t _node_id;

--- a/include/hipSYCL/runtime/data.hpp
+++ b/include/hipSYCL/runtime/data.hpp
@@ -209,8 +209,8 @@ private:
     return pos[0] * _size[1] * _size[2] + pos[1] * _size[2] + pos[2]; 
   }
 
-  std::vector<data_state> _contained_data;
   range<3> _size;
+  std::vector<data_state> _contained_data;
 };
 
 
@@ -284,11 +284,12 @@ public:
   /// dimension must be a multiple of the page size
   /// \param page_size The size (numbers of elements) of the granularity of data
   /// management
-  data_region(range<3> num_elements, std::size_t element_size,
-              range<3> page_size,
-              destruction_handler on_destruction = [](data_region*){})
-      : _element_size{element_size}, _num_elements{num_elements},
-        _page_size{page_size}, _on_destruction{on_destruction}, _is_fork{false} {
+  data_region(
+      range<3> num_elements, std::size_t element_size, range<3> page_size,
+      destruction_handler on_destruction = [](data_region *) {})
+      : _element_size{element_size}, _is_fork{false},
+        _on_destruction{on_destruction}, _page_size{page_size},
+        _num_elements{num_elements} {
 
     unset_id();
 
@@ -307,7 +308,6 @@ public:
                        << _num_pages[0] << " " << _num_pages[1] << " "
                        << _num_pages[2] << std::endl;
   }
-
 
   ~data_region() {
     _on_destruction(this);
@@ -482,7 +482,7 @@ public:
   {
     auto ptr = std::make_unique<data_region>(*this);
     ptr->_is_fork = true;
-    return std::move(ptr);
+    return ptr;
   }
 
   void apply_fork(data_region *fork)

--- a/include/hipSYCL/runtime/device_id.hpp
+++ b/include/hipSYCL/runtime/device_id.hpp
@@ -57,8 +57,8 @@ enum class backend_id {
 struct backend_descriptor
 {
   backend_id id;
-  api_platform sw_platform;
   hardware_platform hw_platform;
+  api_platform sw_platform;
 
   backend_descriptor() = default;
   backend_descriptor(hardware_platform hw_plat, api_platform sw_plat)

--- a/include/hipSYCL/runtime/error.hpp
+++ b/include/hipSYCL/runtime/error.hpp
@@ -112,8 +112,8 @@ public:
   }
 
 private:
-  bool _has_error_code;
   std::string _component;
+  bool _has_error_code;
   int _code;
 };
 

--- a/include/hipSYCL/sycl/libkernel/detail/device_array.hpp
+++ b/include/hipSYCL/sycl/libkernel/detail/device_array.hpp
@@ -28,6 +28,7 @@
 #ifndef HIPSYCL_DEVICE_ARRAY_HPP
 #define HIPSYCL_DEVICE_ARRAY_HPP
 
+#include <cstddef>
 #include <type_traits>
 #include "hipSYCL/sycl/libkernel/backend.hpp"
 

--- a/include/hipSYCL/sycl/libkernel/group.hpp
+++ b/include/hipSYCL/sycl/libkernel/group.hpp
@@ -374,10 +374,10 @@ struct group
 #else
 
 #ifdef _OPENMP
-  #pragma omp simd
+    #pragma omp simd
 #endif
-  for(size_t i = 0; i < numElements; ++i)
-    dest[i] = src[i];
+    for(size_t i = 0; i < numElements; ++i)
+      dest[i] = src[i];
 #endif
 
     return device_event{};
@@ -397,10 +397,10 @@ struct group
 
 #else
 #ifdef _OPENMP
- #pragma omp simd
+    #pragma omp simd
 #endif
-  for(size_t i = 0; i < numElements; ++i)
-    dest[i] = src[i * srcStride];
+    for(size_t i = 0; i < numElements; ++i)
+      dest[i] = src[i * srcStride];
 #endif
 
     return device_event{};

--- a/include/hipSYCL/sycl/usm_query.hpp
+++ b/include/hipSYCL/sycl/usm_query.hpp
@@ -99,6 +99,11 @@ inline rt::backend_id select_usm_backend(const context &ctx) {
     });
     assert(backend_it != devs.backends_end());
     selected_backend = *backend_it;
+  } else {
+    // Prevent warnings about uninitialized use of selected_backend
+    selected_backend = detail::get_host_device().get_backend();
+    throw memory_allocation_error{
+        "USM: Could not select backend to use for USM memory operation"};
   }
   
   return selected_backend;

--- a/src/runtime/cuda/cuda_backend.cpp
+++ b/src/runtime/cuda/cuda_backend.cpp
@@ -39,7 +39,7 @@ cuda_backend::cuda_backend()
 
   backend_descriptor backend_desc{get_hardware_platform(), get_api_platform()};
 
-  for (int i = 0; i < _hw_manager.get_num_devices(); ++i) {
+  for (int i = 0; i < static_cast<int>(_hw_manager.get_num_devices()); ++i) {
     _allocators.push_back(cuda_allocator{backend_desc, i});
   }
 }
@@ -78,7 +78,7 @@ backend_allocator *cuda_backend::get_allocator(device_id dev) const {
         error_info{"cuda_backend: Passed device id from other backend to CUDA backend"});
     return nullptr;
   }
-  if (dev.get_id() >= _allocators.size()) {
+  if (static_cast<std::size_t>(dev.get_id()) >= _allocators.size()) {
     register_error(__hipsycl_here(), error_info{"cuda_backend: Device id is out of bounds"});
   }
   return &(_allocators[dev.get_id()]);

--- a/src/runtime/dag_direct_scheduler.cpp
+++ b/src/runtime/dag_direct_scheduler.cpp
@@ -204,7 +204,6 @@ result submit_requirement(dag_node_ptr req) {
 
   // Make sure that all required allocations exist
   // (they must exist when we try initialize device pointers!)
-  bool allocation_failed = false;
   result res = make_success();
   execute_if_buffer_requirement(req, [&](buffer_memory_requirement *bmem_req) {
     res = ensure_allocation_exists(bmem_req, req->get_assigned_device());

--- a/src/runtime/dag_node.cpp
+++ b/src/runtime/dag_node.cpp
@@ -41,7 +41,7 @@ dag_node::dag_node(const execution_hints &hints,
     : _hints{hints}, _requirements{requirements},
       _assigned_executor{nullptr}, _event{nullptr}, _operation{std::move(op)},
       _is_submitted{false}, _is_complete{false}, _is_virtual{false},
-      _node_id{std::numeric_limits<std::size_t>::max()} {}
+      _is_cancelled{false}, _node_id{std::numeric_limits<std::size_t>::max()} {}
 
 bool dag_node::is_submitted() const { return _is_submitted; }
 

--- a/src/runtime/dag_scheduler.cpp
+++ b/src/runtime/dag_scheduler.cpp
@@ -79,7 +79,8 @@ void for_all_device_assignments(
     Handler h) 
 {
   // Make sure we're not accessing invalid nodes
-  if(current_node_index < is_device_predetermined.size()) {
+  if (static_cast<std::size_t>(current_node_index) <
+      is_device_predetermined.size()) {
 
     // If this device is pretermined, simply move to the next node
     if(is_device_predetermined[current_node_index]) {
@@ -87,7 +88,8 @@ void for_all_device_assignments(
                                  current_state, current_device_index,
                                  current_node_index + 1, h);
     } else {
-      if(current_device_index < devices_to_try.size()) {
+      if (static_cast<std::size_t>(current_device_index) <
+          devices_to_try.size()) {
         // If we are at a valid device, put in the current scheduling
         // configuration
         current_state[current_node_index].set_target_device(

--- a/src/runtime/dag_time_table.cpp
+++ b/src/runtime/dag_time_table.cpp
@@ -45,7 +45,6 @@ cost_type get_runtime_cost(const dag_interpreter &interpreter,
     c += op->get_runtime_costs();
   });
 
-  std::size_t node_id = node->get_node_id();
   
   cost_type max_synchronization_duration = 0.0;
   for(auto synchronization_op : annotation.get_synchronization_ops()) {

--- a/src/runtime/hints.cpp
+++ b/src/runtime/hints.cpp
@@ -46,17 +46,14 @@ execution_hint::~execution_hint(){}
 namespace hints {
 
 bind_to_device::bind_to_device(device_id d)
-: _dev{d}, execution_hint{execution_hint_type::bind_to_device}
+: execution_hint{execution_hint_type::bind_to_device}, _dev{d}
 {}
 
 device_id bind_to_device::get_device_id() const
 { return _dev; }
 
-
 explicit_require::explicit_require(dag_node_ptr node)
-: _dag_node{node}, 
-  execution_hint{execution_hint_type::explicit_require}
-{}
+    : execution_hint{execution_hint_type::explicit_require}, _dag_node{node} {}
 
 dag_node_ptr explicit_require::get_requirement() const
 {

--- a/src/runtime/hip/hip_backend.cpp
+++ b/src/runtime/hip/hip_backend.cpp
@@ -40,7 +40,7 @@ hip_backend::hip_backend()
 
   backend_descriptor backend_desc{get_hardware_platform(), get_api_platform()};
 
-  for (int i = 0; i < _hw_manager.get_num_devices(); ++i) {
+  for (int i = 0; i < static_cast<int>(_hw_manager.get_num_devices()); ++i) {
     _allocators.push_back(hip_allocator{backend_desc, i});
   }
 }
@@ -87,7 +87,7 @@ backend_allocator *hip_backend::get_allocator(device_id dev) const {
         error_info{"hip_backend: Passed device id from other backend to HIP backend"});
     return nullptr;
   }
-  if (dev.get_id() >= _allocators.size()) {
+  if (static_cast<std::size_t>(dev.get_id()) >= _allocators.size()) {
     register_error(__hipsycl_here(), error_info{"hip_backend: Device id is out of bounds"});
   }
   return &(_allocators[dev.get_id()]);

--- a/src/runtime/multi_queue_executor.cpp
+++ b/src/runtime/multi_queue_executor.cpp
@@ -116,14 +116,14 @@ bool multi_queue_executor::is_taskgraph() const {
 
 backend_execution_lane_range
 multi_queue_executor::get_memcpy_execution_lane_range(device_id dev) const {
-  assert(dev.get_id() < _device_data.size());
+  assert(static_cast<std::size_t>(dev.get_id()) < _device_data.size());
 
   return this->_device_data[dev.get_id()].memcpy_lanes;
 }
 
 backend_execution_lane_range
 multi_queue_executor::get_kernel_execution_lane_range(device_id dev) const {
-  assert(dev.get_id() < _device_data.size());
+  assert(static_cast<std::size_t>(dev.get_id()) < _device_data.size());
 
   return this->_device_data[dev.get_id()].kernel_lanes;
 }
@@ -269,7 +269,7 @@ void multi_queue_executor::submit_node(
         // Check that the target node has an event right after it.
         // Otherwise, if we use the generic batch-end event, it
         // *might* create a deadlock
-        std::size_t target_node_id = op->get_target_node()->get_node_id();
+        //std::size_t target_node_id = op->get_target_node()->get_node_id();
 
         q->submit_external_wait_for(op->get_target_node());
       }


### PR DESCRIPTION
* Resolve warnings when compiling hipSYCL with `-Wall`
* Resolve warnings when compiling applications with hipSYCL and `-Wall`
* Fix missing include for `size_t` with some standard libraries