### PR TITLE
Fix multi-gpu device handling

### DIFF
--- a/src/runtime/cuda/cuda_device_manager.cpp
+++ b/src/runtime/cuda/cuda_device_manager.cpp
@@ -27,6 +27,7 @@
 
 #include <cuda_runtime_api.h>
 
+#include "hipSYCL/common/debug.hpp"
 #include "hipSYCL/runtime/cuda/cuda_device_manager.hpp"
 #include "hipSYCL/runtime/error.hpp"
 
@@ -48,6 +49,10 @@ cuda_device_manager::cuda_device_manager() {
 void cuda_device_manager::activate_device(int device_id)
 {
   if (_device != device_id) {
+
+    HIPSYCL_DEBUG_INFO << "cuda_device_manager: Switchting to device "
+                       << device_id << std::endl;
+
     auto err = cudaSetDevice(device_id);
 
     if (err != cudaSuccess){
@@ -56,6 +61,9 @@ void cuda_device_manager::activate_device(int device_id)
         error_info{
             "cuda_device_manager: Could not set active CUDA device",
             error_code{"CUDA", err}});
+    }
+    else {
+      _device = device_id;
     }
   }
 }

--- a/src/runtime/cuda/cuda_queue.cpp
+++ b/src/runtime/cuda/cuda_queue.cpp
@@ -93,6 +93,8 @@ cuda_queue::~cuda_queue() {
 
 /// Inserts an event into the stream
 std::unique_ptr<dag_node_event> cuda_queue::insert_event() {
+  this->activate_device();
+
   cudaEvent_t evt;
   cudaError_t err = cudaEventCreate(&evt);
 

--- a/src/runtime/hip/hip_device_manager.cpp
+++ b/src/runtime/hip/hip_device_manager.cpp
@@ -25,6 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "hipSYCL/common/debug.hpp"
 #include "hipSYCL/runtime/hip/hip_device_manager.hpp"
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/hip/hip_target.hpp"
@@ -47,6 +48,10 @@ hip_device_manager::hip_device_manager() {
 void hip_device_manager::activate_device(int device_id)
 {
   if (_device != device_id) {
+
+    HIPSYCL_DEBUG_INFO << "hip_device_manager: Switchting to device "
+                       << device_id << std::endl;
+
     auto err = hipSetDevice(device_id);
 
     if (err != hipSuccess){
@@ -55,6 +60,8 @@ void hip_device_manager::activate_device(int device_id)
         error_info{
             "hip_device_manager: Could not set active HIP device",
             error_code{"HIP", err}});
+    } else {
+      _device = device_id;
     }
   }
 }

--- a/src/runtime/hip/hip_queue.cpp
+++ b/src/runtime/hip/hip_queue.cpp
@@ -89,6 +89,8 @@ hip_queue::~hip_queue() {
 
 /// Inserts an event into the stream
 std::unique_ptr<dag_node_event> hip_queue::insert_event() {
+  this->activate_device();
+
   hipEvent_t evt;
   hipError_t err = hipEventCreate(&evt);
 


### PR DESCRIPTION
There was a bug preventing hipSYCL from working correctly with multiple GPUs. This PR fixes this:
* Fix missing assignment of updated active device in CUDA/HIP device manager
* Fix missing device activation before constructing an event

With this PR, I can run the multigpu nstream from PRK on two CUDA GPUs. Result validation fails with 4 GPUs, but I believe this is because PRK's calculation of the offsets for the decomposed buffers assigned to individual GPUs seems incorrect to me - ping @jeffhammond

CC @psath - I believe this might fix your multi-GPU issue, but unfortunately I only have a single AMD GPU for testing and can only do multi-GPU testing on NVIDIA.