### PR TITLE
Specify alignment when allocating buffer memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ build/
 
 # Singulrity
 *.sif
+
+# clangd cache
+.cache

--- a/include/hipSYCL/runtime/util.hpp
+++ b/include/hipSYCL/runtime/util.hpp
@@ -211,6 +211,30 @@ template <int Dim> range<Dim> extract_from_range3(range<3> r) {
   return range<Dim>{};
 }
 
+/* borrowed from LLVM
+ * Returns the next power of two (in 64-bits) that is strictly greater than \param a.
+ * Returns zero on overflow.
+ */
+inline std::uint64_t next_power_of_2(std::uint64_t a) {
+  a |= (a >> 1);
+  a |= (a >> 2);
+  a |= (a >> 4);
+  a |= (a >> 8);
+  a |= (a >> 16);
+  a |= (a >> 32);
+  return a + 1;
+}
+
+/*
+ * Returns the power of two which is greater than or equal to the given value.
+ * Essentially, it is a ceil operation across the domain of powers of two.
+ */
+inline std::uint64_t power_of_2_ceil(std::uint64_t a) {
+  if (a == 0)
+    return 0;
+  return next_power_of_2(a - 1);
+}
+
 }
 }
 

--- a/include/hipSYCL/sycl/buffer.hpp
+++ b/include/hipSYCL/sycl/buffer.hpp
@@ -790,13 +790,13 @@ private:
             rt::application::get_backend(host_device.get_backend())
                 .get_allocator(host_device)
                 ->allocate_optimized_host(
-                    0, _impl->data->get_num_elements().size() * sizeof(T));
+                    alignof(T), _impl->data->get_num_elements().size() * sizeof(T));
       } else {
         host_ptr =
             rt::application::get_backend(host_device.get_backend())
                 .get_allocator(host_device)
                 ->allocate(
-                    0, _impl->data->get_num_elements().size() * sizeof(T));
+                    alignof(T), _impl->data->get_num_elements().size() * sizeof(T));
       }
 
       if(!host_ptr)

--- a/src/runtime/dag_direct_scheduler.cpp
+++ b/src/runtime/dag_direct_scheduler.cpp
@@ -89,13 +89,15 @@ result ensure_allocation_exists(buffer_memory_requirement *bmem_req,
                               device_id target_dev) {
   assert(bmem_req);
   if (!bmem_req->get_data_region()->has_allocation(target_dev)) {
-    std::size_t num_bytes =
+    const std::size_t num_bytes =
         bmem_req->get_data_region()->get_num_elements().size() *
         bmem_req->get_data_region()->get_element_size();
-    
+    const std::size_t min_align = // max requested alignment the size of a sycl::vec<double, 16>
+        std::min(bmem_req->get_data_region()->get_element_size(), sizeof(double) * 16);
+
     void *ptr = application::get_backend(target_dev.get_backend())
                     .get_allocator(target_dev)
-                    ->allocate(0, num_bytes);
+                    ->allocate(min_align, num_bytes);
 
     if(!ptr)
       return register_error(

--- a/src/runtime/omp/omp_allocator.cpp
+++ b/src/runtime/omp/omp_allocator.cpp
@@ -29,6 +29,7 @@
 #include "hipSYCL/runtime/device_id.hpp"
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/omp/omp_allocator.hpp"
+#include "hipSYCL/runtime/util.hpp"
 
 namespace hipsycl {
 namespace rt {
@@ -42,6 +43,7 @@ void *omp_allocator::allocate(size_t min_alignment, size_t size_bytes) {
   
   if(size_bytes % min_alignment != 0)
     return nullptr;
+  min_alignment = power_of_2_ceil(min_alignment);
 
   // ToDo: Mac OS CI has a problem with std::aligned_alloc
   // but it's unclear if it's a Mac, or libc++, or toolchain issue


### PR DESCRIPTION
This is required for types with required alignments, otherwise bad things might happen.
As we do currently not propagate the alignment requirements of types, I just used the element size as alignment, capped at `sizeof(double) * 16` (for `sycl::vec<double, 16>` without having to couple the rt there to libkernel)
`aligned_alloc` has implementation defined requirements regarding the alignment.
As posix & Windows require the alignment to be a power of two, I borrowed LLVMs `PowerOf2Ceil` to make sure this requirement is met.