### PR TITLE
HIP,CUDA: Don't emit warning if hip/cudaErrorNoDevice encountered during startup

### DIFF
--- a/src/runtime/cuda/cuda_hardware_manager.cpp
+++ b/src/runtime/cuda/cuda_hardware_manager.cpp
@@ -44,10 +44,12 @@ cuda_hardware_manager::cuda_hardware_manager(hardware_platform hw_platform)
   if (err != cudaSuccess) {
     num_devices = 0;
 
-    print_warning(
-        __hipsycl_here(),
-        error_info{"cuda_hardware_manager: Could not obtain number of devices",
-                   error_code{"CUDA", err}});
+    if(err != cudaErrorNoDevice) {
+      print_warning(
+          __hipsycl_here(),
+          error_info{"cuda_hardware_manager: Could not obtain number of devices",
+                    error_code{"CUDA", err}});
+    }
   }
   
   for (int dev = 0; dev < num_devices; ++dev) {

--- a/src/runtime/hip/hip_hardware_manager.cpp
+++ b/src/runtime/hip/hip_hardware_manager.cpp
@@ -43,10 +43,12 @@ hip_hardware_manager::hip_hardware_manager(hardware_platform hw_platform)
   if (err != hipSuccess) {
     num_devices = 0;
 
-    print_warning(
-        __hipsycl_here(),
-        error_info{"hip_hardware_manager: Could not obtain number of devices",
-                   error_code{"HIP", err}});
+    if(err != hipErrorNoDevice){
+      print_warning(
+          __hipsycl_here(),
+          error_info{"hip_hardware_manager: Could not obtain number of devices",
+                    error_code{"HIP", err}});
+    }
   }
   
   for (int dev = 0; dev < num_devices; ++dev) {


### PR DESCRIPTION
Currently, if hipSYCL is compiled with HIP/CUDA support but no devices are detected, at startup a warning is emitted.

This removes this warning since not having HIP/CUDA devices is a valid configuration - just because the hipSYCL runtime is built with HIP/CUDA support, this does not necessarily mean that there's something wrong if no such devices are present in the target machine.
