### PR TITLE
Make omp iterate functions noexcept

### DIFF
--- a/include/hipSYCL/glue/generic/host/iterate_range.hpp
+++ b/include/hipSYCL/glue/generic/host/iterate_range.hpp
@@ -38,7 +38,7 @@ namespace glue {
 namespace host {
 
 template <int Dim, class Function>
-void iterate_range(sycl::range<Dim> r, Function f) {
+void iterate_range(sycl::range<Dim> r, Function f) noexcept {
 
   if constexpr (Dim == 1) {
     for (std::size_t i = 0; i < r.get(0); ++i) {
@@ -62,7 +62,8 @@ void iterate_range(sycl::range<Dim> r, Function f) {
 }
 
 template <int Dim, class Function>
-void iterate_range(sycl::id<Dim> offset, sycl::range<Dim> r, Function f) {
+void iterate_range(sycl::id<Dim> offset, sycl::range<Dim> r,
+                   Function f) noexcept {
 
   const std::size_t min_i = offset.get(0);
   const std::size_t max_i = offset.get(0) + r.get(0);
@@ -98,7 +99,7 @@ void iterate_range(sycl::id<Dim> offset, sycl::range<Dim> r, Function f) {
 
 template <int Dim, class Function>
 void iterate_partial_range(sycl::range<Dim> whole_range, sycl::id<Dim> begin,
-                           std::size_t num_elements, Function f) {
+                           std::size_t num_elements, Function f) noexcept {
 
   if constexpr (Dim == 1) {
     for (std::size_t i = begin.get(0); i < begin.get(0) + num_elements; ++i) {
@@ -140,7 +141,6 @@ void iterate_partial_range(sycl::range<Dim> whole_range, sycl::id<Dim> begin,
     }
   }
 }
-
 }
 }
 } // namespace hipsycl

--- a/include/hipSYCL/glue/omp/omp_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/omp/omp_kernel_launcher.hpp
@@ -58,7 +58,7 @@ namespace omp_dispatch {
 
 
 template <int Dim, class Function>
-void iterate_range_omp_for(sycl::range<Dim> r, Function f) {
+void iterate_range_omp_for(sycl::range<Dim> r, Function f) noexcept {
 
   if constexpr (Dim == 1) {
     #pragma omp for
@@ -86,7 +86,7 @@ void iterate_range_omp_for(sycl::range<Dim> r, Function f) {
 
 template <int Dim, class Function>
 void iterate_range_omp_for(sycl::id<Dim> offset, sycl::range<Dim> r,
-                           Function f) {
+                           Function f) noexcept {
 
   const std::size_t min_i = offset.get(0);
   const std::size_t max_i = offset.get(0) + r.get(0);


### PR DESCRIPTION
Make iterate functions used inside kernels to loop across groups/work items noexcept. This can lead to a modest speedup in some cases.