### PR TITLE
fixed overflow in group-function tests

### DIFF
--- a/tests/sycl/group_functions/group_functions.hpp
+++ b/tests/sycl/group_functions/group_functions.hpp
@@ -177,28 +177,16 @@ T get_offset(size_t margin, size_t divisor = 1) {
   }
 
   if constexpr (std::is_signed_v<T>) {
-    return static_cast<T>(std::numeric_limits<T>::min() / divisor + margin);
+    return static_cast<T>(std::numeric_limits<T>::min() / divisor + margin + 1);
   }
-  return static_cast<T>(std::numeric_limits<T>::max() / divisor - margin);
+  return static_cast<T>(std::numeric_limits<T>::max() / divisor - margin - 1);
 }
 
 template<typename T, typename std::enable_if_t<!std::is_arithmetic_v<T>, int> = 0>
 HIPSYCL_KERNEL_TARGET
 T get_offset(size_t margin, size_t divisor = 1) {
   using eT = elementType<T>;
-  if (std::numeric_limits<eT>::max() <= margin) {
-    return T{};
-  }
-  if constexpr (std::is_floating_point_v<eT>) {
-    return T{};
-  }
-
-  if constexpr (std::is_signed_v<T>) {
-    return initialize_type<T>(
-        static_cast<eT>(std::numeric_limits<eT>::min() / divisor + margin));
-  }
-  return initialize_type<T>(
-      static_cast<eT>(std::numeric_limits<eT>::max() / divisor - margin));
+  return initialize_type<T>(get_offset<eT>(margin + 16, divisor));
 }
 
 template<typename T>

--- a/tests/sycl/group_functions/group_functions_reduce.cpp
+++ b/tests/sycl/group_functions/group_functions_reduce.cpp
@@ -31,6 +31,55 @@
 
 BOOST_FIXTURE_TEST_SUITE(group_functions_tests, reset_device_fixture)
 
+BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce_mul, T, test_types) {
+  const size_t local_size     = 256;
+  const size_t global_size    = 1024;
+  const size_t local_size_x   = 16;
+  const size_t local_size_y   = 16;
+  const size_t global_size_x  = 32;
+  const size_t global_size_y  = 32;
+  const size_t offset_margin  = global_size;
+  const size_t offset_divisor = 1;
+  const size_t buffer_size    = global_size;
+  const auto data_generator   = [](std::vector<T> &v) {
+    for (size_t i = 0; i < v.size(); ++i)
+      v[i] = (i < 0) ? T{static_cast<T>(2)} : T{static_cast<T>(1)};
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_reduce(g, local_value, std::multiplies<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        T expected = vOrig[i * local_size];
+        for (size_t j = 1; j < local_size; ++j)
+          expected = expected * vOrig[i * local_size + j];
+
+        T computed = vIn[i * local_size];
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected)
+                       << " for case: no init multiplication");
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+}
+
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce, T, test_types) {
   const size_t local_size     = 256;
   const size_t global_size    = 1024;
@@ -64,39 +113,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce, T, test_types) {
                    detail::type_to_string(computed)
                        << " at position " << i << " instead of "
                        << detail::type_to_string(expected) << " for case: no init");
-        if (!detail::compare_type(expected, computed))
-          break;
-      }
-    };
-
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
-
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
-  }
-
-  if constexpr (!std::is_floating_point<T>::value) {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_reduce(g, local_value, std::multiplies<T>());
-    };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
-      for (size_t i = 0; i < global_size / local_size; ++i) {
-        T expected = vOrig[i * local_size];
-        for (size_t j = 1; j < local_size; ++j)
-          expected = expected * vOrig[i * local_size + j];
-
-        T computed = vIn[i * local_size];
-        BOOST_TEST(detail::compare_type(expected, computed),
-                   detail::type_to_string(computed)
-                       << " at position " << i << " instead of "
-                       << detail::type_to_string(expected)
-                       << " for case: no init multiplication");
         if (!detail::compare_type(expected, computed))
           break;
       }
@@ -156,7 +172,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce_ptr, T, test_types) {
   const size_t global_size_y  = 32;
   const size_t buffer_size    = global_size * 3;
   const size_t offset_margin  = buffer_size;
-  const size_t offset_divisor = buffer_size;
+  const size_t offset_divisor = local_size * 2;
   const auto data_generator   = [](std::vector<T> &v) {
     for (size_t i = 0; i < v.size(); ++i)
       v[i] = detail::initialize_type<T>(i) +

--- a/tests/sycl/group_functions/group_functions_scan.cpp
+++ b/tests/sycl/group_functions/group_functions_scan.cpp
@@ -31,6 +31,62 @@
 
 BOOST_FIXTURE_TEST_SUITE(group_functions_tests, reset_device_fixture)
 
+BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan_mul, T, test_types) {
+  const size_t local_size     = 256;
+  const size_t global_size    = 1024;
+  const size_t local_size_x   = 16;
+  const size_t local_size_y   = 16;
+  const size_t global_size_x  = 32;
+  const size_t global_size_y  = 32;
+  const size_t offset_margin  = global_size;
+  const size_t offset_divisor = global_size;
+  const size_t buffer_size    = global_size;
+  const auto data_generator   = [](std::vector<T> &v) {
+    for (size_t i = 0; i < global_size; ++i)
+      v[i] = (i < 0) ? T{static_cast<T>(2)} : T{static_cast<T>(1)};
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_exclusive_scan(g, local_value, detail::initialize_type<T>(10),
+                                     std::multiplies<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      std::vector<T> expected(vOrig.size());
+
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        expected[i * local_size] = detail::initialize_type<T>(10);
+        for (size_t j = 1; j < local_size; ++j)
+          expected[i * local_size + j] =
+              expected[i * local_size + j - 1] * vOrig[i * local_size + j - 1];
+
+        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
+          T computed = vIn[j];
+          BOOST_TEST(detail::compare_type(expected[j], computed),
+                     detail::type_to_string(computed)
+                         << " at position " << j << " instead of "
+                         << detail::type_to_string(expected[j])
+                         << " for case: init multiplication in group " << i);
+          if (!detail::compare_type(expected[j], computed))
+            break;
+        }
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+}
+
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan, T, test_types) {
   const size_t local_size     = 256;
   const size_t global_size    = 1024;
@@ -125,46 +181,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan, T, test_types) {
                                            buffer_size, data_generator, tested_function,
                                            validation_function);
   }
-
-  if constexpr (!std::is_floating_point<T>::value) {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      acc[global_linear_id] =
-          sycl::group_exclusive_scan(g, local_value, detail::initialize_type<T>(10),
-                                     std::multiplies<T>());
-    };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
-      std::vector<T> expected(vOrig.size());
-
-      for (size_t i = 0; i < global_size / local_size; ++i) {
-        expected[i * local_size] = detail::initialize_type<T>(10);
-        for (size_t j = 1; j < local_size; ++j)
-          expected[i * local_size + j] =
-              expected[i * local_size + j - 1] * vOrig[i * local_size + j - 1];
-
-        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
-          T computed = vIn[j];
-          BOOST_TEST(detail::compare_type(expected[j], computed),
-                     detail::type_to_string(computed)
-                         << " at position " << j << " instead of "
-                         << detail::type_to_string(expected[j])
-                         << " for case: init multiplication in group " << i);
-          if (!detail::compare_type(expected[j], computed))
-            break;
-        }
-      }
-    };
-
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
-
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
-  }
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan_ptr, T, test_types) {
@@ -175,8 +191,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan_ptr, T, test_types) {
   const size_t global_size_x  = 32;
   const size_t global_size_y  = 32;
   const size_t buffer_size    = global_size * 4;
-  const size_t offset_margin  = global_size * 2;
-  const size_t offset_divisor = global_size * 2;
+  const size_t offset_margin  = global_size;
+  const size_t offset_divisor = local_size * 2;
   const auto data_generator   = [](std::vector<T> &v) {
     for (size_t i = 0; i < global_size; ++i)
       v[i] = detail::initialize_type<T>(i) +
@@ -359,6 +375,61 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_exclusive_scan, T, test_types) {
 }
 #endif
 
+BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan_mul, T, test_types) {
+  const size_t local_size     = 256;
+  const size_t global_size    = 1024;
+  const size_t local_size_x   = 16;
+  const size_t local_size_y   = 16;
+  const size_t global_size_x  = 32;
+  const size_t global_size_y  = 32;
+  const size_t offset_margin  = global_size;
+  const size_t offset_divisor = global_size;
+  const size_t buffer_size    = global_size;
+  const auto data_generator   = [](std::vector<T> &v) {
+    for (size_t i = 0; i < global_size; ++i)
+      v[i] = (i < 0) ? T{static_cast<T>(2)} : T{static_cast<T>(1)};
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_inclusive_scan(g, local_value, std::multiplies<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig) {
+      std::vector<T> expected(vOrig.size());
+
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        expected[i * local_size] = vOrig[i * local_size];
+        for (size_t j = 1; j < local_size; ++j)
+          expected[i * local_size + j] =
+              expected[i * local_size + j - 1] * vOrig[i * local_size + j];
+
+        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
+          T computed = vIn[j];
+          BOOST_TEST(detail::compare_type(expected[j], computed),
+                     detail::type_to_string(computed)
+                         << " at position " << j << " instead of "
+                         << detail::type_to_string(expected[j])
+                         << " for case: no init multiplication in group " << i);
+          if (!detail::compare_type(expected[j], computed))
+            break;
+        }
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
+                                           offset_divisor, buffer_size, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
+                                           global_size_y, offset_margin, offset_divisor,
+                                           buffer_size, data_generator, tested_function,
+                                           validation_function);
+  }
+}
+
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan, T, test_types) {
   const size_t local_size     = 256;
   const size_t global_size    = 1024;
@@ -397,45 +468,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan, T, test_types) {
                          << " at position " << j << " instead of "
                          << detail::type_to_string(expected[j])
                          << " for case: no init in group " << i);
-          if (!detail::compare_type(expected[j], computed))
-            break;
-        }
-      }
-    };
-
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
-
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
-  }
-
-  if constexpr (!std::is_floating_point<T>::value) {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      acc[global_linear_id] =
-          sycl::group_inclusive_scan(g, local_value, std::multiplies<T>());
-    };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
-      std::vector<T> expected(vOrig.size());
-
-      for (size_t i = 0; i < global_size / local_size; ++i) {
-        expected[i * local_size] = vOrig[i * local_size];
-        for (size_t j = 1; j < local_size; ++j)
-          expected[i * local_size + j] =
-              expected[i * local_size + j - 1] * vOrig[i * local_size + j];
-
-        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
-          T computed = vIn[j];
-          BOOST_TEST(detail::compare_type(expected[j], computed),
-                     detail::type_to_string(computed)
-                         << " at position " << j << " instead of "
-                         << detail::type_to_string(expected[j])
-                         << " for case: no init multiplication in group " << i);
           if (!detail::compare_type(expected[j], computed))
             break;
         }
@@ -501,8 +533,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan_ptr, T, test_types) {
   const size_t global_size_x  = 32;
   const size_t global_size_y  = 32;
   const size_t buffer_size    = global_size * 4;
-  const size_t offset_margin  = global_size * 2;
-  const size_t offset_divisor = global_size * 2;
+  const size_t offset_margin  = global_size;
+  const size_t offset_divisor = local_size * 2;
   const auto data_generator   = [](std::vector<T> &v) {
     for (size_t i = 0; i < global_size; ++i)
       v[i] = detail::initialize_type<T>(i) +


### PR DESCRIPTION
The changes in `group_functions.hpp` are mostly quality of life changes.
The diffs for the reduce/scan tests go crazy, but I only extracted the tests using multiplication and put them into their own test-case and replacing the data generator with one, that is 1 almost everywhere. Also since the multiplication-tests doesn't overflow anymore I don't need to disable float anymore :tada: