### PR TITLE
Use std::promise for omp_node_event instead of busy wait

### DIFF
--- a/include/hipSYCL/runtime/omp/omp_event.hpp
+++ b/include/hipSYCL/runtime/omp/omp_event.hpp
@@ -28,13 +28,39 @@
 #ifndef HIPSYCL_OMP_EVENT_HPP
 #define HIPSYCL_OMP_EVENT_HPP
 
-#include <atomic>
+#include <future>
+#include <chrono>
 
 #include "../event.hpp"
 
 namespace hipsycl {
 namespace rt {
 
+class signal_channel {
+public:
+  signal_channel() {
+    _shared_future = _promise.get_future().share();
+  }
+
+  void signal() {
+    _promise.set_value(true);
+  }
+
+  void wait() {
+    auto future = _shared_future;
+    future.wait();
+  }
+
+  bool has_signalled() const {
+    auto future = _shared_future;
+    return future.wait_for(std::chrono::seconds(0)) ==
+           std::future_status::ready;
+  }
+
+private:
+  std::promise<bool> _promise;
+  std::shared_future<bool> _shared_future;
+};
 
 class omp_node_event : public dag_node_event
 {
@@ -46,9 +72,10 @@ public:
   virtual bool is_complete() const override;
   virtual void wait() override;
 
-  std::shared_ptr<std::atomic<bool>> get_completion_flag() const;
+  std::shared_ptr<signal_channel> get_signal_channel() const;
 private:
-  std::shared_ptr<std::atomic<bool>> _is_complete;
+
+  std::shared_ptr<signal_channel> _signal_channel;
 };
 
 

--- a/src/runtime/omp/omp_event.cpp
+++ b/src/runtime/omp/omp_event.cpp
@@ -27,27 +27,28 @@
 
 #include "hipSYCL/runtime/omp/omp_event.hpp"
 
+
 namespace hipsycl {
 namespace rt {
 
 omp_node_event::omp_node_event()
-: _is_complete{std::make_shared<std::atomic<bool>>(false)}
+: _signal_channel{std::make_shared<signal_channel>()}
 {}
 
 omp_node_event::~omp_node_event()
 {}
 
 bool omp_node_event::is_complete() const {
-  return _is_complete->load();
+  return _signal_channel->has_signalled();
 }
 
 void omp_node_event::wait() {
-  while(!_is_complete->load()) ;
+  _signal_channel->wait();
 }
 
-std::shared_ptr<std::atomic<bool>> 
-omp_node_event::get_completion_flag() const {
-  return _is_complete;
+std::shared_ptr<signal_channel>
+omp_node_event::get_signal_channel() const {
+  return _signal_channel;
 }
 
 }

--- a/src/runtime/omp/omp_queue.cpp
+++ b/src/runtime/omp/omp_queue.cpp
@@ -82,10 +82,10 @@ std::unique_ptr<dag_node_event> omp_queue::insert_event() {
   HIPSYCL_DEBUG_INFO << "omp_queue: Inserting event into queue..." << std::endl;
   
   auto evt = std::make_unique<omp_node_event>();
-  auto completion_flag = evt->get_completion_flag();
+  auto signal_channel = evt->get_signal_channel();
 
-  _worker([completion_flag]{
-    completion_flag->store(true);
+  _worker([signal_channel]{
+    signal_channel->signal();
   });
 
   return evt;


### PR DESCRIPTION
The old implementation of `omp_node_event` was using a spin lock. For CPU backends, this is not a good strategy as it can lead to reduced performance for simultaneously running kernels. This PR uses `std::promise/future` instead as the next best thing in order to mitigate such performance issues.