### PR TITLE
Add scoped parallelism support to private_memory

### DIFF
--- a/doc/scoped-parallelism.md
+++ b/doc/scoped-parallelism.md
@@ -132,6 +132,14 @@ template<class F>
 void sub_group::single_item(F f);
 ```
 
+## New functions `private_memory`
+
+```c++
+// Return managed data for the logical work item
+T& operator()(const logical_item<Dim> &item) noexcept;
+};
+```
+
 ## class `local_memory<T>`
 
 ```c++

--- a/include/hipSYCL/sycl/libkernel/private_memory.hpp
+++ b/include/hipSYCL/sycl/libkernel/private_memory.hpp
@@ -32,6 +32,7 @@
 
 #include "group.hpp"
 #include "h_item.hpp"
+#include "sp_item.hpp"
 
 namespace hipsycl {
 namespace sycl {
@@ -48,6 +49,12 @@ public:
 
   HIPSYCL_KERNEL_TARGET
   T& operator()(const h_item<Dimensions>&)
+  {
+    return _data;
+  }
+
+  HIPSYCL_KERNEL_TARGET
+  T& operator()(const logical_item<Dimensions>&)
   {
     return _data;
   }
@@ -70,14 +77,23 @@ public:
   HIPSYCL_KERNEL_TARGET
   T& operator()(const h_item<Dimensions>& idx)
   {
-    auto id = idx.get_local_id();
+    return get(idx.get_local_id(), idx.get_local_range());
+  }
 
-    return _data.get()[detail::linear_id<Dimensions>::get(
-        id, idx.get_local_range())];
+  HIPSYCL_KERNEL_TARGET
+  T& operator()(const logical_item<Dimensions>& idx)
+  {
+    return get(idx.get_local_id(), idx.get_local_range());
   }
 
 private:
   std::unique_ptr<T []> _data;
+
+  HIPSYCL_KERNEL_TARGET
+  T& get(id<Dimensions> id, range<Dimensions> local_range)
+  {
+    return _data.get()[detail::linear_id<Dimensions>::get(id, local_range)];
+  }
 };
 #endif
 


### PR DESCRIPTION
The docs for scoped parallelism mention `private_memory`, but the API did not actually support it since managed private data could only be accessed with an `h_item` rather than a `logical_item`.

This PR adds the necessary overload for `private_memory::operator()`, includes it in the extension unit test and updates documentation accordingly.