### PR TITLE
[Win] Part 4: Make Boost.Test and Windows happy

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,9 @@ add_definitions(-DHIPSYCL_DEBUG_LEVEL=${HIPSYCL_DEBUG_LEVEL})
 if(HIPSYCL_DISABLE_UNNAMED_LAMBDA_TESTS)
   add_definitions(-DHIPSYCL_DISABLE_UNNAMED_LAMBDA_TESTS)
 endif()
+if(WIN32)
+add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX -D_USE_MATH_DEFINES)
+endif()
 
 add_subdirectory(platform_api)
 

--- a/tests/device_compilation_tests.cpp
+++ b/tests/device_compilation_tests.cpp
@@ -26,7 +26,9 @@
  */
 
 #define BOOST_TEST_MODULE device compilation tests
+#ifndef _WIN32
 #define BOOST_TEST_DYN_LINK
+#endif // _WIN32
 #include <boost/test/unit_test.hpp>
 
 #include <initializer_list>

--- a/tests/runtime/runtime_test_suite.cpp
+++ b/tests/runtime/runtime_test_suite.cpp
@@ -29,5 +29,7 @@
 
 
 #define BOOST_TEST_MODULE hipSYCL runtime tests
+#ifndef _WIN32
 #define BOOST_TEST_DYN_LINK
+#endif // _WIN32
 #include <boost/test/unit_test.hpp>

--- a/tests/sycl/math.cpp
+++ b/tests/sycl/math.cpp
@@ -29,6 +29,8 @@
 
 #include <boost/mpl/joint_view.hpp>
 
+#include <cmath>
+
 BOOST_FIXTURE_TEST_SUITE(math_tests, reset_device_fixture)
 
 // list of types classified as "genfloat" in the SYCL standard
@@ -318,14 +320,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_binary, T,
 
     for(int c = 0; c < std::max(D,1); ++c) {
       int i = 2;
-      BOOST_TEST(comp(acc[i++], c) == atan2(comp(acc[0], c), comp(acc[1], c)), tolerance);
-      BOOST_TEST(comp(acc[i++], c) == copysign(comp(acc[0], c), comp(acc[1], c)), tolerance);
-      BOOST_TEST(comp(acc[i++], c) == fdim(comp(acc[0], c), comp(acc[1], c)), tolerance);
-      BOOST_TEST(comp(acc[i++], c) == fmin(comp(acc[0], c), comp(acc[1], c)), tolerance);
-      BOOST_TEST(comp(acc[i++], c) == fmax(comp(acc[0], c), comp(acc[1], c)), tolerance);
-      BOOST_TEST(comp(acc[i++], c) == fmod(comp(acc[0], c), comp(acc[1], c)), tolerance);
-      BOOST_TEST(comp(acc[i++], c) == hypot(comp(acc[0], c), comp(acc[1], c)), tolerance);
-      BOOST_TEST(comp(acc[i++], c) == pow(comp(acc[0], c), comp(acc[1], c)), tolerance);
+      BOOST_TEST(comp(acc[i++], c) == std::atan2<double>(comp(acc[0], c), comp(acc[1], c)), tolerance);
+      BOOST_TEST(comp(acc[i++], c) == std::copysign<double>(comp(acc[0], c), comp(acc[1], c)), tolerance);
+      BOOST_TEST(comp(acc[i++], c) == std::fdim<double>(comp(acc[0], c), comp(acc[1], c)), tolerance);
+      BOOST_TEST(comp(acc[i++], c) == std::fmin<double>(comp(acc[0], c), comp(acc[1], c)), tolerance);
+      BOOST_TEST(comp(acc[i++], c) == std::fmax<double>(comp(acc[0], c), comp(acc[1], c)), tolerance);
+      BOOST_TEST(comp(acc[i++], c) == std::fmod<double>(comp(acc[0], c), comp(acc[1], c)), tolerance);
+      BOOST_TEST(comp(acc[i++], c) == std::hypot<double>(comp(acc[0], c), comp(acc[1], c)), tolerance);
+      BOOST_TEST(comp(acc[i++], c) == std::pow<double>(comp(acc[0], c), comp(acc[1], c)), tolerance);
     }
   }
 }
@@ -585,10 +587,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(geometric, T, math_test_gengeo::type) {
     auto normalize_ref_result = ref_normalize(acc[0]);
     for(int c = 0; c < std::max(D,1); ++c) {
       int i = 2;
-      BOOST_TEST(comp(acc[i++], c) == dot_ref_result, tolerance);
-      BOOST_TEST(comp(acc[i++], c) == length_ref_result, tolerance);
-      BOOST_TEST(comp(acc[i++], c) == distance_ref_result, tolerance);
-      BOOST_TEST(comp(acc[i++], c) == comp(normalize_ref_result, c), tolerance);
+      BOOST_TEST(comp(acc[i++], c) == static_cast<double>(dot_ref_result), tolerance);
+      BOOST_TEST(comp(acc[i++], c) == static_cast<double>(length_ref_result), tolerance);
+      BOOST_TEST(comp(acc[i++], c) == static_cast<double>(distance_ref_result), tolerance);
+      BOOST_TEST(comp(acc[i++], c) == static_cast<double>(comp(normalize_ref_result, c)), tolerance);
     }
   }
 }
@@ -637,9 +639,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(fast_geometric, T, math_test_gengeofloats::type) {
     auto normalize_ref_result = ref_normalize(acc[0]);
     for(int c = 0; c < std::max(D,1); ++c) {
       int i = 2;
-      BOOST_TEST(comp(acc[i++], c) == length_ref_result, tolerance);
-      BOOST_TEST(comp(acc[i++], c) == distance_ref_result, tolerance);
-      BOOST_TEST(comp(acc[i++], c) == comp(normalize_ref_result, c), tolerance);
+      BOOST_TEST(comp(acc[i++], c) == static_cast<double>(length_ref_result), tolerance);
+      BOOST_TEST(comp(acc[i++], c) == static_cast<double>(distance_ref_result), tolerance);
+      BOOST_TEST(comp(acc[i++], c) == static_cast<double>(comp(normalize_ref_result, c)), tolerance);
     }
   }
 }

--- a/tests/sycl/sycl_test_suite.cpp
+++ b/tests/sycl/sycl_test_suite.cpp
@@ -26,5 +26,7 @@
  */
 
 #define BOOST_TEST_MODULE hipsycl unit tests
+#ifndef _WIN32
 #define BOOST_TEST_DYN_LINK
+#endif // _WIN32
 #include <boost/test/unit_test.hpp>


### PR DESCRIPTION
We don't want `min/max` macros or similar weird stuff from Windows headers, thus this adds some defines to remove them.

Boost.Test (in the version 1.70.0 I managed to get running at all (🙄)) did not use tolerance based comparison, thus using some casts and explicit `double`s to get to tolerance based comparisons.