### PR TITLE
deferred_pointer debug output: Cast pointer to void* before printing to avoid dereferencing with T=char

### DIFF
--- a/include/hipSYCL/glue/deferred_pointer.hpp
+++ b/include/hipSYCL/glue/deferred_pointer.hpp
@@ -94,7 +94,8 @@ private:
       T *target_ptr = *reinterpret_cast<T**>(_ptr);
       if (target_ptr){
         
-        HIPSYCL_DEBUG_INFO << "deferred_pointer: Initialized to " << target_ptr
+        HIPSYCL_DEBUG_INFO << "deferred_pointer: Initialized to "
+                           << static_cast<void*>(target_ptr)
                            << std::endl;
 
         _ptr = target_ptr;


### PR DESCRIPTION
Fixes #424 

When `HIPSYCL_DEBUG_LEVEL=3`, the `deferred_pointer<T>` will print the value it was initialized to as part of diagnostic output. This pointer is of type `T*`, so if `T=char`, this will result in an attempt to interpret it as C-String and dereference it. If it is a device pointer, this will fail spectacularly.

This PR fixes this by casting the pointer to `void*`.