### PR TITLE
[SYCL2020] Group functions

### DIFF
--- a/include/hipSYCL/glue/omp/omp_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/omp/omp_kernel_launcher.hpp
@@ -45,6 +45,7 @@
 #include "hipSYCL/sycl/libkernel/sp_item.hpp"
 #include "hipSYCL/sycl/libkernel/group.hpp"
 #include "hipSYCL/sycl/libkernel/detail/local_memory_allocator.hpp"
+#include "hipSYCL/sycl/libkernel/detail/data_layout.hpp"
 
 #include "hipSYCL/runtime/device_id.hpp"
 #include "hipSYCL/runtime/kernel_launcher.hpp"
@@ -191,6 +192,7 @@ inline void parallel_for_ndrange_kernel(
     sycl::detail::host_local_memory::request_from_threadprivate_pool(
         num_local_mem_bytes);
 
+    void* group_shared_memory_ptr = nullptr;
 
     host::static_range_decomposition<Dim> group_decomposition{
           num_groups, omp_get_num_threads()};
@@ -202,8 +204,10 @@ inline void parallel_for_ndrange_kernel(
     std::function<void()> barrier_impl = [&]() { engine.barrier(); };
 
     engine.run_kernel([&](sycl::id<Dim> local_id, sycl::id<Dim> group_id) {
+      auto linear_group_id = sycl::detail::linear_id<Dim>::get(group_id, num_groups);
       sycl::nd_item<Dim> this_item{&offset,    group_id,   local_id,
-                                   local_size, num_groups, &barrier_impl};
+                                   local_size, num_groups, &barrier_impl,
+                                   &group_shared_memory_ptr};
 
       f(this_item);
     });

--- a/include/hipSYCL/sycl/libkernel/cuda/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/cuda/group_functions.hpp
@@ -1,0 +1,242 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef SYCL_DEVICE_ONLY
+#ifdef HIPSYCL_PLATFORM_CUDA
+
+#ifndef HIPSYCL_LIBKERNEL_CUDA_GROUP_FUNCTIONS_HPP
+#define HIPSYCL_LIBKERNEL_CUDA_GROUP_FUNCTIONS_HPP
+
+#include "../backend.hpp"
+#include "../id.hpp"
+#include "../sub_group.hpp"
+#include "../vec.hpp"
+#include <type_traits>
+
+namespace hipsycl {
+namespace sycl {
+
+namespace detail {
+
+constexpr unsigned int AllMask = 0xFFFFFFFF;
+
+template<typename T,
+         typename std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
+__device__
+T shuffle_impl(T x, int id) {
+  return __shfl_sync(detail::AllMask, x, id);
+}
+
+template<>
+__device__
+char shuffle_impl(char x, int id) {
+  return static_cast<char>(shuffle_impl(static_cast<int>(x), id));
+}
+
+template<typename T, int N>
+__device__
+sycl::vec<T, N> shuffle_impl(sycl::vec<T, N> x, int id) {
+  sycl::vec<T, N> ret{};
+
+  if constexpr (1 <= N)
+    ret.s0() = shuffle_impl(x.s0(), id);
+  if constexpr (2 <= N)
+    ret.s1() = shuffle_impl(x.s1(), id);
+  if constexpr (3 <= N)
+    ret.s2() = shuffle_impl(x.s2(), id);
+  if constexpr (4 <= N)
+    ret.s3() = shuffle_impl(x.s3(), id);
+  if constexpr (8 <= N) {
+    ret.s4() = shuffle_impl(x.s4(), id);
+    ret.s5() = shuffle_impl(x.s5(), id);
+    ret.s6() = shuffle_impl(x.s6(), id);
+    ret.s7() = shuffle_impl(x.s7(), id);
+  }
+  if constexpr (16 <= N) {
+    ret.s8() = shuffle_impl(x.s8(), id);
+    ret.s9() = shuffle_impl(x.s9(), id);
+    ret.sA() = shuffle_impl(x.sA(), id);
+    ret.sB() = shuffle_impl(x.sB(), id);
+    ret.sC() = shuffle_impl(x.sC(), id);
+    ret.sD() = shuffle_impl(x.sD(), id);
+    ret.sE() = shuffle_impl(x.sE(), id);
+    ret.sF() = shuffle_impl(x.sF(), id);
+  }
+
+  return ret;
+}
+
+} // namespace detail
+
+// broadcast
+template<typename T>
+HIPSYCL_KERNEL_TARGET
+T group_broadcast(sub_group g, T x,
+                  typename sub_group::linear_id_type local_linear_id = 0) {
+  return detail::shuffle_impl(x, local_linear_id);
+}
+
+template<typename T, int N>
+HIPSYCL_KERNEL_TARGET
+sycl::vec<T, N> group_broadcast(sub_group g, sycl::vec<T, N> x,
+                                typename sub_group::linear_id_type local_linear_id = 0) {
+  return detail::shuffle_impl(x, local_linear_id);
+}
+
+
+// barrier
+template<typename Group>
+HIPSYCL_KERNEL_TARGET
+inline void group_barrier(Group g, memory_scope fence_scope = Group::fence_scope) {
+  if (fence_scope == memory_scope::device) {
+    __threadfence_system();
+  }
+  __syncthreads();
+}
+
+template<>
+HIPSYCL_KERNEL_TARGET
+inline void group_barrier(sub_group g, memory_scope fence_scope) {
+  if (fence_scope == memory_scope::device) {
+    __threadfence_system();
+  } else if (fence_scope == memory_scope::work_group) {
+    __threadfence_block();
+  }
+  __syncwarp(); // not necessarily needed, but might improve performance
+}
+
+
+// any_of
+template<>
+HIPSYCL_KERNEL_TARGET
+inline bool group_any_of(sub_group g, bool pred) {
+  return __any_sync(detail::AllMask, pred);
+}
+
+
+// all_of
+template<>
+HIPSYCL_KERNEL_TARGET
+inline bool group_all_of(sub_group g, bool pred) {
+  return __all_sync(detail::AllMask, pred);
+}
+
+
+// none_of
+template<>
+HIPSYCL_KERNEL_TARGET
+inline bool group_none_of(sub_group g, bool pred) {
+  return !__any_sync(detail::AllMask, pred);
+}
+
+
+// reduce
+template<typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T group_reduce(sub_group g, T x, BinaryOperation binary_op) {
+  auto lid = g.get_local_linear_id();
+
+  size_t lrange          = 1;
+  auto group_local_range = g.get_local_range();
+  for (int i = 0; i < g.dimensions; ++i)
+    lrange *= group_local_range[i];
+
+  group_barrier(g);
+
+  auto local_x = x;
+
+  for (size_t i = lrange / 2; i > 0; i /= 2) {
+    auto other_x = detail::shuffle_impl(local_x, lid + i);
+    if (lid < i)
+      local_x = binary_op(local_x, other_x);
+  }
+  return detail::shuffle_impl(local_x, 0);
+}
+
+
+// exclusive_scan
+template<typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T group_exclusive_scan(sub_group g, V x, T init, BinaryOperation binary_op) {
+  auto lid      = g.get_local_linear_id();
+  size_t lrange = g.get_local_linear_range();
+
+  auto local_x = x;
+
+  for (size_t i = 1; i < lrange; i *= 2) {
+    size_t next_id = lid - i;
+    if (i > lid)
+      next_id = 0;
+
+    auto other_x = detail::shuffle_impl(local_x, next_id);
+    if (i <= lid && lid < lrange)
+      local_x = binary_op(local_x, other_x);
+  }
+
+  size_t next_id = lid - 1;
+  if (g.leader())
+    next_id = 0;
+
+  auto return_value = detail::shuffle_impl(local_x, lid - 1);
+
+  if (g.leader())
+    return init;
+
+  return binary_op(return_value, init);
+}
+
+
+// inclusive_scan
+template<typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T group_inclusive_scan(sub_group g, T x, BinaryOperation binary_op) {
+  auto lid      = g.get_local_linear_id();
+  size_t lrange = g.get_local_linear_range();
+
+  auto local_x = x;
+
+  for (size_t i = 1; i < lrange; i *= 2) {
+    size_t next_id = lid - i;
+    if (i > lid)
+      next_id = 0;
+
+    auto other_x = detail::shuffle_impl(local_x, next_id);
+    if (i <= lid && lid < lrange)
+      local_x = binary_op(local_x, other_x);
+  }
+
+  return local_x;
+}
+
+
+} // namespace sycl
+} // namespace hipsycl
+
+#endif //HIPSYCL_LIBKERNEL_CUDA_GROUP_FUNCTIONS_HPP
+
+#endif //HIPSYCL_PLATFORM_CUDA
+#endif //SYCL_DEVICE_ONLY

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/group_functions.hpp
@@ -1,0 +1,593 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef SYCL_DEVICE_ONLY
+
+#ifndef HIPSYCL_LIBKERNEL_DEVICE_GROUP_FUNCTIONS_HPP
+#define HIPSYCL_LIBKERNEL_DEVICE_GROUP_FUNCTIONS_HPP
+
+#include "../../backend.hpp"
+#include "../../detail/data_layout.hpp"
+#include "../../detail/thread_hierarchy.hpp"
+#include "../../id.hpp"
+#include "../../sub_group.hpp"
+#include "../../vec.hpp"
+#include <type_traits>
+
+namespace hipsycl {
+namespace sycl {
+
+namespace detail {
+
+template<typename T, int N>
+void writeToMemory(T *scratch, vec<T, N> v) {
+  if constexpr (1 <= N)
+    scratch[0] = v.s0();
+  if constexpr (2 <= N)
+    scratch[1] = v.s1();
+  if constexpr (3 <= N)
+    scratch[2] = v.s2();
+  if constexpr (4 <= N)
+    scratch[3] = v.s3();
+  if constexpr (8 <= N) {
+    scratch[4] = v.s4();
+    scratch[5] = v.s5();
+    scratch[6] = v.s6();
+    scratch[7] = v.s7();
+  }
+  if constexpr (16 <= N) {
+    scratch[8]  = v.s8();
+    scratch[9]  = v.s9();
+    scratch[10] = v.sA();
+    scratch[11] = v.sB();
+    scratch[12] = v.sC();
+    scratch[13] = v.sD();
+    scratch[14] = v.sE();
+    scratch[15] = v.sF();
+  }
+}
+
+template<typename T, int N>
+void readFromMemory(T *scratch, vec<T, N> &v) {
+  if constexpr (1 <= N)
+    v.s0() = scratch[0];
+  if constexpr (2 <= N)
+    v.s1() = scratch[1];
+  if constexpr (3 <= N)
+    v.s2() = scratch[2];
+  if constexpr (4 <= N)
+    v.s3() = scratch[3];
+  if constexpr (8 <= N) {
+    v.s4() = scratch[4];
+    v.s5() = scratch[5];
+    v.s6() = scratch[6];
+    v.s7() = scratch[7];
+  }
+  if constexpr (16 <= N) {
+    v.s8() = scratch[8];
+    v.s9() = scratch[9];
+    v.sA() = scratch[10];
+    v.sB() = scratch[11];
+    v.sC() = scratch[12];
+    v.sD() = scratch[13];
+    v.sE() = scratch[14];
+    v.sF() = scratch[15];
+  }
+}
+
+// reduce implementation
+template<typename Group, typename T, typename BinaryOperation,
+         typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
+HIPSYCL_KERNEL_TARGET
+T group_reduce(Group g, T x, BinaryOperation binary_op, T *scratch) {
+
+  auto lid               = g.get_local_linear_id();
+  size_t lrange          = 1;
+  auto group_local_range = g.get_local_range();
+  for (int i = 0; i < g.dimensions; ++i)
+    lrange *= group_local_range[i];
+
+  scratch[lid] = x;
+  group_barrier(g);
+
+  for (size_t i = lrange / 2; i > 0; i /= 2) {
+    if (lid < i)
+      scratch[lid] = binary_op(scratch[lid], scratch[lid + i]);
+    group_barrier(g);
+  }
+
+  return scratch[0];
+}
+
+template<typename Group, typename T, int N, typename BinaryOperation,
+         typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
+HIPSYCL_KERNEL_TARGET
+vec<T, N> group_reduce(Group g, vec<T, N> x, BinaryOperation binary_op, T *scratch) {
+  auto lid               = g.get_local_linear_id();
+  size_t lrange          = 1;
+  auto group_local_range = g.get_local_range();
+  for (int i = 0; i < g.dimensions; ++i)
+    lrange *= group_local_range[i];
+
+  detail::writeToMemory(scratch + lid * N, x);
+  group_barrier(g);
+
+  for (size_t i = lrange / 2; i > 0; i /= 2) {
+
+    if (lid < i) {
+      vec<T, N> v1, v2;
+
+      detail::readFromMemory(scratch + lid * N, v1);
+      detail::readFromMemory(scratch + (lid + i) * N, v2);
+
+      detail::writeToMemory(scratch + lid * N, binary_op(v1, v2));
+    }
+
+    group_barrier(g);
+  }
+
+  vec<T, N> v;
+  detail::readFromMemory(scratch, v);
+  return v;
+}
+
+
+// any_of
+template<typename Group, typename T>
+HIPSYCL_KERNEL_TARGET
+bool any_of(Group g, T *first, T *last) {
+  auto group_range        = g.get_local_range().size();
+  auto elements_per_group = (last - first + group_range - 1) / group_range;
+  T *start_ptr            = first + elements_per_group * g.get_local_linear_id();
+  T *end_prt              = start_ptr + elements_per_group;
+
+  if (end_prt > last)
+    end_prt = last;
+
+  auto local = *start_ptr;
+
+  for (T *p = start_ptr + 1; p < end_prt; ++p)
+    local |= *p;
+
+  return group_any_of(g, local);
+}
+
+template<typename Group, typename T, typename Predicate>
+HIPSYCL_KERNEL_TARGET
+bool any_of(Group g, T *first, T *last, Predicate pred) {
+  auto group_range        = g.get_local_range().size();
+  auto elements_per_group = (last - first + group_range - 1) / group_range;
+  T *start_ptr            = first + elements_per_group * g.get_local_linear_id();
+  T *end_prt              = start_ptr + elements_per_group;
+
+  if (end_prt > last)
+    end_prt = last;
+
+  auto local = pred(*start_ptr);
+
+  for (T *p = start_ptr + 1; p < end_prt; ++p)
+    local |= pred(*p);
+
+  return group_any_of(g, local);
+}
+
+
+// all_of
+template<typename Group, typename T>
+HIPSYCL_KERNEL_TARGET
+bool all_of(Group g, T *first, T *last) {
+  auto group_range        = g.get_local_range().size();
+  auto elements_per_group = (last - first + group_range - 1) / group_range;
+  T *start_ptr            = first + elements_per_group * g.get_local_linear_id();
+  T *end_prt              = start_ptr + elements_per_group;
+
+  if (end_prt > last)
+    end_prt = last;
+
+  auto local = *start_ptr;
+
+  for (T *p = start_ptr + 1; p < end_prt; ++p)
+    local &= *p;
+
+  return group_all_of(g, local);
+}
+
+template<typename Group, typename T, typename Predicate>
+HIPSYCL_KERNEL_TARGET
+bool all_of(Group g, T *first, T *last, Predicate pred) {
+  auto group_range        = g.get_local_range().size();
+  auto elements_per_group = (last - first + group_range - 1) / group_range;
+  T *start_ptr            = first + elements_per_group * g.get_local_linear_id();
+  T *end_prt              = start_ptr + elements_per_group;
+
+  if (end_prt > last)
+    end_prt = last;
+
+  auto local = pred(*start_ptr);
+
+  for (T *p = start_ptr + 1; p < end_prt; ++p)
+    local &= pred(*p);
+
+  return group_all_of(g, local);
+}
+
+
+// none_of
+template<typename Group, typename T>
+HIPSYCL_KERNEL_TARGET
+bool none_of(Group g, T *first, T *last) {
+  auto group_range        = g.get_local_range().size();
+  auto elements_per_group = (last - first + group_range - 1) / group_range;
+  T *start_ptr            = first + elements_per_group * g.get_local_linear_id();
+  T *end_prt              = start_ptr + elements_per_group;
+
+  if (end_prt > last)
+    end_prt = last;
+
+  auto local = *start_ptr;
+
+  for (T *p = start_ptr + 1; p < end_prt; ++p)
+    local |= *p;
+
+  return group_none_of(g, local);
+}
+
+template<typename Group, typename T, typename Predicate>
+HIPSYCL_KERNEL_TARGET
+bool none_of(Group g, T *first, T *last, Predicate pred) {
+  auto group_range        = g.get_local_range().size();
+  auto elements_per_group = (last - first + group_range - 1) / group_range;
+  T *start_ptr            = first + elements_per_group * g.get_local_linear_id();
+  T *end_prt              = start_ptr + elements_per_group;
+
+  if (end_prt > last)
+    end_prt = last;
+
+  auto local = pred(*start_ptr);
+
+  for (T *p = start_ptr + 1; p < end_prt; ++p)
+    local |= pred(*p);
+
+  return group_none_of(g, local);
+}
+
+
+// reduce
+template<typename Group, typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T reduce(Group g, V *first, V *last, T init, BinaryOperation binary_op) {
+  size_t group_range      = g.get_local_range().size();
+  auto elements_per_group = (last - first + group_range - 1) / group_range;
+  T *start_ptr            = first + elements_per_group * g.get_local_linear_id();
+  T *end_prt              = start_ptr + elements_per_group;
+
+  if (end_prt > last)
+    end_prt = last;
+
+  if (end_prt == start_ptr + 1) { //only one element
+    return group_reduce(g, *start_ptr, init, binary_op);
+  } else if (end_prt > start_ptr + 1) { // more than 1 element
+    auto local = binary_op(*start_ptr, *(start_ptr + 1));
+
+    for (T *p = start_ptr + 2; p < end_prt; ++p)
+      local = binary_op(local, *p);
+
+    return group_reduce(g, local, init, binary_op);
+  } else { // no element
+    return group_reduce(g, init, binary_op);
+  }
+}
+
+template<typename Group, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T reduce(Group g, T *first, T *last, BinaryOperation binary_op) {
+  return reduce(g, first, last, T{}, binary_op);
+}
+
+
+// exclusive_scan
+template<typename Group, typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T *exclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOperation binary_op) {
+  auto lid = g.get_local_linear_id();
+
+  if (g.leader()) {
+    *(result++) = init;
+    while (first != last - 1) {
+      *result = binary_op(*(result - 1), *(first++));
+      result++;
+    }
+  }
+  return group_broadcast(g, result);
+}
+
+template<typename Group, typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T *exclusive_scan(Group g, V *first, V *last, T *result, BinaryOperation binary_op) {
+  return exclusive_scan(g, first, last, result, T{}, binary_op);
+}
+
+
+// inclusive_scan
+template<typename Group, typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T *inclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOperation binary_op) {
+  auto lid = g.get_local_linear_id();
+
+  if (g.leader()) {
+    if (first == last)
+      return result;
+
+    *(result++) = binary_op(init, *(first++));
+    while (first != last) {
+      *result = binary_op(*(result - 1), *(first++));
+      result++;
+      ;
+    }
+  }
+  return group_broadcast(g, result);
+}
+
+template<typename Group, typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T *inclusive_scan(Group g, V *first, V *last, T *result, BinaryOperation binary_op) {
+  return inclusive_scan(g, first, last, result, T{}, binary_op);
+}
+
+} // namespace detail
+
+// broadcast
+template<typename Group, typename T>
+HIPSYCL_KERNEL_TARGET
+T group_broadcast(Group g, T x, typename Group::linear_id_type local_linear_id = 0) {
+  __shared__ T scratch[1];
+  auto lid = g.get_local_linear_id();
+
+  if (lid == local_linear_id)
+    scratch[0] = x;
+  group_barrier(g);
+
+  return scratch[0];
+}
+
+template<typename Group, typename T, int N>
+HIPSYCL_KERNEL_TARGET
+vec<T, N> group_broadcast(Group g, vec<T, N> x,
+                          typename Group::linear_id_type local_linear_id = 0) {
+  __shared__ T scratch[N];
+  auto lid = g.get_local_linear_id();
+
+  if (lid == local_linear_id)
+    detail::writeToMemory(scratch, x);
+  group_barrier(g);
+
+  detail::readFromMemory(scratch, x);
+
+  return x;
+}
+
+template<typename Group, typename T>
+HIPSYCL_KERNEL_TARGET
+T group_broadcast(Group g, T x, typename Group::id_type local_id) {
+  auto target_lid =
+      detail::linear_id<g.dimensions>::get(local_id,
+                                           detail::get_local_size<g.dimensions>());
+
+  return group_broadcast(g, x, target_lid);
+}
+
+
+// any_of
+template<typename Group>
+HIPSYCL_KERNEL_TARGET
+inline bool group_any_of(Group g, bool pred) {
+  return __syncthreads_or(pred);
+}
+
+
+// all_of
+template<typename Group>
+HIPSYCL_KERNEL_TARGET
+inline bool group_all_of(Group g, bool pred) {
+  return __syncthreads_and(pred);
+}
+
+
+// none_of
+template<typename Group>
+HIPSYCL_KERNEL_TARGET
+inline bool group_none_of(Group g, bool pred) {
+  return !__syncthreads_or(pred);
+}
+
+
+// reduce
+template<typename Group, typename T, typename BinaryOperation,
+         typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
+HIPSYCL_KERNEL_TARGET
+T group_reduce(Group g, T x, BinaryOperation binary_op) {
+  __shared__ T scratch[1024];
+
+  return detail::group_reduce(g, x, binary_op, scratch);
+}
+
+template<typename Group, typename T, int N, typename BinaryOperation,
+         typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
+HIPSYCL_KERNEL_TARGET
+vec<T, N> group_reduce(Group g, vec<T, N> x, BinaryOperation binary_op) {
+  __shared__ T scratch[1024 * N];
+
+  return detail::group_reduce(g, x, binary_op, scratch);
+}
+
+
+// exclusive_scan
+template<typename Group, typename V, typename T, typename BinaryOperation,
+         typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
+HIPSYCL_KERNEL_TARGET
+T group_exclusive_scan(Group g, V x, T init, BinaryOperation binary_op) {
+  __shared__ T scratch[1024];
+  auto lid               = g.get_local_linear_id();
+  size_t lrange          = 1;
+  auto group_local_range = g.get_local_range();
+  for (int i = 0; i < g.dimensions; ++i)
+    lrange *= group_local_range[i];
+
+  scratch[lid] = x;
+  group_barrier(g);
+
+  for (size_t i = 1; i < lrange; i *= 2) {
+    size_t next_id = lid - i;
+    T local_x;
+    T other_x;
+    if (i <= lid && lid < lrange) {
+      local_x = scratch[lid];
+      other_x = scratch[next_id];
+    }
+
+    group_barrier(g);
+    if (i <= lid && lid < lrange)
+      scratch[lid] = binary_op(local_x, other_x);
+    group_barrier(g);
+  }
+
+  if (g.leader())
+    return init;
+  return binary_op(scratch[lid - 1], init);
+}
+
+template<typename Group, typename V, typename T, int N, typename BinaryOperation,
+         typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
+HIPSYCL_KERNEL_TARGET
+vec<T, N> group_exclusive_scan(Group g, V x, vec<T, N> init, BinaryOperation binary_op) {
+  __shared__ T scratch[1024 * N];
+  auto lid               = g.get_local_linear_id();
+  size_t lrange          = 1;
+  auto group_local_range = g.get_local_range();
+  for (int i = 0; i < g.dimensions; ++i)
+    lrange *= group_local_range[i];
+
+  detail::writeToMemory(scratch + lid * N, x);
+  group_barrier(g);
+
+  for (size_t i = 1; i < lrange; i *= 2) {
+    size_t next_id = lid - i;
+    vec<T, N> v1, v2;
+    if (i <= lid && lid < lrange) {
+      detail::readFromMemory(scratch + lid * N, v1);
+      detail::readFromMemory(scratch + next_id * N, v2);
+    }
+    group_barrier(g);
+    if (i <= lid && lid < lrange) {
+      detail::writeToMemory(scratch + lid * N, binary_op(v1, v2));
+    }
+
+    group_barrier(g);
+  }
+
+  if (g.leader())
+    return init;
+
+  vec<T, N> v;
+  detail::readFromMemory(scratch + (lid - 1) * N, v);
+  return binary_op(v, init);
+}
+
+
+// inclusive_scan
+template<typename Group, typename T, typename BinaryOperation,
+         typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
+HIPSYCL_KERNEL_TARGET
+T group_inclusive_scan(Group g, T x, BinaryOperation binary_op) {
+  __shared__ T scratch[1024];
+  auto lid               = g.get_local_linear_id();
+  size_t lrange          = 1;
+  auto group_local_range = g.get_local_range();
+  for (int i = 0; i < g.dimensions; ++i)
+    lrange *= group_local_range[i];
+
+  scratch[lid] = x;
+  group_barrier(g);
+
+  for (size_t i = 1; i < lrange; i *= 2) {
+    size_t next_id = lid - i;
+    T local_x;
+    T other_x;
+    if (i <= lid && lid < lrange) {
+      local_x = scratch[lid];
+      other_x = scratch[next_id];
+    }
+
+    group_barrier(g);
+    if (i <= lid && lid < lrange)
+      scratch[lid] = binary_op(local_x, other_x);
+    group_barrier(g);
+  }
+
+  return scratch[lid];
+}
+
+template<typename Group, typename T, int N, typename BinaryOperation,
+         typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
+HIPSYCL_KERNEL_TARGET
+vec<T, N> group_inclusive_scan(Group g, vec<T, N> x, BinaryOperation binary_op) {
+  __shared__ T scratch[1024 * N];
+  auto lid               = g.get_local_linear_id();
+  size_t lrange          = 1;
+  auto group_local_range = g.get_local_range();
+  for (int i = 0; i < g.dimensions; ++i)
+    lrange *= group_local_range[i];
+
+  detail::writeToMemory(scratch + lid * N, x);
+  group_barrier(g);
+
+  for (size_t i = 1; i < lrange; i *= 2) {
+    size_t next_id = lid - i;
+    vec<T, N> v1, v2;
+    if (i <= lid && lid < lrange) {
+      detail::readFromMemory(scratch + lid * N, v1);
+      detail::readFromMemory(scratch + next_id * N, v2);
+    }
+    group_barrier(g);
+    if (i <= lid && lid < lrange) {
+      detail::writeToMemory(scratch + lid * N, binary_op(v1, v2));
+    }
+    group_barrier(g);
+  }
+
+  vec<T, N> v;
+  detail::readFromMemory(scratch + lid * N, v);
+  return v;
+}
+
+
+} // namespace sycl
+} // namespace hipsycl
+
+#endif //HIPSYCL_LIBKERNEL_DEVICE_GROUP_FUNCTIONS_HPP
+
+#endif //SYCL_DEVICE_ONLY

--- a/include/hipSYCL/sycl/libkernel/group.hpp
+++ b/include/hipSYCL/sycl/libkernel/group.hpp
@@ -446,7 +446,13 @@ private:
   const id<Dimensions> _group_id;
   const range<Dimensions> _local_range;
   const range<Dimensions> _num_groups;
+public:
 #endif
+
+  HIPSYCL_KERNEL_TARGET
+  bool leader() const {
+    return get_local_linear_id() == 0;
+  }
 
 #ifdef SYCL_DEVICE_ONLY
   size_t get_linear_local_id() const

--- a/include/hipSYCL/sycl/libkernel/group.hpp
+++ b/include/hipSYCL/sycl/libkernel/group.hpp
@@ -367,7 +367,7 @@ struct group
 #ifdef SYCL_DEVICE_ONLY
     const size_t physical_local_size = get_local_range().size();
     
-    for(size_t i = get_linear_local_id(); i < numElements; i += physical_local_size)
+    for(size_t i = get_local_linear_id(); i < numElements; i += physical_local_size)
       dest[i] = src[i];
     __syncthreads();
 
@@ -391,7 +391,7 @@ struct group
 #ifdef SYCL_DEVICE_ONLY
     const size_t physical_local_size = get_local_range().size();
     
-    for(size_t i = get_linear_local_id(); i < numElements; i += physical_local_size)
+    for(size_t i = get_local_linear_id(); i < numElements; i += physical_local_size)
       dest[i] = src[i * srcStride];
     __syncthreads();
 
@@ -414,7 +414,7 @@ struct group
 #ifdef SYCL_DEVICE_ONLY
     const size_t physical_local_size = get_local_range().size();
     
-    for(size_t i = get_linear_local_id(); i < numElements; i += physical_local_size)
+    for(size_t i = get_local_linear_id(); i < numElements; i += physical_local_size)
       dest[i * destStride] = src[i];
     __syncthreads();
 
@@ -434,18 +434,50 @@ struct group
   void wait_for(eventTN...) const {}
 
 #if !defined(HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO)
+
+  using host_barrier_type = std::function<void()>;
+
   group(id<Dimensions> group_id,
         range<Dimensions> local_range,
-        range<Dimensions> num_groups)
+        range<Dimensions> num_groups,
+        host_barrier_type* group_barrier = nullptr,
+        id_type local_id = 0,
+        void *local_memory_ptr = nullptr)
   : _group_id{group_id}, 
     _local_range{local_range}, 
-    _num_groups{num_groups}
+    _num_groups{num_groups},
+    _group_barrier{group_barrier},
+    _local_id{local_id},
+    _local_memory_ptr(local_memory_ptr)
   {}
+
+  void barrier() {
+    (*_group_barrier)();
+  }
+
+  id_type get_local_id() const
+  {
+    return _local_id;
+  }
+
+  linear_id_type get_local_linear_id() const
+  {
+    return detail::linear_id<Dimensions>::get(_local_id,
+                                              _local_range);
+  }
+
+  void *get_local_memory_ptr() const
+  {
+    return _local_memory_ptr;
+  }
 
 private:
   const id<Dimensions> _group_id;
   const range<Dimensions> _local_range;
   const range<Dimensions> _num_groups;
+  const host_barrier_type* _group_barrier;
+  const id_type _local_id;
+  void *_local_memory_ptr;
 public:
 #endif
 
@@ -455,10 +487,17 @@ public:
   }
 
 #ifdef SYCL_DEVICE_ONLY
-  size_t get_linear_local_id() const
+
+  size_t get_local_linear_id() const
   {
     return detail::linear_id<Dimensions>::get(detail::get_local_id<Dimensions>(),
                                               detail::get_local_size<Dimensions>());
+  }
+
+  [[deprecated]]
+  size_t get_linear_local_id() const
+  {
+    return get_local_linear_id();
   }
 
   template<typename workItemFunctionT>

--- a/include/hipSYCL/sycl/libkernel/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/group_functions.hpp
@@ -1,0 +1,104 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018-2020 Aksel Alpay and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HIPSYCL_LIBKERNEL_GROUP_FUNCTIONS_HPP
+#define HIPSYCL_LIBKERNEL_GROUP_FUNCTIONS_HPP
+
+#include "backend.hpp"
+#include "group.hpp"
+#include <type_traits>
+
+#ifdef SYCL_DEVICE_ONLY
+#include "generic/hiplike/group_functions.hpp"
+
+#ifdef HIPSYCL_PLATFORM_CUDA
+#include "cuda/group_functions.hpp"
+#endif // HIPSYCL_PLATFORM_CUDA
+
+#ifdef HIPSYCL_PLATFORM_HIP
+#include "hip/group_functions.hpp"
+#endif // HIPSYCL_PLATFORM_HIP
+
+#endif // SYCL_DEVICE_ONLY
+
+#include "host/group_functions.hpp"
+
+namespace hipsycl {
+namespace sycl {
+
+// any_of
+template<typename Group, typename T, typename Predicate,
+         typename std::enable_if_t<!std::is_same_v<T, Predicate>, int> = 0>
+HIPSYCL_KERNEL_TARGET
+bool group_any_of(Group g, T x, Predicate pred) {
+  return group_any_of(g, pred(x));
+}
+
+
+// all_of
+template<typename Group, typename T, typename Predicate>
+HIPSYCL_KERNEL_TARGET
+bool group_all_of(Group g, T x, Predicate pred) {
+  return group_all_of(g, pred(x));
+}
+
+
+// none_of
+template<typename Group, typename T, typename Predicate>
+HIPSYCL_KERNEL_TARGET
+bool group_none_of(Group g, T x, Predicate pred) {
+  return group_none_of(g, pred(x));
+}
+
+// reduce
+template<typename Group, typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T group_reduce(Group g, V x, T init, BinaryOperation binary_op) {
+  T reduction = group_reduce(g, T{x}, binary_op);
+  return binary_op(reduction, init);
+}
+
+// exclusive_scan
+template<typename Group, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T group_exclusive_scan(Group g, T x, BinaryOperation binary_op) {
+  return group_exclusive_scan(g, x, T{}, binary_op);
+}
+
+// inclusive_scan
+template<typename Group, typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T group_inclusive_scan(Group g, V x, T init, BinaryOperation binary_op) {
+  T scan = group_inclusive_scan(g, T{x}, binary_op);
+  return binary_op(scan, init);
+}
+
+
+} // namespace sycl
+} // namespace hipsycl
+
+#endif // HIPSYCL_LIBKERNEL_GROUP_FUNCTIONS_HPP

--- a/include/hipSYCL/sycl/libkernel/hip/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/hip/group_functions.hpp
@@ -1,0 +1,255 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef SYCL_DEVICE_ONLY
+#ifdef HIPSYCL_PLATFORM_HIP
+
+#ifndef HIPSYCL_LIBKERNEL_HIP_GROUP_FUNCTIONS_HPP
+#define HIPSYCL_LIBKERNEL_HIP_GROUP_FUNCTIONS_HPP
+
+#include "../backend.hpp"
+#include "../id.hpp"
+#include "../sub_group.hpp"
+#include "../vec.hpp"
+#include <type_traits>
+
+namespace hipsycl {
+namespace sycl {
+
+namespace detail {
+
+template<typename T,
+         typename std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
+__device__
+T shuffle_impl(T x, int id) {
+  if constexpr (std::is_signed_v<T>) {
+    return __shfl(x, id);
+  } else {
+    return static_cast<T>(__shfl(static_cast<std::make_signed_t<T>>(x), id));
+  }
+}
+
+template<>
+__device__
+char shuffle_impl(char x, int id) {
+  return static_cast<char>(__shfl(static_cast<int>(x), id));
+}
+
+template<>
+__device__
+unsigned char shuffle_impl(unsigned char x, int id) {
+  return static_cast<unsigned char>(__shfl(static_cast<int>(x), id));
+}
+
+template<>
+__device__
+bool shuffle_impl(bool x, int id) {
+  return static_cast<bool>(__shfl(static_cast<int>(x), id));
+}
+
+template<typename T, int N>
+__device__
+sycl::vec<T, N> shuffle_impl(sycl::vec<T, N> x, int id) {
+  sycl::vec<T, N> ret{};
+
+  if constexpr (1 <= N)
+    ret.s0() = shuffle_impl(x.s0(), id);
+  if constexpr (2 <= N)
+    ret.s1() = shuffle_impl(x.s1(), id);
+  if constexpr (3 <= N)
+    ret.s2() = shuffle_impl(x.s2(), id);
+  if constexpr (4 <= N)
+    ret.s3() = shuffle_impl(x.s3(), id);
+  if constexpr (8 <= N) {
+    ret.s4() = shuffle_impl(x.s4(), id);
+    ret.s5() = shuffle_impl(x.s5(), id);
+    ret.s6() = shuffle_impl(x.s6(), id);
+    ret.s7() = shuffle_impl(x.s7(), id);
+  }
+  if constexpr (16 <= N) {
+    ret.s8() = shuffle_impl(x.s8(), id);
+    ret.s9() = shuffle_impl(x.s9(), id);
+    ret.sA() = shuffle_impl(x.sA(), id);
+    ret.sB() = shuffle_impl(x.sB(), id);
+    ret.sC() = shuffle_impl(x.sC(), id);
+    ret.sD() = shuffle_impl(x.sD(), id);
+    ret.sE() = shuffle_impl(x.sE(), id);
+    ret.sF() = shuffle_impl(x.sF(), id);
+  }
+
+  return ret;
+}
+
+} // namespace detail
+
+// broadcast
+template<typename T>
+HIPSYCL_KERNEL_TARGET
+T group_broadcast(sub_group g, T x,
+                  typename sub_group::linear_id_type local_linear_id = 0) {
+  return detail::shuffle_impl(x, static_cast<int>(local_linear_id));
+}
+
+template<typename T, int N>
+HIPSYCL_KERNEL_TARGET
+sycl::vec<T, N> group_broadcast(sub_group g, sycl::vec<T, N> x,
+                                typename sub_group::linear_id_type local_linear_id = 0) {
+  return detail::shuffle_impl<T, N>(x, static_cast<int>(local_linear_id));
+}
+
+// barrier
+template<typename Group>
+HIPSYCL_KERNEL_TARGET
+inline void group_barrier(Group g, memory_scope fence_scope = Group::fence_scope) {
+  if (fence_scope == memory_scope::device) {
+    __threadfence_system();
+  }
+  __syncthreads();
+}
+
+template<>
+HIPSYCL_KERNEL_TARGET
+inline void group_barrier(sub_group g, memory_scope fence_scope) {
+  if (fence_scope == memory_scope::device) {
+    __threadfence_system();
+  } else if (fence_scope == memory_scope::work_group) {
+    __threadfence_block();
+  }
+  // threads run in lock-step no sync needed
+}
+
+
+// any_of
+template<>
+HIPSYCL_KERNEL_TARGET
+inline bool group_any_of(sub_group g, bool pred) {
+  return __any(pred);
+}
+
+
+// all_of
+template<>
+HIPSYCL_KERNEL_TARGET
+inline bool group_all_of(sub_group g, bool pred) {
+  return __all(pred);
+}
+
+
+// none_of
+template<>
+HIPSYCL_KERNEL_TARGET
+inline bool group_none_of(sub_group g, bool pred) {
+  return !__any(pred);
+}
+
+
+// reduce
+template<typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T group_reduce(sub_group g, T x, BinaryOperation binary_op) {
+  auto lid = g.get_local_linear_id();
+
+  size_t lrange          = 1;
+  auto group_local_range = g.get_local_range();
+  for (int i = 0; i < g.dimensions; ++i)
+    lrange *= group_local_range[i];
+
+  group_barrier(g);
+
+  auto local_x = x;
+
+  for (size_t i = lrange / 2; i > 0; i /= 2) {
+    auto other_x = detail::shuffle_impl(local_x, lid + i);
+    if (lid < i)
+      local_x = binary_op(local_x, other_x);
+  }
+  return detail::shuffle_impl(local_x, 0);
+}
+
+
+// exclusive_scan
+template<typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T group_exclusive_scan(sub_group g, V x, T init, BinaryOperation binary_op) {
+  auto lid      = g.get_local_linear_id();
+  size_t lrange = g.get_local_linear_range();
+
+  auto local_x = x;
+
+  for (size_t i = 1; i < lrange; i *= 2) {
+    size_t next_id = lid - i;
+    if (i > lid)
+      next_id = 0;
+
+    auto other_x = detail::shuffle_impl(local_x, next_id);
+    if (i <= lid && lid < lrange)
+      local_x = binary_op(local_x, other_x);
+  }
+
+  size_t next_id = lid - 1;
+  if (g.leader())
+    next_id = 0;
+
+  auto return_value = detail::shuffle_impl(local_x, lid - 1);
+
+  if (g.leader())
+    return init;
+
+  return binary_op(return_value, init);
+}
+
+
+// inclusive_scan
+template<typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T group_inclusive_scan(sub_group g, T x, BinaryOperation binary_op) {
+  auto lid      = g.get_local_linear_id();
+  size_t lrange = g.get_local_linear_range();
+
+  auto local_x = x;
+
+  for (size_t i = 1; i < lrange; i *= 2) {
+    size_t next_id = lid - i;
+    if (i > lid)
+      next_id = 0;
+
+    auto other_x = detail::shuffle_impl(local_x, next_id);
+    if (i <= lid && lid < lrange)
+      local_x = binary_op(local_x, other_x);
+  }
+
+  return local_x;
+}
+
+
+} // namespace sycl
+} // namespace hipsycl
+
+#endif //HIPSYCL_LIBKERNEL_HIP_GROUP_FUNCTIONS_HPP
+
+#endif //HIPSYCL_PLATFORM_HIP
+#endif //SYCL_DEVICE_ONLY

--- a/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
@@ -1,0 +1,519 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SYCL_DEVICE_ONLY
+
+#ifndef HIPSYCL_LIBKERNEL_HOST_GROUP_FUNCTIONS_HPP
+#define HIPSYCL_LIBKERNEL_HOST_GROUP_FUNCTIONS_HPP
+
+#include "../backend.hpp"
+#include "../detail/data_layout.hpp"
+#include "../group.hpp"
+#include "../id.hpp"
+#include "../sub_group.hpp"
+#include "../vec.hpp"
+
+
+namespace hipsycl {
+namespace sycl {
+
+namespace detail {
+template<typename T, typename Group>
+T *get_local_memory_ptr(Group g, size_t number_elements = 1) {
+  if (sizeof(T) * number_elements > sizeof(void *)) {
+    T **scratch = static_cast<T **>(g.get_local_memory_ptr());
+
+    if (g.leader())
+      scratch[0] = new T[number_elements];
+
+    group_barrier(g);
+
+    return scratch[0];
+  } else {
+    return static_cast<T *>(g.get_local_memory_ptr());
+  }
+}
+
+template<typename T, typename Group>
+void free_local_memory_ptr(Group g, T *local_memory_ptr) {
+  if (sizeof(T) > sizeof(void *)) {
+    group_barrier(g);
+
+    if (g.leader())
+      delete[] static_cast<void *>(local_memory_ptr);
+  }
+}
+
+// reduce implementation
+template<typename Group, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T group_reduce(Group g, T x, BinaryOperation binary_op, T *scratch) {
+  auto lid = g.get_local_linear_id();
+
+  scratch[lid] = x;
+  group_barrier(g);
+
+  if (g.leader()) {
+    T result = binary_op(scratch[0], scratch[1]);
+
+    for (int i = 2; i < g.get_local_range().size(); ++i)
+      result = binary_op(result, scratch[i]);
+
+    scratch[0] = result;
+  }
+
+  group_barrier(g);
+  T tmp = scratch[0];
+  group_barrier(g);
+
+  return tmp;
+}
+
+
+// functions using pointers
+// any_of
+template<typename Group, typename Ptr>
+HIPSYCL_KERNEL_TARGET
+bool any_of(Group g, Ptr first, Ptr last) {
+  bool result = false;
+
+  if (g.leader()) {
+    while (first < last) {
+      if (*(first++)) {
+        result = true;
+        break;
+      }
+    }
+  }
+  return group_broadcast(g, result);
+}
+
+template<typename Group, typename Ptr, typename Predicate>
+HIPSYCL_KERNEL_TARGET
+bool any_of(Group g, Ptr first, Ptr last, Predicate pred) {
+  bool result = false;
+
+  if (g.leader()) {
+    while (first != last) {
+      if (pred(*(first++))) {
+        result = true;
+        break;
+      }
+    }
+  }
+  return group_broadcast(g, result);
+}
+
+
+// all_of
+template<typename Group, typename Ptr>
+HIPSYCL_KERNEL_TARGET
+bool all_of(Group g, Ptr first, Ptr last) {
+  bool result = true;
+
+  if (g.leader()) {
+    while (first != last) {
+      if (!*(first++)) {
+        result = false;
+        break;
+      }
+    }
+  }
+  return group_broadcast(g, result);
+}
+
+template<typename Group, typename Ptr, typename Predicate>
+HIPSYCL_KERNEL_TARGET
+bool all_of(Group g, Ptr first, Ptr last, Predicate pred) {
+  bool result = true;
+
+  if (g.leader()) {
+    while (first != last) {
+      if (!pred(*(first++))) {
+        result = false;
+        break;
+      }
+    }
+  }
+  return group_broadcast(g, result);
+}
+
+
+// none_of
+template<typename Group, typename Ptr>
+HIPSYCL_KERNEL_TARGET
+bool none_of(Group g, Ptr first, Ptr last) {
+  bool result = true;
+
+  if (g.leader()) {
+    while (first != last) {
+      if (*(first++)) {
+        result = false;
+        break;
+      }
+    }
+  }
+  return group_broadcast(g, result);
+}
+
+template<typename Group, typename Ptr, typename Predicate>
+HIPSYCL_KERNEL_TARGET
+bool none_of(Group g, Ptr first, Ptr last, Predicate pred) {
+  bool result = true;
+
+  if (g.leader()) {
+    while (first != last) {
+      if (pred(*(first++))) {
+        result = false;
+        break;
+      }
+    }
+  }
+  return group_broadcast(g, result);
+}
+
+
+// reduce
+template<typename Group, typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T reduce(Group g, V *first, V *last, T init, BinaryOperation binary_op) {
+  T result{};
+
+  if (first >= last) {
+    return init;
+  }
+
+  if (g.leader()) {
+    result = binary_op(*(first++), init);
+    while (first != last)
+      result = binary_op(result, *(first++));
+  }
+  return group_broadcast(g, result);
+}
+
+template<typename Group, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T reduce(Group g, T *first, T *last, BinaryOperation binary_op) {
+  return reduce(g, first, last, T{}, binary_op);
+}
+
+
+// exclusive_scan
+template<typename Group, typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T *exclusive_scan(Group g, V *first, V *last, T *result, T init,
+                  BinaryOperation binary_op) {
+
+  if (g.leader()) {
+    *(result++) = init;
+    while (first != last - 1) {
+      *result = binary_op(*(result - 1), *(first++));
+      result++;
+    }
+  }
+  return group_broadcast(g, result);
+}
+
+template<typename Group, typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T *exclusive_scan(Group g, V *first, V *last, T *result, BinaryOperation binary_op) {
+  return exclusive_scan(g, first, last, result, T{}, binary_op);
+}
+
+
+// inclusive_scan
+template<typename Group, typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T *inclusive_scan(Group g, V *first, V *last, T *result, T init,
+                  BinaryOperation binary_op) {
+  if (first == last)
+    return result;
+
+  if (g.leader()) {
+    *(result++) = binary_op(init, *(first++));
+    while (first != last) {
+      *result = binary_op(*(result - 1), *(first++));
+      result++;
+    }
+  }
+  return group_broadcast(g, result);
+}
+
+template<typename Group, typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T *inclusive_scan(Group g, V *first, V *last, T *result, BinaryOperation binary_op) {
+  return inclusive_scan(g, first, last, result, T{}, binary_op);
+}
+
+
+} // namespace detail
+
+// broadcast
+template<typename Group, typename T>
+HIPSYCL_KERNEL_TARGET
+T group_broadcast(Group g, T x, typename Group::linear_id_type local_linear_id = 0) {
+  T *scratch = detail::get_local_memory_ptr<T>(g);
+  auto lid   = g.get_local_linear_id();
+
+  if (lid == local_linear_id) {
+    scratch[0] = x;
+  }
+
+  group_barrier(g);
+
+  T tmp = scratch[0];
+
+  group_barrier(g);
+
+  detail::free_local_memory_ptr(g, scratch);
+
+  return tmp;
+}
+
+template<typename Group, typename T>
+HIPSYCL_KERNEL_TARGET
+T group_broadcast(Group g, T x, typename Group::id_type local_id) {
+  auto target_lid = detail::linear_id<g.dimensions>::get(local_id, g.get_local_range());
+  return group_broadcast(g, x, target_lid);
+}
+
+template<typename T>
+HIPSYCL_KERNEL_TARGET
+T group_broadcast(sub_group g, T x,
+                  typename sub_group::linear_id_type local_linear_id = 0) {
+  return x;
+}
+
+
+// barrier
+template<typename Group>
+HIPSYCL_KERNEL_TARGET
+inline void group_barrier(Group g, memory_scope fence_scope = Group::fence_scope) {
+  if (fence_scope == memory_scope::work_item) {
+    // doesn't need sync
+  } else if (fence_scope == memory_scope::sub_group) {
+    // doesn't need sync (sub_group size = 1)
+  } else if (fence_scope == memory_scope::work_group) {
+    g.barrier();
+  } else if (fence_scope == memory_scope::device) {
+    g.barrier();
+  }
+}
+
+template<>
+HIPSYCL_KERNEL_TARGET
+inline void group_barrier(sub_group g, memory_scope fence_scope) {
+  // doesn't need sync
+}
+
+
+// any_of
+template<typename Group>
+HIPSYCL_KERNEL_TARGET
+inline bool group_any_of(Group g, bool pred) {
+  bool *scratch = detail::get_local_memory_ptr<bool>(g);
+
+  scratch[0] = false;
+  group_barrier(g);
+
+  if (pred)
+    scratch[0] = pred;
+
+  group_barrier(g);
+
+  bool tmp = scratch[0];
+
+  group_barrier(g);
+
+  detail::free_local_memory_ptr(g, scratch);
+
+  return tmp;
+}
+
+template<>
+HIPSYCL_KERNEL_TARGET
+inline bool group_any_of(sub_group g, bool pred) {
+  return pred;
+}
+
+
+// all_of
+template<typename Group>
+HIPSYCL_KERNEL_TARGET
+inline bool group_all_of(Group g, bool pred) {
+  bool *scratch = detail::get_local_memory_ptr<bool>(g);
+
+  scratch[0] = true;
+  group_barrier(g);
+
+  if (!pred)
+    scratch[0] = pred;
+
+  group_barrier(g);
+
+  bool tmp = scratch[0];
+
+  group_barrier(g);
+
+  detail::free_local_memory_ptr(g, scratch);
+
+  return tmp;
+}
+
+template<>
+HIPSYCL_KERNEL_TARGET
+inline bool group_all_of(sub_group g, bool pred) {
+  return pred;
+}
+
+
+// none_of
+template<typename Group>
+HIPSYCL_KERNEL_TARGET
+inline bool group_none_of(Group g, bool pred) {
+  bool *scratch = detail::get_local_memory_ptr<bool>(g);
+
+  scratch[0] = true;
+  group_barrier(g);
+
+  if (pred)
+    scratch[0] = !pred;
+
+  group_barrier(g);
+
+  bool tmp = scratch[0];
+
+  group_barrier(g);
+
+  detail::free_local_memory_ptr(g, scratch);
+
+  return tmp;
+}
+
+template<>
+HIPSYCL_KERNEL_TARGET
+inline bool group_none_of(sub_group g, bool pred) {
+  return pred;
+}
+
+
+// reduce
+template<typename Group, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T group_reduce(Group g, T x, BinaryOperation binary_op) {
+  T *scratch = detail::get_local_memory_ptr<T>(g, 1024);
+
+  T tmp = detail::group_reduce(g, x, binary_op, scratch);
+
+  detail::free_local_memory_ptr(g, scratch);
+
+  return tmp;
+}
+
+template<typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T group_reduce(sub_group g, T x, BinaryOperation binary_op) {
+  return x;
+}
+
+
+// exclusive_scan
+template<typename Group, typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T group_exclusive_scan(Group g, V x, T init, BinaryOperation binary_op) {
+  T *scratch = detail::get_local_memory_ptr<T>(g, 1024);
+
+  auto lid = g.get_local_linear_id();
+
+  if (lid + 1 < 1024)
+    scratch[lid + 1] = x;
+  group_barrier(g);
+
+  if (g.leader()) {
+    scratch[0] = init;
+    for (int i = 1; i < g.get_local_range().size(); ++i)
+      scratch[i] = binary_op(scratch[i], scratch[i - 1]);
+  }
+
+  group_barrier(g);
+
+  T tmp = scratch[lid];
+
+  group_barrier(g);
+
+  detail::free_local_memory_ptr(g, scratch);
+
+  return tmp;
+}
+
+template<typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T group_exclusive_scan(sub_group g, V x, T init, BinaryOperation binary_op) {
+  return binary_op(x, init);
+}
+
+
+// inclusive_scan
+template<typename Group, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T group_inclusive_scan(Group g, T x, BinaryOperation binary_op) {
+  T *scratch = detail::get_local_memory_ptr<T>(g, 1024);
+
+  auto lid = g.get_local_linear_id();
+
+  scratch[lid] = x;
+  group_barrier(g);
+
+  if (g.leader()) {
+    for (int i = 1; i < g.get_local_range().size(); ++i)
+      scratch[i] = binary_op(scratch[i], scratch[i - 1]);
+  }
+
+  group_barrier(g);
+
+  T tmp = scratch[lid];
+
+  group_barrier(g);
+
+  detail::free_local_memory_ptr(g, scratch);
+
+  return tmp;
+}
+
+template<typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T group_inclusive_scan(sub_group g, T x, BinaryOperation binary_op) {
+  return x;
+}
+
+
+} // namespace sycl
+} // namespace hipsycl
+
+#endif //HIPSYCL_LIBKERNEL_HOST_GROUP_FUNCTIONS_HPP
+
+#endif // SYCL_DEVICE_ONLY

--- a/include/hipSYCL/sycl/libkernel/nd_item.hpp
+++ b/include/hipSYCL/sycl/libkernel/nd_item.hpp
@@ -166,7 +166,7 @@ struct nd_item
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
     return group<dimensions>{};
 #else
-    return group<dimensions>{_group_id, _local_range, _num_groups};
+    return group<dimensions>{_group_id, _local_range, _num_groups, _group_barrier, get_local_id(), _local_memory_ptr};
 #endif
   }
 
@@ -349,13 +349,15 @@ struct nd_item
   nd_item(id<dimensions>* offset, 
           id<dimensions> group_id, id<dimensions> local_id, 
           range<dimensions> local_range, range<dimensions> num_groups,
-          detail::host_barrier_type* host_group_barrier = nullptr)
+          detail::host_barrier_type* host_group_barrier = nullptr,
+          void* local_memory_ptr = nullptr)
     : _offset{offset}, 
       _group_id{group_id}, 
       _local_id{local_id}, 
       _local_range{local_range},
       _num_groups{num_groups},
-      _global_id{group_id * local_range + local_id}
+      _global_id{group_id * local_range + local_id},
+      _local_memory_ptr(local_memory_ptr)
   {
 #ifndef SYCL_DEVICE_ONLY
     _group_barrier = host_group_barrier;
@@ -372,6 +374,7 @@ private:
   const range<dimensions> _local_range;
   const range<dimensions> _num_groups;
   const id<dimensions> _global_id;
+  void *_local_memory_ptr;
 #endif
 
 #ifndef SYCL_DEVICE_ONLY

--- a/include/hipSYCL/sycl/sycl.hpp
+++ b/include/hipSYCL/sycl/sycl.hpp
@@ -61,6 +61,7 @@
 #include "libkernel/stream.hpp"
 #include "libkernel/sub_group.hpp"
 #include "libkernel/memory.hpp"
+#include "libkernel/group_functions.hpp"
 
 #include "version.hpp"
 #include "types.hpp"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,10 @@ add_executable(sycl_tests
   sycl/explicit_copy.cpp
   sycl/extensions.cpp
   sycl/fill.cpp
+  sycl/group_functions/group_functions_misc.cpp
+  sycl/group_functions/group_functions_binary_reduce.cpp
+  sycl/group_functions/group_functions_reduce.cpp
+  sycl/group_functions/group_functions_scan.cpp
   sycl/id_range.cpp
   sycl/item.cpp
   sycl/kernel_invocation.cpp

--- a/tests/sycl/group_functions/group_functions.hpp
+++ b/tests/sycl/group_functions/group_functions.hpp
@@ -1,0 +1,348 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018-2020 Aksel Alpay and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef TESTS_GROUP_FUNCTIONS_HH
+#define TESTS_GROUP_FUNCTIONS_HH
+
+#include <cstddef>
+#include <cstdio>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <math.h>
+#include <type_traits>
+
+#include <sstream>
+#include <string>
+
+using namespace cl;
+
+#ifdef TESTS_GROUPFUNCTION_FULL
+using test_types =
+    boost::mpl::list<char, int, unsigned int, long long, float, double, sycl::vec<int, 1>,
+                     sycl::vec<int, 2>, sycl::vec<int, 3>, sycl::vec<int, 4>, sycl::vec<int, 8>,
+                     sycl::vec<short, 16>, sycl::vec<long, 3>, sycl::vec<unsigned int, 3>>;
+#else
+using test_types = boost::mpl::list<char, unsigned int, float, double, sycl::vec<int, 2>>;
+#endif
+
+namespace detail {
+
+template<typename T>
+using elementType = std::remove_reference_t<decltype(T{}.s0())>;
+
+template<typename T, int N>
+std::string type_to_string(sycl::vec<T, N> v) {
+  std::stringstream ss{};
+
+  ss << "(";
+  if constexpr (1 <= N)
+    ss << +v.s0();
+  if constexpr (2 <= N)
+    ss << ", " << +v.s1();
+  if constexpr (3 <= N)
+    ss << ", " << +v.s2();
+  if constexpr (4 <= N)
+    ss << ", " << +v.s3();
+  if constexpr (8 <= N) {
+    ss << ", " << +v.s4();
+    ss << ", " << +v.s5();
+    ss << ", " << +v.s6();
+    ss << ", " << +v.s7();
+  }
+  if constexpr (16 <= N) {
+    ss << ", " << +v.s8();
+    ss << ", " << +v.s9();
+    ss << ", " << +v.sA();
+    ss << ", " << +v.sB();
+    ss << ", " << +v.sC();
+    ss << ", " << +v.sD();
+    ss << ", " << +v.sE();
+    ss << ", " << +v.sF();
+  }
+  ss << ")";
+
+  return ss.str();
+}
+
+template<typename T>
+std::string type_to_string(T x) {
+  std::stringstream ss{};
+  ss << +x;
+
+  return ss.str();
+}
+
+template<typename T, int N>
+bool compare_type(sycl::vec<T, N> v1, sycl::vec<T, N> v2) {
+  bool ret = true;
+  if constexpr (1 <= N)
+    ret &= v1.s0() == v2.s0();
+  if constexpr (2 <= N)
+    ret &= v1.s1() == v2.s1();
+  if constexpr (3 <= N)
+    ret &= v1.s2() == v2.s2();
+  if constexpr (4 <= N)
+    ret &= v1.s3() == v2.s3();
+  if constexpr (8 <= N) {
+    ret &= v1.s4() == v2.s4();
+    ret &= v1.s5() == v2.s5();
+    ret &= v1.s6() == v2.s6();
+    ret &= v1.s7() == v2.s7();
+  }
+  if constexpr (16 <= N) {
+    ret &= v1.s8() == v2.s8();
+    ret &= v1.s9() == v2.s9();
+    ret &= v1.sA() == v2.sA();
+    ret &= v1.sB() == v2.sB();
+    ret &= v1.sC() == v2.sC();
+    ret &= v1.sD() == v2.sD();
+    ret &= v1.sE() == v2.sE();
+    ret &= v1.sF() == v2.sF();
+  }
+
+  return ret;
+}
+
+template<typename T>
+bool compare_type(T x1, T x2) {
+  return x1 == x2;
+}
+
+template<typename T, typename std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
+HIPSYCL_KERNEL_TARGET
+T initialize_type(T init) {
+  return init;
+}
+
+template<typename T, typename std::enable_if_t<!std::is_arithmetic_v<T>, int> = 0>
+HIPSYCL_KERNEL_TARGET
+T initialize_type(elementType<T> init) {
+  constexpr size_t N = T::get_count();
+
+  if constexpr (std::is_same_v<elementType<T>, bool>)
+    return T{init};
+
+  if constexpr (N == 1) {
+    return T{init};
+  } else if constexpr (N == 2) {
+    return T{init, init + 1};
+  } else if constexpr (N == 3) {
+    return T{init, init + 1, init + 2};
+  } else if constexpr (N == 4) {
+    return T{init, init + 1, init + 2, init + 3};
+  } else if constexpr (N == 8) {
+    return T{init, init + 1, init + 2, init + 3, init + 4, init + 5, init + 6, init + 7};
+  } else if constexpr (N == 16) {
+    return T{init,      init + 1,  init + 2,  init + 3, init + 4,  init + 5,
+             init + 6,  init + 7,  init + 8,  init + 9, init + 10, init + 11,
+             init + 12, init + 13, init + 14, init + 15};
+  }
+
+  static_assert(true, "invalide vector type!");
+}
+
+template<typename T, typename std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
+HIPSYCL_KERNEL_TARGET
+T get_offset(size_t margin, size_t divisor = 1) {
+  if (std::numeric_limits<T>::max() <= margin) {
+    return T{};
+  }
+  if constexpr (std::is_floating_point_v<T>) {
+    return T{};
+  }
+
+  if constexpr (std::is_signed_v<T>) {
+    return static_cast<T>(std::numeric_limits<T>::min() / divisor + margin);
+  }
+  return static_cast<T>(std::numeric_limits<T>::max() / divisor - margin);
+}
+
+template<typename T, typename std::enable_if_t<!std::is_arithmetic_v<T>, int> = 0>
+HIPSYCL_KERNEL_TARGET
+T get_offset(size_t margin, size_t divisor = 1) {
+  using eT = elementType<T>;
+  if (std::numeric_limits<eT>::max() <= margin) {
+    return T{};
+  }
+  if constexpr (std::is_floating_point_v<eT>) {
+    return T{};
+  }
+
+  if constexpr (std::is_signed_v<T>) {
+    return initialize_type<T>(
+        static_cast<eT>(std::numeric_limits<eT>::min() / divisor + margin));
+  }
+  return initialize_type<T>(
+      static_cast<eT>(std::numeric_limits<eT>::max() / divisor - margin));
+}
+
+template<typename T>
+HIPSYCL_KERNEL_TARGET
+elementType<T> local_value(size_t id, size_t offsetBase) {
+  const size_t N = T{}.get_count();
+
+  auto offset = get_offset<elementType<T>>(offsetBase);
+  return static_cast<elementType<T>>(id + offset);
+}
+
+inline void create_bool_test_data(std::vector<char> &buffer, size_t local_size,
+                                  size_t global_size) {
+  BOOST_REQUIRE(global_size == 4 * local_size);
+  BOOST_REQUIRE(local_size + 10 < 2 * local_size);
+
+  // create host_buf 4 different possible configurations:
+  // 1: everything except one false
+  // 2: everything false
+  // 3: everything except one true
+  // 4: everything true
+
+  for (size_t i = 0; i < 2 * local_size; ++i)
+    buffer[i] = false;
+  for (size_t i = 2 * local_size; i < 4 * local_size; ++i)
+    buffer[i] = true;
+
+  buffer[10]                  = true;
+  buffer[2 * local_size + 10] = false;
+
+  BOOST_REQUIRE(buffer[0] == false);
+  BOOST_REQUIRE(buffer[10] == true);
+  BOOST_REQUIRE(buffer[local_size] == false);
+  BOOST_REQUIRE(buffer[10 + local_size] == false);
+  BOOST_REQUIRE(buffer[local_size * 2] == true);
+  BOOST_REQUIRE(buffer[10 + local_size * 2] == false);
+  BOOST_REQUIRE(buffer[local_size * 3] == true);
+  BOOST_REQUIRE(buffer[10 + local_size * 3] == true);
+}
+
+template<typename T, int Line>
+void check_binary_reduce(std::vector<T> buffer, size_t local_size, size_t global_size,
+                         std::vector<bool> expected, std::string name,
+                         size_t break_size = 0, size_t offset = 0) {
+  std::vector<std::string> cases{"everything except one false", "everything false",
+                                 "everything except one true", "everything true"};
+  BOOST_REQUIRE(global_size / local_size == expected.size());
+  for (size_t i = 0; i < global_size / local_size; ++i) {
+    for (size_t j = 0; j < local_size; ++j) {
+      // used to stop after first subgroup
+      if (break_size != 0 && j == break_size)
+        break;
+
+      T computed      = buffer[i * local_size + j + offset];
+      T expectedValue = initialize_type<T>(expected[i]);
+
+      BOOST_TEST(compare_type(expectedValue, computed),
+                 Line << ":" << type_to_string(computed) << " at position " << j
+                      << " instead of " << type_to_string(expectedValue)
+                      << " for case: " << cases[i] << " " << name);
+
+      if (!compare_type(expectedValue, computed))
+        break;
+    }
+  }
+}
+
+} // namespace detail
+
+template<int N, int M, typename T>
+class test_kernel;
+
+template<int CallingLine, typename T, typename DataGenerator, typename TestedFunction,
+         typename ValidationFunction>
+void test_nd_group_function_1d(size_t local_size, size_t global_size, size_t offset_margin,
+                               size_t offset_divisor, size_t buffer_size,
+                               DataGenerator dg, TestedFunction f, ValidationFunction vf) {
+  sycl::queue queue;
+  std::vector<T> host_buf(buffer_size, T{});
+
+  dg(host_buf);
+
+  std::vector<T> original_host_buf(host_buf);
+
+  {
+    sycl::buffer<T, 1> buf{host_buf.data(), host_buf.size()};
+
+    queue.submit([&](sycl::handler &cgh) {
+      using namespace sycl::access;
+      auto acc = buf.template get_access<mode::read_write>(cgh);
+
+      cgh.parallel_for<class test_kernel<1, CallingLine, T>>(
+        sycl::nd_range<1>{global_size, local_size},
+        [=](sycl::nd_item<1> item) {
+        auto g  = item.get_group();
+        auto sg = item.get_sub_group();
+
+        T local_value = acc[item.get_global_linear_id()];
+
+        f(acc, item.get_global_linear_id(), sg, g, local_value);
+      });
+    });
+  }
+
+  vf(host_buf, original_host_buf);
+}
+
+template<int CallingLine, typename T, typename DataGenerator, typename TestedFunction,
+         typename ValidationFunction>
+void test_nd_group_function_2d(size_t local_size_x, size_t local_size_y,
+                               size_t global_size_x, size_t global_size_y,
+                               size_t offset_margin, size_t offset_divisor,
+                               size_t buffer_size, DataGenerator dg, TestedFunction f,
+                               ValidationFunction vf) {
+  sycl::queue queue;
+  std::vector<T> host_buf(buffer_size, T{});
+
+  dg(host_buf);
+
+  std::vector<T> original_host_buf(host_buf);
+
+  {
+    sycl::buffer<T, 1> buf{host_buf.data(), host_buf.size()};
+
+    queue.submit([&](sycl::handler &cgh) {
+      using namespace sycl::access;
+      auto acc = buf.template get_access<mode::read_write>(cgh);
+
+      cgh.parallel_for<class test_kernel<2, CallingLine, T>>(
+        sycl::nd_range<2>{sycl::range<2>(global_size_x, global_size_y), sycl::range<2>(local_size_x, local_size_y)},
+        [=](sycl::nd_item<2> item) {
+        auto g                  = item.get_group();
+        auto sg                 = item.get_sub_group();
+        size_t custom_linear_id = item.get_local_linear_id() +
+                                  local_size_x * local_size_y * item.get_group_linear_id();
+
+        T local_value = acc[custom_linear_id];
+
+        f(acc, custom_linear_id, sg, g, local_value);
+      });
+    });
+  }
+
+  vf(host_buf, original_host_buf);
+}
+
+#endif // TESTS_GROUP_FUNCTIONS_HH

--- a/tests/sycl/group_functions/group_functions_binary_reduce.cpp
+++ b/tests/sycl/group_functions/group_functions_binary_reduce.cpp
@@ -1,0 +1,545 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018-2020 Aksel Alpay and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "../sycl_test_suite.hpp"
+#include "group_functions.hpp"
+
+using namespace cl;
+
+BOOST_FIXTURE_TEST_SUITE(group_functions_tests, reset_device_fixture)
+
+BOOST_AUTO_TEST_CASE(group_x_of_local) {
+  using T = char;
+
+  const size_t local_size     = 256;
+  const size_t global_size    = 1024;
+  const size_t local_size_x   = 16;
+  const size_t local_size_y   = 16;
+  const size_t global_size_x  = 32;
+  const size_t global_size_y  = 32;
+  const size_t offset_margin  = global_size;
+  const size_t offset_divisor = 1;
+  const size_t buffer_size    = global_size;
+  const auto data_generator   = [](std::vector<T> &v) {
+    detail::create_bool_test_data(v, local_size, global_size);
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_any_of(g, static_cast<bool>(local_value));
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{true, false, true, true},
+                                               "any_of");
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_all_of(g, static_cast<bool>(local_value));
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{false, false, false, true},
+                                               "all_of");
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_none_of(g, static_cast<bool>(local_value));
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{false, true, false, false},
+                                               "none_of");
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(group_x_of_ptr) {
+  using T = char;
+
+  const size_t local_size     = 256;
+  const size_t global_size    = 1024;
+  const size_t local_size_x   = 16;
+  const size_t local_size_y   = 16;
+  const size_t global_size_x  = 32;
+  const size_t global_size_y  = 32;
+  const size_t offset_margin  = global_size * 2;
+  const size_t offset_divisor = 1;
+  const size_t buffer_size    = global_size * 3;
+  const auto data_generator   = [](std::vector<T> &v) {
+    detail::create_bool_test_data(v, local_size * 2, global_size * 2);
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      auto local_size = g.get_local_range().size();
+      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end   = start + local_size * 2;
+
+      auto local = sycl::detail::any_of(g, start.get(), end.get());
+      sycl::group_barrier(g);
+      acc[global_linear_id + 2 * global_size] = local;
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{true, false, true, true},
+                                               "any_of", 0, 2 * global_size);
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      auto local_size = g.get_local_range().size();
+      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end   = start + local_size * 2;
+
+      auto local = sycl::detail::all_of(g, start.get(), end.get());
+      sycl::group_barrier(g);
+      acc[global_linear_id + 2 * global_size] = local;
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{false, false, false, true},
+                                               "all_of", 0, 2 * global_size);
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      auto local_size = g.get_local_range().size();
+      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end   = start + local_size * 2;
+
+      auto local = sycl::detail::none_of(g, start.get(), end.get());
+      sycl::group_barrier(g);
+      acc[global_linear_id + 2 * global_size] = local;
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{false, true, false, false},
+                                               "none_of", 0, 2 * global_size);
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+}
+
+#if defined(HIPSYCL_PLATFORM_CUDA) || defined(HIPSYCL_PLATFORM_HIP)
+BOOST_AUTO_TEST_CASE(sub_group_x_of_local) {
+  using T = char;
+
+  const size_t local_size      = 256;
+  const size_t global_size     = 1024;
+  const size_t offset_margin   = global_size;
+  const size_t offset_divisor  = 1;
+  const size_t buffer_size     = global_size;
+  const uint32_t subgroup_size = static_cast<uint32_t>(warpSize);
+
+  const auto data_generator = [](std::vector<T> &v) {
+    detail::create_bool_test_data(v, local_size, global_size);
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_any_of(sg, static_cast<bool>(local_value));
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{true, false, true, true},
+                                               "any_of", subgroup_size);
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_all_of(sg, static_cast<bool>(local_value));
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{false, false, false, true},
+                                               "all_of", subgroup_size);
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_none_of(sg, static_cast<bool>(local_value));
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{false, true, false, false},
+                                               "none_of", subgroup_size);
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+  }
+}
+#endif
+
+BOOST_AUTO_TEST_CASE(group_x_of_ptr_function) {
+  using T = char;
+
+  const size_t local_size     = 256;
+  const size_t global_size    = 1024;
+  const size_t local_size_x   = 16;
+  const size_t local_size_y   = 16;
+  const size_t global_size_x  = 32;
+  const size_t global_size_y  = 32;
+  const size_t offset_margin  = global_size;
+  const size_t offset_divisor = 1;
+  const size_t buffer_size    = global_size * 3;
+  const auto data_generator   = [](std::vector<T> &v) {
+    detail::create_bool_test_data(v, local_size * 2, global_size * 2);
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      auto local_size = g.get_local_range().size();
+      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end   = start + local_size * 2;
+
+      auto local = sycl::detail::any_of(g, start.get(), end.get(), std::logical_not<T>());
+      sycl::group_barrier(g);
+      acc[global_linear_id + 2 * global_size] = local;
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{true, true, true, false},
+                                               "any_of", 0, 2 * global_size);
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      auto local_size = g.get_local_range().size();
+      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end   = start + local_size * 2;
+
+      auto local = sycl::detail::all_of(g, start.get(), end.get(), std::logical_not<T>());
+      sycl::group_barrier(g);
+      acc[global_linear_id + 2 * global_size] = local;
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{false, true, false, false},
+                                               "all_of", 0, 2 * global_size);
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      auto local_size = g.get_local_range().size();
+      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end   = start + local_size * 2;
+
+      auto local = sycl::detail::none_of(g, start.get(), end.get(), std::logical_not<T>());
+      sycl::group_barrier(g);
+      acc[global_linear_id + 2 * global_size] = local;
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{false, false, false, true},
+                                               "none_of", 0, 2 * global_size);
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(group_x_of_function) {
+  using T = char;
+
+  const size_t local_size     = 256;
+  const size_t global_size    = 1024;
+  const size_t local_size_x   = 16;
+  const size_t local_size_y   = 16;
+  const size_t global_size_x  = 32;
+  const size_t global_size_y  = 32;
+  const size_t offset_margin  = global_size;
+  const size_t offset_divisor = 1;
+  const size_t buffer_size    = global_size;
+  const auto data_generator   = [](std::vector<T> &v) {
+    detail::create_bool_test_data(v, local_size, global_size);
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_any_of(g, static_cast<bool>(local_value), std::logical_not<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{true, true, true, false},
+                                               "any_of");
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_all_of(g, static_cast<bool>(local_value), std::logical_not<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{false, true, false, false},
+                                               "all_of");
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_none_of(g, static_cast<bool>(local_value), std::logical_not<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{false, false, false, true},
+                                               "none_of");
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+}
+
+#if defined(HIPSYCL_PLATFORM_CUDA) || defined(HIPSYCL_PLATFORM_HIP)
+BOOST_AUTO_TEST_CASE(sub_group_x_of_function) {
+  using T = char;
+
+  const size_t local_size      = 256;
+  const size_t global_size     = 1024;
+  const size_t offset_margin   = global_size;
+  const size_t offset_divisor  = 1;
+  const size_t buffer_size     = global_size;
+  const uint32_t subgroup_size = static_cast<uint32_t>(warpSize);
+
+  const auto data_generator = [](std::vector<T> &v) {
+    detail::create_bool_test_data(v, local_size, global_size);
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_any_of(sg, static_cast<bool>(local_value), std::logical_not<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{true, true, true, false},
+                                               "any_of", subgroup_size);
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_all_of(sg, static_cast<bool>(local_value), std::logical_not<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{false, true, false, false},
+                                               "all_of", subgroup_size);
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_none_of(sg, static_cast<bool>(local_value), std::logical_not<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{false, false, false, true},
+                                               "none_of", subgroup_size);
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+  }
+}
+#endif
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/sycl/group_functions/group_functions_misc.cpp
+++ b/tests/sycl/group_functions/group_functions_misc.cpp
@@ -1,0 +1,301 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018-2020 Aksel Alpay and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "../sycl_test_suite.hpp"
+#include "group_functions.hpp"
+
+BOOST_FIXTURE_TEST_SUITE(group_functions_tests, reset_device_fixture)
+
+BOOST_AUTO_TEST_CASE(group_barrier) {
+  using T = int;
+
+  const size_t local_size     = 256;
+  const size_t global_size    = 1024;
+  const size_t offset_margin  = 0;
+  const size_t offset_divisor = 1;
+  const size_t buffer_size    = global_size;
+  const auto data_generator   = [](std::vector<T> &v) {
+    for (size_t i = 0; i < v.size(); ++i)
+      v[i] = detail::initialize_type<T>(i);
+  };
+
+  {
+    const auto tested_function = [=](auto acc, size_t global_linear_id,
+                                     sycl::sub_group sg, auto g, T local_value) {
+      int tmp             = -10000;
+      size_t local_id     = g.get_local_linear_id();
+      size_t group_offset = (global_linear_id / local_size) * local_size;
+      for (int i = 0; i < local_size; ++i) {
+        if (local_id == i) {
+          for (int j = 0; j < 10000; ++j)
+            tmp++;
+        }
+        sycl::group_barrier(g);
+        if (local_id == i)
+          acc[group_offset + i] = tmp;
+        sycl::group_barrier(g);
+        tmp = acc[group_offset + i];
+      }
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      for (size_t i = 0; i < vIn.size(); ++i) {
+        T expected = (i % local_size) * 10000;
+        T computed = vIn[i];
+
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed) << " at position " << i << " instead of "
+                                                    << detail::type_to_string(expected)
+                                                    << " for group: " << i / local_size);
+
+        //        if (!detail::compare_type(expected, computed))
+        //          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+  }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(group_broadcast, T, test_types) {
+  const size_t local_size     = 256;
+  const size_t global_size    = 1024;
+  const size_t local_size_x   = 16;
+  const size_t local_size_y   = 16;
+  const size_t global_size_x  = 32;
+  const size_t global_size_y  = 32;
+  const size_t offset_margin  = global_size;
+  const size_t offset_divisor = 1;
+  const size_t buffer_size    = global_size;
+  const auto data_generator   = [](std::vector<T> &v) {
+    for (size_t i = 0; i < v.size(); ++i)
+      v[i] = detail::initialize_type<T>(i) + detail::get_offset<T>(global_size);
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_broadcast(g, local_value);
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      for (size_t i = 0; i < vIn.size(); ++i) {
+        T expected = detail::initialize_type<T>(((int)i / local_size) * local_size) +
+                     detail::get_offset<T>(offset_margin, offset_divisor);
+        T computed = vIn[i];
+
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: no id");
+
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_broadcast(g, local_value, 10);
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      for (size_t i = 0; i < vIn.size(); ++i) {
+        T expected = detail::initialize_type<T>(((int)i / local_size) * local_size + 10) +
+                     detail::get_offset<T>(offset_margin, offset_divisor);
+        T computed = vIn[i];
+
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: linear id");
+
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+
+  {
+    const auto tested_function_1d = [](auto acc, size_t global_linear_id,
+                                       sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_broadcast(g, local_value, sycl::id<1>(10));
+    };
+    const auto tested_function_2d = [](auto acc, size_t global_linear_id,
+                                       sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_broadcast(g, local_value, sycl::id<2>(0, 10));
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      for (size_t i = 0; i < vIn.size(); ++i) {
+        T expected = detail::initialize_type<T>(((int)i / local_size) * local_size + 10) +
+                     detail::get_offset<T>(offset_margin, offset_divisor);
+        T computed = vIn[i];
+
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: id");
+
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function_1d, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator,
+                                           tested_function_2d, validation_function);
+  }
+}
+
+#if defined(HIPSYCL_PLATFORM_CUDA) || defined(HIPSYCL_PLATFORM_HIP)
+BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_broadcast, T, test_types) {
+  const size_t local_size      = 256;
+  const size_t global_size     = 1024;
+  const size_t offset_margin   = global_size;
+  const size_t offset_divisor  = 1;
+  const size_t buffer_size     = global_size;
+  const uint32_t subgroup_size = static_cast<uint32_t>(warpSize);
+
+  const auto data_generator = [](std::vector<T> &v) {
+    for (size_t i = 0; i < v.size(); ++i)
+      v[i] = detail::initialize_type<T>(i) + detail::get_offset<T>(global_size);
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_broadcast(sg, local_value);
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      for (size_t i = 0; i < vIn.size(); ++i) {
+        T expected = detail::initialize_type<T>(((int)i / subgroup_size) * subgroup_size) +
+                     detail::get_offset<T>(offset_margin, offset_divisor);
+        T computed = vIn[i];
+
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: no id");
+
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_broadcast(sg, local_value, 10);
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      for (size_t i = 0; i < vIn.size(); ++i) {
+        T expected =
+            detail::initialize_type<T>(((int)i / subgroup_size) * subgroup_size + 10) +
+            detail::get_offset<T>(offset_margin, offset_divisor);
+        T computed = vIn[i];
+
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: linear id");
+
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_broadcast(sg, local_value, sycl::id<1>(10));
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      for (size_t i = 0; i < vIn.size(); ++i) {
+        T expected =
+            detail::initialize_type<T>(((int)i / subgroup_size) * subgroup_size + 10) +
+            detail::get_offset<T>(offset_margin, offset_divisor);
+        T computed = vIn[i];
+
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: id");
+
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+  }
+}
+#endif
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/sycl/group_functions/group_functions_reduce.cpp
+++ b/tests/sycl/group_functions/group_functions_reduce.cpp
@@ -1,0 +1,316 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018-2020 Aksel Alpay and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "../sycl_test_suite.hpp"
+#include "group_functions.hpp"
+
+BOOST_FIXTURE_TEST_SUITE(group_functions_tests, reset_device_fixture)
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce, T, test_types) {
+  const size_t local_size     = 256;
+  const size_t global_size    = 1024;
+  const size_t local_size_x   = 16;
+  const size_t local_size_y   = 16;
+  const size_t global_size_x  = 32;
+  const size_t global_size_y  = 32;
+  const size_t offset_margin  = global_size;
+  const size_t offset_divisor = 1;
+  const size_t buffer_size    = global_size;
+  const auto data_generator   = [](std::vector<T> &v) {
+    for (size_t i = 0; i < v.size(); ++i)
+      v[i] =
+          detail::initialize_type<T>(i) + detail::get_offset<T>(global_size, global_size);
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_reduce(g, local_value, std::plus<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        T expected = T{};
+        for (size_t j = 0; j < local_size; ++j)
+          expected = expected + vOrig[i * local_size + j];
+
+        T computed = vIn[i * local_size];
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: no init");
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+
+  if constexpr (!std::is_floating_point<T>::value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_reduce(g, local_value, std::multiplies<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        T expected = vOrig[i * local_size];
+        for (size_t j = 1; j < local_size; ++j)
+          expected = expected * vOrig[i * local_size + j];
+
+        T computed = vIn[i * local_size];
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected)
+                       << " for case: no init multiplication");
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_reduce(g, local_value, detail::initialize_type<T>(10),
+                             std::plus<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        T expected = detail::initialize_type<T>(10);
+        for (size_t j = 0; j < local_size; ++j)
+          expected = expected + vOrig[i * local_size + j];
+
+        T computed = vIn[i * local_size];
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: init");
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce_ptr, T, test_types) {
+  const size_t local_size     = 256;
+  const size_t global_size    = 1024;
+  const size_t local_size_x   = 16;
+  const size_t local_size_y   = 16;
+  const size_t global_size_x  = 32;
+  const size_t global_size_y  = 32;
+  const size_t buffer_size    = global_size * 3;
+  const size_t offset_margin  = buffer_size;
+  const size_t offset_divisor = buffer_size;
+  const auto data_generator   = [](std::vector<T> &v) {
+    for (size_t i = 0; i < v.size(); ++i)
+      v[i] = detail::initialize_type<T>(i) +
+             detail::get_offset<T>(offset_margin, offset_divisor);
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      auto local_size = g.get_local_range().size();
+      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end   = start + local_size * 2;
+
+      T local = sycl::detail::reduce(g, start.get(), end.get(), std::plus<T>());
+      sycl::group_barrier(g);
+      acc[global_linear_id + 2 * global_size] = local;
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        T expected = T{};
+        for (size_t j = 0; j < local_size * 2; ++j)
+          expected = expected + vOrig[i * 2 * local_size + j];
+
+        T computed = vIn[2 * global_size + i * local_size];
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: no init");
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      auto local_size = g.get_local_range().size();
+      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end   = start + local_size * 2;
+
+      T local = sycl::detail::reduce(g, start.get(), end.get(),
+                                     detail::initialize_type<T>(10), std::plus<T>());
+      sycl::group_barrier(g);
+      acc[global_linear_id + 2 * global_size] = local;
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        T expected = detail::initialize_type<T>(10);
+        for (size_t j = 0; j < local_size * 2; ++j)
+          expected = expected + vOrig[i * 2 * local_size + j];
+
+        T computed = vIn[i * local_size + 2 * global_size];
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: init");
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+}
+
+#if defined(HIPSYCL_PLATFORM_CUDA) || defined(HIPSYCL_PLATFORM_HIP)
+BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_reduce, T, test_types) {
+  const uint32_t subgroup_size = static_cast<uint32_t>(warpSize);
+  const size_t local_size      = subgroup_size;
+  const size_t global_size     = subgroup_size * 4;
+  const size_t offset_margin   = global_size;
+  const size_t offset_divisor  = 1;
+  const size_t buffer_size     = global_size;
+  const auto data_generator    = [](std::vector<T> &v) {
+    for (size_t i = 0; i < v.size(); ++i)
+      v[i] =
+          detail::initialize_type<T>(i) + detail::get_offset<T>(global_size, global_size);
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_reduce(sg, local_value, std::plus<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        T expected = T{};
+        for (size_t j = 0; j < local_size; ++j)
+          expected = expected + vOrig[i * local_size + j];
+
+        T computed = vIn[i * local_size];
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: no init");
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_reduce(sg, local_value, detail::initialize_type<T>(10),
+                             std::plus<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        T expected = detail::initialize_type<T>(10);
+        for (size_t j = 0; j < local_size; ++j)
+          expected = expected + vOrig[i * local_size + j];
+
+        T computed = vIn[i * local_size];
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: init");
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+  }
+}
+#endif
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/sycl/group_functions/group_functions_scan.cpp
+++ b/tests/sycl/group_functions/group_functions_scan.cpp
@@ -1,0 +1,686 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018-2020 Aksel Alpay and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "../sycl_test_suite.hpp"
+#include "group_functions.hpp"
+
+BOOST_FIXTURE_TEST_SUITE(group_functions_tests, reset_device_fixture)
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan, T, test_types) {
+  const size_t local_size     = 256;
+  const size_t global_size    = 1024;
+  const size_t local_size_x   = 16;
+  const size_t local_size_y   = 16;
+  const size_t global_size_x  = 32;
+  const size_t global_size_y  = 32;
+  const size_t offset_margin  = global_size;
+  const size_t offset_divisor = global_size;
+  const size_t buffer_size    = global_size;
+  const auto data_generator   = [](std::vector<T> &v) {
+    for (size_t i = 0; i < global_size; ++i)
+      v[i] = detail::initialize_type<T>(i) +
+             detail::get_offset<T>(offset_margin, offset_divisor);
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_exclusive_scan(g, local_value, std::plus<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      std::vector<T> expected(vOrig.size());
+
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        expected[i * local_size] = T{};
+        for (size_t j = 1; j < local_size; ++j)
+          expected[i * local_size + j] =
+              expected[i * local_size + j - 1] + vOrig[i * local_size + j - 1];
+
+        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
+          T computed = vIn[j];
+          BOOST_TEST(detail::compare_type(expected[j], computed),
+                     detail::type_to_string(computed)
+                         << " at position " << j << " instead of "
+                         << detail::type_to_string(expected[j])
+                         << " for case: no init in group " << i);
+
+          if (!detail::compare_type(expected[j], computed))
+            break;
+        }
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_exclusive_scan(g, local_value, detail::initialize_type<T>(10),
+                                     std::plus<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      std::vector<T> expected(vOrig.size());
+
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        expected[i * local_size] = detail::initialize_type<T>(10);
+        for (size_t j = 1; j < local_size; ++j)
+          expected[i * local_size + j] =
+              expected[i * local_size + j - 1] + vOrig[i * local_size + j - 1];
+
+        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
+          T computed = vIn[j];
+          BOOST_TEST(detail::compare_type(expected[j], computed),
+                     detail::type_to_string(computed)
+                         << " at position " << j << " instead of "
+                         << detail::type_to_string(expected[j])
+                         << " for case: init in group " << i);
+          if (!detail::compare_type(expected[j], computed))
+            break;
+        }
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+
+  if constexpr (!std::is_floating_point<T>::value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_exclusive_scan(g, local_value, detail::initialize_type<T>(10),
+                                     std::multiplies<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      std::vector<T> expected(vOrig.size());
+
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        expected[i * local_size] = detail::initialize_type<T>(10);
+        for (size_t j = 1; j < local_size; ++j)
+          expected[i * local_size + j] =
+              expected[i * local_size + j - 1] * vOrig[i * local_size + j - 1];
+
+        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
+          T computed = vIn[j];
+          BOOST_TEST(detail::compare_type(expected[j], computed),
+                     detail::type_to_string(computed)
+                         << " at position " << j << " instead of "
+                         << detail::type_to_string(expected[j])
+                         << " for case: init multiplication in group " << i);
+          if (!detail::compare_type(expected[j], computed))
+            break;
+        }
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan_ptr, T, test_types) {
+  const size_t local_size     = 256;
+  const size_t global_size    = 1024;
+  const size_t local_size_x   = 16;
+  const size_t local_size_y   = 16;
+  const size_t global_size_x  = 32;
+  const size_t global_size_y  = 32;
+  const size_t buffer_size    = global_size * 4;
+  const size_t offset_margin  = global_size * 2;
+  const size_t offset_divisor = global_size * 2;
+  const auto data_generator   = [](std::vector<T> &v) {
+    for (size_t i = 0; i < global_size; ++i)
+      v[i] = detail::initialize_type<T>(i) +
+             detail::get_offset<T>(offset_margin, offset_divisor);
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      auto local_size = g.get_local_range().size();
+      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end   = start + local_size * 2;
+      auto out   = acc.get_pointer() + 2 * 4 * local_size +
+                 (global_linear_id / local_size) * local_size * 2;
+
+      sycl::detail::exclusive_scan(g, start.get(), end.get(), out.get(), std::plus<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      std::vector<T> expected(vOrig.size());
+
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        expected[i * 2 * local_size] = T{};
+        for (size_t j = 1; j < local_size * 2; ++j)
+          expected[i * 2 * local_size + j] =
+              expected[i * 2 * local_size + j - 1] + vOrig[i * 2 * local_size + j - 1];
+
+        for (size_t j = i * 2 * local_size; j < (i + 1) * local_size * 2; ++j) {
+          T computed = vIn[j + global_size * 2];
+          BOOST_TEST(detail::compare_type(expected[j], computed),
+                     detail::type_to_string(computed)
+                         << " at position " << j << " instead of "
+                         << detail::type_to_string(expected[j])
+                         << " for case: no init in group " << i);
+
+          if (!detail::compare_type(expected[j], computed))
+            break;
+        }
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      auto local_size = g.get_local_range().size();
+      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end   = start + local_size * 2;
+      auto out   = acc.get_pointer() + 2 * 4 * local_size +
+                 (global_linear_id / local_size) * local_size * 2;
+
+      sycl::detail::exclusive_scan(g, start.get(), end.get(), out.get(),
+                                   detail::initialize_type<T>(10), std::plus<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      std::vector<T> expected(vOrig.size());
+
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        expected[i * 2 * local_size] = detail::initialize_type<T>(10);
+        for (size_t j = 1; j < local_size * 2; ++j)
+          expected[i * 2 * local_size + j] =
+              expected[i * 2 * local_size + j - 1] + vOrig[i * 2 * local_size + j - 1];
+
+        for (size_t j = i * 2 * local_size; j < (i + 1) * local_size * 2; ++j) {
+          T computed = vIn[j + global_size * 2];
+          BOOST_TEST(detail::compare_type(expected[j], computed),
+                     detail::type_to_string(computed)
+                         << " at position " << j << " instead of "
+                         << detail::type_to_string(expected[j])
+                         << " for case: init in group " << i);
+          if (!detail::compare_type(expected[j], computed))
+            break;
+        }
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+}
+
+#if defined(HIPSYCL_PLATFORM_CUDA) || defined(HIPSYCL_PLATFORM_HIP)
+BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_exclusive_scan, T, test_types) {
+  const uint32_t subgroup_size = static_cast<uint32_t>(warpSize);
+  const size_t local_size      = subgroup_size;
+  const size_t global_size     = subgroup_size * 4;
+  const size_t offset_margin   = global_size;
+  const size_t offset_divisor  = global_size;
+  const size_t buffer_size     = global_size;
+  const auto data_generator    = [](std::vector<T> &v) {
+    for (size_t i = 0; i < global_size; ++i)
+      v[i] = detail::initialize_type<T>(i) +
+             detail::get_offset<T>(offset_margin, offset_divisor);
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_exclusive_scan(sg, local_value, std::plus<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      std::vector<T> expected(vOrig.size());
+
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        expected[i * local_size] = T{};
+        for (size_t j = 1; j < local_size; ++j)
+          expected[i * local_size + j] =
+              expected[i * local_size + j - 1] + vOrig[i * local_size + j - 1];
+
+        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
+          T computed = vIn[j];
+          BOOST_TEST(detail::compare_type(expected[j], computed),
+                     detail::type_to_string(computed)
+                         << " at position " << j << " instead of "
+                         << detail::type_to_string(expected[j])
+                         << " for case: no init in group " << i);
+
+          if (!detail::compare_type(expected[j], computed))
+            break;
+        }
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_exclusive_scan(sg, local_value, detail::initialize_type<T>(10),
+                                     std::plus<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      std::vector<T> expected(vOrig.size());
+
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        expected[i * local_size] = detail::initialize_type<T>(10);
+        for (size_t j = 1; j < local_size; ++j)
+          expected[i * local_size + j] =
+              expected[i * local_size + j - 1] + vOrig[i * local_size + j - 1];
+
+        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
+          T computed = vIn[j];
+          BOOST_TEST(detail::compare_type(expected[j], computed),
+                     detail::type_to_string(computed)
+                         << " at position " << j << " instead of "
+                         << detail::type_to_string(expected[j])
+                         << " for case: init in group " << i);
+          if (!detail::compare_type(expected[j], computed))
+            break;
+        }
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+  }
+}
+#endif
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan, T, test_types) {
+  const size_t local_size     = 256;
+  const size_t global_size    = 1024;
+  const size_t local_size_x   = 16;
+  const size_t local_size_y   = 16;
+  const size_t global_size_x  = 32;
+  const size_t global_size_y  = 32;
+  const size_t offset_margin  = global_size;
+  const size_t offset_divisor = global_size;
+  const size_t buffer_size    = global_size;
+  const auto data_generator   = [](std::vector<T> &v) {
+    for (size_t i = 0; i < global_size; ++i)
+      v[i] = detail::initialize_type<T>(i) +
+             detail::get_offset<T>(offset_margin, offset_divisor);
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_inclusive_scan(g, local_value, std::plus<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      std::vector<T> expected(vOrig.size());
+
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        expected[i * local_size] = vOrig[i * local_size];
+        for (size_t j = 1; j < local_size; ++j)
+          expected[i * local_size + j] =
+              expected[i * local_size + j - 1] + vOrig[i * local_size + j];
+
+        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
+          T computed = vIn[j];
+          BOOST_TEST(detail::compare_type(expected[j], computed),
+                     detail::type_to_string(computed)
+                         << " at position " << j << " instead of "
+                         << detail::type_to_string(expected[j])
+                         << " for case: no init in group " << i);
+          if (!detail::compare_type(expected[j], computed))
+            break;
+        }
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+
+  if constexpr (!std::is_floating_point<T>::value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_inclusive_scan(g, local_value, std::multiplies<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      std::vector<T> expected(vOrig.size());
+
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        expected[i * local_size] = vOrig[i * local_size];
+        for (size_t j = 1; j < local_size; ++j)
+          expected[i * local_size + j] =
+              expected[i * local_size + j - 1] * vOrig[i * local_size + j];
+
+        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
+          T computed = vIn[j];
+          BOOST_TEST(detail::compare_type(expected[j], computed),
+                     detail::type_to_string(computed)
+                         << " at position " << j << " instead of "
+                         << detail::type_to_string(expected[j])
+                         << " for case: no init multiplication in group " << i);
+          if (!detail::compare_type(expected[j], computed))
+            break;
+        }
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_inclusive_scan(g, local_value, detail::initialize_type<T>(10),
+                                     std::plus<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      std::vector<T> expected(vOrig.size());
+
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        expected[i * local_size] = vOrig[i * local_size] + detail::initialize_type<T>(10);
+        for (size_t j = 1; j < local_size; ++j)
+          expected[i * local_size + j] =
+              expected[i * local_size + j - 1] + vOrig[i * local_size + j];
+
+        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
+          T computed = vIn[j];
+          BOOST_TEST(detail::compare_type(expected[j], computed),
+                     detail::type_to_string(computed)
+                         << " at position " << j << " instead of "
+                         << detail::type_to_string(expected[j])
+                         << " for case: init in group " << i);
+          if (!detail::compare_type(expected[j], computed))
+            break;
+        }
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan_ptr, T, test_types) {
+  const size_t local_size     = 256;
+  const size_t global_size    = 1024;
+  const size_t local_size_x   = 16;
+  const size_t local_size_y   = 16;
+  const size_t global_size_x  = 32;
+  const size_t global_size_y  = 32;
+  const size_t buffer_size    = global_size * 4;
+  const size_t offset_margin  = global_size * 2;
+  const size_t offset_divisor = global_size * 2;
+  const auto data_generator   = [](std::vector<T> &v) {
+    for (size_t i = 0; i < global_size; ++i)
+      v[i] = detail::initialize_type<T>(i) +
+             detail::get_offset<T>(offset_margin, offset_divisor);
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      auto local_size = g.get_local_range().size();
+      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end   = start + local_size * 2;
+      auto out   = acc.get_pointer() + 2 * 4 * local_size +
+                 (global_linear_id / local_size) * local_size * 2;
+
+      sycl::detail::inclusive_scan(g, start.get(), end.get(), out.get(), std::plus<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      std::vector<T> expected(vOrig.size());
+
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        expected[i * 2 * local_size] = vOrig[i * 2 * local_size];
+        for (size_t j = 1; j < local_size * 2; ++j)
+          expected[i * 2 * local_size + j] =
+              expected[i * 2 * local_size + j - 1] + vOrig[i * 2 * local_size + j];
+
+        for (size_t j = i * 2 * local_size; j < (i + 1) * local_size * 2; ++j) {
+          T computed = vIn[j + 2 * global_size];
+          BOOST_TEST(detail::compare_type(expected[j], computed),
+                     detail::type_to_string(computed)
+                         << " at position " << j << " instead of "
+                         << detail::type_to_string(expected[j])
+                         << " for case: init in group " << i);
+          if (!detail::compare_type(expected[j], computed))
+            break;
+        }
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      auto local_size = g.get_local_range().size();
+      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end   = start + local_size * 2;
+      auto out   = acc.get_pointer() + 2 * 4 * local_size +
+                 (global_linear_id / local_size) * local_size * 2;
+
+      sycl::detail::inclusive_scan(g, start.get(), end.get(), out.get(),
+                                   detail::initialize_type<T>(10), std::plus<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      std::vector<T> expected(vOrig.size());
+
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        expected[i * 2 * local_size] =
+            vOrig[i * 2 * local_size] + detail::initialize_type<T>(10);
+        for (size_t j = 1; j < local_size * 2; ++j)
+          expected[i * 2 * local_size + j] =
+              expected[i * 2 * local_size + j - 1] + vOrig[i * 2 * local_size + j];
+
+        for (size_t j = i * 2 * local_size; j < (i + 1) * local_size * 2; ++j) {
+          T computed = vIn[j + 2 * global_size];
+          BOOST_TEST(detail::compare_type(expected[j], computed),
+                     detail::type_to_string(computed)
+                         << " at position " << j << " instead of "
+                         << detail::type_to_string(expected[j])
+                         << " for case: init in group " << i);
+          if (!detail::compare_type(expected[j], computed))
+            break;
+        }
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+}
+
+#if defined(HIPSYCL_PLATFORM_CUDA) || defined(HIPSYCL_PLATFORM_HIP)
+BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_inclusive_scan, T, test_types) {
+  const uint32_t subgroup_size = static_cast<uint32_t>(warpSize);
+  const size_t local_size      = subgroup_size;
+  const size_t global_size     = subgroup_size * 4;
+  const size_t offset_margin   = global_size;
+  const size_t offset_divisor  = global_size;
+  const size_t buffer_size     = global_size;
+  const auto data_generator    = [](std::vector<T> &v) {
+    for (size_t i = 0; i < global_size; ++i)
+      v[i] = detail::initialize_type<T>(i) +
+             detail::get_offset<T>(offset_margin, offset_divisor);
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_inclusive_scan(sg, local_value, std::plus<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      std::vector<T> expected(vOrig.size());
+
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        expected[i * local_size] = vOrig[i * local_size];
+        for (size_t j = 1; j < local_size; ++j)
+          expected[i * local_size + j] =
+              expected[i * local_size + j - 1] + vOrig[i * local_size + j];
+
+        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
+          T computed = vIn[j];
+          BOOST_TEST(detail::compare_type(expected[j], computed),
+                     detail::type_to_string(computed)
+                         << " at position " << j << " instead of "
+                         << detail::type_to_string(expected[j])
+                         << " for case: init in group " << i);
+          if (!detail::compare_type(expected[j], computed))
+            break;
+        }
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_inclusive_scan(sg, local_value, detail::initialize_type<T>(10),
+                                     std::plus<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      std::vector<T> expected(vOrig.size());
+
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        expected[i * local_size] = vOrig[i * local_size] + detail::initialize_type<T>(10);
+        for (size_t j = 1; j < local_size; ++j)
+          expected[i * local_size + j] =
+              expected[i * local_size + j - 1] + vOrig[i * local_size + j];
+
+        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
+          T computed = vIn[j];
+          BOOST_TEST(detail::compare_type(expected[j], computed),
+                     detail::type_to_string(computed)
+                         << " at position " << j << " instead of "
+                         << detail::type_to_string(expected[j])
+                         << " for case: init in group " << i);
+          if (!detail::compare_type(expected[j], computed))
+            break;
+        }
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+  }
+}
+#endif
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR adds a naive implementation for group_functions to hipSYCL. This includes implementations of
* group_broadcast
* group_barrier
* group_{any,all,none]_of
* group_reduce
* group_{ex,in}clusive_scan

on CPU and NVIDIA/AMD GPUs, as well as tests for these functions. I will provide optimized versions in later PRs.
It also includes (group_)functions using two pointers (beginning/end), but these are not in the specification and are not meant to be used yet (as such they reside in the `detail` namespace).

At the moment all tests pass (except some problems with the pointer-based functions on CPU which sometimes fail, I am still investigating). [(private results)](https://github.com/hipSYCL/hipSYCL-ci-bot/actions/runs/387445691)

I would love to get some feedback. If you find some template-parameters or formatting you don't like, there is a chance I missed them in one of my cleanup/refactoring attempts. Just tell me so I can fix it. Some small changes like splitting the tests into multiple files for faster compilation might be added here,