### PR TITLE
Implement queue profiling

### DIFF
--- a/include/hipSYCL/runtime/dag_node.hpp
+++ b/include/hipSYCL/runtime/dag_node.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2019 Aksel Alpay
+ * Copyright (c) 2019-2020 Aksel Alpay and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,6 +30,7 @@
 
 #include <memory>
 #include <atomic>
+#include <future>
 
 #include "hints.hpp"
 #include "event.hpp"

--- a/include/hipSYCL/runtime/hints.hpp
+++ b/include/hipSYCL/runtime/hints.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2019 Aksel Alpay
+ * Copyright (c) 2019-2020 Aksel Alpay and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -52,6 +52,7 @@ enum class execution_hint_type
   // Mark a DAG node as explicitly requiring another node
   // (TODO: not yet implemented)
   explicit_require,
+  enable_profiling,
 };
 
 class execution_hint
@@ -84,7 +85,7 @@ public:
   static constexpr execution_hint_type type = 
     execution_hint_type::bind_to_device;
 
-  bind_to_device(device_id d);
+  explicit bind_to_device(device_id d);
 
   device_id get_device_id() const;
 private:
@@ -97,12 +98,20 @@ public:
   static constexpr execution_hint_type type = 
     execution_hint_type::explicit_require;
 
-  explicit_require(dag_node_ptr node);
+  explicit explicit_require(dag_node_ptr node);
 
   dag_node_ptr get_requirement() const;
 
 private:
   dag_node_ptr _dag_node;
+};
+
+class enable_profiling : public execution_hint
+{
+public:
+  static constexpr execution_hint_type type = execution_hint_type::enable_profiling;
+
+  enable_profiling();
 };
 
 } // hints

--- a/include/hipSYCL/runtime/hip/hip_event.hpp
+++ b/include/hipSYCL/runtime/hip/hip_event.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2019 Aksel Alpay
+ * Copyright (c) 2019-2020 Aksel Alpay and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,14 +34,20 @@
 namespace hipsycl {
 namespace rt {
 
+struct hip_event_deleter {
+  void operator()(hipEvent_t evt) const;
+};
+
 /// Manages a hipEvent_t.
+using hip_unique_event = std::unique_ptr<ihipEvent_t, hip_event_deleter>;
+
+hip_unique_event make_hip_event();
+
 class hip_node_event : public dag_node_event
 {
 public:
-  /// Takes ownership of supplied hipEvent_t. \c evt Must
-  /// have been properly initialized and recorded.
-  hip_node_event(device_id dev, hipEvent_t evt);
-  ~hip_node_event();
+  /// \c evt Must have been properly initialized and recorded.
+  hip_node_event(device_id dev, hip_unique_event evt);
 
   virtual bool is_complete() const override;
   virtual void wait() override;
@@ -50,7 +56,7 @@ public:
   device_id get_device() const;
 private:
   device_id _dev;
-  hipEvent_t _evt;
+  hip_unique_event _evt;
 };
 
 }

--- a/include/hipSYCL/runtime/hip/hip_instrumentation.hpp
+++ b/include/hipSYCL/runtime/hip/hip_instrumentation.hpp
@@ -25,44 +25,51 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef HIPSYCL_CUDA_EVENT_HPP
-#define HIPSYCL_CUDA_EVENT_HPP
+#ifndef HIPSYCL_HIP_INSTRUMENTATION_HPP
+#define HIPSYCL_HIP_INSTRUMENTATION_HPP
 
-#include "../event.hpp"
-
-// Note: CUevent_st* == cudaEvent_t 
-struct CUevent_st;
+#include "hip_event.hpp"
+#include "../instrumentation.hpp"
 
 namespace hipsycl {
 namespace rt {
 
-struct cuda_event_deleter {
-  void operator()(CUevent_st *evt) const;
-};
-
-/// Manages a cudaEvent_t.
-using cuda_unique_event = std::unique_ptr<CUevent_st, cuda_event_deleter>;
-
-cuda_unique_event make_cuda_event();
-
-class cuda_node_event : public dag_node_event
+class hip_timestamp_profiler final : public timestamp_profiler
 {
 public:
-  /// \c evt Must have been properly initialized and recorded.
-  cuda_node_event(device_id dev, cuda_unique_event evt);
+  // host and device "timestamps" for converting relative time measurements
+  // from hipEventElapsedTime to absolute profiler_clock times
+  class baseline {
+  public:
+    // precondition: activate device
+    static baseline record(hipStream_t stream);
 
-  virtual bool is_complete() const override;
-  virtual void wait() override;
+    hipEvent_t get_device_event() const { return _device_event.get(); }
+    profiler_clock::time_point get_host_time() const { return _host_time; }
 
-  CUevent_st* get_event() const;
-  device_id get_device() const;
+  private:
+    hip_unique_event _device_event;
+    profiler_clock::time_point _host_time;
+  };
+
+  // queue_created_device and queue_created_host must represent the same instance in time.
+  // queue_create_device must be recorded and synchronized already.
+  explicit hip_timestamp_profiler(const baseline *b);
+
+  // precondition: activate device
+  void record_before_operation(hipStream_t stream);
+  void record_after_operation(hipStream_t stream);
+
+  virtual profiler_clock::time_point await_event(event event) const override;
+
 private:
-  device_id _dev;
-  cuda_unique_event _evt;
+  const baseline *_baseline;  // shared, owned by the hip_queue
+  profiler_clock::time_point _operation_submitted;
+  hip_unique_event _operation_started;
+  hip_unique_event _operation_finished;
 };
 
 }
 }
-
 
 #endif

--- a/include/hipSYCL/runtime/hip/hip_queue.hpp
+++ b/include/hipSYCL/runtime/hip/hip_queue.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2019 Aksel Alpay
+ * Copyright (c) 2019-2020 Aksel Alpay and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,10 +31,10 @@
 #include "../executor.hpp"
 #include "../inorder_queue.hpp"
 #include "hip_target.hpp"
+#include "hip_instrumentation.hpp"
 
 namespace hipsycl {
 namespace rt {
-
 
 class hip_queue : public inorder_queue
 {
@@ -48,10 +48,10 @@ public:
   /// Inserts an event into the stream
   virtual std::unique_ptr<dag_node_event> insert_event() override;
 
-  virtual result submit_memcpy(const memcpy_operation&) override;
-  virtual result submit_kernel(const kernel_operation&) override;
-  virtual result submit_prefetch(const prefetch_operation &) override;
-  virtual result submit_memset(const memset_operation&) override;
+  virtual result submit_memcpy(memcpy_operation&) override;
+  virtual result submit_kernel(kernel_operation&) override;
+  virtual result submit_prefetch(prefetch_operation &) override;
+  virtual result submit_memset(memset_operation&) override;
   
   /// Causes the queue to wait until an event on another queue has occured.
   /// the other queue must be from the same backend
@@ -61,9 +61,13 @@ public:
   device_id get_device() const { return _dev; }
 private:
   void activate_device() const;
-  
+
+  std::unique_ptr<hip_timestamp_profiler> begin_profiling(const operation &op) const;
+  void finish_profiling(operation &op, std::unique_ptr<hip_timestamp_profiler> profiler) const;
+
   device_id _dev;
   hipStream_t _stream;
+  hip_timestamp_profiler::baseline _profiler_baseline;
 };
 
 }

--- a/include/hipSYCL/runtime/inorder_queue.hpp
+++ b/include/hipSYCL/runtime/inorder_queue.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2019 Aksel Alpay
+ * Copyright (c) 2019-2020 Aksel Alpay and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -45,10 +45,10 @@ public:
   /// Inserts an event into the stream
   virtual std::unique_ptr<dag_node_event> insert_event() = 0;
 
-  virtual result submit_memcpy(const memcpy_operation&) = 0;
-  virtual result submit_kernel(const kernel_operation&) = 0;
-  virtual result submit_prefetch(const prefetch_operation &) = 0;
-  virtual result submit_memset(const memset_operation&) = 0;
+  virtual result submit_memcpy(memcpy_operation&) = 0;
+  virtual result submit_kernel(kernel_operation&) = 0;
+  virtual result submit_prefetch(prefetch_operation &) = 0;
+  virtual result submit_memset(memset_operation&) = 0;
   
   /// Causes the queue to wait until an event on another queue has occured.
   /// the other queue must be from the same backend

--- a/include/hipSYCL/runtime/instrumentation.hpp
+++ b/include/hipSYCL/runtime/instrumentation.hpp
@@ -1,0 +1,135 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2019-2020 Aksel Alpay and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HIPSYCL_INSTRUMENTATION_HPP
+#define HIPSYCL_INSTRUMENTATION_HPP
+
+#include <cstdint>
+#include <chrono>
+#include <future>
+#include <unordered_map>
+#include <typeindex>
+#include <type_traits>
+
+namespace hipsycl {
+namespace rt {
+
+// SYCL defines timestamps as uint64_t with nanosecond resolution
+class profiler_clock {
+public:
+  using rep = uint64_t;
+  using period = std::nano;
+  using duration = std::chrono::duration<rep, period>;
+  using time_point = std::chrono::time_point<profiler_clock>;
+
+  constexpr static bool is_steady = true;
+
+  static time_point now() {
+    return time_point{duration{std::chrono::steady_clock::now().time_since_epoch()}};
+  }
+};
+
+class instrumentation {
+public:
+  virtual ~instrumentation() = default;
+};
+
+template<typename T>
+inline constexpr bool is_instrumentation_v
+    = std::is_convertible_v<std::remove_cv_t<T> *, instrumentation *>;
+
+// Provides synchronization points for instrumentations between front- and backend threads.
+//
+// Thread safety: Before submission - single-threaded access only
+//                After submission: - concurrent access, but do not call instrument<>()
+class instrumentation_set {
+public:
+  // Create a producer-consumer channel for a particular instrumentation
+  template<typename Instr>
+  void instrument() {
+    static_assert(is_instrumentation_v<Instr>);
+    if (_instrs.find(typeid(Instr)) == _instrs.end()) {
+      _instrs.emplace(typeid(Instr), future_instrumentation{});
+    }
+  }
+
+  // Whether instrument<Instr>() has been called before.
+  template<typename Instr>
+  bool is_instrumented() const {
+    static_assert(is_instrumentation_v<Instr>);
+    return _instrs.find(typeid(Instr)) != _instrs.end();
+  }
+
+  // Resolve the instrument<Instr>() promise by providing an instrumentation instance.
+  // instrument<Instr>() must have been called before submission.
+  template<typename Instr, typename T>
+  void provide(std::unique_ptr<T> instr) {
+    static_assert(is_instrumentation_v<Instr>);
+    static_assert(std::is_convertible_v<T*, Instr*>);
+    _instrs.at(typeid(Instr)).provide(std::move(instr));
+  }
+
+  // Wait until another thread provide()s an instance of Instr.
+  // instrument<Instr>() must have been called before submission.
+  template<typename Instr> const Instr &await() const {
+    static_assert(is_instrumentation_v<Instr>);
+      // static_cast: type is statically checked in resolve()
+    return static_cast<const Instr &>(_instrs.at(typeid(Instr)).await());
+  }
+
+private:
+  class future_instrumentation {
+  public:
+    future_instrumentation(): _future{_promise.get_future()} {}
+    void provide(std::unique_ptr<instrumentation> instr) { _promise.set_value(std::move(instr)); }
+    const instrumentation &await() const { return *_future.get(); }
+
+  private:
+    std::promise<std::unique_ptr<instrumentation>> _promise;
+    std::shared_future<std::unique_ptr<instrumentation>> _future;
+  };
+
+  std::unordered_map<std::type_index, future_instrumentation> _instrs;
+};
+
+class timestamp_profiler: public instrumentation
+{
+public:
+  enum class event
+  {
+    operation_submitted,
+    operation_started,
+    operation_finished
+  };
+
+  virtual profiler_clock::time_point await_event(event) const = 0;
+};
+
+}
+}
+
+#endif

--- a/include/hipSYCL/runtime/omp/omp_queue.hpp
+++ b/include/hipSYCL/runtime/omp/omp_queue.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2020 Aksel Alpay
+ * Copyright (c) 2020 Aksel Alpay and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,6 +32,7 @@
 #include "../executor.hpp"
 #include "../inorder_queue.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
+#include "omp_instrumentation.hpp"
 
 namespace hipsycl {
 namespace rt {
@@ -45,10 +46,10 @@ public:
   /// Inserts an event into the stream
   virtual std::unique_ptr<dag_node_event> insert_event() override;
 
-  virtual result submit_memcpy(const memcpy_operation&) override;
-  virtual result submit_kernel(const kernel_operation&) override;
-  virtual result submit_prefetch(const prefetch_operation &) override;
-  virtual result submit_memset(const memset_operation&) override;
+  virtual result submit_memcpy(memcpy_operation&) override;
+  virtual result submit_kernel(kernel_operation&) override;
+  virtual result submit_prefetch(prefetch_operation &) override;
+  virtual result submit_memset(memset_operation&) override;
   
   /// Causes the queue to wait until an event on another queue has occured.
   /// the other queue must be from the same backend
@@ -59,6 +60,9 @@ public:
 private:
   backend_id _backend_id;
   worker_thread _worker;
+
+  static std::unique_ptr<omp_timestamp_profiler> begin_profiling(const operation &op);
+  static void finish_profiling(operation &op, std::unique_ptr<omp_timestamp_profiler> profiler);
 };
 
 }

--- a/include/hipSYCL/runtime/operations.hpp
+++ b/include/hipSYCL/runtime/operations.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2019-2020 Aksel Alpay
+ * Copyright (c) 2019-2020 Aksel Alpay and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -58,6 +58,8 @@ class backend_executor;
 class dag_node;
 using dag_node_ptr = std::shared_ptr<dag_node>;
 
+class instrumentation_set;
+
 class kernel_operation;
 class memcpy_operation;
 class prefetch_operation;
@@ -76,7 +78,8 @@ public:
 class operation
 {
 public:
-  virtual ~operation(){}
+  operation() noexcept;
+  virtual ~operation();
 
   virtual cost_type get_runtime_costs() { return 1.; }
   virtual bool is_requirement() const { return false; }
@@ -88,6 +91,14 @@ public:
   }
 
   virtual result dispatch(operation_dispatcher* dispatch) = 0;
+
+  bool is_instrumented() const { return _instr_set != nullptr; }
+  instrumentation_set &get_instrumentations();
+  const instrumentation_set &get_instrumentations() const;
+
+private:
+  // unique_ptr: reduce memory footprint in the non-instrumented case
+  mutable std::unique_ptr<instrumentation_set> _instr_set;
 };
 
 

--- a/include/hipSYCL/sycl/handler.hpp
+++ b/include/hipSYCL/sycl/handler.hpp
@@ -476,7 +476,7 @@ public:
       hints.overwrite_with(rt::make_execution_hint<rt::hints::bind_to_device>(
           usm_dev));
     }
-    
+
     auto op = rt::make_operation<rt::prefetch_operation>(
         ptr, num_bytes, target_dev);
 
@@ -485,7 +485,7 @@ public:
 
     _command_group_nodes.push_back(node);
   }
-  
+
   void prefetch(const void *ptr, std::size_t num_bytes) {
 
     if(!_execution_hints.has_hint<rt::hints::bind_to_device>())
@@ -503,7 +503,7 @@ public:
       // Otherwise, run prefetch on the queue's device to the
       // queue's device
       rt::dag_build_guard build{rt::application::dag()};
-      
+
       auto op = rt::make_operation<rt::prefetch_operation>(
           ptr, num_bytes, executing_dev);
 
@@ -535,7 +535,7 @@ public:
             sycl::range<3>{},
             0, f),
         _requirements);
-    
+
     rt::dag_node_ptr node = build.builder()->add_kernel(
         std::move(custom_kernel_op), _requirements, _execution_hints);
     
@@ -573,7 +573,7 @@ private:
             offset, local_range, global_range, shared_mem_size, f,
             reductions...),
         _requirements);
-    
+
     rt::dag_node_ptr node = build.builder()->add_kernel(
         std::move(kernel_op), _requirements, _execution_hints);
     

--- a/include/hipSYCL/sycl/info/event.hpp
+++ b/include/hipSYCL/sycl/info/event.hpp
@@ -29,6 +29,8 @@
 #ifndef HIPSYCL_INFO_EVENT_HPP
 #define HIPSYCL_INFO_EVENT_HPP
 
+#include <cstdint>
+
 #include "../types.hpp"
 #include "param_traits.hpp"
 
@@ -59,6 +61,10 @@ enum class event_profiling : int
 
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(event, event::command_execution_status, event_command_status);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(event, event::reference_count, detail::u_int);
+
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(event_profiling, event_profiling::command_submit, uint64_t);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(event_profiling, event_profiling::command_start, uint64_t);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(event_profiling, event_profiling::command_end, uint64_t);
 
 }
 }

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -30,6 +30,7 @@ if(WITH_CUDA_BACKEND)
   set(HIPSYCL_SOURCES ${HIPSYCL_SOURCES}
     cuda/cuda_event.cpp
     cuda/cuda_queue.cpp
+    cuda/cuda_instrumentation.cpp
     cuda/cuda_allocator.cpp
     cuda/cuda_device_manager.cpp
     cuda/cuda_hardware_manager.cpp
@@ -40,6 +41,7 @@ if(WITH_ROCM_BACKEND)
   set(HIPSYCL_SOURCES ${HIPSYCL_SOURCES}
     hip/hip_event.cpp
     hip/hip_queue.cpp
+    hip/hip_instrumentation.cpp
     hip/hip_allocator.cpp
     hip/hip_device_manager.cpp
     hip/hip_hardware_manager.cpp
@@ -52,6 +54,7 @@ if(WITH_CPU_BACKEND)
     omp/omp_backend.cpp
     omp/omp_event.cpp
     omp/omp_hardware_manager.cpp
+    omp/omp_instrumentation.cpp
     omp/omp_queue.cpp)
 endif()
 

--- a/src/runtime/cuda/cuda_instrumentation.cpp
+++ b/src/runtime/cuda/cuda_instrumentation.cpp
@@ -1,0 +1,157 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2019-2020 Aksel Alpay and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "hipSYCL/runtime/cuda/cuda_instrumentation.hpp"
+#include "hipSYCL/runtime/error.hpp"
+#include "hipSYCL/runtime/cuda/cuda_event.hpp"
+
+#include <cuda_runtime_api.h>
+
+#include <cassert>
+#include <memory>
+
+namespace hipsycl {
+namespace rt {
+
+namespace {
+
+// precondition: activate device
+cuda_unique_event async_record_event(cudaStream_t stream) {
+  auto evt = make_cuda_event();
+  if (!evt) return nullptr;
+
+  // cudaEventRecord has different semantics for null and non-null stream parameters. A null-stream
+  // will serialize the CUDA context, waiting until all streams have finished their current task
+  // before recording the event. A non-null stream will record the event as soon as the previous
+  // task in the same stream has retired.
+  // There is some discussion online about which type of call should be preferred for timing, e.g.
+  // https://stackoverflow.com/a/5846331/1522056 or https://stackoverflow.com/a/49331700/1522056.
+  // If a kernel using all GPU resources is running on another stream, passing a null-stream here
+  // avoids counting that kernel's remaining runtime towards the measured interval. However, as far
+  // as I understand, there is no guarantee for the time between two serializing events: Kernel
+  // launches from other threads could race with the kernel launch we intend to measure, and other
+  // processes on the machine might also tie up GPU resources from other contexts.
+  // Furthermore, serializing the context makes accurately profiling overlapped kernel executions
+  // and buffer transfers impossible, which a user might expect to be able to measure.
+  // I decided in favor of the non-serializing variant, which has the same semantics that can be
+  // expected when measuring CPU execution times on the host with gettimeofday() on a multicore
+  // CPU with a preempting process scheduler.
+  auto err = cudaEventRecord(evt.get(), stream);
+  if (err != cudaSuccess) {
+    register_error(__hipsycl_here(),
+                   error_info{"cuda_timestamp_profiler: cudaEventRecord() failed",
+                              error_code{"CUDA", err}});
+    return nullptr;
+  }
+
+  return evt;
+}
+
+profiler_clock::duration wait_and_measure_elapsed_time(cudaEvent_t start, cudaEvent_t end) {
+  if (!end) {
+    register_error(__hipsycl_here(), error_info{"cuda_timestamp_profiler: event not recorded"});
+  }
+
+  auto err = cudaEventSynchronize(end);
+  if (err != cudaSuccess) {
+    register_error(__hipsycl_here(),
+                   error_info{"cuda_timestamp_profiler: cudaEventSynchronize() failed",
+                              error_code{"CUDA", err}});
+  }
+
+  float ms = 0.0f;
+  err = cudaEventElapsedTime(&ms, start, end);
+  if (err != cudaSuccess) {
+    register_error(__hipsycl_here(),
+                   error_info{"cuda_timestamp_profiler: cudaEventElapsedTime() failed",
+                              error_code{"CUDA", err}});
+  }
+
+  return std::chrono::round<profiler_clock::duration>(
+      std::chrono::duration<float, std::milli>{ms});
+}
+
+}
+
+cuda_timestamp_profiler::baseline cuda_timestamp_profiler::baseline::record(cudaStream_t stream) {
+  baseline b;
+  b._device_event = async_record_event(stream);
+
+  auto err = cudaEventSynchronize(b._device_event.get());
+  if (err != cudaSuccess) {
+    register_error(__hipsycl_here(),
+                   error_info{"cuda_queue: cudaEventSynchronize() failed",
+                              error_code{"CUDA", err}});
+  }
+
+  b._host_time = profiler_clock::now();
+  return b;
+}
+
+cuda_timestamp_profiler::cuda_timestamp_profiler(const baseline *b): _baseline(b) {}
+
+void cuda_timestamp_profiler::record_before_operation(CUstream_st *stream) {
+  assert(_operation_submitted == profiler_clock::time_point{});
+  assert(_operation_started == nullptr);
+  _operation_submitted = profiler_clock::now();
+  _operation_started = async_record_event(stream);
+}
+
+void cuda_timestamp_profiler::record_after_operation(CUstream_st *stream) {
+  assert(_operation_finished == nullptr);
+  _operation_finished = async_record_event(stream);
+}
+
+profiler_clock::time_point cuda_timestamp_profiler::await_event(event event) const {
+  if (event == event::operation_submitted) {
+    // The function creating the profiler must also record the submission. This happens before
+    // yielding the profiler to the profiler_promise, so all reads on that variable can happen
+    // concurrently without synchronization.
+    assert(_operation_submitted != profiler_clock::time_point{});
+    return _operation_submitted;
+  }
+
+  auto queue_creation_to_start = wait_and_measure_elapsed_time(
+      _baseline->get_device_event(), _operation_started.get());
+  if (event == event::operation_started) {
+    return _baseline->get_host_time() + queue_creation_to_start;
+  }
+
+  // CUDA reports elapsed time as a single-precision float with 0.5 µs resolution. Since this
+  // type can only represent 7.22 decimal digits, precision will drop once the elapsed time
+  // exceeds about 10 seconds (= 1e7 µs). To allow precise measurement of run times (end - start),
+  // we measure twice and add the durations in the higher-precision profiler_clock representation.
+
+  assert(event == event::operation_finished);
+  auto start_to_end = wait_and_measure_elapsed_time(_operation_started.get(),
+                                                    _operation_finished.get());
+  return _baseline->get_host_time() + queue_creation_to_start + start_to_end;
+}
+
+}
+}
+

--- a/src/runtime/hints.cpp
+++ b/src/runtime/hints.cpp
@@ -60,6 +60,10 @@ dag_node_ptr explicit_require::get_requirement() const
   return _dag_node;
 }
 
+enable_profiling::enable_profiling()
+    : execution_hint{execution_hint_type::enable_profiling}
+{}
+
 } // hints
 
 void execution_hints::add_hint(execution_hint_ptr hint)

--- a/src/runtime/hip/hip_event.cpp
+++ b/src/runtime/hip/hip_event.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2019 Aksel Alpay
+ * Copyright (c) 2019-2020 Aksel Alpay and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,14 +31,8 @@
 namespace hipsycl {
 namespace rt {
 
-
-hip_node_event::hip_node_event(device_id dev, hipEvent_t evt)
-: _dev{dev}, _evt{evt}
-{}
-
-hip_node_event::~hip_node_event()
-{
-  auto err = hipEventDestroy(_evt);
+void hip_event_deleter::operator()(hipEvent_t evt) const {
+  auto err = hipEventDestroy(evt);
   if (err != hipSuccess) {
     register_error(__hipsycl_here(),
                    error_info{"hip_node_event: Couldn't destroy event",
@@ -46,9 +40,26 @@ hip_node_event::~hip_node_event()
   }
 }
 
+hip_unique_event make_hip_event() {
+  hipEvent_t evt;
+  if (hipError_t err = hipEventCreate(&evt); err != hipSuccess) {
+    register_error(
+        __hipsycl_here(),
+        error_info{"hip_event: Couldn't create event", error_code{"HIP", err}});
+    return nullptr;
+  } else {
+    return hip_unique_event{evt};
+  }
+}
+
+
+hip_node_event::hip_node_event(device_id dev, hip_unique_event evt)
+: _dev{dev}, _evt{std::move(evt)}
+{}
+
 bool hip_node_event::is_complete() const
 {
-  hipError_t err = hipEventQuery(_evt);
+  hipError_t err = hipEventQuery(_evt.get());
   if (err != hipErrorNotReady && err != hipSuccess) {
     register_error(__hipsycl_here(),
                    error_info{"hip_node_event: Couldn't query event status",
@@ -59,7 +70,7 @@ bool hip_node_event::is_complete() const
 
 void hip_node_event::wait()
 {
-  auto err = hipEventSynchronize(_evt);
+  auto err = hipEventSynchronize(_evt.get());
   if (err != hipSuccess) {
     register_error(__hipsycl_here(),
                    error_info{"hip_node_event: hipEventSynchronize() failed",
@@ -69,7 +80,7 @@ void hip_node_event::wait()
 
 hipEvent_t hip_node_event::get_event() const
 {
-  return _evt;
+  return _evt.get();
 }
 
 device_id hip_node_event::get_device() const

--- a/src/runtime/hip/hip_instrumentation.cpp
+++ b/src/runtime/hip/hip_instrumentation.cpp
@@ -1,0 +1,140 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2019-2020 Aksel Alpay and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "hipSYCL/runtime/hip/hip_instrumentation.hpp"
+#include "hipSYCL/runtime/error.hpp"
+#include "hipSYCL/runtime/hip/hip_event.hpp"
+
+#include <cassert>
+#include <memory>
+
+namespace hipsycl {
+namespace rt {
+
+namespace {
+
+// precondition: activate device
+hip_unique_event async_record_event(hipStream_t stream) {
+  auto evt = make_hip_event();
+  if (!evt) return nullptr;
+
+  // see cuda_instrumentation.cpp async_record_event()
+  auto err = hipEventRecord(evt.get(), stream);
+  if (err != hipSuccess) {
+    register_error(__hipsycl_here(),
+                   error_info{"hip_timestamp_profiler: hipEventRecord() failed",
+                              error_code{"HIP", err}});
+    return nullptr;
+  }
+
+  return evt;
+}
+
+profiler_clock::duration wait_and_measure_elapsed_time(hipEvent_t start, hipEvent_t end) {
+  if (!end) {
+    register_error(__hipsycl_here(), error_info{"hip_timestamp_profiler: event not recorded"});
+  }
+
+  auto err = hipEventSynchronize(end);
+  if (err != hipSuccess) {
+    register_error(__hipsycl_here(),
+                   error_info{"hip_timestamp_profiler: hipEventSynchronize() failed",
+                              error_code{"HIP", err}});
+  }
+
+  float ms = 0.0f;
+  err = hipEventElapsedTime(&ms, start, end);
+  if (err != hipSuccess) {
+    register_error(__hipsycl_here(),
+                   error_info{"hip_timestamp_profiler: hipEventElapsedTime() failed",
+                              error_code{"HIP", err}});
+  }
+
+  return std::chrono::round<profiler_clock::duration>(
+      std::chrono::duration<float, std::milli>{ms});
+}
+
+}
+
+hip_timestamp_profiler::baseline hip_timestamp_profiler::baseline::record(hipStream_t stream) {
+  baseline b;
+  b._device_event = async_record_event(stream);
+
+  auto err = hipEventSynchronize(b._device_event.get());
+  if (err != hipSuccess) {
+    register_error(__hipsycl_here(),
+                   error_info{"hip_queue: hipEventSynchronize() failed",
+                              error_code{"HIP", err}});
+  }
+
+  b._host_time = profiler_clock::now();
+  return b;
+}
+
+hip_timestamp_profiler::hip_timestamp_profiler(const baseline *b): _baseline(b) {}
+
+void hip_timestamp_profiler::record_before_operation(hipStream_t stream) {
+  assert(_operation_submitted == profiler_clock::time_point{});
+  assert(_operation_started == nullptr);
+  _operation_submitted = profiler_clock::now();
+  _operation_started = async_record_event(stream);
+}
+
+void hip_timestamp_profiler::record_after_operation(hipStream_t stream) {
+  assert(_operation_finished == nullptr);
+  _operation_finished = async_record_event(stream);
+}
+
+profiler_clock::time_point hip_timestamp_profiler::await_event(event event) const {
+  if (event == event::operation_submitted) {
+    // The function creating the profiler must also record the submission. This happens before
+    // yielding the profiler to the profiler_promise, so all reads on that variable can happen
+    // concurrently without synchronization.
+    assert(_operation_submitted != profiler_clock::time_point{});
+    return _operation_submitted;
+  }
+
+  auto queue_creation_to_start = wait_and_measure_elapsed_time(
+      _baseline->get_device_event(), _operation_started.get());
+  if (event == event::operation_started) {
+    return _baseline->get_host_time() + queue_creation_to_start;
+  }
+
+  // HIP reports elapsed time as a single-precision float with around 1 µs resolution. Since this
+  // type can only represent 7.22 decimal digits, precision will drop once the elapsed time
+  // exceeds about 10 seconds (= 1e7 µs). To allow precise measurement of run times (end - start),
+  // we measure twice and add the durations in the higher-precision profiler_clock representation.
+
+  assert(event == event::operation_finished);
+  auto start_to_end = wait_and_measure_elapsed_time(_operation_started.get(),
+                                                    _operation_finished.get());
+  return _baseline->get_host_time() + queue_creation_to_start + start_to_end;
+}
+
+}
+}
+

--- a/src/runtime/omp/omp_instrumentation.cpp
+++ b/src/runtime/omp/omp_instrumentation.cpp
@@ -1,0 +1,93 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2019-2020 Aksel Alpay and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "hipSYCL/runtime/omp/omp_instrumentation.hpp"
+#include "hipSYCL/runtime/error.hpp"
+
+#include <cassert>
+
+namespace hipsycl {
+namespace rt {
+
+inline void omp_timestamp_profiler::record(profiler_clock::time_point &event) {
+  {
+    std::lock_guard lock{_mutex};
+    assert(event == profiler_clock::time_point{});
+    event = profiler_clock::now();
+  }
+  _update.notify_all();
+}
+
+void omp_timestamp_profiler::record_submit() {
+  record(_operation_submitted);
+}
+
+void omp_timestamp_profiler::record_start() {
+  record(_operation_started);
+}
+
+void omp_timestamp_profiler::record_finish() {
+  record(_operation_finished);
+}
+
+profiler_clock::time_point omp_timestamp_profiler::await_event(event event) const {
+  const profiler_clock::time_point *wait_for;
+  switch (event) {
+    case event::operation_submitted:
+      wait_for = &_operation_submitted;
+      break;
+    case event::operation_started:
+      wait_for = &_operation_started;
+      break;
+    case event::operation_finished:
+      wait_for = &_operation_finished;
+      break;
+  }
+
+  if (event == event::operation_submitted) {
+    if (_operation_submitted == profiler_clock::time_point{}) {
+      register_error(__hipsycl_here(),
+                     error_info{"omp_timestamp_profiler: submission event not recorded"});
+    }
+    return _operation_submitted;
+  }
+
+  std::unique_lock lock{_mutex};
+  _update.wait(lock, [&] { return *wait_for != profiler_clock::time_point{}; });
+  return *wait_for;
+}
+
+std::unique_ptr<omp_timestamp_profiler> omp_timestamp_profiler::make_no_op()
+{
+  auto p = std::make_unique<omp_timestamp_profiler>();
+  p->_operation_finished = p->_operation_started = p->_operation_submitted = profiler_clock::now();
+  return p;
+}
+
+}
+}
+

--- a/src/runtime/operations.cpp
+++ b/src/runtime/operations.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2019 Aksel Alpay
+ * Copyright (c) 2019-2020 Aksel Alpay and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,13 +27,36 @@
 
 #include "hipSYCL/runtime/operations.hpp"
 #include "hipSYCL/runtime/dag_node.hpp"
+#include "hipSYCL/runtime/instrumentation.hpp"
 
 namespace hipsycl {
 namespace rt {
 
+namespace {
+
+template<typename T>
+T &ensure_instance(std::unique_ptr<T> &ptr) {
+  if (!ptr) {
+    ptr = std::make_unique<T>();
+  }
+  return *ptr;
+}
+
+}
+
+operation::operation() noexcept = default;
+operation::~operation() = default;
+
+instrumentation_set &operation::get_instrumentations() {
+  return ensure_instance(_instr_set);
+}
+
+const instrumentation_set &operation::get_instrumentations() const {
+  return ensure_instance(_instr_set);
+}
+
 kernel_operation::kernel_operation(
-    const std::string &kernel_name, 
-    std::vector<std::unique_ptr<backend_kernel_launcher>> kernels,
+    const std::string &kernel_name, std::vector<std::unique_ptr<backend_kernel_launcher>> kernels,
     const requirements_list& reqs)
     : _kernel_name{kernel_name}, _launcher{std::move(kernels)}
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,6 +62,7 @@ add_executable(sycl_tests
   sycl/item.cpp
   sycl/kernel_invocation.cpp
   sycl/math.cpp
+  sycl/profiler.cpp
   sycl/reduction.cpp
   sycl/sub_group.cpp
   sycl/sycl_test_suite.cpp 

--- a/tests/runtime/dag_builder.cpp
+++ b/tests/runtime/dag_builder.cpp
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(default_hints) {
       "test_kernel",
       std::vector<std::unique_ptr<rt::backend_kernel_launcher>>{},
       reqs);
-  
+
   rt::dag_node_ptr node = builder.add_kernel(
       std::move(dummy_kernel_op), reqs, hints);
 

--- a/tests/sycl/profiler.cpp
+++ b/tests/sycl/profiler.cpp
@@ -1,0 +1,194 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2020 Aksel Alpay and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sycl_test_suite.hpp"
+
+BOOST_FIXTURE_TEST_SUITE(profiler_tests, reset_device_fixture)
+
+
+BOOST_AUTO_TEST_CASE(queue_no_profiling_exception)
+{
+  cl::sycl::queue queue;  // no enable_profiling
+  constexpr size_t n = 4;
+
+  cl::sycl::buffer<int, 1> buf1{cl::sycl::range<1>(1)};
+  auto evt1 = queue.submit([&](cl::sycl::handler &cgh) {
+    auto acc = buf1.get_access<cl::sycl::access::mode::discard_write>(cgh);
+    cgh.single_task<class no_profile_single_task>([=]() {
+      acc[0] = 42;
+    });
+  });
+  BOOST_CHECK_THROW(evt1.get_profiling_info<cl::sycl::info::event_profiling::command_submit>(),
+                    cl::sycl::invalid_object_error);
+
+  auto evt2 = queue.submit([&](cl::sycl::handler &cgh) {
+    auto acc = buf1.get_access<cl::sycl::access::mode::discard_write>(cgh);
+    cgh.parallel_for<class no_profile_parallel_for>(buf1.get_range(), [=](cl::sycl::item<1> item) {
+      acc[item] = item.get_id()[0];
+    });
+  });
+
+  cl::sycl::buffer<int, 1> buf2{buf1.get_range()};
+  auto evt3 = queue.submit([&](cl::sycl::handler &cgh) {
+    cgh.copy(buf1.get_access<cl::sycl::access::mode::read>(cgh),
+             buf2.get_access<cl::sycl::access::mode::discard_write>(cgh));
+  });
+
+  BOOST_CHECK_THROW(evt3.get_profiling_info<cl::sycl::info::event_profiling::command_end>(),
+                    cl::sycl::invalid_object_error);
+  BOOST_CHECK_THROW(evt2.get_profiling_info<cl::sycl::info::event_profiling::command_start>(),
+                    cl::sycl::invalid_object_error);
+
+  auto evt4 = queue.submit([&](cl::sycl::handler &cgh) {
+    cgh.fill(buf1.get_access<cl::sycl::access::mode::discard_write>(cgh), 1);
+  });
+
+  int host_array[n];
+  auto evt5 = queue.submit([&](cl::sycl::handler &cgh) {
+    // copy to pointer
+    cgh.copy(buf2.get_access<cl::sycl::access::mode::read>(cgh), host_array);
+  });
+
+  BOOST_CHECK_THROW(evt4.get_profiling_info<cl::sycl::info::event_profiling::command_submit>(),
+                    cl::sycl::invalid_object_error);
+  BOOST_CHECK_THROW(evt5.get_profiling_info<cl::sycl::info::event_profiling::command_submit>(),
+                    cl::sycl::invalid_object_error);
+}
+
+BOOST_AUTO_TEST_CASE(queue_profiling)
+{
+  cl::sycl::queue queue{cl::sycl::property::queue::enable_profiling{}};
+  constexpr size_t n = 4;
+  cl::sycl::buffer<int, 1> buf1{cl::sycl::range<1>(n)};
+
+  auto evt1 = queue.submit([&](cl::sycl::handler &cgh) {
+    auto acc = buf1.get_access<cl::sycl::access::mode::discard_write>(cgh);
+    cgh.single_task<class profile_single_task>([=]() {
+      acc[0] = 42;
+    });
+  });
+
+  auto t12 = evt1.get_profiling_info<cl::sycl::info::event_profiling::command_start>();
+  auto t11 = evt1.get_profiling_info<cl::sycl::info::event_profiling::command_submit>();
+  auto t13 = evt1.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
+  BOOST_CHECK(t11 <= t12 && t12 <= t13);
+
+  auto evt2 = queue.submit([&](cl::sycl::handler &cgh) {
+    auto acc = buf1.get_access<cl::sycl::access::mode::discard_write>(cgh);
+    cgh.parallel_for<class profile_parallel_for>(buf1.get_range(), [=](cl::sycl::item<1> item) {
+      acc[item] = item.get_id()[0];
+    });
+  });
+
+  cl::sycl::buffer<int, 1> buf2{buf1.get_range()};
+  auto evt3 = queue.submit([&](cl::sycl::handler &cgh) {
+    cgh.copy(buf1.get_access<cl::sycl::access::mode::read>(cgh),
+             buf2.get_access<cl::sycl::access::mode::discard_write>(cgh));
+  });
+
+  auto t21 = evt2.get_profiling_info<cl::sycl::info::event_profiling::command_submit>();
+  auto t22 = evt2.get_profiling_info<cl::sycl::info::event_profiling::command_start>();
+  auto t23 = evt2.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
+  BOOST_CHECK(t21 <= t22 && t22 <= t23);
+
+  auto t31 = evt3.get_profiling_info<cl::sycl::info::event_profiling::command_submit>();
+  auto t32 = evt3.get_profiling_info<cl::sycl::info::event_profiling::command_start>();
+  auto t33 = evt3.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
+  BOOST_CHECK(t31 <= t32 && t32 <= t33);
+  BOOST_CHECK(t21 <= t31 && t23 <= t32);
+
+  auto evt4 = queue.submit([&](cl::sycl::handler &cgh) {
+    cgh.fill(buf1.get_access<cl::sycl::access::mode::discard_write>(cgh), 1);
+  });
+
+  int host_array[n];
+  auto evt5 = queue.submit([&](cl::sycl::handler &cgh) {
+    // copy to pointer
+    cgh.copy(buf2.get_access<cl::sycl::access::mode::read>(cgh), host_array);
+  });
+
+  auto t51 = evt5.get_profiling_info<cl::sycl::info::event_profiling::command_submit>();
+  auto t52 = evt5.get_profiling_info<cl::sycl::info::event_profiling::command_start>();
+  auto t53 = evt5.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
+  BOOST_CHECK(t51 <= t52 && t52 <= t53);
+
+  // re-ordered
+  auto t41 = evt4.get_profiling_info<cl::sycl::info::event_profiling::command_submit>();
+  auto t42 = evt4.get_profiling_info<cl::sycl::info::event_profiling::command_start>();
+  auto t43 = evt4.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
+  BOOST_CHECK(t41 <= t42 && t42 <= t43);
+
+  // usm
+  auto *src = cl::sycl::malloc_shared<int>(n, queue);
+  auto *dest = cl::sycl::malloc_shared<int>(n, queue);
+  auto evt6 = queue.submit([&](cl::sycl::handler &cgh) {
+    cgh.memset(src, 0, sizeof src);
+  });
+  auto t61 = evt6.get_profiling_info<cl::sycl::info::event_profiling::command_submit>();
+  auto t62 = evt6.get_profiling_info<cl::sycl::info::event_profiling::command_start>();
+  auto t63 = evt6.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
+  BOOST_CHECK(t61 <= t62 && t62 <= t63);
+
+  auto evt7 = queue.submit([&](cl::sycl::handler &cgh) {
+    cgh.memcpy(dest, src, sizeof src);
+  });
+  auto t71 = evt7.get_profiling_info<cl::sycl::info::event_profiling::command_submit>();
+  auto t72 = evt7.get_profiling_info<cl::sycl::info::event_profiling::command_start>();
+  auto t73 = evt7.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
+  BOOST_CHECK(t71 <= t72 && t72 <= t73);
+
+  auto evt8 = queue.submit([&](cl::sycl::handler &cgh) {
+    cgh.prefetch(dest, sizeof src);
+  });
+  auto t81 = evt8.get_profiling_info<cl::sycl::info::event_profiling::command_submit>();
+  auto t82 = evt8.get_profiling_info<cl::sycl::info::event_profiling::command_start>();
+  auto t83 = evt8.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
+  // run time may be zero if prefetching is a no-op
+  BOOST_CHECK(t81 <= t82 && t82 <= t83);
+}
+
+// update_host is an explicit operation, but implemented as a requirement and thus not profiled.
+// remove the warning and merge this test into queue_profiling if that is ever resolved.
+BOOST_AUTO_TEST_CASE(queue_profiling_update_host_supported)
+{
+  cl::sycl::queue queue{cl::sycl::property::queue::enable_profiling{}};
+  int i = 1337;
+  cl::sycl::buffer<int, 1> buf{&i, cl::sycl::range<1>(1)};
+  queue.submit([&](cl::sycl::handler &cgh) {
+    auto acc = buf.get_access<cl::sycl::access::mode::discard_write>(cgh);
+    cgh.single_task<class basic_single_task>([=]() {
+      acc[0] = 42;
+    });
+  });
+  auto evt = queue.submit([&](cl::sycl::handler &cgh) {
+    cgh.update_host(buf.get_access<cl::sycl::access::mode::read>(cgh));
+  });
+  BOOST_WARN_NO_THROW(evt.get_profiling_info<cl::sycl::info::event_profiling::command_start>());
+}
+
+
+BOOST_AUTO_TEST_SUITE_END() // NOTE: Make sure not to add anything below this line


### PR DESCRIPTION
Resolves #417 by implementing the SYCL `event::get_profiling_info` API using CUDA / HIP events on GPU backends and simple `<chrono>` timestamps on the OpenMP backend. In addition to the requirements in the spec, the returned timestamps are relative to the `std::chrono::system_clock` epoch and can thus be converted into wall-clock time.

The `enable_profiling` queue property is passed to the handler using the `rt::hints::enable_profiling` execution hint. The handler instantiates all explicit operations with their `enable_profiling` flag set, signalling to the backend `inorder_queue` that a profiler should be constructed.
Each backend implements the profiling functionality by subclassing the abstract `rt::profiler`, which allows the frontend to wait for an operation to be submitted, started or finished in a platform-independent manner and yields device timestamps for the event in question.
For CUDA / HIP, the relative timings from are converted to absolute timestamps by recording a reference CUDA / HIP event together with a reference host timestamp on `cuda_queue` construction.

All explicit operation types (kernel launches, copies, memset...) are now based on `rt::profiled_operation`, a subclass of `rt::operation` that supports profiling when enabled. `profiled_operation` allows the backend `inorder_queue` to asynchronously set a profiler for the operation and the frontend to wait for said construction from the main thread.
Since memory requirements are usually purely implicit operations, I decided to omit instrumentation from `rt::requirement`, so requirement operations continue to inherit from `rt::operation` directly. This means that `handler::update_host()` and `handler::require()` cannot currently be profiled. I believe this is a sane decision since as requirements, they can still be optimized away, meaning that we cannot guarantee that a profiler will be constructed anyway.

A new unit test is included, checking that profiling is available for all supported kernel types, that timestamps have sane ordering and that the queue throws exceptions when profiling is disabled as required by the spec. Tests were run on OpenMP and CUDA sm_61 + sm_75 in both Debug and Release configuration. Unfortunately, I do not have any AMD GPUs to test the ROCm implementation with.

This PR is based on #427, so that will have to be merged first.
