### PR TITLE
Add --rocm-path argument when compiling for HIP

### DIFF
--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -556,6 +556,10 @@ class hip_invocation:
     flags = [
         "-x", "hip",
         "--hip-device-lib-path=" + os.path.join(self._rocm_path, "lib"),
+        #--rocm-path is not yet supported by clang 10
+        #"--rocm-path=" + self._rocm_path, use -nogpuinc instead
+        # as we already handle includes
+        "-nogpuinc",
         "-D__HIPSYCL_ENABLE_HIP_TARGET__",
         "-D__HIPSYCL_CLANG__",
         # clang erroneously sets feature detection flags for 


### PR DESCRIPTION
Compile with `--rocm-path` when targeting ROCm.
It seems that newer clang versions need this, e.g. the clang 11 as shipped on Arch Linux.

EDIT: clang 10 supports neither `--rocm-path` nor the alternative `-nogpuinc`. This puts us in a difficult spot as clang 11 seems to require those arguments.

@sbalint98 This may be relevant for your work on syclcc.