### PR TITLE
Fix linker flags order for GNU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,11 +28,11 @@ find_package(HIP QUIET HINTS ${ROCM_PATH} ${ROCM_PATH}/lib/cmake)
 
 # In case HIP is not found via the cmake pkgs we fall back to the legacy rocm discovery:
 if (NOT HIP_FOUND)
-  message(STATUS "Could not find hip cmake integration falling back to finding hipcc")
+  message(STATUS "Could not find HIP cmake integration, falling back to finding hipcc")
   find_program(HIPCC_COMPILER NAMES hipcc HINTS ${ROCM_PATH})
   set(ROCM_PATH /opt/rocm CACHE PATH "Path to ROCm installation")
   if(HIPCC_COMPILER MATCHES "-NOTFOUND")
-    message(STATUS "Could not find rocm install with looking for hpcc. No rocm")
+    message(STATUS "Could not find ROCm installation by looking for hipcc. ROCm support unavailable.")
     set(ROCM_FOUND false)
   else()
     set(ROCM_FOUND true)

--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -748,10 +748,11 @@ class compiler:
     args = []
     if self._requires_compilation:
       args += cxx_flags
-    if self._requires_linking:
-      args += ld_flags
 
     args += self._user_args
+
+    if self._requires_linking:
+      args += ld_flags
 
     return run_or_print([compiler_executable] + args,
                         self._is_dry_run)


### PR DESCRIPTION
GNU ld/gcc needs to have the linked libraries after the source files for which they are needed. This was not taken into account, so using gcc as host compiler was broken. This PR fixes this.

Additionally fixes some minor typos in the cmake message output.