### PR TITLE
Fix runtime teardown order.

### DIFF
--- a/include/hipSYCL/runtime/runtime.hpp
+++ b/include/hipSYCL/runtime/runtime.hpp
@@ -61,10 +61,11 @@ public:
   const async_error_list& errors() const { return _errors; }
 
 private:
-
-  dag_manager _dag_manager;
-  backend_manager _backends;
+  
+  // !! Attention: order is important, as backends have to be still present, when the dag_manager is destructed!
   async_error_list _errors;
+  backend_manager _backends;
+  dag_manager _dag_manager;
 };
 
 }


### PR DESCRIPTION
The `backend_manager` must only be destructed after all dag nodes are torn down, after the `dag_manager` is torn down.
This can be achieved by fixing the order of members, as the C++ standard guarantees order of member construction top-down and tear down the opposite way.

I also put `async_error_list` to be constructed first and destructed last, as it has no dependencies, but might be a dependency.