### PR TITLE
Disable clang 12 in CI due to unrelated clang ICE

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        clang_version: [10, 11, 12]
+        clang_version: [10, 11]
         rocm_version: [3.8]
         os: [ubuntu-20.04, ubuntu-18.04]
         cuda: [10.0, 10.2, 11.0]


### PR DESCRIPTION
It seems clang 12 was recently updated in the apt.llvm.org repos, and it now segfaults when compiling our unit tests. Since nothing from hipSYCL appears in the stack trace, I assume that it is unrelated and simply caused by instability of clang 12 (which is still unreleased and in development, so entirely possible).

This PR disables clang 12 in CI.