### PR TITLE
Bump cmake version to 3.12 for the tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(hipsycl-tests)
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 
 set(Boost_USE_STATIC_LIBS off)
 set(BUILD_SHARED_LIBS on)


### PR DESCRIPTION
We should bump the minimum cmake version from 3.5 to 3.12 for the tests, since `list(JOIN ...)` is [used](https://github.com/illuhad/hipSYCL/blob/2b5132ab34ee4c1a0961b7b676b133f244fec04d/cmake/hipsycl-config.cmake.in#L30) in the CMake integration. Therefore we should bump the minimum required version to 3.12.
Note that the cmake from the ubuntu 18.04 repo is 3.10.