### PR TITLE
use the rocm cmake integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,12 +24,19 @@ find_package(Boost COMPONENTS context fiber REQUIRED)
 
 # Check for CUDA/ROCm and clang
 find_package(CUDA QUIET)
-# We currently search for hipcc to check for ROCm installation
-find_program(HIPCC_COMPILER NAMES hipcc HINTS ${ROCM_PATH})
-set(ROCM_PATH /opt/rocm CACHE PATH "Path to ROCm installation")
+find_package(HIP QUIET HINTS ${ROCM_PATH} ${ROCM_PATH}/lib/cmake)
 
-if(HIPCC_COMPILER MATCHES "-NOTFOUND")
-  set(ROCM_FOUND false)
+# In case HIP is not found via the cmake pkgs we fall back to the legacy rocm discovery:
+if (NOT HIP_FOUND)
+  message(STATUS "Could not find hip cmake integration falling back to finding hipcc")
+  find_program(HIPCC_COMPILER NAMES hipcc HINTS ${ROCM_PATH})
+  set(ROCM_PATH /opt/rocm CACHE PATH "Path to ROCm installation")
+  if(HIPCC_COMPILER MATCHES "-NOTFOUND")
+    message(STATUS "Could not find rocm install with looking for hpcc. No rocm")
+    set(ROCM_FOUND false)
+  else()
+    set(ROCM_FOUND true)
+  endif()
 else()
   set(ROCM_FOUND true)
 endif()

--- a/include/hipSYCL/runtime/hip/hip_target.hpp
+++ b/include/hipSYCL/runtime/hip/hip_target.hpp
@@ -40,7 +40,9 @@
 #define __HIP_PLATFORM_NVCC__
 #include <hip/hip_runtime.h>
 #elif defined(HIPSYCL_RT_HIP_TARGET_ROCM)
+#ifndef __HIP_PLATFORM_HCC__
 #define __HIP_PLATFORM_HCC__
+#endif
 #include <hip/hip_runtime.h>
 #elif defined(HIPSYCL_RT_HIP_TARGET_HIPCPU)
 #include "hipCPU/hip/hip_runtime.h"

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 set(HIPSYCL_SOURCES
   application.cpp
@@ -74,8 +75,14 @@ endif()
 
 if(WITH_ROCM_BACKEND) 
   target_compile_definitions(hipSYCL-rt PRIVATE HIPSYCL_RT_ENABLE_HIP_BACKEND=1 HIPSYCL_RT_HIP_TARGET_ROCM=1)
-  target_include_directories(hipSYCL-rt PRIVATE ${ROCM_PATH}/include)
-  target_link_libraries(hipSYCL-rt PRIVATE ${ROCM_LIBS})
+  if(NOT HIP_FOUND)
+    target_include_directories(hipSYCL-rt PRIVATE ${ROCM_PATH}/include)
+    target_link_libraries(hipSYCL-rt PRIVATE ${ROCM_LIBS})
+  else()
+    # Supress warnings because wrongly set CXX arguments
+    target_compile_options(hipSYCL-rt PRIVATE -Wno-unused-command-line-argument)
+    target_link_libraries(hipSYCL-rt PRIVATE hip::host)
+  endif()
 endif()
 
 if(WITH_CPU_BACKEND)


### PR DESCRIPTION
This PR changes the cmake scripts to use the rocm cmake integration fi available. If hip si not found using find_package, we fall back to finding rocm by looking for hipcc

This PR is a draft because of the following issues:
* during compilation the following two types of warnings are displayed:
```
/tmp/hipsycl-installer-sbalint/include/hipSYCL/runtime/hip/hip_target.hpp:43:9: warning: '__HIP_PLATFORM_HCC__' macro redefined [-Wmacro-redefined]                        
#define __HIP_PLATFORM_HCC__
        ^
<command line>:5:9: note: previous definition is here
#define __HIP_PLATFORM_HCC__ 1
        ^
1 warning generated when compiling for gfx908.
In file included from /tmp/hipsycl-installer-sbalint/src/runtime/hip/hip_event.cpp:28:
In file included from /tmp/hipsycl-installer-sbalint/include/hipSYCL/runtime/hip/hip_event.hpp:32:
```
and
```
[ 62%] Building CXX object src/runtime/CMakeFiles/hipSYCL-rt.dir/hw_model/memcpy.cpp.o                                                                                      
clang-10: warning: -lclang_rt.builtins-x86_64: 'linker' input unused [-Wunused-command-line-argument]                                                                       
clang-10: warning: argument unused during compilation: '-amdgpu-function-calls=false' [-Wunused-command-line-argument]                                                      
clang-10: warning: argument unused during compilation: '-L/opt/hipSYCL/llvm/llvm/lib/clang/10.0.1/include/../lib/linux' [-Wunused-command-line-argument]                    
clang-10: warning: -lclang_rt.builtins-x86_64: 'linker' input unused [-Wunused-command-line-argument]                                                                       
clang-10: warning: argument unused during compilation: '-amdgpu-function-calls=false' [-Wunused-command-line-argument]                                                      
clang-10: warning: argument unused during compilation: '-L/opt/hipSYCL/llvm/llvm/lib/clang/10.0.1/include/../lib/linux' [-Wunused-command-line-argument]                    
```
I believe it would be okay to suppress these, but I am not sure. 
* Although compilation works for rocm targets, I was not able to check for any runtime problems. I don't expect any problems, but better to be sure. 