### PR TITLE
Make cuda|hip_device_manager thread_local

### DIFF
--- a/include/hipSYCL/runtime/cuda/cuda_device_manager.hpp
+++ b/include/hipSYCL/runtime/cuda/cuda_device_manager.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2019 Aksel Alpay
+ * Copyright (c) 2019-2021 Aksel Alpay and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,23 +31,25 @@
 namespace hipsycl {
 namespace rt {
 
-/// Manages setting the active device *in the hipSYCL worker thread*
-/// It assumes:
-/// * There are no external calls to hipSetDevice() from the user in the calling thread
-/// * It is only called by one thread, i.e. no thread-safety required
+/// CUDA keeps track of the currently active device on a per-thread basis.
+/// The cuda_device_manager acts as a wrapper for this functionality.
+/// It is implemented as a per-thread singleton and assumes that
+/// no external calls to cudaSetDevice() are made by the user.
 class cuda_device_manager
 {
 public:
-  cuda_device_manager();
   void activate_device(int device_id);
   int get_active_device() const;
 
   static cuda_device_manager &get() {
-    static cuda_device_manager instance;
+    static thread_local cuda_device_manager instance;
     return instance;
   }
+
 private:
   int _device;
+
+  cuda_device_manager();
 };
 
 }

--- a/include/hipSYCL/runtime/hip/hip_device_manager.hpp
+++ b/include/hipSYCL/runtime/hip/hip_device_manager.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2019 Aksel Alpay
+ * Copyright (c) 2019-2021 Aksel Alpay and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,23 +31,25 @@
 namespace hipsycl {
 namespace rt {
 
-/// Manages setting the active device *in the hipSYCL worker thread*
-/// It assumes:
-/// * There are no external calls to hipSetDevice() from the user in the calling thread
-/// * It is only called by one thread, i.e. no thread-safety required
+/// HIP keeps track of the currently active device on a per-thread basis.
+/// The hip_device_manager acts as a wrapper for this functionality.
+/// It is implemented as a per-thread singleton and assumes that
+/// no external calls to hipSetDevice() are made by the user.
 class hip_device_manager
 {
 public:
-  hip_device_manager();
   void activate_device(int device_id);
   int get_active_device() const;
 
   static hip_device_manager &get() {
-    static hip_device_manager instance;
+    static thread_local hip_device_manager instance;
     return instance;
   }
+
 private:
   int _device;
+
+  hip_device_manager();
 };
 
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,8 @@ find_package(Boost COMPONENTS unit_test_framework REQUIRED)
 
 find_package(hipSYCL REQUIRED)
 
+find_package(Threads REQUIRED)
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
@@ -75,8 +77,9 @@ add_sycl_to_target(TARGET sycl_tests)
 add_executable(rt_tests 
   runtime/runtime_test_suite.cpp 
   runtime/dag_builder.cpp
-  runtime/data.cpp)
+  runtime/data.cpp
+  runtime/device_manager.cpp)
 
 target_include_directories(rt_tests PRIVATE ${Boost_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(rt_tests PRIVATE ${Boost_LIBRARIES})
+target_link_libraries(rt_tests PRIVATE ${Boost_LIBRARIES} Threads::Threads)
 add_sycl_to_target(TARGET rt_tests)

--- a/tests/runtime/device_manager.cpp
+++ b/tests/runtime/device_manager.cpp
@@ -1,0 +1,139 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2020-2021 Aksel Alpay and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "runtime_test_suite.hpp"
+
+#include <future>
+
+#include <SYCL/sycl.hpp>
+#include <hipSYCL/runtime/device_id.hpp>
+
+#ifdef HIPSYCL_PLATFORM_CUDA
+#include <hipSYCL/runtime/cuda/cuda_backend.hpp>
+#include <hipSYCL/runtime/cuda/cuda_device_manager.hpp>
+#endif
+
+#ifdef HIPSYCL_PLATFORM_HIP
+#include <hipSYCL/runtime/hip/hip_backend.hpp>
+#include <hipSYCL/runtime/hip/hip_device_manager.hpp>
+#endif
+
+using namespace hipsycl;
+
+template <rt::backend_id Backend> struct backend_enabled {
+  static constexpr bool value = false;
+};
+
+template <rt::backend_id Backend> struct backend_class { using type = void; };
+
+template <rt::backend_id Backend> struct backend_device_manager {
+  using type = void;
+};
+
+#ifdef HIPSYCL_PLATFORM_CUDA
+template <> struct backend_enabled<rt::backend_id::cuda> {
+  static constexpr bool value = true;
+};
+
+template <> struct backend_class<rt::backend_id::cuda> {
+  using type = rt::cuda_backend;
+};
+
+template <> struct backend_device_manager<rt::backend_id::cuda> {
+  using type = rt::cuda_device_manager;
+};
+#endif
+
+#ifdef HIPSYCL_PLATFORM_HIP
+template <> struct backend_enabled<rt::backend_id::hip> {
+  static constexpr bool value = true;
+};
+
+template <> struct backend_class<rt::backend_id::hip> {
+  using type = rt::hip_backend;
+};
+
+template <> struct backend_device_manager<rt::backend_id::hip> {
+  using type = rt::hip_device_manager;
+};
+#endif
+
+BOOST_FIXTURE_TEST_SUITE(device_manager, reset_device_fixture)
+
+namespace btt = boost::test_tools;
+
+template <rt::backend_id Backend>
+struct if_backend_and_devices_available {
+  btt::assertion_result operator()(boost::unit_test::test_unit_id) {
+    btt::assertion_result ans(false);
+    if constexpr (!backend_enabled<Backend>::value) {
+      ans.message() << "backend is not enabled.";
+      return ans;
+    } else {
+      typename backend_class<Backend>::type backend;
+      if (backend.get_hardware_manager()->get_num_devices() < 2) {
+        ans.message() << "at least two devices are required.";
+        return ans;
+      }
+    }
+    return true;
+  }
+};
+
+template <rt::backend_id Backend>
+void run_device_manager_multithreaded_test() {
+  if constexpr (backend_enabled<Backend>::value) {
+    using mngr = typename backend_device_manager<Backend>::type;
+
+    mngr::get().activate_device(1);
+    BOOST_CHECK(mngr::get().get_active_device() == 1);
+
+    std::async(std::launch::async, [] {
+      BOOST_CHECK(mngr::get().get_active_device() == 0);
+      mngr::get().activate_device(0);
+    }).wait();
+
+    BOOST_CHECK(mngr::get().get_active_device() == 1);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(
+    cuda_device_manager_multithreaded,
+    *boost::unit_test::precondition(
+        if_backend_and_devices_available<rt::backend_id::cuda>{})) {
+  run_device_manager_multithreaded_test<rt::backend_id::cuda>();
+}
+
+BOOST_AUTO_TEST_CASE(
+    hip_device_manager_multithreaded,
+    *boost::unit_test::precondition(
+        if_backend_and_devices_available<rt::backend_id::hip>{})) {
+  run_device_manager_multithreaded_test<rt::backend_id::hip>();
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
CUDA/HIP keep track of the active device on a per-thread basis. While the `cuda|hip_device_manager`  classes were originally never intended to be used from multiple threads, they in fact are (for example within the `cuda|hip_queue` constructors). This can lead to subtle bugs when running hipSYCL on a machine with multiple CUDA/HIP devices.

To remedy this, the `cuda|hip_device_manager` singletons are now stored as `thread_local`, meaning there is a unique instance for each new thread.

Fixes #444.

---

Side note: I may have gone slightly overboard with the unit tests, but the functionality is actually pretty cool: When running the tests using `./rt_tests --log-level=test_suite` on my machine I now get this:

![image](https://user-images.githubusercontent.com/791348/105832798-a74ef680-5fc8-11eb-97d0-fcb43f9937ac.png)

And when running with less than 2 GPUs (i.e. `CUDA_VISIBLE_DEVICES=0 ./rt_tests --log-level=test_suite`) it will say:

![image](https://user-images.githubusercontent.com/791348/105832842-b33ab880-5fc8-11eb-8549-6a0bde80887f.png)
