### PR TITLE
Fix missing return value in hip_queue::submit_prefetch()

### DIFF
--- a/src/runtime/hip/hip_queue.cpp
+++ b/src/runtime/hip/hip_queue.cpp
@@ -259,8 +259,8 @@ result hip_queue::submit_prefetch(const prefetch_operation& op) {
                            "support prefetching memory."
                         << std::endl;
 
-  return make_success();
 #endif
+  return make_success();
 }
 
 result hip_queue::submit_memset(const memset_operation &op) {


### PR DESCRIPTION
* Fix missing return value in `hip_queue::submit_prefetch()` if `HIPSYCL_RT_HIP_SUPPORTS_UNIFIED_MEMORY` is defined (it isn't by default).