### PR TITLE
allow groups < 128 and > 256 on AMD-GPUs

### DIFF
--- a/include/hipSYCL/compiler/Frontend.hpp
+++ b/include/hipSYCL/compiler/Frontend.hpp
@@ -205,7 +205,7 @@ public:
   bool VisitFunctionDecl(clang::FunctionDecl *f) {
     if(!f)
       return true;
-    
+
     this->processFunctionDecl(f);
 
     return true;
@@ -318,8 +318,21 @@ public:
           CustomAttributes::SyclKernel.isAttachedTo(F)) {
 
         auto* NewAttr = clang::CUDAGlobalAttr::CreateImplicit(Instance.getASTContext());
-        
+
         F->addAttr(NewAttr);
+
+        // create amdgpu_flat_work_group_size attribute to allow sub_groups outside of [128, 256]
+        // first we need to create Expressions containing the workgroup-sizes
+        auto sizeType = Instance.getASTContext().getSizeType();
+        auto minFlatWorkgroupSize = llvm::APInt(Instance.getASTContext().getTypeSize(sizeType), 64);
+        auto maxFlatWorkgroupSize = llvm::APInt(Instance.getASTContext().getTypeSize(sizeType), 1024);
+        auto* minFlatWorkgroupExpr = clang::IntegerLiteral::Create(Instance.getASTContext(), minFlatWorkgroupSize, sizeType, clang::SourceLocation{});
+        auto* maxFlatWorkgroupExpr = clang::IntegerLiteral::Create(Instance.getASTContext(), maxFlatWorkgroupSize, sizeType, clang::SourceLocation{});
+
+        // to finally create the attribute itself
+        auto * NewAMDGPUAttr = clang::AMDGPUFlatWorkGroupSizeAttr::CreateImplicit(Instance.getASTContext(), minFlatWorkgroupExpr , maxFlatWorkgroupExpr);
+
+        F->addAttr(NewAMDGPUAttr);
       }
     }
 


### PR DESCRIPTION
This extends the clang-plugin to create the `amdgpu_flat_work_group_size` to allow groups between 64 and 1024 work items on AMD-GPUs.
Previously when using larger/smaller groups could result in wrong results or even crashes.

I chose to set the valid range to [64, 1024]. Maybe the limits could be exposed via environment variables, for now they are hardcoded.

It compiles (on my system), but maybe we want additional includes **?**  I didn't add for example `llvm/ADT/APInt.h`, because it wasn't present in [lib/Sema/SemaDeclCXX.cpp](https://github.com/llvm/llvm-project/blob/main/clang/lib/Sema/SemaDeclCXX.cpp) which I referenced.

Currently I only add the attribute to marked kernels. It might also be needed for other functions or add a check to only apply on AMD-GPU passes **?**