### PR TITLE
Expose the cxx flags and link lines for all backends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ endif()
 set(DEFAULT_GPU_ARCH "" CACHE STRING "Optional: Default GPU architecture to compile for when targeting GPUs (e.g.: sm_60 or gfx900)")
 set(ROCM_LIBS "-L${ROCM_PATH}/lib -L${ROCM_PATH}/hip/lib -lamdhip64" CACHE STRING "Necessary libraries for ROCm")
 if(NOT ROCM_LINK_LINE)
-  set(ROCM_LINK_LINE "-rpath $HIPSYCL_ROCM_PATH/lib -Wl,-rpath=$HIPSYCL_ROCM_PATH/hip/lib ${ROCM_LIBS}")
+  set(ROCM_LINK_LINE "-Wl,-rpath=$HIPSYCL_ROCM_PATH/lib -Wl,-rpath=$HIPSYCL_ROCM_PATH/hip/lib ${ROCM_LIBS}")
 endif()
 if(NOT ROCM_CXX_FLAGS)
   # clang erroneously sets feature detection flags for 
@@ -140,7 +140,7 @@ if(NOT ROCM_CXX_FLAGS)
   set(ROCM_CXX_FLAGS "-isystem ${CLANG_INCLUDE_PATH} -U__FLOAT128__ -U__SIZEOF_FLOAT128__ -I$HIPSYCL_ROCM_PATH/include -I$HIPSYCL_ROCM_PATH/include --hip-device-lib-path=$HIPSYCL_ROCM_PATH/lib ")
 endif()
 if(NOT CUDA_LINK_LINE) 
-  set(CUDA_LINK_LINE "-rpath $HIPSYCL_CUDA_LIB_PATH -L$HIPSYCL_CUDA_LIB_PATH -lcudart" CACHE STRING "Arguments passed to compiler to link CUDA libraries to SYCL applications")
+  set(CUDA_LINK_LINE "-Wl,-rpath=$HIPSYCL_CUDA_LIB_PATH -L$HIPSYCL_CUDA_LIB_PATH -lcudart" CACHE STRING "Arguments passed to compiler to link CUDA libraries to SYCL applications")
 endif()
 if(NOT CUDA_CXX_FLAGS)	
   # clang erroneously sets feature detection flags for 
@@ -169,7 +169,6 @@ set(SYCLCC_CONFIG_FILE "{
   \"default-gpu-arch\"  : \"${DEFAULT_GPU_ARCH}\",
   \"default-cpu-cxx\"   : \"${CMAKE_CXX_COMPILER}\",
   \"default-rocm-path\" : \"${ROCM_PATH}\",
-  \"default-boost-path\" : \"${BOOST_PATH}\",
   \"default-use-bootstrap-mode\" : \"false\",
   \"default-is-dryrun\" : \"false\",
   \"default-clang-include-path\" : \"${CLANG_INCLUDE_PATH}\",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,8 @@ FORCE)
   endif()
 endif()
 
+set(ENV{BOOST_ROOT} ${BOOST_PATH})
 find_package(Boost COMPONENTS context fiber REQUIRED)
-
 # Check for CUDA/ROCm and clang
 find_package(CUDA QUIET)
 # We currently search for hipcc to check for ROCm installation
@@ -130,9 +130,36 @@ endif()
 
 set(DEFAULT_GPU_ARCH "" CACHE STRING "Optional: Default GPU architecture to compile for when targeting GPUs (e.g.: sm_60 or gfx900)")
 set(ROCM_LIBS "-L${ROCM_PATH}/lib -L${ROCM_PATH}/hip/lib -lamdhip64" CACHE STRING "Necessary libraries for ROCm")
-set(ROCM_LINK_LINE "-rpath ${ROCM_PATH}/lib -rpath ${ROCM_PATH}/hip/lib ${ROCM_LIBS}")
-set(CUDA_LINK_LINE "-rpath $HIPSYCL_CUDA_LIB_PATH -L$HIPSYCL_CUDA_LIB_PATH -lcudart" CACHE STRING "Arguments passed to compiler to link CUDA libraries to SYCL applications")
-
+if(NOT ROCM_LINK_LINE)
+  set(ROCM_LINK_LINE "-rpath $HIPSYCL_ROCM_PATH/lib -Wl,-rpath=$HIPSYCL_ROCM_PATH/hip/lib ${ROCM_LIBS}")
+endif()
+if(NOT ROCM_CXX_FLAGS)
+  # clang erroneously sets feature detection flags for 
+  # __float128 even though it is not supported for CUDA / HIP,
+  # see https://bugs.llvm.org/show_bug.cgi?id=47559.
+  set(ROCM_CXX_FLAGS "-isystem ${CLANG_INCLUDE_PATH} -U__FLOAT128__ -U__SIZEOF_FLOAT128__ -I$HIPSYCL_ROCM_PATH/include -I$HIPSYCL_ROCM_PATH/include --hip-device-lib-path=$HIPSYCL_ROCM_PATH/lib ")
+endif()
+if(NOT CUDA_LINK_LINE) 
+  set(CUDA_LINK_LINE "-rpath $HIPSYCL_CUDA_LIB_PATH -L$HIPSYCL_CUDA_LIB_PATH -lcudart" CACHE STRING "Arguments passed to compiler to link CUDA libraries to SYCL applications")
+endif()
+if(NOT CUDA_CXX_FLAGS)	
+  # clang erroneously sets feature detection flags for 
+  # __float128 even though it is not supported for CUDA / HIP,
+  # see https://bugs.llvm.org/show_bug.cgi?id=47559.
+  set(CUDA_CXX_FLAGS "-U__FLOAT128__ -U__SIZEOF_FLOAT128__")
+endif()
+if(NOT OMP_LINK_LINE)
+  set(OMP_LINK_LINE "-L${BOOST_PATH}/lib -lboost_context -lboost_fiber -Wl,-rpath=${BOOST_PATH}/lib -fopenmp")
+endif()
+if(NOT OMP_CXX_FLAGS) 
+  set(OMP_CXX_FLAGS "-I${BOOST_PATH}/include -fopenmp")
+endif()
+if(NOT SEQUENTIAL_LINK_LINE) 
+  set(SEQUENTIAL_LINK_LINE "-L${BOOST_PATH}/lib -lboost_context -lboost_fiber -lomp  -Wl,-rpath=${BOOST_PATH}/lib")
+endif()
+if(NOT SEQUENTIAL_CXX_FLAGS) 
+  set(SEQUENTIAL_CXX_FLAGS "-I${BOOST_PATH}/include")
+endif()
 add_subdirectory(src)
 
 set(SYCLCC_CONFIG_FILE "{
@@ -142,11 +169,18 @@ set(SYCLCC_CONFIG_FILE "{
   \"default-gpu-arch\"  : \"${DEFAULT_GPU_ARCH}\",
   \"default-cpu-cxx\"   : \"${CMAKE_CXX_COMPILER}\",
   \"default-rocm-path\" : \"${ROCM_PATH}\",
+  \"default-boost-path\" : \"${BOOST_PATH}\",
   \"default-use-bootstrap-mode\" : \"false\",
   \"default-is-dryrun\" : \"false\",
   \"default-clang-include-path\" : \"${CLANG_INCLUDE_PATH}\",
+  \"default-sequential-link-line\" : \"${SEQUENTIAL_LINK_LINE}\",
+  \"default-sequential-cxx-flags\" : \"${SEQUENTIAL_CXX_FLAGS}\",
+  \"default-omp-link-line\" : \"${OMP_LINK_LINE}\",
+  \"default-omp-cxx-flags\" : \"${OMP_CXX_FLAGS}\",
   \"default-rocm-link-line\" : \"${ROCM_LINK_LINE}\",
-  \"default-cuda-link-line\" : \"${CUDA_LINK_LINE}\"
+  \"default-rocm-cxx-flags\" : \"${ROCM_CXX_FLAGS}\",
+  \"default-cuda-link-line\" : \"${CUDA_LINK_LINE}\",
+  \"default-cuda-cxx-flags\" : \"${CUDA_CXX_FLAGS}\"
 }
 ")
 

--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -313,6 +313,7 @@ class syclcc_config:
   def _get_omp_substitution_vars(self):
     return {
       'HIPSYCL_PATH' : self.hipsycl_installation_path,
+      'HIPSYCL_LIB_PATH' : os.path.join(self.hipsycl_installation_path, "lib")
     }
 
   def _substitute_template_string(self, template_string, substitution_dict):
@@ -579,9 +580,6 @@ class cuda_invocation:
         "--cuda-path=" + self._cuda_path,
         "-D__HIPSYCL_ENABLE_CUDA_TARGET__",
         "-D__HIPSYCL_CLANG__",
-        # clang erroneously sets feature detection flags for 
-        # __float128 even though it is not supported for CUDA / HIP,
-        # see https://bugs.llvm.org/show_bug.cgi?id=47559.
         "-fplugin=" + os.path.join(self._hipsycl_lib_path, "libhipSYCL_clang.so")
       ]
     flags += self._cxx_flags
@@ -618,11 +616,6 @@ class hip_invocation:
         "-x", "hip",
         "-D__HIPSYCL_ENABLE_HIP_TARGET__",
         "-D__HIPSYCL_CLANG__",
-        # This here is necessary because some distributions of clang
-        # incorrectly have the gcc/system headers *before* clangs own
-        # include path. This causes "file not found" errors when the
-        # clang CUDA wrapper headers try to include the system headers
-        # with #include_next <...>
         "-fplugin=" + os.path.join(self._hipsycl_lib_path, "libhipSYCL_clang.so")
       ]
     for t in self._hip_targets:

--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -153,11 +153,29 @@ class syclcc_config:
       'clang-include-path' : option("--hipsycl-clang-include-path", "HIPSYCL_CLANG_INCLUDE_PATH", "default-clang-include-path",
 """  The path to clang's internal include headers. Typically of the form $PREFIX/include/clang/<version>/include. Only required by ROCm."""),
 
+      'sequential-link-line' : option("--hipsycl-squential-link-line", "HIPSYCL_SEQUENTIAL_LINK_LINE", "default-sequential-link-line",
+""" The arguments passed to the linker for the sequential backend"""),
+
+      'sequential-cxx-flags' : option("--hipsycl-squential-cxx-flags", "HIPSYCL_SEQUENTIAL_CXX_FLAGS", "default-sequential-cxx-flags",
+""" The arguments passed to the compiler to compile for the sequential backend"""),
+
+      'omp-link-line' : option("--hipsycl-omp-link-line", "HIPSYCL_OMP_LINK_LINE", "default-omp-link-line",
+""" The arguments passed to the linker for the OpenMP backend."""),
+
+      'omp-cxx-flags' : option("--hipsycl-omp-cxx-flags", "HIPSYCL_OMP_CXX_FLAGS", "default-omp-cxx-flags",
+""" The arguments passed to the compiler to compile for the OpenMP backend"""),
+
       'rocm-link-line' : option("--hipsycl-rocm-link-line", "HIPSYCL_ROCM_LINK_LINE", "default-rocm-link-line",
-""" The arguments passed to the compiler to link with ROCm libraries."""),
-      
+""" The arguments passed to the linker for the ROCm backend."""),
+
+      'rocm-cxx-flags' : option("--hipsycl-rocm-cxx-flags", "HIPSYCL_ROCM_CXX_FLAGS", "default-rocm-cxx-flags",
+""" The arguments passed to the compiler to compile for the ROCm backend"""),
+
       'cuda-link-line' : option("--hipsycl-cuda-link-line", "HIPSYCL_CUDA_LINK_LINE", "default-cuda-link-line",
-""" The arguments passed to the compiler to link with CUDA libraries."""),
+""" The arguments passed to the linker for the CUDA backend."""),
+
+      'cuda-cxx-flags' : option("--hipsycl-cuda-cxx-flags", "HIPSYCL_CUDA_CXX_FLAGS", "default-cuda-cxx-flags",
+""" The arguments passed to the compiler to compile for the CUDA backend"""),
 
       'config-file' : option("--hipsycl-config-file", "HIPSYCL_CONFIG_FILE", "default-config-file",
 """  Select an alternative path for the config file containing the default hipSYCL settings.
@@ -292,6 +310,11 @@ class syclcc_config:
       'HIPSYCL_LIB_PATH' : os.path.join(self.hipsycl_installation_path, "lib")
     }
 
+  def _get_omp_substitution_vars(self):
+    return {
+      'HIPSYCL_PATH' : self.hipsycl_installation_path,
+    }
+
   def _substitute_template_string(self, template_string, substitution_dict):
     template = string.Template(template_string)
     return template.substitute(substitution_dict)
@@ -303,6 +326,10 @@ class syclcc_config:
   def _substitute_cuda_template_string(self, template_string):
     return self._substitute_template_string(
       template_string, self._get_cuda_substitution_vars())
+
+  def _substitute_omp_template_string(self, template_string):
+    return self._substitute_template_string(
+      template_string, self._get_omp_substitution_vars())
 
   def _is_option_set_to_non_default_value(self, option_name):
     opt = self._options[option_name]
@@ -316,7 +343,7 @@ class syclcc_config:
     
     return False
 
-  def _retrieve_option(self, option_name):
+  def _retrieve_option(self, option_name, allow_unset=False):
     opt = self._options[option_name]
 
     # Try commandline first
@@ -331,9 +358,12 @@ class syclcc_config:
     # Try config file
     if self._config_file.contains_key(opt.configfile):
       return self._config_file.get(opt.configfile)
-
-    raise OptionNotSet("Required command line argument {} or environment variable {} not specified".format(
+  
+    if not allow_unset:
+      raise OptionNotSet("Required command line argument {} or environment variable {} not specified".format(
             opt.commandline, opt.environment))
+    else:
+      return ""
 
   # Make sure that at least c++17 is added to the common args
   def _get_std_compiler_args(self):
@@ -437,13 +467,43 @@ class syclcc_config:
     return os.path.join(syclcc_path, "..")
 
   @property
+  def sequential_link_line(self):
+    components = self._retrieve_option("sequential-link-line", allow_unset=True).split(' ')
+    return [self._substitute_omp_template_string(arg) for arg in components]
+
+  @property
+  def sequential_cxx_flags(self):
+    components = self._retrieve_option("sequential-cxx-flags", allow_unset=False).split(' ')
+    return [self._substitute_omp_template_string(arg) for arg in components]
+
+  @property
+  def omp_link_line(self):
+    components = self._retrieve_option("omp-link-line", allow_unset=True).split(' ')
+    return [self._substitute_omp_template_string(arg) for arg in components]
+
+  @property
+  def omp_cxx_flags(self):
+    components = self._retrieve_option("omp-cxx-flags", allow_unset=True).split(' ')
+    return [self._substitute_omp_template_string(arg) for arg in components]
+
+  @property
   def rocm_link_line(self):
-    components = self._retrieve_option("rocm-link-line").split(' ')
+    components = self._retrieve_option("rocm-link-line", allow_unset=True).split(' ')
     return [self._substitute_rocm_template_string(arg) for arg in components]
-  
+
+  @property
+  def rocm_cxx_flags(self):
+    components = self._retrieve_option("rocm-cxx-flags", allow_unset=True).split(' ')
+    return [self._substitute_rocm_template_string(arg) for arg in components]
+
   @property
   def cuda_link_line(self):
-    components = self._retrieve_option("cuda-link-line").split(' ')
+    components = self._retrieve_option("cuda-link-line", allow_unset=True).split(' ')
+    return [self._substitute_cuda_template_string(arg) for arg in components]
+
+  @property
+  def cuda_cxx_flags(self):
+    components = self._retrieve_option("cuda-cxx-flags", allow_unset=True).split(' ')
     return [self._substitute_cuda_template_string(arg) for arg in components]
 
   @property
@@ -505,8 +565,9 @@ class cuda_invocation:
     self._cuda_targets = config.targets["cuda"]
     self._cuda_path = config.cuda_path
     self._clang = config.clang_path
-    self._linker_args = config.cuda_link_line
     self._hipsycl_lib_path = os.path.join(config.hipsycl_installation_path, "lib/")
+    self._linker_args = config.cuda_link_line
+    self._cxx_flags = config.cuda_cxx_flags
 
   def get_compiler_preference(self):
     return (self._clang, 100)
@@ -521,10 +582,9 @@ class cuda_invocation:
         # clang erroneously sets feature detection flags for 
         # __float128 even though it is not supported for CUDA / HIP,
         # see https://bugs.llvm.org/show_bug.cgi?id=47559.
-        "-U__FLOAT128__", "-U__SIZEOF_FLOAT128__",
         "-fplugin=" + os.path.join(self._hipsycl_lib_path, "libhipSYCL_clang.so")
       ]
-
+    flags += self._cxx_flags
     for t in self._cuda_targets:
       flags += ["--cuda-gpu-arch=" + t]
       
@@ -545,6 +605,7 @@ class hip_invocation:
     self._rocm_path = config.rocm_path
     self._clang = config.clang_path
     self._linker_args = config.rocm_link_line
+    self._cxx_flags = config.rocm_cxx_flags
     self._clang_include_path = config.clang_include_path
     self._hipsycl_lib_path = os.path.join(config.hipsycl_installation_path, "lib/")
 
@@ -552,26 +613,18 @@ class hip_invocation:
     return (self._clang, 100)
 
   def get_cxx_flags(self):
-
-    flags = [
+    flags = self._cxx_flags
+    flags += [
         "-x", "hip",
-        "--hip-device-lib-path=" + os.path.join(self._rocm_path, "lib"),
         "-D__HIPSYCL_ENABLE_HIP_TARGET__",
         "-D__HIPSYCL_CLANG__",
-        # clang erroneously sets feature detection flags for 
-        # __float128 even though it is not supported for CUDA / HIP,
-        # see https://bugs.llvm.org/show_bug.cgi?id=47559.
-        "-U__FLOAT128__", "-U__SIZEOF_FLOAT128__",
-        "-I" + os.path.join(self._rocm_path, "include"),
         # This here is necessary because some distributions of clang
         # incorrectly have the gcc/system headers *before* clangs own
         # include path. This causes "file not found" errors when the
         # clang CUDA wrapper headers try to include the system headers
         # with #include_next <...>
-        "-isystem", self._clang_include_path,
         "-fplugin=" + os.path.join(self._hipsycl_lib_path, "libhipSYCL_clang.so")
       ]
-
     for t in self._hip_targets:
       flags += ["--cuda-gpu-arch=" + t]
       
@@ -582,6 +635,9 @@ class hip_invocation:
 
 class omp_invocation:
   def __init__(self, config):
+    self._linker_args = config.omp_link_line
+    self._cxx_flags = config.omp_cxx_flags
+
     if not "omp" in config.targets:
       raise RuntimeError("OpenMP not among targets")
     if len(config.targets["omp"]) != 0:
@@ -593,28 +649,20 @@ class omp_invocation:
     return (self._cxx, 1)
 
   def get_cxx_flags(self):
-
-    flags = [
-        "-D__HIPSYCL_ENABLE_OMPHOST_TARGET__",
-      ]
+    flags =["-D__HIPSYCL_ENABLE_OMPHOST_TARGET__"]
+    flags += self._cxx_flags
 
     if sys.platform == "darwin":
         # y'all still need libomp installed
         flags += ["-Xclang"]
-    flags += ["-fopenmp"]
       
     return flags
 
   def get_linker_flags(self):
-    linker_args = [
-      "-lboost_context",
-      "-lboost_fiber"
-    ]
-
+    linker_args = self._linker_args
     if sys.platform == "darwin":
         # y'all still need libomp installed
         linker_args += ["-Xclang"]
-    linker_args += ["-fopenmp"]
 
     return linker_args
 
@@ -625,26 +673,19 @@ class omp_invocation:
 class omp_sequential_invocation:
   def __init__(self, config):
     self._cxx = config.pure_cpu_compiler
+    self._linker_args = config.sequential_link_line
+    self._cxx_flags = config.sequential_cxx_flags
 
   def get_compiler_preference(self):
     return (self._cxx, 1)
 
   def get_cxx_flags(self):
-
-    flags = [
-        "-D__HIPSYCL_ENABLE_OMPHOST_TARGET__",
-      ]
-      
+    flags = ["-D__HIPSYCL_ENABLE_OMPHOST_TARGET__"]
+    flags += self._cxx_flags
     return flags
 
   def get_linker_flags(self):
-    linker_args = [
-      "-lboost_context",
-      "-lboost_fiber",
-      "-lomp"
-    ]
-    
-    return linker_args
+    return self._linker_args
 
 class compiler:
   def __init__(self, config):

--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(hipSYCL_clang)
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 
 get_filename_component(CLANG_BINARY_PREFIX ${CLANG_EXECUTABLE_PATH} DIRECTORY)


### PR DESCRIPTION
This pr exposed the cxx flags and the link lines for all backends. This is a WIP PR since I am not sure if we should expose all the flags that are added in syclcc in syclcc.json. Currently, the flags necessary for hipSYCL to work with a spack base installation are exposed. 