### PR TITLE
[SYCL2020] optimized group_functions

### DIFF
--- a/include/hipSYCL/compiler/Frontend.hpp
+++ b/include/hipSYCL/compiler/Frontend.hpp
@@ -205,7 +205,7 @@ public:
   bool VisitFunctionDecl(clang::FunctionDecl *f) {
     if(!f)
       return true;
-    
+
     this->processFunctionDecl(f);
 
     return true;
@@ -318,8 +318,24 @@ public:
           CustomAttributes::SyclKernel.isAttachedTo(F)) {
 
         auto* NewAttr = clang::CUDAGlobalAttr::CreateImplicit(Instance.getASTContext());
-        
+
         F->addAttr(NewAttr);
+      }
+
+      if (!F->hasAttr<clang::AMDGPUFlatWorkGroupSizeAttr>() &&
+          CustomAttributes::SyclKernel.isAttachedTo(F)) {
+        // create amdgpu_flat_work_group_size attribute to allow sub_groups outside of [128, 256]
+        // first we need to create Expressions containing the workgroup-sizes
+        const auto sizeType = Instance.getASTContext().getSizeType();
+        const auto minFlatWorkgroupSize = llvm::APInt(Instance.getASTContext().getTypeSize(sizeType), 64);
+        const auto maxFlatWorkgroupSize = llvm::APInt(Instance.getASTContext().getTypeSize(sizeType), 1024);
+        auto* minFlatWorkgroupExpr = clang::IntegerLiteral::Create(Instance.getASTContext(), minFlatWorkgroupSize, sizeType, clang::SourceLocation{});
+        auto* maxFlatWorkgroupExpr = clang::IntegerLiteral::Create(Instance.getASTContext(), maxFlatWorkgroupSize, sizeType, clang::SourceLocation{});
+
+        // to finally create the attribute itself
+        auto* NewAMDGPUAttr = clang::AMDGPUFlatWorkGroupSizeAttr::CreateImplicit(Instance.getASTContext(), minFlatWorkgroupExpr , maxFlatWorkgroupExpr);
+
+        F->addAttr(NewAMDGPUAttr);
       }
     }
 

--- a/include/hipSYCL/compiler/Frontend.hpp
+++ b/include/hipSYCL/compiler/Frontend.hpp
@@ -205,7 +205,7 @@ public:
   bool VisitFunctionDecl(clang::FunctionDecl *f) {
     if(!f)
       return true;
-
+    
     this->processFunctionDecl(f);
 
     return true;
@@ -318,24 +318,8 @@ public:
           CustomAttributes::SyclKernel.isAttachedTo(F)) {
 
         auto* NewAttr = clang::CUDAGlobalAttr::CreateImplicit(Instance.getASTContext());
-
+        
         F->addAttr(NewAttr);
-      }
-
-      if (!F->hasAttr<clang::AMDGPUFlatWorkGroupSizeAttr>() &&
-          CustomAttributes::SyclKernel.isAttachedTo(F)) {
-        // create amdgpu_flat_work_group_size attribute to allow sub_groups outside of [128, 256]
-        // first we need to create Expressions containing the workgroup-sizes
-        const auto sizeType = Instance.getASTContext().getSizeType();
-        const auto minFlatWorkgroupSize = llvm::APInt(Instance.getASTContext().getTypeSize(sizeType), 64);
-        const auto maxFlatWorkgroupSize = llvm::APInt(Instance.getASTContext().getTypeSize(sizeType), 1024);
-        auto* minFlatWorkgroupExpr = clang::IntegerLiteral::Create(Instance.getASTContext(), minFlatWorkgroupSize, sizeType, clang::SourceLocation{});
-        auto* maxFlatWorkgroupExpr = clang::IntegerLiteral::Create(Instance.getASTContext(), maxFlatWorkgroupSize, sizeType, clang::SourceLocation{});
-
-        // to finally create the attribute itself
-        auto* NewAMDGPUAttr = clang::AMDGPUFlatWorkGroupSizeAttr::CreateImplicit(Instance.getASTContext(), minFlatWorkgroupExpr , maxFlatWorkgroupExpr);
-
-        F->addAttr(NewAMDGPUAttr);
       }
     }
 

--- a/include/hipSYCL/glue/omp/omp_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/omp/omp_kernel_launcher.hpp
@@ -243,7 +243,8 @@ inline void parallel_for_ndrange_kernel(
     sycl::detail::host_local_memory::request_from_threadprivate_pool(
         num_local_mem_bytes);
 
-    void* group_shared_memory_ptr = nullptr;
+    // 128 kiB as local memory for group algorithms
+    std::aligned_storage_t<128*1024, alignof(std::max_align_t)> group_shared_memory_ptr{};
 
     host::static_range_decomposition<Dim> group_decomposition{
           num_groups, omp_get_num_threads()};

--- a/include/hipSYCL/sycl/libkernel/cuda/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/cuda/group_functions.hpp
@@ -32,6 +32,7 @@
 #define HIPSYCL_LIBKERNEL_CUDA_GROUP_FUNCTIONS_HPP
 
 #include "../backend.hpp"
+#include "../generic/hiplike/warp_shuffle.hpp"
 #include "../id.hpp"
 #include "../sub_group.hpp"
 #include "../vec.hpp"
@@ -40,63 +41,10 @@
 namespace hipsycl {
 namespace sycl {
 
-namespace detail {
-
-constexpr unsigned int AllMask = 0xFFFFFFFF;
-
-template<typename T,
-         typename std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
-__device__
-T shuffle_impl(T x, int id) {
-  return __shfl_sync(detail::AllMask, x, id);
-}
-
-template<>
-__device__
-char shuffle_impl(char x, int id) {
-  return static_cast<char>(shuffle_impl(static_cast<int>(x), id));
-}
-
-template<typename T, int N>
-__device__
-sycl::vec<T, N> shuffle_impl(sycl::vec<T, N> x, int id) {
-  sycl::vec<T, N> ret{};
-
-  if constexpr (1 <= N)
-    ret.s0() = shuffle_impl(x.s0(), id);
-  if constexpr (2 <= N)
-    ret.s1() = shuffle_impl(x.s1(), id);
-  if constexpr (3 <= N)
-    ret.s2() = shuffle_impl(x.s2(), id);
-  if constexpr (4 <= N)
-    ret.s3() = shuffle_impl(x.s3(), id);
-  if constexpr (8 <= N) {
-    ret.s4() = shuffle_impl(x.s4(), id);
-    ret.s5() = shuffle_impl(x.s5(), id);
-    ret.s6() = shuffle_impl(x.s6(), id);
-    ret.s7() = shuffle_impl(x.s7(), id);
-  }
-  if constexpr (16 <= N) {
-    ret.s8() = shuffle_impl(x.s8(), id);
-    ret.s9() = shuffle_impl(x.s9(), id);
-    ret.sA() = shuffle_impl(x.sA(), id);
-    ret.sB() = shuffle_impl(x.sB(), id);
-    ret.sC() = shuffle_impl(x.sC(), id);
-    ret.sD() = shuffle_impl(x.sD(), id);
-    ret.sE() = shuffle_impl(x.sE(), id);
-    ret.sF() = shuffle_impl(x.sF(), id);
-  }
-
-  return ret;
-}
-
-} // namespace detail
-
 // broadcast
 template<typename T>
 HIPSYCL_KERNEL_TARGET
-T group_broadcast(sub_group g, T x,
-                  typename sub_group::linear_id_type local_linear_id = 0) {
+T group_broadcast(sub_group g, T x, typename sub_group::linear_id_type local_linear_id = 0) {
   return detail::shuffle_impl(x, local_linear_id);
 }
 
@@ -106,7 +54,6 @@ sycl::vec<T, N> group_broadcast(sub_group g, sycl::vec<T, N> x,
                                 typename sub_group::linear_id_type local_linear_id = 0) {
   return detail::shuffle_impl(x, local_linear_id);
 }
-
 
 // barrier
 template<typename Group>
@@ -129,61 +76,46 @@ inline void group_barrier(sub_group g, memory_scope fence_scope) {
   __syncwarp(); // not necessarily needed, but might improve performance
 }
 
-
 // any_of
 template<>
 HIPSYCL_KERNEL_TARGET
-inline bool group_any_of(sub_group g, bool pred) {
-  return __any_sync(detail::AllMask, pred);
-}
-
+inline bool group_any_of(sub_group g, bool pred) { return __any_sync(detail::AllMask, pred); }
 
 // all_of
 template<>
 HIPSYCL_KERNEL_TARGET
-inline bool group_all_of(sub_group g, bool pred) {
-  return __all_sync(detail::AllMask, pred);
-}
-
+inline bool group_all_of(sub_group g, bool pred) { return __all_sync(detail::AllMask, pred); }
 
 // none_of
 template<>
 HIPSYCL_KERNEL_TARGET
-inline bool group_none_of(sub_group g, bool pred) {
-  return !__any_sync(detail::AllMask, pred);
-}
-
+inline bool group_none_of(sub_group g, bool pred) { return !__any_sync(detail::AllMask, pred); }
 
 // reduce
 template<typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
 T group_reduce(sub_group g, T x, BinaryOperation binary_op) {
-  auto lid = g.get_local_linear_id();
-
-  size_t lrange          = 1;
-  auto group_local_range = g.get_local_range();
-  for (int i = 0; i < g.dimensions; ++i)
-    lrange *= group_local_range[i];
-
-  group_barrier(g);
+  auto         lid        = g.get_local_linear_id();
+  size_t       lrange     = g.get_local_linear_range();
+  unsigned int activemask = __activemask();
 
   auto local_x = x;
 
   for (size_t i = lrange / 2; i > 0; i /= 2) {
     auto other_x = detail::shuffle_impl(local_x, lid + i);
-    if (lid < i)
+    if (activemask & (1 << (lid + i)))
       local_x = binary_op(local_x, other_x);
   }
   return detail::shuffle_impl(local_x, 0);
 }
 
-
 // exclusive_scan
 template<typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
 T group_exclusive_scan(sub_group g, V x, T init, BinaryOperation binary_op) {
-  auto lid      = g.get_local_linear_id();
-  size_t lrange = g.get_local_linear_range();
+  auto         lid        = g.get_local_linear_id();
+  size_t       lrange     = g.get_local_linear_range();
+  unsigned int activemask = __activemask();
 
   auto local_x = x;
 
@@ -193,7 +125,7 @@ T group_exclusive_scan(sub_group g, V x, T init, BinaryOperation binary_op) {
       next_id = 0;
 
     auto other_x = detail::shuffle_impl(local_x, next_id);
-    if (i <= lid && lid < lrange)
+    if (activemask & (1 << (next_id)) && i <= lid && lid < lrange)
       local_x = binary_op(local_x, other_x);
   }
 
@@ -209,13 +141,13 @@ T group_exclusive_scan(sub_group g, V x, T init, BinaryOperation binary_op) {
   return binary_op(return_value, init);
 }
 
-
 // inclusive_scan
 template<typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
 T group_inclusive_scan(sub_group g, T x, BinaryOperation binary_op) {
-  auto lid      = g.get_local_linear_id();
-  size_t lrange = g.get_local_linear_range();
+  auto         lid        = g.get_local_linear_id();
+  size_t       lrange     = g.get_local_linear_range();
+  unsigned int activemask = __activemask();
 
   auto local_x = x;
 
@@ -225,18 +157,17 @@ T group_inclusive_scan(sub_group g, T x, BinaryOperation binary_op) {
       next_id = 0;
 
     auto other_x = detail::shuffle_impl(local_x, next_id);
-    if (i <= lid && lid < lrange)
+    if (activemask & (1 << (next_id)) && i <= lid && lid < lrange)
       local_x = binary_op(local_x, other_x);
   }
 
   return local_x;
 }
 
-
 } // namespace sycl
 } // namespace hipsycl
 
-#endif //HIPSYCL_LIBKERNEL_CUDA_GROUP_FUNCTIONS_HPP
+#endif // HIPSYCL_LIBKERNEL_CUDA_GROUP_FUNCTIONS_HPP
 
-#endif //HIPSYCL_PLATFORM_CUDA
-#endif //SYCL_DEVICE_ONLY
+#endif // HIPSYCL_PLATFORM_CUDA
+#endif // SYCL_DEVICE_ONLY

--- a/include/hipSYCL/sycl/libkernel/cuda/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/cuda/group_functions.hpp
@@ -48,13 +48,6 @@ T group_broadcast(sub_group g, T x, typename sub_group::linear_id_type local_lin
   return detail::shuffle_impl(x, local_linear_id);
 }
 
-template<typename T, int N>
-HIPSYCL_KERNEL_TARGET
-sycl::vec<T, N> group_broadcast(sub_group g, sycl::vec<T, N> x,
-                                typename sub_group::linear_id_type local_linear_id = 0) {
-  return detail::shuffle_impl(x, local_linear_id);
-}
-
 // barrier
 template<typename Group>
 HIPSYCL_KERNEL_TARGET

--- a/include/hipSYCL/sycl/libkernel/cuda/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/cuda/group_functions.hpp
@@ -72,25 +72,31 @@ inline void group_barrier(sub_group g, memory_scope fence_scope) {
 // any_of
 template<>
 HIPSYCL_KERNEL_TARGET
-inline bool group_any_of(sub_group g, bool pred) { return __any_sync(detail::AllMask, pred); }
+inline bool group_any_of(sub_group g, bool pred) {
+  return __any_sync(detail::AllMask, pred);
+}
 
 // all_of
 template<>
 HIPSYCL_KERNEL_TARGET
-inline bool group_all_of(sub_group g, bool pred) { return __all_sync(detail::AllMask, pred); }
+inline bool group_all_of(sub_group g, bool pred) {
+  return __all_sync(detail::AllMask, pred);
+}
 
 // none_of
 template<>
 HIPSYCL_KERNEL_TARGET
-inline bool group_none_of(sub_group g, bool pred) { return !__any_sync(detail::AllMask, pred); }
+inline bool group_none_of(sub_group g, bool pred) {
+  return !__any_sync(detail::AllMask, pred);
+}
 
 // reduce
 template<typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
 T group_reduce(sub_group g, T x, BinaryOperation binary_op) {
-  auto         lid        = g.get_local_linear_id();
-  size_t       lrange     = g.get_local_linear_range();
-  unsigned int activemask = __activemask();
+  const size_t       lid        = g.get_local_linear_id();
+  const size_t       lrange     = g.get_local_linear_range();
+  const unsigned int activemask = __activemask();
 
   auto local_x = x;
 
@@ -106,9 +112,9 @@ T group_reduce(sub_group g, T x, BinaryOperation binary_op) {
 template<typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
 T group_exclusive_scan(sub_group g, V x, T init, BinaryOperation binary_op) {
-  auto         lid        = g.get_local_linear_id();
-  size_t       lrange     = g.get_local_linear_range();
-  unsigned int activemask = __activemask();
+  const size_t       lid        = g.get_local_linear_id();
+  const size_t       lrange     = g.get_local_linear_range();
+  const unsigned int activemask = __activemask();
 
   auto local_x = x;
 
@@ -126,7 +132,7 @@ T group_exclusive_scan(sub_group g, V x, T init, BinaryOperation binary_op) {
   if (g.leader())
     next_id = 0;
 
-  auto return_value = detail::shuffle_impl(local_x, lid - 1);
+  auto return_value = detail::shuffle_impl(local_x, next_id);
 
   if (g.leader())
     return init;
@@ -138,9 +144,9 @@ T group_exclusive_scan(sub_group g, V x, T init, BinaryOperation binary_op) {
 template<typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
 T group_inclusive_scan(sub_group g, T x, BinaryOperation binary_op) {
-  auto         lid        = g.get_local_linear_id();
-  size_t       lrange     = g.get_local_linear_range();
-  unsigned int activemask = __activemask();
+  const size_t       lid        = g.get_local_linear_id();
+  const size_t       lrange     = g.get_local_linear_range();
+  const unsigned int activemask = __activemask();
 
   auto local_x = x;
 

--- a/include/hipSYCL/sycl/libkernel/cuda/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/cuda/group_functions.hpp
@@ -44,7 +44,8 @@ namespace sycl {
 // broadcast
 template<typename T>
 HIPSYCL_KERNEL_TARGET
-T group_broadcast(sub_group g, T x, typename sub_group::linear_id_type local_linear_id = 0) {
+T group_broadcast(sub_group g, T x,
+                  typename sub_group::linear_id_type local_linear_id = 0) {
   return detail::shuffle_impl(x, local_linear_id);
 }
 

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/group_functions.hpp
@@ -77,16 +77,12 @@ template<typename Group, typename T>
 HIPSYCL_KERNEL_TARGET
 bool any_of(Group g, T *first, T *last) {
   auto group_range        = g.get_local_range().size();
-  auto elements_per_group = (last - first + group_range - 1) / group_range;
-  T *  start_ptr          = first + elements_per_group * g.get_local_linear_id();
-  T *  end_prt            = start_ptr + elements_per_group;
+  auto lid        = g.get_local_linear_id();
+  T *  start_ptr          = first + lid;
 
-  if (end_prt > last)
-    end_prt = last;
+  bool local = false;
 
-  auto local = *start_ptr;
-
-  for (T *p = start_ptr + 1; p < end_prt; ++p)
+  for (T *p = start_ptr; p < last; p += group_range)
     local |= *p;
 
   return group_any_of(g, local);
@@ -96,16 +92,12 @@ template<typename Group, typename T, typename Predicate>
 HIPSYCL_KERNEL_TARGET
 bool any_of(Group g, T *first, T *last, Predicate pred) {
   auto group_range        = g.get_local_range().size();
-  auto elements_per_group = (last - first + group_range - 1) / group_range;
-  T *  start_ptr          = first + elements_per_group * g.get_local_linear_id();
-  T *  end_prt            = start_ptr + elements_per_group;
+  auto lid        = g.get_local_linear_id();
+  T *  start_ptr          = first + lid;
 
-  if (end_prt > last)
-    end_prt = last;
+  bool local = false;
 
-  auto local = pred(*start_ptr);
-
-  for (T *p = start_ptr + 1; p < end_prt; ++p)
+  for (T *p = start_ptr; p < last; p += group_range)
     local |= pred(*p);
 
   return group_any_of(g, local);
@@ -128,16 +120,12 @@ template<typename Group, typename T>
 HIPSYCL_KERNEL_TARGET
 bool all_of(Group g, T *first, T *last) {
   auto group_range        = g.get_local_range().size();
-  auto elements_per_group = (last - first + group_range - 1) / group_range;
-  T *  start_ptr          = first + elements_per_group * g.get_local_linear_id();
-  T *  end_prt            = start_ptr + elements_per_group;
+  auto lid        = g.get_local_linear_id();
+  T *  start_ptr          = first + lid;
 
-  if (end_prt > last)
-    end_prt = last;
+  bool local = true;
 
-  auto local = *start_ptr;
-
-  for (T *p = start_ptr + 1; p < end_prt; ++p)
+  for (T *p = start_ptr; p < last; p += group_range)
     local &= *p;
 
   return group_all_of(g, local);
@@ -147,16 +135,12 @@ template<typename Group, typename T, typename Predicate>
 HIPSYCL_KERNEL_TARGET
 bool all_of(Group g, T *first, T *last, Predicate pred) {
   auto group_range        = g.get_local_range().size();
-  auto elements_per_group = (last - first + group_range - 1) / group_range;
-  T *  start_ptr          = first + elements_per_group * g.get_local_linear_id();
-  T *  end_prt            = start_ptr + elements_per_group;
+  auto lid        = g.get_local_linear_id();
+  T *  start_ptr          = first + lid;
 
-  if (end_prt > last)
-    end_prt = last;
+  bool local = true;
 
-  auto local = pred(*start_ptr);
-
-  for (T *p = start_ptr + 1; p < end_prt; ++p)
+  for (T *p = start_ptr; p < last; p += group_range)
     local &= pred(*p);
 
   return group_all_of(g, local);
@@ -179,16 +163,12 @@ template<typename Group, typename T>
 HIPSYCL_KERNEL_TARGET
 bool none_of(Group g, T *first, T *last) {
   auto group_range        = g.get_local_range().size();
-  auto elements_per_group = (last - first + group_range - 1) / group_range;
-  T *  start_ptr          = first + elements_per_group * g.get_local_linear_id();
-  T *  end_prt            = start_ptr + elements_per_group;
+  auto lid        = g.get_local_linear_id();
+  T *  start_ptr          = first + lid;
 
-  if (end_prt > last)
-    end_prt = last;
+  bool local = false;
 
-  auto local = *start_ptr;
-
-  for (T *p = start_ptr + 1; p < end_prt; ++p)
+  for (T *p = start_ptr; p < last; p += group_range)
     local |= *p;
 
   return group_none_of(g, local);
@@ -198,16 +178,12 @@ template<typename Group, typename T, typename Predicate>
 HIPSYCL_KERNEL_TARGET
 bool none_of(Group g, T *first, T *last, Predicate pred) {
   auto group_range        = g.get_local_range().size();
-  auto elements_per_group = (last - first + group_range - 1) / group_range;
-  T *  start_ptr          = first + elements_per_group * g.get_local_linear_id();
-  T *  end_prt            = start_ptr + elements_per_group;
+  auto lid        = g.get_local_linear_id();
+  T *  start_ptr          = first + lid;
 
-  if (end_prt > last)
-    end_prt = last;
+  bool local = false;
 
-  auto local = pred(*start_ptr);
-
-  for (T *p = start_ptr + 1; p < end_prt; ++p)
+  for (T *p = start_ptr; p < last; p += group_range)
     local |= pred(*p);
 
   return group_none_of(g, local);

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/group_functions.hpp
@@ -7,22 +7,23 @@
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifdef SYCL_DEVICE_ONLY
@@ -33,9 +34,11 @@
 #include "../../backend.hpp"
 #include "../../detail/data_layout.hpp"
 #include "../../detail/thread_hierarchy.hpp"
+#include "warp_shuffle.hpp"
 #include "../../id.hpp"
 #include "../../sub_group.hpp"
 #include "../../vec.hpp"
+#include "warp_shuffle.hpp"
 #include <type_traits>
 
 namespace hipsycl {
@@ -105,40 +108,43 @@ template<typename Group, typename T, typename BinaryOperation,
 HIPSYCL_KERNEL_TARGET
 T group_reduce(Group g, T x, BinaryOperation binary_op, T *scratch) {
 
-  auto lid               = g.get_local_linear_id();
-  size_t lrange          = 1;
-  auto group_local_range = g.get_local_range();
-  for (int i = 0; i < g.dimensions; ++i)
-    lrange *= group_local_range[i];
+  auto   lid    = g.get_local_linear_id();
+  size_t lrange = g.get_local_range().size();
+
+  if (lrange == 1)
+    return x;
 
   scratch[lid] = x;
   group_barrier(g);
 
-  for (size_t i = lrange / 2; i > 0; i /= 2) {
-    if (lid < i)
+  size_t outputs = lrange;
+  for (size_t i = (lrange + 1) / 2; i > 1; i = (i + 1) / 2) {
+    if (lid < i && lid + i < outputs)
       scratch[lid] = binary_op(scratch[lid], scratch[lid + i]);
+    outputs = outputs / 2 + outputs % 2;
     group_barrier(g);
   }
 
-  return scratch[0];
+  return binary_op(scratch[0], scratch[1]);
 }
 
 template<typename Group, typename T, int N, typename BinaryOperation,
          typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
 HIPSYCL_KERNEL_TARGET
 vec<T, N> group_reduce(Group g, vec<T, N> x, BinaryOperation binary_op, T *scratch) {
-  auto lid               = g.get_local_linear_id();
-  size_t lrange          = 1;
-  auto group_local_range = g.get_local_range();
-  for (int i = 0; i < g.dimensions; ++i)
-    lrange *= group_local_range[i];
+  auto   lid    = g.get_local_linear_id();
+  size_t lrange = g.get_local_range().size();
+
+  if (lrange == 1)
+    return x;
 
   detail::writeToMemory(scratch + lid * N, x);
   group_barrier(g);
 
-  for (size_t i = lrange / 2; i > 0; i /= 2) {
+  size_t outputs = lrange;
+  for (size_t i = (lrange + 1) / 2; i > 1; i = (i + 1) / 2) {
 
-    if (lid < i) {
+    if (lid < i && lid + i < outputs) {
       vec<T, N> v1, v2;
 
       detail::readFromMemory(scratch + lid * N, v1);
@@ -147,14 +153,16 @@ vec<T, N> group_reduce(Group g, vec<T, N> x, BinaryOperation binary_op, T *scrat
       detail::writeToMemory(scratch + lid * N, binary_op(v1, v2));
     }
 
+    outputs = outputs / 2 + outputs % 2;
     group_barrier(g);
   }
 
-  vec<T, N> v;
-  detail::readFromMemory(scratch, v);
-  return v;
-}
+  vec<T, N> v1, v2;
 
+  detail::readFromMemory(scratch, v1);
+  detail::readFromMemory(scratch + N, v2);
+  return binary_op(v1, v2);
+}
 
 // any_of
 template<typename Group, typename T>
@@ -162,8 +170,8 @@ HIPSYCL_KERNEL_TARGET
 bool any_of(Group g, T *first, T *last) {
   auto group_range        = g.get_local_range().size();
   auto elements_per_group = (last - first + group_range - 1) / group_range;
-  T *start_ptr            = first + elements_per_group * g.get_local_linear_id();
-  T *end_prt              = start_ptr + elements_per_group;
+  T *  start_ptr          = first + elements_per_group * g.get_local_linear_id();
+  T *  end_prt            = start_ptr + elements_per_group;
 
   if (end_prt > last)
     end_prt = last;
@@ -181,8 +189,8 @@ HIPSYCL_KERNEL_TARGET
 bool any_of(Group g, T *first, T *last, Predicate pred) {
   auto group_range        = g.get_local_range().size();
   auto elements_per_group = (last - first + group_range - 1) / group_range;
-  T *start_ptr            = first + elements_per_group * g.get_local_linear_id();
-  T *end_prt              = start_ptr + elements_per_group;
+  T *  start_ptr          = first + elements_per_group * g.get_local_linear_id();
+  T *  end_prt            = start_ptr + elements_per_group;
 
   if (end_prt > last)
     end_prt = last;
@@ -195,6 +203,17 @@ bool any_of(Group g, T *first, T *last, Predicate pred) {
   return group_any_of(g, local);
 }
 
+template<typename Group, typename T>
+HIPSYCL_KERNEL_TARGET
+bool leader_any_of(Group g, T *first, T *last) {
+  return any_of(g, first, last);
+}
+
+template<typename Group, typename T, typename Predicate>
+HIPSYCL_KERNEL_TARGET
+bool leader_any_of(Group g, T *first, T *last, Predicate pred) {
+  return any_of(g, first, last, pred);
+}
 
 // all_of
 template<typename Group, typename T>
@@ -202,8 +221,8 @@ HIPSYCL_KERNEL_TARGET
 bool all_of(Group g, T *first, T *last) {
   auto group_range        = g.get_local_range().size();
   auto elements_per_group = (last - first + group_range - 1) / group_range;
-  T *start_ptr            = first + elements_per_group * g.get_local_linear_id();
-  T *end_prt              = start_ptr + elements_per_group;
+  T *  start_ptr          = first + elements_per_group * g.get_local_linear_id();
+  T *  end_prt            = start_ptr + elements_per_group;
 
   if (end_prt > last)
     end_prt = last;
@@ -221,8 +240,8 @@ HIPSYCL_KERNEL_TARGET
 bool all_of(Group g, T *first, T *last, Predicate pred) {
   auto group_range        = g.get_local_range().size();
   auto elements_per_group = (last - first + group_range - 1) / group_range;
-  T *start_ptr            = first + elements_per_group * g.get_local_linear_id();
-  T *end_prt              = start_ptr + elements_per_group;
+  T *  start_ptr          = first + elements_per_group * g.get_local_linear_id();
+  T *  end_prt            = start_ptr + elements_per_group;
 
   if (end_prt > last)
     end_prt = last;
@@ -235,6 +254,17 @@ bool all_of(Group g, T *first, T *last, Predicate pred) {
   return group_all_of(g, local);
 }
 
+template<typename Group, typename T>
+HIPSYCL_KERNEL_TARGET
+bool leader_all_of(Group g, T *first, T *last) {
+  return all_of(g, first, last);
+}
+
+template<typename Group, typename T, typename Predicate>
+HIPSYCL_KERNEL_TARGET
+bool leader_all_of(Group g, T *first, T *last, Predicate pred) {
+  return all_of(g, first, last, pred);
+}
 
 // none_of
 template<typename Group, typename T>
@@ -242,8 +272,8 @@ HIPSYCL_KERNEL_TARGET
 bool none_of(Group g, T *first, T *last) {
   auto group_range        = g.get_local_range().size();
   auto elements_per_group = (last - first + group_range - 1) / group_range;
-  T *start_ptr            = first + elements_per_group * g.get_local_linear_id();
-  T *end_prt              = start_ptr + elements_per_group;
+  T *  start_ptr          = first + elements_per_group * g.get_local_linear_id();
+  T *  end_prt            = start_ptr + elements_per_group;
 
   if (end_prt > last)
     end_prt = last;
@@ -261,8 +291,8 @@ HIPSYCL_KERNEL_TARGET
 bool none_of(Group g, T *first, T *last, Predicate pred) {
   auto group_range        = g.get_local_range().size();
   auto elements_per_group = (last - first + group_range - 1) / group_range;
-  T *start_ptr            = first + elements_per_group * g.get_local_linear_id();
-  T *end_prt              = start_ptr + elements_per_group;
+  T *  start_ptr          = first + elements_per_group * g.get_local_linear_id();
+  T *  end_prt            = start_ptr + elements_per_group;
 
   if (end_prt > last)
     end_prt = last;
@@ -275,62 +305,93 @@ bool none_of(Group g, T *first, T *last, Predicate pred) {
   return group_none_of(g, local);
 }
 
+template<typename Group, typename T>
+HIPSYCL_KERNEL_TARGET
+bool leader_none_of(Group g, T *first, T *last) {
+  return none_of(g, first, last);
+}
+
+template<typename Group, typename T, typename Predicate>
+HIPSYCL_KERNEL_TARGET
+bool leader_none_of(Group g, T *first, T *last, Predicate pred) {
+  return none_of(g, first, last, pred);
+}
+
 
 // reduce
+template<typename Group, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T reduce(Group g, T *first, T *last, BinaryOperation binary_op) {
+  __shared__ std::aligned_storage_t<sizeof(T) * 1024, alignof(T)> scratch_storage;
+  T *                                                             scratch = reinterpret_cast<T *>(&scratch_storage);
+
+  const size_t group_range         = g.get_local_range().size();
+  const size_t num_elements        = last - first;
+  const size_t lid                 = g.get_local_linear_id();
+
+  T *start_ptr = first + lid;
+
+  if (num_elements == 1)
+    return *first;
+
+  if (num_elements >= group_range) {
+    auto local = *start_ptr;
+
+    for (T *p = start_ptr + group_range; p < last; p += group_range)
+      local = binary_op(local, *p);
+
+    return detail::group_reduce(g, local, binary_op, scratch);
+  } else {
+    const size_t warp_id           = lid / warpSize;
+    const size_t num_warps         = num_elements / warpSize;
+    const size_t elements_per_warp = (num_elements + num_warps - 1) / num_warps;
+    size_t       outputs           = num_elements;
+
+    if (num_warps == 0 && lid < num_elements) {
+      scratch[lid] = first[lid];
+    } else if (warp_id < num_warps) {
+      const size_t active_threads = num_warps * warpSize;
+
+      auto local = *start_ptr;
+
+      for (T *p = start_ptr + active_threads; p < last; p += active_threads)
+        local = binary_op(local, *p);
+
+      sub_group sg{};
+
+      local = group_reduce(sg, local, binary_op);
+      if (sg.leader())
+        scratch[warp_id] = local;
+      outputs = num_warps;
+    }
+    group_barrier(g);
+
+    for (size_t i = (outputs + 1) / 2; i > 1; i = (i + 1) / 2) {
+      if (lid < i && lid + i < outputs)
+        scratch[lid] = binary_op(scratch[lid], scratch[lid + i]);
+      outputs = outputs / 2 + outputs % 2;
+      group_barrier(g);
+    }
+
+    return binary_op(scratch[0], scratch[1]);
+  }
+}
+
 template<typename Group, typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
 T reduce(Group g, V *first, V *last, T init, BinaryOperation binary_op) {
-  size_t group_range      = g.get_local_range().size();
-  auto elements_per_group = (last - first + group_range - 1) / group_range;
-  T *start_ptr            = first + elements_per_group * g.get_local_linear_id();
-  T *end_prt              = start_ptr + elements_per_group;
+  return binary_op(reduce(g, first, last, binary_op), init);
+}
 
-  if (end_prt > last)
-    end_prt = last;
-
-  if (end_prt == start_ptr + 1) { //only one element
-    return group_reduce(g, *start_ptr, init, binary_op);
-  } else if (end_prt > start_ptr + 1) { // more than 1 element
-    auto local = binary_op(*start_ptr, *(start_ptr + 1));
-
-    for (T *p = start_ptr + 2; p < end_prt; ++p)
-      local = binary_op(local, *p);
-
-    return group_reduce(g, local, init, binary_op);
-  } else { // no element
-    return group_reduce(g, init, binary_op);
-  }
+template<typename Group, typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T leader_reduce(Group g, V *first, V *last, T init, BinaryOperation binary_op) {
+  return reduce(g, first, last, init, binary_op);
 }
 
 template<typename Group, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
-T reduce(Group g, T *first, T *last, BinaryOperation binary_op) {
-  return reduce(g, first, last, T{}, binary_op);
-}
-
-
-// exclusive_scan
-template<typename Group, typename V, typename T, typename BinaryOperation>
-HIPSYCL_KERNEL_TARGET
-T *exclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOperation binary_op) {
-  auto lid = g.get_local_linear_id();
-
-  if (g.leader()) {
-    *(result++) = init;
-    while (first != last - 1) {
-      *result = binary_op(*(result - 1), *(first++));
-      result++;
-    }
-  }
-  return group_broadcast(g, result);
-}
-
-template<typename Group, typename V, typename T, typename BinaryOperation>
-HIPSYCL_KERNEL_TARGET
-T *exclusive_scan(Group g, V *first, V *last, T *result, BinaryOperation binary_op) {
-  return exclusive_scan(g, first, last, result, T{}, binary_op);
-}
-
+T leader_reduce(Group g, T *first, T *last, BinaryOperation binary_op) { return reduce(g, first, last, binary_op); }
 
 // inclusive_scan
 template<typename Group, typename V, typename T, typename BinaryOperation>
@@ -346,7 +407,6 @@ T *inclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOperation
     while (first != last) {
       *result = binary_op(*(result - 1), *(first++));
       result++;
-      ;
     }
   }
   return group_broadcast(g, result);
@@ -355,17 +415,70 @@ T *inclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOperation
 template<typename Group, typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
 T *inclusive_scan(Group g, V *first, V *last, T *result, BinaryOperation binary_op) {
-  return inclusive_scan(g, first, last, result, T{}, binary_op);
+  auto lid = g.get_local_linear_id();
+
+  if (g.leader()) {
+    if (first == last)
+      return result;
+
+    *(result++) = *(first++);
+    while (first != last) {
+      *result = binary_op(*(result - 1), *(first++));
+      result++;
+    }
+  }
+  return group_broadcast(g, result);
+}
+
+template<typename Group, typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T *leader_inclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOperation binary_op) {
+  return inclusive_scan(g, first, last, result, init, binary_op);
+}
+
+template<typename Group, typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T *leader_inclusive_scan(Group g, V *first, V *last, T *result, BinaryOperation binary_op) {
+  return inclusive_scan(g, first, last, result, binary_op);
+}
+
+
+// exclusive_scan
+template<typename Group, typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T *exclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOperation binary_op) {
+  auto lid = g.get_local_linear_id();
+  if (lid == 0 && last - first > 0)
+    result[0] = init;
+  return inclusive_scan(g, first, last - 1, result + 1, init, binary_op);
+}
+
+template<typename Group, typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T *exclusive_scan(Group g, V *first, V *last, T *result, BinaryOperation binary_op) {
+  return exclusive_scan(g, first, last, result, T{}, binary_op);
+}
+
+template<typename Group, typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T *leader_exclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOperation binary_op) {
+  return exclusive_scan(g, first, last, result, init, binary_op);
+}
+
+template<typename Group, typename V, typename T, typename BinaryOperation>
+HIPSYCL_KERNEL_TARGET
+T *eleader_xclusive_scan(Group g, V *first, V *last, T *result, BinaryOperation binary_op) {
+  return exclusive_scan(g, first, last, result, binary_op);
 }
 
 } // namespace detail
 
 // broadcast
-template<typename Group, typename T>
+template<typename Group, typename T, typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
 HIPSYCL_KERNEL_TARGET
 T group_broadcast(Group g, T x, typename Group::linear_id_type local_linear_id = 0) {
   __shared__ T scratch[1];
-  auto lid = g.get_local_linear_id();
+  auto         lid = g.get_local_linear_id();
 
   if (lid == local_linear_id)
     scratch[0] = x;
@@ -374,12 +487,11 @@ T group_broadcast(Group g, T x, typename Group::linear_id_type local_linear_id =
   return scratch[0];
 }
 
-template<typename Group, typename T, int N>
+template<typename Group, typename T, int N, typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
 HIPSYCL_KERNEL_TARGET
-vec<T, N> group_broadcast(Group g, vec<T, N> x,
-                          typename Group::linear_id_type local_linear_id = 0) {
+vec<T, N> group_broadcast(Group g, vec<T, N> x, typename Group::linear_id_type local_linear_id = 0) {
   __shared__ T scratch[N];
-  auto lid = g.get_local_linear_id();
+  auto         lid = g.get_local_linear_id();
 
   if (lid == local_linear_id)
     detail::writeToMemory(scratch, x);
@@ -393,37 +505,25 @@ vec<T, N> group_broadcast(Group g, vec<T, N> x,
 template<typename Group, typename T>
 HIPSYCL_KERNEL_TARGET
 T group_broadcast(Group g, T x, typename Group::id_type local_id) {
-  auto target_lid =
-      detail::linear_id<g.dimensions>::get(local_id,
-                                           detail::get_local_size<g.dimensions>());
+  auto target_lid = detail::linear_id<g.dimensions>::get(local_id, detail::get_local_size<g.dimensions>());
 
   return group_broadcast(g, x, target_lid);
 }
 
-
 // any_of
 template<typename Group>
 HIPSYCL_KERNEL_TARGET
-inline bool group_any_of(Group g, bool pred) {
-  return __syncthreads_or(pred);
-}
-
+inline bool group_any_of(Group g, bool pred) { return __syncthreads_or(pred); }
 
 // all_of
 template<typename Group>
 HIPSYCL_KERNEL_TARGET
-inline bool group_all_of(Group g, bool pred) {
-  return __syncthreads_and(pred);
-}
-
+inline bool group_all_of(Group g, bool pred) { return __syncthreads_and(pred); }
 
 // none_of
 template<typename Group>
 HIPSYCL_KERNEL_TARGET
-inline bool group_none_of(Group g, bool pred) {
-  return !__syncthreads_or(pred);
-}
-
+inline bool group_none_of(Group g, bool pred) { return !__syncthreads_or(pred); }
 
 // reduce
 template<typename Group, typename T, typename BinaryOperation,
@@ -444,136 +544,31 @@ vec<T, N> group_reduce(Group g, vec<T, N> x, BinaryOperation binary_op) {
   return detail::group_reduce(g, x, binary_op, scratch);
 }
 
-
 // exclusive_scan
-template<typename Group, typename V, typename T, typename BinaryOperation,
+template<typename Group, typename T, int N, typename V, typename BinaryOperation,
          typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
 HIPSYCL_KERNEL_TARGET
-T group_exclusive_scan(Group g, V x, T init, BinaryOperation binary_op) {
-  __shared__ T scratch[1024];
-  auto lid               = g.get_local_linear_id();
-  size_t lrange          = 1;
-  auto group_local_range = g.get_local_range();
-  for (int i = 0; i < g.dimensions; ++i)
-    lrange *= group_local_range[i];
-
-  scratch[lid] = x;
-  group_barrier(g);
-
-  for (size_t i = 1; i < lrange; i *= 2) {
-    size_t next_id = lid - i;
-    T local_x;
-    T other_x;
-    if (i <= lid && lid < lrange) {
-      local_x = scratch[lid];
-      other_x = scratch[next_id];
-    }
-
-    group_barrier(g);
-    if (i <= lid && lid < lrange)
-      scratch[lid] = binary_op(local_x, other_x);
-    group_barrier(g);
-  }
-
-  if (g.leader())
-    return init;
-  return binary_op(scratch[lid - 1], init);
-}
-
-template<typename Group, typename V, typename T, int N, typename BinaryOperation,
-         typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
-HIPSYCL_KERNEL_TARGET
-vec<T, N> group_exclusive_scan(Group g, V x, vec<T, N> init, BinaryOperation binary_op) {
+vec<T, N> group_exclusive_scan(Group g, vec<T, N> x, V init, BinaryOperation binary_op) {
   __shared__ T scratch[1024 * N];
-  auto lid               = g.get_local_linear_id();
-  size_t lrange          = 1;
-  auto group_local_range = g.get_local_range();
-  for (int i = 0; i < g.dimensions; ++i)
-    lrange *= group_local_range[i];
+  auto         lid               = g.get_local_linear_id();
+  auto         group_local_range = g.get_local_range().size();
 
-  detail::writeToMemory(scratch + lid * N, x);
+  if (lid + 1 < group_local_range) {
+    detail::writeToMemory(scratch + (lid + 1) * N, x);
+  } else {
+    detail::writeToMemory(scratch, init);
+  }
   group_barrier(g);
 
-  for (size_t i = 1; i < lrange; i *= 2) {
-    size_t next_id = lid - i;
+  for (size_t i = 1; i < group_local_range; i *= 2) {
+    size_t    next_id = lid - i;
     vec<T, N> v1, v2;
-    if (i <= lid && lid < lrange) {
+    if (i <= lid && lid < group_local_range) {
       detail::readFromMemory(scratch + lid * N, v1);
       detail::readFromMemory(scratch + next_id * N, v2);
     }
     group_barrier(g);
-    if (i <= lid && lid < lrange) {
-      detail::writeToMemory(scratch + lid * N, binary_op(v1, v2));
-    }
-
-    group_barrier(g);
-  }
-
-  if (g.leader())
-    return init;
-
-  vec<T, N> v;
-  detail::readFromMemory(scratch + (lid - 1) * N, v);
-  return binary_op(v, init);
-}
-
-
-// inclusive_scan
-template<typename Group, typename T, typename BinaryOperation,
-         typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
-HIPSYCL_KERNEL_TARGET
-T group_inclusive_scan(Group g, T x, BinaryOperation binary_op) {
-  __shared__ T scratch[1024];
-  auto lid               = g.get_local_linear_id();
-  size_t lrange          = 1;
-  auto group_local_range = g.get_local_range();
-  for (int i = 0; i < g.dimensions; ++i)
-    lrange *= group_local_range[i];
-
-  scratch[lid] = x;
-  group_barrier(g);
-
-  for (size_t i = 1; i < lrange; i *= 2) {
-    size_t next_id = lid - i;
-    T local_x;
-    T other_x;
-    if (i <= lid && lid < lrange) {
-      local_x = scratch[lid];
-      other_x = scratch[next_id];
-    }
-
-    group_barrier(g);
-    if (i <= lid && lid < lrange)
-      scratch[lid] = binary_op(local_x, other_x);
-    group_barrier(g);
-  }
-
-  return scratch[lid];
-}
-
-template<typename Group, typename T, int N, typename BinaryOperation,
-         typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
-HIPSYCL_KERNEL_TARGET
-vec<T, N> group_inclusive_scan(Group g, vec<T, N> x, BinaryOperation binary_op) {
-  __shared__ T scratch[1024 * N];
-  auto lid               = g.get_local_linear_id();
-  size_t lrange          = 1;
-  auto group_local_range = g.get_local_range();
-  for (int i = 0; i < g.dimensions; ++i)
-    lrange *= group_local_range[i];
-
-  detail::writeToMemory(scratch + lid * N, x);
-  group_barrier(g);
-
-  for (size_t i = 1; i < lrange; i *= 2) {
-    size_t next_id = lid - i;
-    vec<T, N> v1, v2;
-    if (i <= lid && lid < lrange) {
-      detail::readFromMemory(scratch + lid * N, v1);
-      detail::readFromMemory(scratch + next_id * N, v2);
-    }
-    group_barrier(g);
-    if (i <= lid && lid < lrange) {
+    if (i <= lid && lid < group_local_range) {
       detail::writeToMemory(scratch + lid * N, binary_op(v1, v2));
     }
     group_barrier(g);
@@ -584,10 +579,102 @@ vec<T, N> group_inclusive_scan(Group g, vec<T, N> x, BinaryOperation binary_op) 
   return v;
 }
 
+template<typename Group, typename T, typename V, typename BinaryOperation,
+         typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
+HIPSYCL_KERNEL_TARGET
+T group_exclusive_scan(Group g, T x, V init, BinaryOperation binary_op) {
+  __shared__ T scratch[1024];
+  auto         lid               = g.get_local_linear_id();
+  auto         group_local_range = g.get_local_range().size();
+
+  if (lid + 1 < group_local_range) {
+    scratch[lid + 1] = x;
+  } else {
+    scratch[0] = init;
+  }
+  group_barrier(g);
+
+  for (size_t i = 1; i < group_local_range; i *= 2) {
+    size_t next_id = lid - i;
+    T      local_x;
+    T      other_x;
+    if (i <= lid && lid < group_local_range) {
+      local_x = scratch[lid];
+      other_x = scratch[next_id];
+    }
+
+    group_barrier(g);
+    if (i <= lid && lid < group_local_range)
+      scratch[lid] = binary_op(local_x, other_x);
+    group_barrier(g);
+  }
+
+  return scratch[lid];
+}
+
+// inclusive_scan
+template<typename Group, typename T, int N, typename BinaryOperation,
+         typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
+HIPSYCL_KERNEL_TARGET
+vec<T, N> group_inclusive_scan(Group g, vec<T, N> x, BinaryOperation binary_op) {
+  __shared__ T scratch[1024 * N];
+  auto         lid               = g.get_local_linear_id();
+  auto         group_local_range = g.get_local_range().size();
+
+  detail::writeToMemory(scratch + lid * N, x);
+  group_barrier(g);
+
+  for (size_t i = 1; i < group_local_range; i *= 2) {
+    size_t    next_id = lid - i;
+    vec<T, N> v1, v2;
+    if (i <= lid && lid < group_local_range) {
+      detail::readFromMemory(scratch + lid * N, v1);
+      detail::readFromMemory(scratch + next_id * N, v2);
+    }
+    group_barrier(g);
+    if (i <= lid && lid < group_local_range) {
+      detail::writeToMemory(scratch + lid * N, binary_op(v1, v2));
+    }
+    group_barrier(g);
+  }
+
+  vec<T, N> v;
+  detail::readFromMemory(scratch + lid * N, v);
+  return v;
+}
+
+template<typename Group, typename T, typename BinaryOperation,
+         typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
+HIPSYCL_KERNEL_TARGET
+T group_inclusive_scan(Group g, T x, BinaryOperation binary_op) {
+  __shared__ T scratch[1024];
+  auto         lid               = g.get_local_linear_id();
+  auto         group_local_range = g.get_local_range().size();
+
+  scratch[lid] = x;
+  group_barrier(g);
+
+  for (size_t i = 1; i < group_local_range; i *= 2) {
+    size_t next_id = lid - i;
+    T      local_x;
+    T      other_x;
+    if (i <= lid && lid < group_local_range) {
+      local_x = scratch[lid];
+      other_x = scratch[next_id];
+    }
+
+    group_barrier(g);
+    if (i <= lid && lid < group_local_range)
+      scratch[lid] = binary_op(local_x, other_x);
+    group_barrier(g);
+  }
+
+  return scratch[lid];
+}
 
 } // namespace sycl
 } // namespace hipsycl
 
-#endif //HIPSYCL_LIBKERNEL_DEVICE_GROUP_FUNCTIONS_HPP
+#endif // HIPSYCL_LIBKERNEL_DEVICE_GROUP_FUNCTIONS_HPP
 
-#endif //SYCL_DEVICE_ONLY
+#endif // SYCL_DEVICE_ONLY

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/group_functions.hpp
@@ -8,7 +8,7 @@
  * modification, are permitted provided that the following conditions are met:
  *
  * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
+ *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
@@ -91,7 +91,7 @@ HIPSYCL_KERNEL_TARGET
 bool any_of(Group g, T *first, T *last) {
   const auto lrange    = g.get_local_range().size();
   const auto lid       = g.get_local_linear_id();
-  T *  start_ptr = first + lid;
+  T *        start_ptr = first + lid;
 
   bool local = false;
 
@@ -106,7 +106,7 @@ HIPSYCL_KERNEL_TARGET
 bool any_of(Group g, T *first, T *last, Predicate pred) {
   const auto lrange    = g.get_local_range().size();
   const auto lid       = g.get_local_linear_id();
-  T *  start_ptr = first + lid;
+  T *        start_ptr = first + lid;
 
   bool local = false;
 
@@ -134,7 +134,7 @@ HIPSYCL_KERNEL_TARGET
 bool all_of(Group g, T *first, T *last) {
   const auto lrange    = g.get_local_range().size();
   const auto lid       = g.get_local_linear_id();
-  T *  start_ptr = first + lid;
+  T *        start_ptr = first + lid;
 
   bool local = true;
 
@@ -149,7 +149,7 @@ HIPSYCL_KERNEL_TARGET
 bool all_of(Group g, T *first, T *last, Predicate pred) {
   const auto lrange    = g.get_local_range().size();
   const auto lid       = g.get_local_linear_id();
-  T *  start_ptr = first + lid;
+  T *        start_ptr = first + lid;
 
   bool local = true;
 
@@ -177,7 +177,7 @@ HIPSYCL_KERNEL_TARGET
 bool none_of(Group g, T *first, T *last) {
   const auto lrange    = g.get_local_range().size();
   const auto lid       = g.get_local_linear_id();
-  T *  start_ptr = first + lid;
+  T *        start_ptr = first + lid;
 
   bool local = false;
 
@@ -192,7 +192,7 @@ HIPSYCL_KERNEL_TARGET
 bool none_of(Group g, T *first, T *last, Predicate pred) {
   const auto lrange    = g.get_local_range().size();
   const auto lid       = g.get_local_linear_id();
-  T *  start_ptr = first + lid;
+  T *        start_ptr = first + lid;
 
   bool local = false;
 
@@ -218,8 +218,9 @@ bool leader_none_of(Group g, T *first, T *last, Predicate pred) {
 template<typename Group, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
 T reduce(Group g, T *first, T *last, BinaryOperation binary_op) {
-  __shared__ std::aligned_storage_t<sizeof(T) * 1024 / warpSize, alignof(T)> scratch_storage;
-  T *scratch = reinterpret_cast<T *>(&scratch_storage);
+  __shared__ std::aligned_storage_t<sizeof(T) * 1024 / warpSize, alignof(T)>
+             scratch_storage;
+  T *        scratch = reinterpret_cast<T *>(&scratch_storage);
 
   const size_t lrange       = g.get_local_range().size();
   const size_t num_elements = last - first;
@@ -295,14 +296,16 @@ T leader_reduce(Group g, T *first, T *last, BinaryOperation binary_op) {
 // inclusive_scan
 template<typename Group, typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
-T *inclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOperation binary_op) {
+T *inclusive_scan(Group g, V *first, V *last, T *result, T init,
+                  BinaryOperation binary_op) {
   auto         lid          = g.get_local_linear_id();
   auto         wid          = lid / warpSize;
   size_t       lrange       = g.get_local_range().size();
   const size_t num_elements = last - first;
   const size_t iterations   = (num_elements + lrange - 1) / lrange;
 
-  const size_t warp_size = (wid == lrange / warpSize && lrange % warpSize != 0) ? lrange % warpSize : warpSize;
+  const size_t warp_size =
+      (wid == lrange / warpSize && lrange % warpSize != 0) ? lrange % warpSize : warpSize;
 
   size_t offset     = lid;
   T      carry_over = init;
@@ -354,20 +357,23 @@ T *inclusive_scan(Group g, V *first, V *last, T *result, BinaryOperation binary_
 
 template<typename Group, typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
-T *leader_inclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOperation binary_op) {
+T *leader_inclusive_scan(Group g, V *first, V *last, T *result, T init,
+                         BinaryOperation binary_op) {
   return inclusive_scan(g, first, last, result, init, binary_op);
 }
 
 template<typename Group, typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
-T *leader_inclusive_scan(Group g, V *first, V *last, T *result, BinaryOperation binary_op) {
+T *leader_inclusive_scan(Group g, V *first, V *last, T *result,
+                         BinaryOperation binary_op) {
   return inclusive_scan(g, first, last, result, binary_op);
 }
 
 // exclusive_scan
 template<typename Group, typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
-T *exclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOperation binary_op) {
+T *exclusive_scan(Group g, V *first, V *last, T *result, T init,
+                  BinaryOperation binary_op) {
   auto lid = g.get_local_linear_id();
   if (lid == 0 && last - first > 0)
     result[0] = init;
@@ -382,25 +388,28 @@ T *exclusive_scan(Group g, V *first, V *last, T *result, BinaryOperation binary_
 
 template<typename Group, typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
-T *leader_exclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOperation binary_op) {
+T *leader_exclusive_scan(Group g, V *first, V *last, T *result, T init,
+                         BinaryOperation binary_op) {
   return exclusive_scan(g, first, last, result, init, binary_op);
 }
 
 template<typename Group, typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
-T *eleader_xclusive_scan(Group g, V *first, V *last, T *result, BinaryOperation binary_op) {
+T *eleader_xclusive_scan(Group g, V *first, V *last, T *result,
+                         BinaryOperation binary_op) {
   return exclusive_scan(g, first, last, result, binary_op);
 }
 
 } // namespace detail
 
 // broadcast
-template<typename Group, typename T, typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
+template<typename Group, typename T,
+         typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
 HIPSYCL_KERNEL_TARGET
 T group_broadcast(Group g, T x, typename Group::linear_id_type local_linear_id = 0) {
   __shared__ std::aligned_storage_t<sizeof(T), alignof(T)> scratch_storage;
-  T *                                                      scratch = reinterpret_cast<T *>(&scratch_storage);
-  const size_t                                             lid     = g.get_local_linear_id();
+  T *          scratch = reinterpret_cast<T *>(&scratch_storage);
+  const size_t lid     = g.get_local_linear_id();
 
   if (lid == local_linear_id)
     scratch[0] = x;
@@ -412,7 +421,8 @@ T group_broadcast(Group g, T x, typename Group::linear_id_type local_linear_id =
 template<typename Group, typename T>
 HIPSYCL_KERNEL_TARGET
 T group_broadcast(Group g, T x, typename Group::id_type local_id) {
-  const auto target_lid = detail::linear_id<g.dimensions>::get(local_id, detail::get_local_size<g.dimensions>());
+  const auto target_lid = detail::linear_id<g.dimensions>::get(
+      local_id, detail::get_local_size<g.dimensions>());
   return group_broadcast(g, x, target_lid);
 }
 
@@ -442,8 +452,9 @@ template<typename Group, typename T, typename BinaryOperation,
          typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
 HIPSYCL_KERNEL_TARGET
 T group_reduce(Group g, T x, BinaryOperation binary_op) {
-  __shared__ std::aligned_storage_t<sizeof(T) * 1024 / warpSize, alignof(T)> scratch_storage;
-  T *scratch = reinterpret_cast<T *>(&scratch_storage);
+  __shared__ std::aligned_storage_t<sizeof(T) * 1024 / warpSize, alignof(T)>
+             scratch_storage;
+  T *        scratch = reinterpret_cast<T *>(&scratch_storage);
 
   return detail::group_reduce(g, x, binary_op, scratch);
 }
@@ -453,7 +464,8 @@ template<typename Group, typename T, typename V, typename BinaryOperation,
          typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
 HIPSYCL_KERNEL_TARGET
 T group_exclusive_scan(Group g, T x, V init, BinaryOperation binary_op) {
-  __shared__ std::aligned_storage_t<sizeof(T) * 1024 / warpSize, alignof(T)> scratch_storage;
+  __shared__   std::aligned_storage_t<sizeof(T) * 1024 / warpSize, alignof(T)>
+               scratch_storage;
   T *          scratch  = reinterpret_cast<T *>(&scratch_storage);
   const size_t lid      = g.get_local_linear_id();
   const size_t wid      = lid / warpSize;
@@ -468,7 +480,7 @@ T group_exclusive_scan(Group g, T x, V init, BinaryOperation binary_op) {
 
   if (lid < warpSize) {
     const size_t scratch_index = (lid < 1024 / warpSize) ? lid : 0;
-    const T      tmp           = group_inclusive_scan(sg, scratch[scratch_index], binary_op);
+    const T      tmp = group_inclusive_scan(sg, scratch[scratch_index], binary_op);
 
     if (lid < (lrange + warpSize - 1) / warpSize)
       scratch[lid] = tmp;
@@ -491,7 +503,8 @@ template<typename Group, typename T, typename BinaryOperation,
          typename std::enable_if_t<!std::is_same_v<Group, sub_group>, int> = 0>
 HIPSYCL_KERNEL_TARGET
 T group_inclusive_scan(Group g, T x, BinaryOperation binary_op) {
-  __shared__ std::aligned_storage_t<sizeof(T) * 1024 / warpSize, alignof(T)> scratch_storage;
+  __shared__   std::aligned_storage_t<sizeof(T) * 1024 / warpSize, alignof(T)>
+               scratch_storage;
   T *          scratch  = reinterpret_cast<T *>(&scratch_storage);
   const size_t lid      = g.get_local_linear_id();
   size_t       wid      = lid / warpSize;

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/group_functions.hpp
@@ -51,9 +51,9 @@ template<typename Group, typename T, typename BinaryOperation,
 HIPSYCL_KERNEL_TARGET
 T group_reduce(Group g, T x, BinaryOperation binary_op, T *scratch) {
 
-  auto      lid    = g.get_local_linear_id();
-  size_t    lrange = (g.get_local_range().size() + warpSize - 1) / warpSize;
-  sub_group sg{};
+  const auto   lid    = g.get_local_linear_id();
+  const size_t lrange = (g.get_local_range().size() + warpSize - 1) / warpSize;
+  sub_group    sg{};
 
   x = group_reduce(sg, x, binary_op);
   if (sg.leader())
@@ -89,13 +89,13 @@ T group_reduce(Group g, T x, BinaryOperation binary_op, T *scratch) {
 template<typename Group, typename T>
 HIPSYCL_KERNEL_TARGET
 bool any_of(Group g, T *first, T *last) {
-  auto group_range = g.get_local_range().size();
-  auto lid         = g.get_local_linear_id();
-  T *  start_ptr   = first + lid;
+  const auto lrange    = g.get_local_range().size();
+  const auto lid       = g.get_local_linear_id();
+  T *  start_ptr = first + lid;
 
   bool local = false;
 
-  for (T *p = start_ptr; p < last; p += group_range)
+  for (T *p = start_ptr; p < last; p += lrange)
     local |= *p;
 
   return group_any_of(g, local);
@@ -104,13 +104,13 @@ bool any_of(Group g, T *first, T *last) {
 template<typename Group, typename T, typename Predicate>
 HIPSYCL_KERNEL_TARGET
 bool any_of(Group g, T *first, T *last, Predicate pred) {
-  auto group_range = g.get_local_range().size();
-  auto lid         = g.get_local_linear_id();
-  T *  start_ptr   = first + lid;
+  const auto lrange    = g.get_local_range().size();
+  const auto lid       = g.get_local_linear_id();
+  T *  start_ptr = first + lid;
 
   bool local = false;
 
-  for (T *p = start_ptr; p < last; p += group_range)
+  for (T *p = start_ptr; p < last; p += lrange)
     local |= pred(*p);
 
   return group_any_of(g, local);
@@ -118,23 +118,27 @@ bool any_of(Group g, T *first, T *last, Predicate pred) {
 
 template<typename Group, typename T>
 HIPSYCL_KERNEL_TARGET
-bool leader_any_of(Group g, T *first, T *last) { return any_of(g, first, last); }
+bool leader_any_of(Group g, T *first, T *last) {
+  return any_of(g, first, last);
+}
 
 template<typename Group, typename T, typename Predicate>
 HIPSYCL_KERNEL_TARGET
-bool leader_any_of(Group g, T *first, T *last, Predicate pred) { return any_of(g, first, last, pred); }
+bool leader_any_of(Group g, T *first, T *last, Predicate pred) {
+  return any_of(g, first, last, pred);
+}
 
 // all_of
 template<typename Group, typename T>
 HIPSYCL_KERNEL_TARGET
 bool all_of(Group g, T *first, T *last) {
-  auto group_range = g.get_local_range().size();
-  auto lid         = g.get_local_linear_id();
-  T *  start_ptr   = first + lid;
+  const auto lrange    = g.get_local_range().size();
+  const auto lid       = g.get_local_linear_id();
+  T *  start_ptr = first + lid;
 
   bool local = true;
 
-  for (T *p = start_ptr; p < last; p += group_range)
+  for (T *p = start_ptr; p < last; p += lrange)
     local &= *p;
 
   return group_all_of(g, local);
@@ -143,13 +147,13 @@ bool all_of(Group g, T *first, T *last) {
 template<typename Group, typename T, typename Predicate>
 HIPSYCL_KERNEL_TARGET
 bool all_of(Group g, T *first, T *last, Predicate pred) {
-  auto group_range = g.get_local_range().size();
-  auto lid         = g.get_local_linear_id();
-  T *  start_ptr   = first + lid;
+  const auto lrange    = g.get_local_range().size();
+  const auto lid       = g.get_local_linear_id();
+  T *  start_ptr = first + lid;
 
   bool local = true;
 
-  for (T *p = start_ptr; p < last; p += group_range)
+  for (T *p = start_ptr; p < last; p += lrange)
     local &= pred(*p);
 
   return group_all_of(g, local);
@@ -157,23 +161,27 @@ bool all_of(Group g, T *first, T *last, Predicate pred) {
 
 template<typename Group, typename T>
 HIPSYCL_KERNEL_TARGET
-bool leader_all_of(Group g, T *first, T *last) { return all_of(g, first, last); }
+bool leader_all_of(Group g, T *first, T *last) {
+  return all_of(g, first, last);
+}
 
 template<typename Group, typename T, typename Predicate>
 HIPSYCL_KERNEL_TARGET
-bool leader_all_of(Group g, T *first, T *last, Predicate pred) { return all_of(g, first, last, pred); }
+bool leader_all_of(Group g, T *first, T *last, Predicate pred) {
+  return all_of(g, first, last, pred);
+}
 
 // none_of
 template<typename Group, typename T>
 HIPSYCL_KERNEL_TARGET
 bool none_of(Group g, T *first, T *last) {
-  auto group_range = g.get_local_range().size();
-  auto lid         = g.get_local_linear_id();
-  T *  start_ptr   = first + lid;
+  const auto lrange    = g.get_local_range().size();
+  const auto lid       = g.get_local_linear_id();
+  T *  start_ptr = first + lid;
 
   bool local = false;
 
-  for (T *p = start_ptr; p < last; p += group_range)
+  for (T *p = start_ptr; p < last; p += lrange)
     local |= *p;
 
   return group_none_of(g, local);
@@ -182,13 +190,13 @@ bool none_of(Group g, T *first, T *last) {
 template<typename Group, typename T, typename Predicate>
 HIPSYCL_KERNEL_TARGET
 bool none_of(Group g, T *first, T *last, Predicate pred) {
-  auto group_range = g.get_local_range().size();
-  auto lid         = g.get_local_linear_id();
-  T *  start_ptr   = first + lid;
+  const auto lrange    = g.get_local_range().size();
+  const auto lid       = g.get_local_linear_id();
+  T *  start_ptr = first + lid;
 
   bool local = false;
 
-  for (T *p = start_ptr; p < last; p += group_range)
+  for (T *p = start_ptr; p < last; p += lrange)
     local |= pred(*p);
 
   return group_none_of(g, local);
@@ -196,11 +204,15 @@ bool none_of(Group g, T *first, T *last, Predicate pred) {
 
 template<typename Group, typename T>
 HIPSYCL_KERNEL_TARGET
-bool leader_none_of(Group g, T *first, T *last) { return none_of(g, first, last); }
+bool leader_none_of(Group g, T *first, T *last) {
+  return none_of(g, first, last);
+}
 
 template<typename Group, typename T, typename Predicate>
 HIPSYCL_KERNEL_TARGET
-bool leader_none_of(Group g, T *first, T *last, Predicate pred) { return none_of(g, first, last, pred); }
+bool leader_none_of(Group g, T *first, T *last, Predicate pred) {
+  return none_of(g, first, last, pred);
+}
 
 // reduce
 template<typename Group, typename T, typename BinaryOperation>
@@ -209,7 +221,7 @@ T reduce(Group g, T *first, T *last, BinaryOperation binary_op) {
   __shared__ std::aligned_storage_t<sizeof(T) * 1024 / warpSize, alignof(T)> scratch_storage;
   T *scratch = reinterpret_cast<T *>(&scratch_storage);
 
-  const size_t group_range  = g.get_local_range().size();
+  const size_t lrange       = g.get_local_range().size();
   const size_t num_elements = last - first;
   const size_t lid          = g.get_local_linear_id();
 
@@ -218,10 +230,10 @@ T reduce(Group g, T *first, T *last, BinaryOperation binary_op) {
   if (num_elements == 1)
     return *first;
 
-  if (num_elements >= group_range) {
+  if (num_elements >= lrange) {
     auto local = *start_ptr;
 
-    for (T *p = start_ptr + group_range; p < last; p += group_range)
+    for (T *p = start_ptr + lrange; p < last; p += lrange)
       local = binary_op(local, *p);
 
     return detail::group_reduce(g, local, binary_op, scratch);
@@ -276,7 +288,9 @@ T leader_reduce(Group g, V *first, V *last, T init, BinaryOperation binary_op) {
 
 template<typename Group, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
-T leader_reduce(Group g, T *first, T *last, BinaryOperation binary_op) { return reduce(g, first, last, binary_op); }
+T leader_reduce(Group g, T *first, T *last, BinaryOperation binary_op) {
+  return reduce(g, first, last, binary_op);
+}
 
 // inclusive_scan
 template<typename Group, typename V, typename T, typename BinaryOperation>
@@ -287,7 +301,6 @@ T *inclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOperation
   size_t       lrange       = g.get_local_range().size();
   const size_t num_elements = last - first;
   const size_t iterations   = (num_elements + lrange - 1) / lrange;
-  sub_group    sg{};
 
   const size_t warp_size = (wid == lrange / warpSize && lrange % warpSize != 0) ? lrange % warpSize : warpSize;
 
@@ -387,7 +400,7 @@ HIPSYCL_KERNEL_TARGET
 T group_broadcast(Group g, T x, typename Group::linear_id_type local_linear_id = 0) {
   __shared__ std::aligned_storage_t<sizeof(T), alignof(T)> scratch_storage;
   T *                                                      scratch = reinterpret_cast<T *>(&scratch_storage);
-  auto                                                     lid     = g.get_local_linear_id();
+  const size_t                                             lid     = g.get_local_linear_id();
 
   if (lid == local_linear_id)
     scratch[0] = x;
@@ -399,24 +412,30 @@ T group_broadcast(Group g, T x, typename Group::linear_id_type local_linear_id =
 template<typename Group, typename T>
 HIPSYCL_KERNEL_TARGET
 T group_broadcast(Group g, T x, typename Group::id_type local_id) {
-  auto target_lid = detail::linear_id<g.dimensions>::get(local_id, detail::get_local_size<g.dimensions>());
+  const auto target_lid = detail::linear_id<g.dimensions>::get(local_id, detail::get_local_size<g.dimensions>());
   return group_broadcast(g, x, target_lid);
 }
 
 // any_of
 template<typename Group>
 HIPSYCL_KERNEL_TARGET
-inline bool group_any_of(Group g, bool pred) { return __syncthreads_or(pred); }
+inline bool group_any_of(Group g, bool pred) {
+  return __syncthreads_or(pred);
+}
 
 // all_of
 template<typename Group>
 HIPSYCL_KERNEL_TARGET
-inline bool group_all_of(Group g, bool pred) { return __syncthreads_and(pred); }
+inline bool group_all_of(Group g, bool pred) {
+  return __syncthreads_and(pred);
+}
 
 // none_of
 template<typename Group>
 HIPSYCL_KERNEL_TARGET
-inline bool group_none_of(Group g, bool pred) { return !__syncthreads_or(pred); }
+inline bool group_none_of(Group g, bool pred) {
+  return !__syncthreads_or(pred);
+}
 
 // reduce
 template<typename Group, typename T, typename BinaryOperation,
@@ -435,27 +454,25 @@ template<typename Group, typename T, typename V, typename BinaryOperation,
 HIPSYCL_KERNEL_TARGET
 T group_exclusive_scan(Group g, T x, V init, BinaryOperation binary_op) {
   __shared__ std::aligned_storage_t<sizeof(T) * 1024 / warpSize, alignof(T)> scratch_storage;
-  T *    scratch           = reinterpret_cast<T *>(&scratch_storage);
-  auto   lid               = g.get_local_linear_id();
-  auto   wid               = lid / warpSize;
-  size_t lrange            = 1;
-  auto   group_local_range = g.get_local_range();
-  for (int i = 0; i < g.dimensions; ++i)
-    lrange *= group_local_range[i];
+  T *          scratch  = reinterpret_cast<T *>(&scratch_storage);
+  const size_t lid      = g.get_local_linear_id();
+  const size_t wid      = lid / warpSize;
+  const size_t lrange   = g.get_local_range().size();
+  const size_t last_wid = (wid + 1) * warpSize - 1;
+  sub_group    sg{};
 
-  sub_group sg{};
-
-  auto local_x  = group_inclusive_scan(sg, x, binary_op);
-  auto last_wid = (wid + 1) * warpSize - 1;
+  auto local_x = group_inclusive_scan(sg, x, binary_op);
   if (lid == (lrange < last_wid ? lrange - 1 : last_wid))
     scratch[wid] = local_x;
   group_barrier(g);
 
-  size_t scratch_index = (lid < 1024 / warpSize) ? lid : 0;
-  T      tmp           = group_inclusive_scan(sg, scratch[scratch_index], binary_op);
+  if (lid < warpSize) {
+    const size_t scratch_index = (lid < 1024 / warpSize) ? lid : 0;
+    const T      tmp           = group_inclusive_scan(sg, scratch[scratch_index], binary_op);
 
-  if (lid < (lrange + warpSize - 1) / warpSize)
-    scratch[lid] = tmp;
+    if (lid < (lrange + warpSize - 1) / warpSize)
+      scratch[lid] = tmp;
+  }
   group_barrier(g);
 
   auto prefix = init;
@@ -475,22 +492,22 @@ template<typename Group, typename T, typename BinaryOperation,
 HIPSYCL_KERNEL_TARGET
 T group_inclusive_scan(Group g, T x, BinaryOperation binary_op) {
   __shared__ std::aligned_storage_t<sizeof(T) * 1024 / warpSize, alignof(T)> scratch_storage;
-  T *    scratch = reinterpret_cast<T *>(&scratch_storage);
-  auto   lid     = g.get_local_linear_id();
-  auto   wid     = lid / warpSize;
-  size_t lrange  = g.get_local_range().size();
+  T *          scratch  = reinterpret_cast<T *>(&scratch_storage);
+  const size_t lid      = g.get_local_linear_id();
+  size_t       wid      = lid / warpSize;
+  size_t       lrange   = g.get_local_range().size();
+  size_t       last_wid = (wid + 1) * warpSize - 1;
 
   sub_group sg{};
 
-  auto local_x  = group_inclusive_scan(sg, x, binary_op);
-  auto last_wid = (wid + 1) * warpSize - 1;
+  auto local_x = group_inclusive_scan(sg, x, binary_op);
   if (lid == (lrange < last_wid ? lrange - 1 : last_wid))
     scratch[wid] = local_x;
   group_barrier(g);
 
   if (lid < warpSize) {
-    size_t scratch_index = (lid < (lrange + warpSize - 1) / warpSize) ? lid : 0;
-    T      tmp           = group_inclusive_scan(sg, scratch[scratch_index], binary_op);
+    size_t  scratch_index = (lid < (lrange + warpSize - 1) / warpSize) ? lid : 0;
+    const T tmp           = group_inclusive_scan(sg, scratch[scratch_index], binary_op);
 
     if (lid < 1024 / warpSize) {
       scratch[lid] = tmp;

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/group_functions.hpp
@@ -228,6 +228,9 @@ T reduce(Group g, T *first, T *last, BinaryOperation binary_op) {
 
   T *start_ptr = first + lid;
 
+  if (num_elements <= 0)
+    return T{};
+
   if (num_elements == 1)
     return *first;
 

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/group_functions.hpp
@@ -55,7 +55,7 @@ T group_reduce(Group g, T x, BinaryOperation binary_op, T *scratch) {
   size_t    lrange = (g.get_local_range().size() + warpSize - 1) / warpSize;
   sub_group sg{};
 
-  x            = group_reduce(sg, x, binary_op);
+  x = group_reduce(sg, x, binary_op);
   if (sg.leader())
     scratch[lid / warpSize] = x;
   group_barrier(g);
@@ -89,9 +89,9 @@ T group_reduce(Group g, T x, BinaryOperation binary_op, T *scratch) {
 template<typename Group, typename T>
 HIPSYCL_KERNEL_TARGET
 bool any_of(Group g, T *first, T *last) {
-  auto group_range        = g.get_local_range().size();
-  auto lid        = g.get_local_linear_id();
-  T *  start_ptr          = first + lid;
+  auto group_range = g.get_local_range().size();
+  auto lid         = g.get_local_linear_id();
+  T *  start_ptr   = first + lid;
 
   bool local = false;
 
@@ -104,9 +104,9 @@ bool any_of(Group g, T *first, T *last) {
 template<typename Group, typename T, typename Predicate>
 HIPSYCL_KERNEL_TARGET
 bool any_of(Group g, T *first, T *last, Predicate pred) {
-  auto group_range        = g.get_local_range().size();
-  auto lid        = g.get_local_linear_id();
-  T *  start_ptr          = first + lid;
+  auto group_range = g.get_local_range().size();
+  auto lid         = g.get_local_linear_id();
+  T *  start_ptr   = first + lid;
 
   bool local = false;
 
@@ -118,23 +118,19 @@ bool any_of(Group g, T *first, T *last, Predicate pred) {
 
 template<typename Group, typename T>
 HIPSYCL_KERNEL_TARGET
-bool leader_any_of(Group g, T *first, T *last) {
-  return any_of(g, first, last);
-}
+bool leader_any_of(Group g, T *first, T *last) { return any_of(g, first, last); }
 
 template<typename Group, typename T, typename Predicate>
 HIPSYCL_KERNEL_TARGET
-bool leader_any_of(Group g, T *first, T *last, Predicate pred) {
-  return any_of(g, first, last, pred);
-}
+bool leader_any_of(Group g, T *first, T *last, Predicate pred) { return any_of(g, first, last, pred); }
 
 // all_of
 template<typename Group, typename T>
 HIPSYCL_KERNEL_TARGET
 bool all_of(Group g, T *first, T *last) {
-  auto group_range        = g.get_local_range().size();
-  auto lid        = g.get_local_linear_id();
-  T *  start_ptr          = first + lid;
+  auto group_range = g.get_local_range().size();
+  auto lid         = g.get_local_linear_id();
+  T *  start_ptr   = first + lid;
 
   bool local = true;
 
@@ -147,9 +143,9 @@ bool all_of(Group g, T *first, T *last) {
 template<typename Group, typename T, typename Predicate>
 HIPSYCL_KERNEL_TARGET
 bool all_of(Group g, T *first, T *last, Predicate pred) {
-  auto group_range        = g.get_local_range().size();
-  auto lid        = g.get_local_linear_id();
-  T *  start_ptr          = first + lid;
+  auto group_range = g.get_local_range().size();
+  auto lid         = g.get_local_linear_id();
+  T *  start_ptr   = first + lid;
 
   bool local = true;
 
@@ -161,23 +157,19 @@ bool all_of(Group g, T *first, T *last, Predicate pred) {
 
 template<typename Group, typename T>
 HIPSYCL_KERNEL_TARGET
-bool leader_all_of(Group g, T *first, T *last) {
-  return all_of(g, first, last);
-}
+bool leader_all_of(Group g, T *first, T *last) { return all_of(g, first, last); }
 
 template<typename Group, typename T, typename Predicate>
 HIPSYCL_KERNEL_TARGET
-bool leader_all_of(Group g, T *first, T *last, Predicate pred) {
-  return all_of(g, first, last, pred);
-}
+bool leader_all_of(Group g, T *first, T *last, Predicate pred) { return all_of(g, first, last, pred); }
 
 // none_of
 template<typename Group, typename T>
 HIPSYCL_KERNEL_TARGET
 bool none_of(Group g, T *first, T *last) {
-  auto group_range        = g.get_local_range().size();
-  auto lid        = g.get_local_linear_id();
-  T *  start_ptr          = first + lid;
+  auto group_range = g.get_local_range().size();
+  auto lid         = g.get_local_linear_id();
+  T *  start_ptr   = first + lid;
 
   bool local = false;
 
@@ -190,9 +182,9 @@ bool none_of(Group g, T *first, T *last) {
 template<typename Group, typename T, typename Predicate>
 HIPSYCL_KERNEL_TARGET
 bool none_of(Group g, T *first, T *last, Predicate pred) {
-  auto group_range        = g.get_local_range().size();
-  auto lid        = g.get_local_linear_id();
-  T *  start_ptr          = first + lid;
+  auto group_range = g.get_local_range().size();
+  auto lid         = g.get_local_linear_id();
+  T *  start_ptr   = first + lid;
 
   bool local = false;
 
@@ -204,16 +196,11 @@ bool none_of(Group g, T *first, T *last, Predicate pred) {
 
 template<typename Group, typename T>
 HIPSYCL_KERNEL_TARGET
-bool leader_none_of(Group g, T *first, T *last) {
-  return none_of(g, first, last);
-}
+bool leader_none_of(Group g, T *first, T *last) { return none_of(g, first, last); }
 
 template<typename Group, typename T, typename Predicate>
 HIPSYCL_KERNEL_TARGET
-bool leader_none_of(Group g, T *first, T *last, Predicate pred) {
-  return none_of(g, first, last, pred);
-}
-
+bool leader_none_of(Group g, T *first, T *last, Predicate pred) { return none_of(g, first, last, pred); }
 
 // reduce
 template<typename Group, typename T, typename BinaryOperation>
@@ -295,28 +282,28 @@ T leader_reduce(Group g, T *first, T *last, BinaryOperation binary_op) { return 
 template<typename Group, typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
 T *inclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOperation binary_op) {
-  auto                                                     lid          = g.get_local_linear_id();
-  auto                                                     wid          = lid / warpSize;
-  size_t                                                   lrange       = g.get_local_range().size();
-  const size_t                                             num_elements = last - first;
-  const size_t                                             iterations   = (num_elements + lrange - 1) / lrange;
-  sub_group                                                sg{};
+  auto         lid          = g.get_local_linear_id();
+  auto         wid          = lid / warpSize;
+  size_t       lrange       = g.get_local_range().size();
+  const size_t num_elements = last - first;
+  const size_t iterations   = (num_elements + lrange - 1) / lrange;
+  sub_group    sg{};
 
   const size_t warp_size = (wid == lrange / warpSize && lrange % warpSize != 0) ? lrange % warpSize : warpSize;
 
-  size_t offset = lid;
+  size_t offset     = lid;
   T      carry_over = init;
   T      local_x;
 
   for (int i = 0; i < iterations; ++i) {
-    const size_t offset = lid + i*lrange;
-    local_x = (offset < num_elements) ? first[offset] : V{};
-    local_x = group_inclusive_scan(g, local_x, carry_over, binary_op);
+    const size_t offset = lid + i * lrange;
+    local_x             = (offset < num_elements) ? first[offset] : V{};
+    local_x             = group_inclusive_scan(g, local_x, carry_over, binary_op);
 
     if (offset < num_elements)
       result[offset] = local_x;
 
-    carry_over = group_broadcast(g, local_x, lrange-1);
+    carry_over = group_broadcast(g, local_x, lrange - 1);
   }
 
   return result + num_elements;
@@ -325,18 +312,18 @@ T *inclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOperation
 template<typename Group, typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
 T *inclusive_scan(Group g, V *first, V *last, T *result, BinaryOperation binary_op) {
-  auto                                                     lid          = g.get_local_linear_id();
-  auto                                                     wid          = lid / warpSize;
-  size_t                                                   lrange       = g.get_local_range().size();
-  const size_t                                             num_elements = last - first;
-  const size_t                                             iterations   = (num_elements + lrange - 1) / lrange;
+  auto         lid          = g.get_local_linear_id();
+  auto         wid          = lid / warpSize;
+  size_t       lrange       = g.get_local_range().size();
+  const size_t num_elements = last - first;
+  const size_t iterations   = (num_elements + lrange - 1) / lrange;
 
-  T      carry_over;
-  T      local_x;
+  T carry_over;
+  T local_x;
 
   for (int i = 0; i < iterations; ++i) {
-    const size_t offset = lid + i*lrange;
-    local_x = (offset < num_elements) ? first[offset] : V{};
+    const size_t offset = lid + i * lrange;
+    local_x             = (offset < num_elements) ? first[offset] : V{};
     if (i > 0) {
       local_x = group_inclusive_scan(g, local_x, carry_over, binary_op);
     } else {
@@ -346,7 +333,7 @@ T *inclusive_scan(Group g, V *first, V *last, T *result, BinaryOperation binary_
     if (offset < num_elements)
       result[offset] = local_x;
 
-    carry_over = group_broadcast(g, local_x, lrange-1);
+    carry_over = group_broadcast(g, local_x, lrange - 1);
   }
 
   return result + num_elements;
@@ -363,7 +350,6 @@ HIPSYCL_KERNEL_TARGET
 T *leader_inclusive_scan(Group g, V *first, V *last, T *result, BinaryOperation binary_op) {
   return inclusive_scan(g, first, last, result, binary_op);
 }
-
 
 // exclusive_scan
 template<typename Group, typename V, typename T, typename BinaryOperation>
@@ -502,11 +488,11 @@ T group_inclusive_scan(Group g, T x, BinaryOperation binary_op) {
     scratch[wid] = local_x;
   group_barrier(g);
 
-  if (lid  < warpSize) {
-    size_t scratch_index = (lid < (lrange + warpSize-1) / warpSize) ? lid : 0;
-    T tmp           = group_inclusive_scan(sg, scratch[scratch_index], binary_op);
+  if (lid < warpSize) {
+    size_t scratch_index = (lid < (lrange + warpSize - 1) / warpSize) ? lid : 0;
+    T      tmp           = group_inclusive_scan(sg, scratch[scratch_index], binary_op);
 
-    if (lid < 1024/warpSize) {
+    if (lid < 1024 / warpSize) {
       scratch[lid] = tmp;
     }
   }

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/warp_shuffle.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/warp_shuffle.hpp
@@ -1,0 +1,162 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef SYCL_DEVICE_ONLY
+
+#ifndef HIPSYCL_DETAIL_WARP_SHUFFLE
+#define HIPSYCL_DETAIL_WARP_SHUFFLE
+
+namespace hipsycl {
+namespace sycl {
+
+namespace detail {
+
+#ifdef HIPSYCL_PLATFORM_HIP
+template<typename T, typename Operation>
+__device__
+T apply_on_data(T x, Operation op) {
+  constexpr int words_no = (sizeof(T) + sizeof(int) - 1) / sizeof(int);
+
+  int words[words_no];
+  __builtin_memcpy(words, &x, sizeof(T));
+
+#pragma unroll
+  for (int i = 0; i < words_no; i++)
+    words[i] = op(words[i]);
+
+  T output;
+  __builtin_memcpy(&output, words, sizeof(T));
+
+  return output;
+}
+
+// implemented based on warp_shuffle_op in rocPRIM
+template<typename T>
+__device__
+T shuffle_impl(T x, int id) {
+  return apply_on_data(x, [id](int data) { return __shfl(data, id); });
+}
+template<typename T>
+__device__
+T shuffle_up_impl(T x, int offset) {
+  return apply_on_data(x, [offset](int data) { return __shfl_up(data, offset); });
+}
+template<typename T>
+__device__
+T shuffle_down_impl(T x, int offset) {
+  return apply_on_data(x, [offset](int data) { return __shfl_down(data, offset); });
+}
+
+// dpp sharing instruction abstraction based on rocPRIM
+// the dpp_ctrl can be found in the GCN3 ISA manual
+template<typename T, int dpp_ctrl, int row_mask = 0xf, int bank_mask = 0xf, bool bound_ctrl = false>
+__device__
+T warp_move_dpp(T x) {
+  return apply_on_data(
+      x, [=](int data) { return __builtin_amdgcn_update_dpp(0, data, dpp_ctrl, row_mask, bank_mask, bound_ctrl); });
+}
+#endif // HIPSYCL_PLATFORM_HIP
+
+#ifdef HIPSYCL_PLATFORM_CUDA
+constexpr unsigned int AllMask = 0xFFFFFFFF;
+
+// shuffle_impl implemented based on ShuffleIndex in cub
+template<typename T, typename Operation, typename std::enable_if_t<(sizeof(T) == sizeof(unsigned char)), int> = 0>
+__device__
+T apply_on_data(T x, Operation op) {
+  T              data     = x;
+  unsigned char *data_ptr = reinterpret_cast<unsigned char *>(&data);
+  *data_ptr               = op(*data_ptr);
+  return data;
+}
+
+template<typename T, typename Operation, typename std::enable_if_t<(sizeof(T) == sizeof(unsigned short)), int> = 0>
+__device__
+T apply_on_data(T x, Operation op) {
+  T               data     = x;
+  unsigned short *data_ptr = reinterpret_cast<unsigned short *>(&data);
+  *data_ptr                = op(*data_ptr);
+  return data;
+}
+
+template<typename T, typename Operation, typename std::enable_if_t<(sizeof(T) == sizeof(unsigned int)), int> = 0>
+__device__
+T apply_on_data(T x, Operation op) {
+  T             data     = x;
+  unsigned int *data_ptr = reinterpret_cast<unsigned int *>(&data);
+  *data_ptr              = op(*data_ptr);
+  return data;
+}
+
+template<typename T, typename Operation,
+         typename std::enable_if_t<(sizeof(T) != sizeof(unsigned char) && sizeof(T) != sizeof(unsigned short) &&
+                                    sizeof(T) != sizeof(unsigned int)),
+                                   int> = 0>
+__device__
+T apply_on_data(T x, Operation op) {
+  constexpr int words_no = (sizeof(T) + sizeof(unsigned int) - 1) / sizeof(unsigned int);
+
+  unsigned int words[words_no];
+  memcpy(words, &x, sizeof(T));
+
+#pragma unroll
+  for (int i = 0; i < words_no; i++)
+    words[i] = op(words[i]);
+
+  T output;
+  memcpy(&output, words, sizeof(T));
+
+  return output;
+}
+
+template<typename T>
+__device__
+T shuffle_impl(T x, int id) {
+  return apply_on_data(x, [id](int data) { return __shfl_sync(AllMask, data, id); });
+}
+template<typename T>
+__device__
+T shuffle_up_impl(T x, int offset) {
+  return apply_on_data(x, [offset](int data) { return __shfl_up_sync(AllMask, data, offset); });
+}
+template<typename T>
+__device__
+T shuffle_down_impl(T x, int offset) {
+  return apply_on_data(x, [offset](int data) { return __shfl_down_sync(AllMask, data, offset); });
+}
+
+#endif // HIPSYCL_PLATFORM_CUDA
+
+} // namespace detail
+
+} // namespace sycl
+} // namespace hipsycl
+
+#endif // HIPSYCL_DETAIL_WARP_SHUFFLE
+
+#endif // SYCL_DEVICE_ONLY

--- a/include/hipSYCL/sycl/libkernel/hip/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/hip/group_functions.hpp
@@ -92,42 +92,43 @@ T group_reduce(sub_group g, T x, BinaryOperation binary_op) {
   uint64_t activemask;
   asm("s_mov_b64 %0, exec" : "=r"(activemask));
 
-  if (~activemask == 0) {
-    // adaption of rocprim dpp_reduce
-    // quad_perm: add 0+1, 2+3
-    local_x = binary_op(detail::warp_move_dpp<T, 0xb1>(local_x), local_x);
-    // quad_perm: add 0+2
-    local_x = binary_op(detail::warp_move_dpp<T, 0x4e>(local_x), local_x);
-    // row_sr: add 0+4
-    local_x = binary_op(detail::warp_move_dpp<T, 0x114>(local_x), local_x);
-    // row_sr: add 0+8
-    local_x = binary_op(detail::warp_move_dpp<T, 0x118>(local_x), local_x);
-    // row_bcast15: add 0+15
-    local_x = binary_op(detail::warp_move_dpp<T, 0x142>(local_x), local_x);
+  if constexpr (sizeof(T) > 2*sizeof(double)) {
+    if (~activemask == 0) {
+      // adaption of rocprim dpp_reduce
+      // quad_perm: add 0+1, 2+3
+      local_x = binary_op(detail::warp_move_dpp<T, 0xb1>(local_x), local_x);
+      // quad_perm: add 0+2
+      local_x = binary_op(detail::warp_move_dpp<T, 0x4e>(local_x), local_x);
+      // row_sr: add 0+4
+      local_x = binary_op(detail::warp_move_dpp<T, 0x114>(local_x), local_x);
+      // row_sr: add 0+8
+      local_x = binary_op(detail::warp_move_dpp<T, 0x118>(local_x), local_x);
+      // row_bcast15: add 0+15
+      local_x = binary_op(detail::warp_move_dpp<T, 0x142>(local_x), local_x);
 
-    if constexpr (warpSize > 32) {
-      // row_bcast31: add 0+31
-      local_x = binary_op(detail::warp_move_dpp<T, 0x143>(local_x), local_x);
+      if constexpr (warpSize > 32) {
+        // row_bcast31: add 0+31
+        local_x = binary_op(detail::warp_move_dpp<T, 0x143>(local_x), local_x);
+      }
+
+      // get the result from last thead
+      return detail::shuffle_impl(local_x, warpSize - 1);
     }
-
-    // get the result from last thead
-    return detail::shuffle_impl(local_x, warpSize - 1);
-  } else {
-    auto lid = g.get_local_linear_id();
-
-    size_t lrange = g.get_local_range().size();
-
-    group_barrier(g);
-
-    for (size_t i = lrange / 2; i > 0; i /= 2) {
-      auto other_x = detail::shuffle_impl(local_x, lid + i);
-
-      // check if target thread exists/is active
-      if (activemask & (1l << (lid + i)))
-        local_x = binary_op(local_x, other_x);
-    }
-    return detail::shuffle_impl(local_x, 0);
   }
+  auto lid = g.get_local_linear_id();
+
+  size_t lrange = g.get_local_range().size();
+
+  group_barrier(g);
+
+  for (size_t i = lrange / 2; i > 0; i /= 2) {
+    auto other_x = detail::shuffle_impl(local_x, lid + i);
+
+    // check if target thread exists/is active
+    if (activemask & (1l << (lid + i)))
+      local_x = binary_op(local_x, other_x);
+  }
+  return detail::shuffle_impl(local_x, 0);
 }
 
 // inclusive_scan
@@ -140,59 +141,60 @@ T group_inclusive_scan(sub_group g, T x, BinaryOperation binary_op) {
   uint64_t activemask;
   asm("s_mov_b64 %0, exec" : "=r"(activemask));
 
-  if (~activemask == 0) {
-    auto row_id  = lid % 16;
-    auto lane_id = lid % warpSize;
-    // adaption of rocprim dpp_scan
-    T tmp;
-    // row_sr:1
-    tmp = binary_op(detail::warp_move_dpp<T, 0x111>(local_x), local_x);
-    if (row_id > 0)
-      local_x = tmp;
-
-    // row_sr:2
-    tmp = binary_op(detail::warp_move_dpp<T, 0x112>(local_x), local_x);
-    if (row_id > 1)
-      local_x = tmp;
-
-    // row_sr:4
-    tmp = binary_op(detail::warp_move_dpp<T, 0x114>(local_x), local_x);
-    if (row_id > 3)
-      local_x = tmp;
-
-    // row_sr:8
-    tmp = binary_op(detail::warp_move_dpp<T, 0x118>(local_x), local_x);
-    if (row_id > 7)
-      local_x = tmp;
-
-    // row_bcast15
-    tmp = binary_op(detail::warp_move_dpp<T, 0x142>(local_x), local_x);
-    if (lane_id % 32 > 15)
-      local_x = tmp;
-
-    if constexpr (warpSize > 32) {
-      // row_bcast31
-      tmp = binary_op(detail::warp_move_dpp<T, 0x143>(local_x), local_x);
-      if (lane_id > 31)
+  if constexpr (sizeof(T) > 2*sizeof(double)) {
+    if (~activemask == 0) {
+      auto row_id  = lid % 16;
+      auto lane_id = lid % warpSize;
+      // adaption of rocprim dpp_scan
+      T tmp;
+      // row_sr:1
+      tmp = binary_op(detail::warp_move_dpp<T, 0x111>(local_x), local_x);
+      if (row_id > 0)
         local_x = tmp;
+
+      // row_sr:2
+      tmp = binary_op(detail::warp_move_dpp<T, 0x112>(local_x), local_x);
+      if (row_id > 1)
+        local_x = tmp;
+
+      // row_sr:4
+      tmp = binary_op(detail::warp_move_dpp<T, 0x114>(local_x), local_x);
+      if (row_id > 3)
+        local_x = tmp;
+
+      // row_sr:8
+      tmp = binary_op(detail::warp_move_dpp<T, 0x118>(local_x), local_x);
+      if (row_id > 7)
+        local_x = tmp;
+
+      // row_bcast15
+      tmp = binary_op(detail::warp_move_dpp<T, 0x142>(local_x), local_x);
+      if (lane_id % 32 > 15)
+        local_x = tmp;
+
+      if constexpr (warpSize > 32) {
+        // row_bcast31
+        tmp = binary_op(detail::warp_move_dpp<T, 0x143>(local_x), local_x);
+        if (lane_id > 31)
+          local_x = tmp;
+      }
+
+      return local_x;
     }
-
-    return local_x;
-  } else {
-    size_t lrange = g.get_local_linear_range();
-
-    for (size_t i = 1; i < lrange; i *= 2) {
-      size_t next_id = lid - i;
-      if (i > lid)
-        next_id = 0;
-
-      auto other_x = detail::shuffle_impl(local_x, next_id);
-      if (activemask & (1l << (next_id)) && i <= lid && lid < lrange)
-        local_x = binary_op(local_x, other_x);
-    }
-
-    return local_x;
   }
+  size_t lrange = g.get_local_linear_range();
+
+  for (size_t i = 1; i < lrange; i *= 2) {
+    size_t next_id = lid - i;
+    if (i > lid)
+      next_id = 0;
+
+    auto other_x = detail::shuffle_impl(local_x, next_id);
+    if (activemask & (1l << (next_id)) && i <= lid && lid < lrange)
+      local_x = binary_op(local_x, other_x);
+  }
+
+  return local_x;
 }
 
 // exclusive_scan

--- a/include/hipSYCL/sycl/libkernel/hip/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/hip/group_functions.hpp
@@ -91,34 +91,99 @@ T group_reduce(sub_group g, T x, BinaryOperation binary_op) {
   auto     local_x = x;
   uint64_t activemask;
   asm("s_mov_b64 %0, exec" : "=r"(activemask));
-  auto lid = g.get_local_linear_id();
 
-  size_t lrange = g.get_local_range().size();
+  if (~activemask == 0) {
+    // adaption of rocprim dpp_reduce
+    // quad_perm: add 0+1, 2+3
+    local_x = binary_op(detail::warp_move_dpp<T, 0xb1>(local_x), local_x);
+    // quad_perm: add 0+2
+    local_x = binary_op(detail::warp_move_dpp<T, 0x4e>(local_x), local_x);
+    // row_sr: add 0+4
+    local_x = binary_op(detail::warp_move_dpp<T, 0x114>(local_x), local_x);
+    // row_sr: add 0+8
+    local_x = binary_op(detail::warp_move_dpp<T, 0x118>(local_x), local_x);
+    // row_bcast15: add 0+15
+    local_x = binary_op(detail::warp_move_dpp<T, 0x142>(local_x), local_x);
 
-  group_barrier(g);
+    if constexpr (warpSize > 32) {
+      // row_bcast31: add 0+31
+      local_x = binary_op(detail::warp_move_dpp<T, 0x143>(local_x), local_x);
+    }
 
-  for (size_t i = lrange / 2; i > 0; i /= 2) {
-    auto other_x = detail::shuffle_impl(local_x, lid + i);
+    // get the result from last thead
+    return detail::shuffle_impl(local_x, warpSize - 1);
+  } else {
+    auto lid = g.get_local_linear_id();
 
-    // check if target thread exists/is active
-    if (activemask & (1l << (lid + i)))
-      local_x = binary_op(local_x, other_x);
+    size_t lrange = g.get_local_range().size();
+
+    group_barrier(g);
+
+    for (size_t i = lrange / 2; i > 0; i /= 2) {
+      auto other_x = detail::shuffle_impl(local_x, lid + i);
+
+      // check if target thread exists/is active
+      if (activemask & (1l << (lid + i)))
+        local_x = binary_op(local_x, other_x);
+    }
+    return detail::shuffle_impl(local_x, 0);
   }
-  return detail::shuffle_impl(local_x, 0);
 }
 
 // inclusive_scan
 template<typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
 T group_inclusive_scan(sub_group g, T x, BinaryOperation binary_op) {
-  auto   lid    = g.get_local_linear_id();
-  size_t lrange = g.get_local_linear_range();
-
   auto local_x = x;
-  auto row_id  = lid % warpSize;
+  auto lid     = g.get_local_linear_id();
 
   uint64_t activemask;
   asm("s_mov_b64 %0, exec" : "=r"(activemask));
+
+  if constexpr (sizeof(T) > 4*sizeof(unsigned int)){
+    if (~activemask == 0) {
+      auto row_id  = lid % 16;
+      auto lane_id = lid % warpSize;
+      // adaption of rocprim dpp_scan
+      T tmp;
+      // row_sr:1
+      tmp = binary_op(detail::warp_move_dpp<T, 0x111>(local_x), local_x);
+      if (row_id > 0)
+        local_x = tmp;
+
+      // row_sr:2
+      tmp = binary_op(detail::warp_move_dpp<T, 0x112>(local_x), local_x);
+      if (row_id > 1)
+        local_x = tmp;
+
+      // row_sr:4
+      tmp = binary_op(detail::warp_move_dpp<T, 0x114>(local_x), local_x);
+      if (row_id > 3)
+        local_x = tmp;
+
+      // row_sr:8
+      tmp = binary_op(detail::warp_move_dpp<T, 0x118>(local_x), local_x);
+      if (row_id > 7)
+        local_x = tmp;
+
+      // row_bcast15
+      tmp = binary_op(detail::warp_move_dpp<T, 0x142>(local_x), local_x);
+      if (lane_id % 32 > 15)
+        local_x = tmp;
+
+      if constexpr (warpSize > 32) {
+        // row_bcast31
+        tmp = binary_op(detail::warp_move_dpp<T, 0x143>(local_x), local_x);
+        if (lane_id > 31)
+          local_x = tmp;
+      }
+
+      return local_x;
+    }
+  }
+
+  // else (~activemask == 0)
+  size_t lrange = g.get_local_linear_range();
 
   for (size_t i = 1; i < lrange; i *= 2) {
     size_t next_id = lid - i;

--- a/include/hipSYCL/sycl/libkernel/hip/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/hip/group_functions.hpp
@@ -92,42 +92,25 @@ T group_reduce(sub_group g, T x, BinaryOperation binary_op) {
   uint64_t activemask;
   asm("s_mov_b64 %0, exec" : "=r"(activemask));
 
-  if (~activemask == 0) {
-    // adaption of rocprim dpp_reduce
-    // quad_perm: add 0+1, 2+3
-    local_x = binary_op(detail::warp_move_dpp<T, 0xb1>(local_x), local_x);
-    // quad_perm: add 0+2
-    local_x = binary_op(detail::warp_move_dpp<T, 0x4e>(local_x), local_x);
-    // row_sr: add 0+4
-    local_x = binary_op(detail::warp_move_dpp<T, 0x114>(local_x), local_x);
-    // row_sr: add 0+8
-    local_x = binary_op(detail::warp_move_dpp<T, 0x118>(local_x), local_x);
-    // row_bcast15: add 0+15
-    local_x = binary_op(detail::warp_move_dpp<T, 0x142>(local_x), local_x);
+  // adaption of rocprim dpp_reduce
+  // quad_perm: add 0+1, 2+3
+  local_x = binary_op(detail::warp_move_dpp<T, 0xb1>(local_x), local_x);
+  // quad_perm: add 0+2
+  local_x = binary_op(detail::warp_move_dpp<T, 0x4e>(local_x), local_x);
+  // row_sr: add 0+4
+  local_x = binary_op(detail::warp_move_dpp<T, 0x114>(local_x), local_x);
+  // row_sr: add 0+8
+  local_x = binary_op(detail::warp_move_dpp<T, 0x118>(local_x), local_x);
+  // row_bcast15: add 0+15
+  local_x = binary_op(detail::warp_move_dpp<T, 0x142>(local_x), local_x);
 
-    if constexpr (warpSize > 32) {
-      // row_bcast31: add 0+31
-      local_x = binary_op(detail::warp_move_dpp<T, 0x143>(local_x), local_x);
-    }
-
-    // get the result from last thead
-    return detail::shuffle_impl(local_x, warpSize - 1);
-  } else {
-    auto lid = g.get_local_linear_id();
-
-    size_t lrange = g.get_local_range().size();
-
-    group_barrier(g);
-
-    for (size_t i = lrange / 2; i > 0; i /= 2) {
-      auto other_x = detail::shuffle_impl(local_x, lid + i);
-
-      // check if target thread exists/is active
-      if (activemask & (1l << (lid + i)))
-        local_x = binary_op(local_x, other_x);
-    }
-    return detail::shuffle_impl(local_x, 0);
+  if constexpr (warpSize > 32) {
+    // row_bcast31: add 0+31
+    local_x = binary_op(detail::warp_move_dpp<T, 0x143>(local_x), local_x);
   }
+
+  // get the result from last thead
+  return detail::shuffle_impl(local_x, warpSize - 1);
 }
 
 // inclusive_scan
@@ -140,59 +123,40 @@ T group_inclusive_scan(sub_group g, T x, BinaryOperation binary_op) {
   uint64_t activemask;
   asm("s_mov_b64 %0, exec" : "=r"(activemask));
 
-  if constexpr (sizeof(T) > 4*sizeof(unsigned int)){
-    if (~activemask == 0) {
-      auto row_id  = lid % 16;
-      auto lane_id = lid % warpSize;
-      // adaption of rocprim dpp_scan
-      T tmp;
-      // row_sr:1
-      tmp = binary_op(detail::warp_move_dpp<T, 0x111>(local_x), local_x);
-      if (row_id > 0)
-        local_x = tmp;
+  auto row_id  = lid % 16;
+  auto lane_id = lid % warpSize;
+  // adaption of rocprim dpp_scan
+  T tmp;
+  // row_sr:1
+  tmp = binary_op(detail::warp_move_dpp<T, 0x111>(local_x), local_x);
+  if (row_id > 0)
+    local_x = tmp;
 
-      // row_sr:2
-      tmp = binary_op(detail::warp_move_dpp<T, 0x112>(local_x), local_x);
-      if (row_id > 1)
-        local_x = tmp;
+  // row_sr:2
+  tmp = binary_op(detail::warp_move_dpp<T, 0x112>(local_x), local_x);
+  if (row_id > 1)
+    local_x = tmp;
 
-      // row_sr:4
-      tmp = binary_op(detail::warp_move_dpp<T, 0x114>(local_x), local_x);
-      if (row_id > 3)
-        local_x = tmp;
+  // row_sr:4
+  tmp = binary_op(detail::warp_move_dpp<T, 0x114>(local_x), local_x);
+  if (row_id > 3)
+    local_x = tmp;
 
-      // row_sr:8
-      tmp = binary_op(detail::warp_move_dpp<T, 0x118>(local_x), local_x);
-      if (row_id > 7)
-        local_x = tmp;
+  // row_sr:8
+  tmp = binary_op(detail::warp_move_dpp<T, 0x118>(local_x), local_x);
+  if (row_id > 7)
+    local_x = tmp;
 
-      // row_bcast15
-      tmp = binary_op(detail::warp_move_dpp<T, 0x142>(local_x), local_x);
-      if (lane_id % 32 > 15)
-        local_x = tmp;
+  // row_bcast15
+  tmp = binary_op(detail::warp_move_dpp<T, 0x142>(local_x), local_x);
+  if (lane_id % 32 > 15)
+    local_x = tmp;
 
-      if constexpr (warpSize > 32) {
-        // row_bcast31
-        tmp = binary_op(detail::warp_move_dpp<T, 0x143>(local_x), local_x);
-        if (lane_id > 31)
-          local_x = tmp;
-      }
-
-      return local_x;
-    }
-  }
-
-  // else (~activemask == 0)
-  size_t lrange = g.get_local_linear_range();
-
-  for (size_t i = 1; i < lrange; i *= 2) {
-    size_t next_id = lid - i;
-    if (i > lid)
-      next_id = 0;
-
-    auto other_x = detail::shuffle_impl(local_x, next_id);
-    if (activemask & (1l << (next_id)) && i <= lid && lid < lrange)
-      local_x = binary_op(local_x, other_x);
+  if constexpr (warpSize > 32) {
+    // row_bcast31
+    tmp = binary_op(detail::warp_move_dpp<T, 0x143>(local_x), local_x);
+    if (lane_id > 31)
+      local_x = tmp;
   }
 
   return local_x;

--- a/include/hipSYCL/sycl/libkernel/hip/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/hip/group_functions.hpp
@@ -92,25 +92,42 @@ T group_reduce(sub_group g, T x, BinaryOperation binary_op) {
   uint64_t activemask;
   asm("s_mov_b64 %0, exec" : "=r"(activemask));
 
-  // adaption of rocprim dpp_reduce
-  // quad_perm: add 0+1, 2+3
-  local_x = binary_op(detail::warp_move_dpp<T, 0xb1>(local_x), local_x);
-  // quad_perm: add 0+2
-  local_x = binary_op(detail::warp_move_dpp<T, 0x4e>(local_x), local_x);
-  // row_sr: add 0+4
-  local_x = binary_op(detail::warp_move_dpp<T, 0x114>(local_x), local_x);
-  // row_sr: add 0+8
-  local_x = binary_op(detail::warp_move_dpp<T, 0x118>(local_x), local_x);
-  // row_bcast15: add 0+15
-  local_x = binary_op(detail::warp_move_dpp<T, 0x142>(local_x), local_x);
+  if (~activemask == 0) {
+    // adaption of rocprim dpp_reduce
+    // quad_perm: add 0+1, 2+3
+    local_x = binary_op(detail::warp_move_dpp<T, 0xb1>(local_x), local_x);
+    // quad_perm: add 0+2
+    local_x = binary_op(detail::warp_move_dpp<T, 0x4e>(local_x), local_x);
+    // row_sr: add 0+4
+    local_x = binary_op(detail::warp_move_dpp<T, 0x114>(local_x), local_x);
+    // row_sr: add 0+8
+    local_x = binary_op(detail::warp_move_dpp<T, 0x118>(local_x), local_x);
+    // row_bcast15: add 0+15
+    local_x = binary_op(detail::warp_move_dpp<T, 0x142>(local_x), local_x);
 
-  if constexpr (warpSize > 32) {
-    // row_bcast31: add 0+31
-    local_x = binary_op(detail::warp_move_dpp<T, 0x143>(local_x), local_x);
+    if constexpr (warpSize > 32) {
+      // row_bcast31: add 0+31
+      local_x = binary_op(detail::warp_move_dpp<T, 0x143>(local_x), local_x);
+    }
+
+    // get the result from last thead
+    return detail::shuffle_impl(local_x, warpSize - 1);
+  } else {
+    auto lid = g.get_local_linear_id();
+
+    size_t lrange = g.get_local_range().size();
+
+    group_barrier(g);
+
+    for (size_t i = lrange / 2; i > 0; i /= 2) {
+      auto other_x = detail::shuffle_impl(local_x, lid + i);
+
+      // check if target thread exists/is active
+      if (activemask & (1l << (lid + i)))
+        local_x = binary_op(local_x, other_x);
+    }
+    return detail::shuffle_impl(local_x, 0);
   }
-
-  // get the result from last thead
-  return detail::shuffle_impl(local_x, warpSize - 1);
 }
 
 // inclusive_scan
@@ -123,43 +140,59 @@ T group_inclusive_scan(sub_group g, T x, BinaryOperation binary_op) {
   uint64_t activemask;
   asm("s_mov_b64 %0, exec" : "=r"(activemask));
 
-  auto row_id  = lid % 16;
-  auto lane_id = lid % warpSize;
-  // adaption of rocprim dpp_scan
-  T tmp;
-  // row_sr:1
-  tmp = binary_op(detail::warp_move_dpp<T, 0x111>(local_x), local_x);
-  if (row_id > 0)
-    local_x = tmp;
-
-  // row_sr:2
-  tmp = binary_op(detail::warp_move_dpp<T, 0x112>(local_x), local_x);
-  if (row_id > 1)
-    local_x = tmp;
-
-  // row_sr:4
-  tmp = binary_op(detail::warp_move_dpp<T, 0x114>(local_x), local_x);
-  if (row_id > 3)
-    local_x = tmp;
-
-  // row_sr:8
-  tmp = binary_op(detail::warp_move_dpp<T, 0x118>(local_x), local_x);
-  if (row_id > 7)
-    local_x = tmp;
-
-  // row_bcast15
-  tmp = binary_op(detail::warp_move_dpp<T, 0x142>(local_x), local_x);
-  if (lane_id % 32 > 15)
-    local_x = tmp;
-
-  if constexpr (warpSize > 32) {
-    // row_bcast31
-    tmp = binary_op(detail::warp_move_dpp<T, 0x143>(local_x), local_x);
-    if (lane_id > 31)
+  if (~activemask == 0) {
+    auto row_id  = lid % 16;
+    auto lane_id = lid % warpSize;
+    // adaption of rocprim dpp_scan
+    T tmp;
+    // row_sr:1
+    tmp = binary_op(detail::warp_move_dpp<T, 0x111>(local_x), local_x);
+    if (row_id > 0)
       local_x = tmp;
-  }
 
-  return local_x;
+    // row_sr:2
+    tmp = binary_op(detail::warp_move_dpp<T, 0x112>(local_x), local_x);
+    if (row_id > 1)
+      local_x = tmp;
+
+    // row_sr:4
+    tmp = binary_op(detail::warp_move_dpp<T, 0x114>(local_x), local_x);
+    if (row_id > 3)
+      local_x = tmp;
+
+    // row_sr:8
+    tmp = binary_op(detail::warp_move_dpp<T, 0x118>(local_x), local_x);
+    if (row_id > 7)
+      local_x = tmp;
+
+    // row_bcast15
+    tmp = binary_op(detail::warp_move_dpp<T, 0x142>(local_x), local_x);
+    if (lane_id % 32 > 15)
+      local_x = tmp;
+
+    if constexpr (warpSize > 32) {
+      // row_bcast31
+      tmp = binary_op(detail::warp_move_dpp<T, 0x143>(local_x), local_x);
+      if (lane_id > 31)
+        local_x = tmp;
+    }
+
+    return local_x;
+  } else {
+    size_t lrange = g.get_local_linear_range();
+
+    for (size_t i = 1; i < lrange; i *= 2) {
+      size_t next_id = lid - i;
+      if (i > lid)
+        next_id = 0;
+
+      auto other_x = detail::shuffle_impl(local_x, next_id);
+      if (activemask & (1l << (next_id)) && i <= lid && lid < lrange)
+        local_x = binary_op(local_x, other_x);
+    }
+
+    return local_x;
+  }
 }
 
 // exclusive_scan

--- a/include/hipSYCL/sycl/libkernel/hip/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/hip/group_functions.hpp
@@ -99,42 +99,20 @@ T group_reduce(sub_group g, T x, BinaryOperation binary_op) {
   uint64_t activemask;
   asm("s_mov_b64 %0, exec" : "=r"(activemask));
 
-  if (~activemask == 0) {
-    // adaption of rocprim dpp_reduce
-    // quad_perm: add 0+1, 2+3
-    local_x = binary_op(detail::warp_move_dpp<T, 0xb1>(local_x), local_x);
-    // quad_perm: add 0+2
-    local_x = binary_op(detail::warp_move_dpp<T, 0x4e>(local_x), local_x);
-    // row_sr: add 0+4
-    local_x = binary_op(detail::warp_move_dpp<T, 0x114>(local_x), local_x);
-    // row_sr: add 0+8
-    local_x = binary_op(detail::warp_move_dpp<T, 0x118>(local_x), local_x);
-    // row_bcast15: add 0+15
-    local_x = binary_op(detail::warp_move_dpp<T, 0x142>(local_x), local_x);
+  auto lid = g.get_local_linear_id();
 
-    if constexpr (warpSize > 32) {
-      // row_bcast31: add 0+31
-      local_x = binary_op(detail::warp_move_dpp<T, 0x143>(local_x), local_x);
-    }
+  size_t lrange = g.get_local_range().size();
 
-    // get the result from last thead
-    return detail::shuffle_impl(local_x, warpSize - 1);
-  } else {
-    auto lid = g.get_local_linear_id();
+  group_barrier(g);
 
-    size_t lrange = g.get_local_range().size();
+  for (size_t i = lrange / 2; i > 0; i /= 2) {
+    auto other_x = detail::shuffle_impl(local_x, lid + i);
 
-    group_barrier(g);
-
-    for (size_t i = lrange / 2; i > 0; i /= 2) {
-      auto other_x = detail::shuffle_impl(local_x, lid + i);
-
-      // check if target thread exists/is active
-      if (activemask & (1l << (lid + i)))
-        local_x = binary_op(local_x, other_x);
-    }
-    return detail::shuffle_impl(local_x, 0);
+    // check if target thread exists/is active
+    if (activemask & (1l << (lid + i)))
+      local_x = binary_op(local_x, other_x);
   }
+  return detail::shuffle_impl(local_x, 0);
 }
 
 // inclusive_scan
@@ -147,59 +125,19 @@ T group_inclusive_scan(sub_group g, T x, BinaryOperation binary_op) {
   uint64_t activemask;
   asm("s_mov_b64 %0, exec" : "=r"(activemask));
 
-  if (~activemask == 0) {
-    const size_t row_id  = lid % 16;
-    const size_t lane_id = lid % warpSize;
-    // adaption of rocprim dpp_scan
-    T tmp;
-    // row_sr:1
-    tmp = binary_op(detail::warp_move_dpp<T, 0x111>(local_x), local_x);
-    if (row_id > 0)
-      local_x = tmp;
+  size_t lrange = g.get_local_linear_range();
 
-    // row_sr:2
-    tmp = binary_op(detail::warp_move_dpp<T, 0x112>(local_x), local_x);
-    if (row_id > 1)
-      local_x = tmp;
+  for (size_t i = 1; i < lrange; i *= 2) {
+    size_t next_id = lid - i;
+    if (i > lid)
+      next_id = 0;
 
-    // row_sr:4
-    tmp = binary_op(detail::warp_move_dpp<T, 0x114>(local_x), local_x);
-    if (row_id > 3)
-      local_x = tmp;
-
-    // row_sr:8
-    tmp = binary_op(detail::warp_move_dpp<T, 0x118>(local_x), local_x);
-    if (row_id > 7)
-      local_x = tmp;
-
-    // row_bcast15
-    tmp = binary_op(detail::warp_move_dpp<T, 0x142>(local_x), local_x);
-    if (lane_id % 32 > 15)
-      local_x = tmp;
-
-    if constexpr (warpSize > 32) {
-      // row_bcast31
-      tmp = binary_op(detail::warp_move_dpp<T, 0x143>(local_x), local_x);
-      if (lane_id > 31)
-        local_x = tmp;
-    }
-
-    return local_x;
-  } else {
-    size_t lrange = g.get_local_linear_range();
-
-    for (size_t i = 1; i < lrange; i *= 2) {
-      size_t next_id = lid - i;
-      if (i > lid)
-        next_id = 0;
-
-      auto other_x = detail::shuffle_impl(local_x, next_id);
-      if (activemask & (1l << (next_id)) && i <= lid && lid < lrange)
-        local_x = binary_op(local_x, other_x);
-    }
-
-    return local_x;
+    auto other_x = detail::shuffle_impl(local_x, next_id);
+    if (activemask & (1l << (next_id)) && i <= lid && lid < lrange)
+      local_x = binary_op(local_x, other_x);
   }
+
+  return local_x;
 }
 
 // exclusive_scan

--- a/include/hipSYCL/sycl/libkernel/hip/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/hip/group_functions.hpp
@@ -72,17 +72,23 @@ inline void group_barrier(sub_group g, memory_scope fence_scope) {
 // any_of
 template<>
 HIPSYCL_KERNEL_TARGET
-inline bool group_any_of(sub_group g, bool pred) { return __any(pred); }
+inline bool group_any_of(sub_group g, bool pred) {
+  return __any(pred);
+}
 
 // all_of
 template<>
 HIPSYCL_KERNEL_TARGET
-inline bool group_all_of(sub_group g, bool pred) { return __all(pred); }
+inline bool group_all_of(sub_group g, bool pred) {
+  return __all(pred);
+}
 
 // none_of
 template<>
 HIPSYCL_KERNEL_TARGET
-inline bool group_none_of(sub_group g, bool pred) { return !__any(pred); }
+inline bool group_none_of(sub_group g, bool pred) {
+  return !__any(pred);
+}
 
 // reduce
 template<typename T, typename BinaryOperation>
@@ -134,15 +140,15 @@ T group_reduce(sub_group g, T x, BinaryOperation binary_op) {
 template<typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
 T group_inclusive_scan(sub_group g, T x, BinaryOperation binary_op) {
-  auto local_x = x;
-  auto lid     = g.get_local_linear_id();
+  auto         local_x = x;
+  const size_t lid     = g.get_local_linear_id();
 
   uint64_t activemask;
   asm("s_mov_b64 %0, exec" : "=r"(activemask));
 
   if (~activemask == 0) {
-    auto row_id  = lid % 16;
-    auto lane_id = lid % warpSize;
+    const size_t row_id  = lid % 16;
+    const size_t lane_id = lid % warpSize;
     // adaption of rocprim dpp_scan
     T tmp;
     // row_sr:1
@@ -199,7 +205,7 @@ T group_inclusive_scan(sub_group g, T x, BinaryOperation binary_op) {
 template<typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
 T group_exclusive_scan(sub_group g, V x, T init, BinaryOperation binary_op) {
-  auto lid     = g.get_local_linear_id();
+  const size_t lid     = g.get_local_linear_id();
   auto local_x = x;
 
   local_x = detail::shuffle_up_impl(local_x, 1);

--- a/include/hipSYCL/sycl/libkernel/hip/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/hip/group_functions.hpp
@@ -44,7 +44,8 @@ namespace sycl {
 // broadcast
 template<typename T>
 HIPSYCL_KERNEL_TARGET
-T group_broadcast(sub_group g, T x, typename sub_group::linear_id_type local_linear_id = 0) {
+T group_broadcast(sub_group g, T x,
+                  typename sub_group::linear_id_type local_linear_id = 0) {
   return detail::shuffle_impl(x, static_cast<int>(local_linear_id));
 }
 
@@ -206,7 +207,7 @@ template<typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
 T group_exclusive_scan(sub_group g, V x, T init, BinaryOperation binary_op) {
   const size_t lid     = g.get_local_linear_id();
-  auto local_x = x;
+  auto         local_x = x;
 
   local_x = detail::shuffle_up_impl(local_x, 1);
   if (lid == 0)

--- a/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
@@ -269,10 +269,10 @@ T *leader_exclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOp
 
   if (g.leader()) {
     *(result++) = init;
-    size_t num_elements = last-first - 1;
-#pragma omp simd
-    for (size_t i = 0; i < num_elements; ++i)
-      result[i] = binary_op(result[i - 1], first[i]);
+    while (first != last - 1) {
+      *result = binary_op(*(result - 1), *(first++));
+      result++;
+    }
   }
   return result;
 }
@@ -286,13 +286,7 @@ T *leader_exclusive_scan(Group g, V *first, V *last, T *result, BinaryOperation 
 template<typename Group, typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
 T *exclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOperation binary_op) {
-  if (g.leader()) {
-    *(result++) = init;
-    while (first != last - 1) {
-      *result = binary_op(*(result - 1), *(first++));
-      result++;
-    }
-  }
+  auto ret = leader_exclusive_scan(g, first, last, result, init, binary_op);
   return group_broadcast(g, result);
 }
 
@@ -311,12 +305,12 @@ T *leader_inclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOp
 
   if (g.leader()) {
     *(result++) = binary_op(init, *(first++));
-    size_t num_elements = last-first;
-#pragma omp simd
-    for (size_t i = 0; i < num_elements; ++i)
-      result[i] = binary_op(result[i - 1], first[i]);
+    while (first != last) {
+      *result = binary_op(*(result - 1), *(first++));
+      result++;
+    }
   }
-  return last;
+  return result;
 }
 
 template<typename Group, typename V, typename T, typename BinaryOperation>
@@ -328,17 +322,8 @@ T *leader_inclusive_scan(Group g, V *first, V *last, T *result, BinaryOperation 
 template<typename Group, typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
 T *inclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOperation binary_op) {
-  if (first == last)
-    return result;
-
-  if (g.leader()) {
-    *(result++) = binary_op(init, *(first++));
-    while (first != last) {
-      *result = binary_op(*(result - 1), *(first++));
-      result++;
-    }
-  }
-  return group_broadcast(g, result);
+  auto ret = leader_inclusive_scan(g, first, last,result, init, binary_op);
+  return group_broadcast(g, ret);
 }
 
 template<typename Group, typename V, typename T, typename BinaryOperation>

--- a/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
@@ -37,7 +37,6 @@
 #include "../id.hpp"
 #include "../sub_group.hpp"
 #include "../vec.hpp"
-#include <xsimd/xsimd.hpp>
 
 namespace hipsycl {
 namespace sycl {
@@ -226,33 +225,6 @@ T leader_reduce(Group g, T *first, T *last, BinaryOperation binary_op) {
       result = binary_op(result, *i);
   }
   return result;
-}
-
-template<typename Group, typename T, std::enable_if_t<!std::is_same_v<T, xsimd::simd_type<T>>, int> = 0>
-HIPSYCL_KERNEL_TARGET
-T leader_reduce(Group g, T *first, T *last, plus<T> binary_op) {
-  T result{};
-
-  using v_type         = xsimd::simd_type<T>;
-  constexpr size_t inc = v_type::size;
-
-  if (first >= last) {
-    return T{};
-  }
-
-  if (g.leader()) {
-    result = T{};
-
-    while (first + inc < last) {
-      v_type x = xsimd::load_aligned(first);
-      result += xsimd::hadd(x);
-      first += inc;
-    }
-    while (first < last) {
-      result += *(first++);
-    }
-  }
-  return T(result);
 }
 
 template<typename Group, typename V, typename T, typename BinaryOperation>

--- a/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
@@ -32,12 +32,12 @@
 
 #include "../backend.hpp"
 #include "../detail/data_layout.hpp"
+#include "../functional.hpp"
 #include "../group.hpp"
 #include "../id.hpp"
 #include "../sub_group.hpp"
 #include "../vec.hpp"
 #include <xsimd/xsimd.hpp>
-#include "../functional.hpp"
 
 namespace hipsycl {
 namespace sycl {
@@ -228,13 +228,12 @@ T leader_reduce(Group g, T *first, T *last, BinaryOperation binary_op) {
   return result;
 }
 
-
 template<typename Group, typename T, std::enable_if_t<!std::is_same_v<T, xsimd::simd_type<T>>, int> = 0>
 HIPSYCL_KERNEL_TARGET
 T leader_reduce(Group g, T *first, T *last, plus<T> binary_op) {
   T result{};
 
-  using v_type = xsimd::simd_type<T>;
+  using v_type         = xsimd::simd_type<T>;
   constexpr size_t inc = v_type::size;
 
   if (first >= last) {
@@ -352,7 +351,7 @@ T *leader_inclusive_scan(Group g, V *first, V *last, T *result, BinaryOperation 
 template<typename Group, typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
 T *inclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOperation binary_op) {
-  auto ret = leader_inclusive_scan(g, first, last,result, init, binary_op);
+  auto ret = leader_inclusive_scan(g, first, last, result, init, binary_op);
   return group_broadcast(g, ret);
 }
 

--- a/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
@@ -266,7 +266,8 @@ T reduce(Group g, V *first, V *last, T init, BinaryOperation binary_op) {
 // exclusive_scan
 template<typename Group, typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
-T *leader_exclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOperation binary_op) {
+T *leader_exclusive_scan(Group g, V *first, V *last, T *result, T init,
+                         BinaryOperation binary_op) {
 
   if (g.leader()) {
     *(result++) = init;
@@ -280,13 +281,15 @@ T *leader_exclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOp
 
 template<typename Group, typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
-T *leader_exclusive_scan(Group g, V *first, V *last, T *result, BinaryOperation binary_op) {
+T *leader_exclusive_scan(Group g, V *first, V *last, T *result,
+                         BinaryOperation binary_op) {
   return leader_exclusive_scan(g, first, last, result, T{}, binary_op);
 }
 
 template<typename Group, typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
-T *exclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOperation binary_op) {
+T *exclusive_scan(Group g, V *first, V *last, T *result, T init,
+                  BinaryOperation binary_op) {
   const auto ret = leader_exclusive_scan(g, first, last, result, init, binary_op);
   return group_broadcast(g, ret);
 }
@@ -300,7 +303,8 @@ T *exclusive_scan(Group g, V *first, V *last, T *result, BinaryOperation binary_
 // inclusive_scan
 template<typename Group, typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
-T *leader_inclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOperation binary_op) {
+T *leader_inclusive_scan(Group g, V *first, V *last, T *result, T init,
+                         BinaryOperation binary_op) {
   if (first == last)
     return result;
 
@@ -316,13 +320,15 @@ T *leader_inclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOp
 
 template<typename Group, typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
-T *leader_inclusive_scan(Group g, V *first, V *last, T *result, BinaryOperation binary_op) {
+T *leader_inclusive_scan(Group g, V *first, V *last, T *result,
+                         BinaryOperation binary_op) {
   return leader_inclusive_scan(g, first, last, result, T{}, binary_op);
 }
 
 template<typename Group, typename V, typename T, typename BinaryOperation>
 HIPSYCL_KERNEL_TARGET
-T *inclusive_scan(Group g, V *first, V *last, T *result, T init, BinaryOperation binary_op) {
+T *inclusive_scan(Group g, V *first, V *last, T *result, T init,
+                  BinaryOperation binary_op) {
   auto ret = leader_inclusive_scan(g, first, last, result, init, binary_op);
   return group_broadcast(g, ret);
 }
@@ -356,13 +362,15 @@ T group_broadcast(Group g, T x, typename Group::linear_id_type local_linear_id =
 template<typename Group, typename T>
 HIPSYCL_KERNEL_TARGET
 T group_broadcast(Group g, T x, typename Group::id_type local_id) {
-  const size_t target_lid = detail::linear_id<g.dimensions>::get(local_id, g.get_local_range());
+  const size_t target_lid =
+      detail::linear_id<g.dimensions>::get(local_id, g.get_local_range());
   return group_broadcast(g, x, target_lid);
 }
 
 template<typename T>
 HIPSYCL_KERNEL_TARGET
-T group_broadcast(sub_group g, T x, typename sub_group::linear_id_type local_linear_id = 0) {
+T group_broadcast(sub_group g, T x,
+                  typename sub_group::linear_id_type local_linear_id = 0) {
   return x;
 }
 

--- a/tests/sycl/group_functions/group_functions.hpp
+++ b/tests/sycl/group_functions/group_functions.hpp
@@ -49,8 +49,7 @@ using test_types =
                      sycl::vec<int, 4>, sycl::vec<int, 8>, sycl::vec<short, 16>,
                      sycl::vec<long, 3>, sycl::vec<unsigned int, 3>>;
 #else
-using test_types =
-    boost::mpl::list<char, unsigned int, float, double, sycl::vec<int, 2>>;
+using test_types = boost::mpl::list<char, unsigned int, float, double, sycl::vec<int, 2>>;
 #endif
 
 namespace detail {

--- a/tests/sycl/group_functions/group_functions.hpp
+++ b/tests/sycl/group_functions/group_functions.hpp
@@ -7,22 +7,23 @@
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TESTS_GROUP_FUNCTIONS_HH
@@ -43,20 +44,21 @@ using namespace cl;
 
 #ifdef TESTS_GROUPFUNCTION_FULL
 using test_types =
-    boost::mpl::list<char, int, unsigned int, long long, float, double, sycl::vec<int, 1>,
-                     sycl::vec<int, 2>, sycl::vec<int, 3>, sycl::vec<int, 4>, sycl::vec<int, 8>,
-                     sycl::vec<short, 16>, sycl::vec<long, 3>, sycl::vec<unsigned int, 3>>;
+    boost::mpl::list<char, int, unsigned int, long long, float, double,
+                     sycl::vec<int, 1>, sycl::vec<int, 2>, sycl::vec<int, 3>,
+                     sycl::vec<int, 4>, sycl::vec<int, 8>, sycl::vec<short, 16>,
+                     sycl::vec<long, 3>, sycl::vec<unsigned int, 3>>;
 #else
-using test_types = boost::mpl::list<char, unsigned int, float, double, sycl::vec<int, 2>>;
+using test_types =
+    boost::mpl::list<char, unsigned int, float, double, sycl::vec<int, 2>>;
 #endif
 
 namespace detail {
 
-template<typename T>
+template <typename T>
 using elementType = std::remove_reference_t<decltype(T{}.s0())>;
 
-template<typename T, int N>
-std::string type_to_string(sycl::vec<T, N> v) {
+template <typename T, int N> std::string type_to_string(sycl::vec<T, N> v) {
   std::stringstream ss{};
 
   ss << "(";
@@ -89,15 +91,14 @@ std::string type_to_string(sycl::vec<T, N> v) {
   return ss.str();
 }
 
-template<typename T>
-std::string type_to_string(T x) {
+template <typename T> std::string type_to_string(T x) {
   std::stringstream ss{};
   ss << +x;
 
   return ss.str();
 }
 
-template<typename T, int N>
+template <typename T, int N>
 bool compare_type(sycl::vec<T, N> v1, sycl::vec<T, N> v2) {
   bool ret = true;
   if constexpr (1 <= N)
@@ -128,20 +129,17 @@ bool compare_type(sycl::vec<T, N> v1, sycl::vec<T, N> v2) {
   return ret;
 }
 
-template<typename T>
-bool compare_type(T x1, T x2) {
-  return x1 == x2;
-}
+template <typename T> bool compare_type(T x1, T x2) { return x1 == x2; }
 
-template<typename T, typename std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
-HIPSYCL_KERNEL_TARGET
-T initialize_type(T init) {
+template <typename T,
+          typename std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
+HIPSYCL_KERNEL_TARGET T initialize_type(T init) {
   return init;
 }
 
-template<typename T, typename std::enable_if_t<!std::is_arithmetic_v<T>, int> = 0>
-HIPSYCL_KERNEL_TARGET
-T initialize_type(elementType<T> init) {
+template <typename T,
+          typename std::enable_if_t<!std::is_arithmetic_v<T>, int> = 0>
+HIPSYCL_KERNEL_TARGET T initialize_type(elementType<T> init) {
   constexpr size_t N = T::get_count();
 
   if constexpr (std::is_same_v<elementType<T>, bool>)
@@ -156,7 +154,8 @@ T initialize_type(elementType<T> init) {
   } else if constexpr (N == 4) {
     return T{init, init + 1, init + 2, init + 3};
   } else if constexpr (N == 8) {
-    return T{init, init + 1, init + 2, init + 3, init + 4, init + 5, init + 6, init + 7};
+    return T{init,     init + 1, init + 2, init + 3,
+             init + 4, init + 5, init + 6, init + 7};
   } else if constexpr (N == 16) {
     return T{init,      init + 1,  init + 2,  init + 3, init + 4,  init + 5,
              init + 6,  init + 7,  init + 8,  init + 9, init + 10, init + 11,
@@ -166,9 +165,10 @@ T initialize_type(elementType<T> init) {
   static_assert(true, "invalide vector type!");
 }
 
-template<typename T, typename std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
-HIPSYCL_KERNEL_TARGET
-T get_offset(size_t margin, size_t divisor = 1) {
+template <typename T,
+          typename std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
+HIPSYCL_KERNEL_TARGET T get_offset(size_t margin, size_t divisor = 1) {
+  return T{};
   if (std::numeric_limits<T>::max() <= margin) {
     return T{};
   }
@@ -182,16 +182,15 @@ T get_offset(size_t margin, size_t divisor = 1) {
   return static_cast<T>(std::numeric_limits<T>::max() / divisor - margin - 1);
 }
 
-template<typename T, typename std::enable_if_t<!std::is_arithmetic_v<T>, int> = 0>
-HIPSYCL_KERNEL_TARGET
-T get_offset(size_t margin, size_t divisor = 1) {
+template <typename T,
+          typename std::enable_if_t<!std::is_arithmetic_v<T>, int> = 0>
+HIPSYCL_KERNEL_TARGET T get_offset(size_t margin, size_t divisor = 1) {
   using eT = elementType<T>;
   return initialize_type<T>(get_offset<eT>(margin + 16, divisor));
 }
 
-template<typename T>
-HIPSYCL_KERNEL_TARGET
-elementType<T> local_value(size_t id, size_t offsetBase) {
+template <typename T>
+HIPSYCL_KERNEL_TARGET elementType<T> local_value(size_t id, size_t offsetBase) {
   const size_t N = T{}.get_count();
 
   auto offset = get_offset<elementType<T>>(offsetBase);
@@ -214,7 +213,7 @@ inline void create_bool_test_data(std::vector<char> &buffer, size_t local_size,
   for (size_t i = 2 * local_size; i < 4 * local_size; ++i)
     buffer[i] = true;
 
-  buffer[10]                  = true;
+  buffer[10] = true;
   buffer[2 * local_size + 10] = false;
 
   BOOST_REQUIRE(buffer[0] == false);
@@ -227,12 +226,14 @@ inline void create_bool_test_data(std::vector<char> &buffer, size_t local_size,
   BOOST_REQUIRE(buffer[10 + local_size * 3] == true);
 }
 
-template<typename T, int Line>
-void check_binary_reduce(std::vector<T> buffer, size_t local_size, size_t global_size,
-                         std::vector<bool> expected, std::string name,
-                         size_t break_size = 0, size_t offset = 0) {
-  std::vector<std::string> cases{"everything except one false", "everything false",
-                                 "everything except one true", "everything true"};
+template <typename T, int Line>
+void check_binary_reduce(std::vector<T> buffer, size_t local_size,
+                         size_t global_size, std::vector<bool> expected,
+                         std::string name, size_t break_size = 0,
+                         size_t offset = 0) {
+  std::vector<std::string> cases{
+      "everything except one false", "everything false",
+      "everything except one true", "everything true"};
   BOOST_REQUIRE(global_size / local_size == expected.size());
   for (size_t i = 0; i < global_size / local_size; ++i) {
     for (size_t j = 0; j < local_size; ++j) {
@@ -240,7 +241,7 @@ void check_binary_reduce(std::vector<T> buffer, size_t local_size, size_t global
       if (break_size != 0 && j == break_size)
         break;
 
-      T computed      = buffer[i * local_size + j + offset];
+      T computed = buffer[i * local_size + j + offset];
       T expectedValue = initialize_type<T>(expected[i]);
 
       BOOST_TEST(compare_type(expectedValue, computed),
@@ -256,81 +257,93 @@ void check_binary_reduce(std::vector<T> buffer, size_t local_size, size_t global
 
 } // namespace detail
 
-template<int N, int M, typename T>
-class test_kernel;
+template <int N, int M, typename T> class test_kernel;
 
-template<int CallingLine, typename T, typename DataGenerator, typename TestedFunction,
-         typename ValidationFunction>
-void test_nd_group_function_1d(size_t local_size, size_t global_size, size_t offset_margin,
-                               size_t offset_divisor, size_t buffer_size,
-                               DataGenerator dg, TestedFunction f, ValidationFunction vf) {
-  sycl::queue queue;
-  std::vector<T> host_buf(buffer_size, T{});
+template <int CallingLine, typename T, typename DataGenerator,
+          typename TestedFunction, typename ValidationFunction>
+void test_nd_group_function_1d(size_t elements_per_thread, DataGenerator dg,
+                               TestedFunction f, ValidationFunction vf) {
+  std::vector<size_t> local_sizes = {25, 144, 256};
+  std::vector<size_t> global_sizes = {100, 576, 1024};
+  for (int i = 0; i < local_sizes.size(); ++i) {
+    size_t local_size = local_sizes[i];
+    size_t global_size = global_sizes[i];
 
-  dg(host_buf);
+    sycl::queue queue;
+    std::vector<T> host_buf(elements_per_thread * global_size, T{});
 
-  std::vector<T> original_host_buf(host_buf);
+    dg(host_buf, local_size, global_size);
 
-  {
-    sycl::buffer<T, 1> buf{host_buf.data(), host_buf.size()};
+    std::vector<T> original_host_buf(host_buf);
 
-    queue.submit([&](sycl::handler &cgh) {
-      using namespace sycl::access;
-      auto acc = buf.template get_access<mode::read_write>(cgh);
+    {
+      sycl::buffer<T, 1> buf{host_buf.data(), host_buf.size()};
 
-      cgh.parallel_for<class test_kernel<1, CallingLine, T>>(
-        sycl::nd_range<1>{global_size, local_size},
-        [=](sycl::nd_item<1> item) {
-        auto g  = item.get_group();
-        auto sg = item.get_sub_group();
+      queue.submit([&](sycl::handler &cgh) {
+        using namespace sycl::access;
+        auto acc = buf.template get_access<mode::read_write>(cgh);
 
-        T local_value = acc[item.get_global_linear_id()];
+        cgh.parallel_for<class test_kernel<1, CallingLine, T>>(
+          sycl::nd_range<1>{global_size, local_size},
+          [=](sycl::nd_item<1> item) {
+          auto g = item.get_group();
+          auto sg = item.get_sub_group();
 
-        f(acc, item.get_global_linear_id(), sg, g, local_value);
+          T local_value = acc[item.get_global_linear_id()];
+
+          f(acc, item.get_global_linear_id(), sg, g, local_value);
+        });
       });
-    });
-  }
+    }
 
-  vf(host_buf, original_host_buf);
+    vf(host_buf, original_host_buf, local_size, global_size);
+  }
 }
 
-template<int CallingLine, typename T, typename DataGenerator, typename TestedFunction,
-         typename ValidationFunction>
-void test_nd_group_function_2d(size_t local_size_x, size_t local_size_y,
-                               size_t global_size_x, size_t global_size_y,
-                               size_t offset_margin, size_t offset_divisor,
-                               size_t buffer_size, DataGenerator dg, TestedFunction f,
-                               ValidationFunction vf) {
-  sycl::queue queue;
-  std::vector<T> host_buf(buffer_size, T{});
+template <int CallingLine, typename T, typename DataGenerator,
+          typename TestedFunction, typename ValidationFunction>
+void test_nd_group_function_2d(size_t elements_per_thread, DataGenerator dg,
+                               TestedFunction f, ValidationFunction vf) {
+  std::vector<size_t> local_sizes = {5, 12, 16};
+  std::vector<size_t> global_sizes = {10, 24, 32};
+  for (int i = 0; i < local_sizes.size(); ++i) {
+    size_t local_size = local_sizes[i];
+    size_t global_size = global_sizes[i];
 
-  dg(host_buf);
+    sycl::queue queue;
+    std::vector<T> host_buf(elements_per_thread * global_size * global_size,
+                            T{});
 
-  std::vector<T> original_host_buf(host_buf);
+    dg(host_buf, local_size * local_size, global_size * global_size);
 
-  {
-    sycl::buffer<T, 1> buf{host_buf.data(), host_buf.size()};
+    std::vector<T> original_host_buf(host_buf);
 
-    queue.submit([&](sycl::handler &cgh) {
-      using namespace sycl::access;
-      auto acc = buf.template get_access<mode::read_write>(cgh);
+    {
+      sycl::buffer<T, 1> buf{host_buf.data(), host_buf.size()};
 
-      cgh.parallel_for<class test_kernel<2, CallingLine, T>>(
-        sycl::nd_range<2>{sycl::range<2>(global_size_x, global_size_y), sycl::range<2>(local_size_x, local_size_y)},
-        [=](sycl::nd_item<2> item) {
-        auto g                  = item.get_group();
-        auto sg                 = item.get_sub_group();
-        size_t custom_linear_id = item.get_local_linear_id() +
-                                  local_size_x * local_size_y * item.get_group_linear_id();
+      queue.submit([&](sycl::handler &cgh) {
+        using namespace sycl::access;
+        auto acc = buf.template get_access<mode::read_write>(cgh);
 
-        T local_value = acc[custom_linear_id];
+        cgh.parallel_for<class test_kernel<2, CallingLine, T>>(
+          sycl::nd_range<2>{sycl::range<2>(global_size, global_size), sycl::range<2>(local_size, local_size)},
+          [=](sycl::nd_item<2> item) {
+          auto g = item.get_group();
+          auto sg = item.get_sub_group();
+          size_t custom_linear_id =
+              item.get_local_linear_id() +
+              local_size * local_size * item.get_group_linear_id();
 
-        f(acc, custom_linear_id, sg, g, local_value);
+          T local_value = acc[custom_linear_id];
+
+          f(acc, custom_linear_id, sg, g, local_value);
+        });
       });
-    });
-  }
+    }
 
-  vf(host_buf, original_host_buf);
+    vf(host_buf, original_host_buf, local_size * local_size,
+       global_size * global_size);
+  }
 }
 
 #endif // TESTS_GROUP_FUNCTIONS_HH

--- a/tests/sycl/group_functions/group_functions.hpp
+++ b/tests/sycl/group_functions/group_functions.hpp
@@ -8,7 +8,7 @@
  * modification, are permitted provided that the following conditions are met:
  *
  * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
+ *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
@@ -43,9 +43,11 @@
 using namespace cl;
 
 #ifdef TESTS_GROUPFUNCTION_FULL
-using test_types = boost::mpl::list<char, int, unsigned int, long long, float, double, sycl::vec<int, 1>,
-                                    sycl::vec<int, 2>, sycl::vec<int, 3>, sycl::vec<int, 4>, sycl::vec<int, 8>,
-                                    sycl::vec<short, 16>, sycl::vec<long, 3>, sycl::vec<unsigned int, 3>>;
+using test_types =
+    boost::mpl::list<char, int, unsigned int, long long, float, double, sycl::vec<int, 1>,
+                     sycl::vec<int, 2>, sycl::vec<int, 3>, sycl::vec<int, 4>,
+                     sycl::vec<int, 8>, sycl::vec<short, 16>, sycl::vec<long, 3>,
+                     sycl::vec<unsigned int, 3>>;
 #else
 using test_types = boost::mpl::list<char, unsigned int, float, double, sycl::vec<int, 2>>;
 #endif
@@ -158,8 +160,9 @@ T initialize_type(elementType<T> init) {
   } else if constexpr (N == 8) {
     return T{init, init + 1, init + 2, init + 3, init + 4, init + 5, init + 6, init + 7};
   } else if constexpr (N == 16) {
-    return T{init,     init + 1, init + 2,  init + 3,  init + 4,  init + 5,  init + 6,  init + 7,
-             init + 8, init + 9, init + 10, init + 11, init + 12, init + 13, init + 14, init + 15};
+    return T{init,      init + 1,  init + 2,  init + 3, init + 4,  init + 5,
+             init + 6,  init + 7,  init + 8,  init + 9, init + 10, init + 11,
+             init + 12, init + 13, init + 14, init + 15};
   }
 
   static_assert(true, "invalide vector type!");
@@ -198,7 +201,8 @@ elementType<T> local_value(size_t id, size_t offsetBase) {
   return static_cast<elementType<T>>(id + offset);
 }
 
-inline void create_bool_test_data(std::vector<char> &buffer, size_t local_size, size_t global_size) {
+inline void create_bool_test_data(std::vector<char> &buffer, size_t local_size,
+                                  size_t global_size) {
   BOOST_REQUIRE(global_size == 4 * local_size);
   BOOST_REQUIRE(local_size + 10 < 2 * local_size);
 
@@ -227,10 +231,11 @@ inline void create_bool_test_data(std::vector<char> &buffer, size_t local_size, 
 }
 
 template<typename T, int Line>
-void check_binary_reduce(std::vector<T> buffer, size_t local_size, size_t global_size, std::vector<bool> expected,
-                         std::string name, size_t break_size = 0, size_t offset = 0) {
-  std::vector<std::string> cases{"everything except one false", "everything false", "everything except one true",
-                                 "everything true"};
+void check_binary_reduce(std::vector<T> buffer, size_t local_size, size_t global_size,
+                         std::vector<bool> expected, std::string name,
+                         size_t break_size = 0, size_t offset = 0) {
+  std::vector<std::string> cases{"everything except one false", "everything false",
+                                 "everything except one true", "everything true"};
   BOOST_REQUIRE(global_size / local_size == expected.size());
   for (size_t i = 0; i < global_size / local_size; ++i) {
     for (size_t j = 0; j < local_size; ++j) {
@@ -241,9 +246,10 @@ void check_binary_reduce(std::vector<T> buffer, size_t local_size, size_t global
       T computed      = buffer[i * local_size + j + offset];
       T expectedValue = initialize_type<T>(expected[i]);
 
-      BOOST_TEST(compare_type(expectedValue, computed), Line << ":" << type_to_string(computed) << " at position " << j
-                                                             << " instead of " << type_to_string(expectedValue)
-                                                             << " for case: " << cases[i] << " " << name);
+      BOOST_TEST(compare_type(expectedValue, computed),
+                 Line << ":" << type_to_string(computed) << " at position " << j
+                      << " instead of " << type_to_string(expectedValue)
+                      << " for case: " << cases[i] << " " << name);
 
       if (!compare_type(expectedValue, computed))
         break;
@@ -256,8 +262,10 @@ void check_binary_reduce(std::vector<T> buffer, size_t local_size, size_t global
 template<int N, int M, typename T>
 class test_kernel;
 
-template<int CallingLine, typename T, typename DataGenerator, typename TestedFunction, typename ValidationFunction>
-void test_nd_group_function_1d(size_t elements_per_thread, DataGenerator dg, TestedFunction f, ValidationFunction vf) {
+template<int CallingLine, typename T, typename DataGenerator, typename TestedFunction,
+         typename ValidationFunction>
+void test_nd_group_function_1d(size_t elements_per_thread, DataGenerator dg,
+                               TestedFunction f, ValidationFunction vf) {
 // currently only groupsizes between 128 and 256 are supportet for HIP
 #ifdef HIPSYCL_PLATFORM_ROCM
   std::vector<size_t> local_sizes  = {256};
@@ -301,8 +309,10 @@ void test_nd_group_function_1d(size_t elements_per_thread, DataGenerator dg, Tes
   }
 }
 
-template<int CallingLine, typename T, typename DataGenerator, typename TestedFunction, typename ValidationFunction>
-void test_nd_group_function_2d(size_t elements_per_thread, DataGenerator dg, TestedFunction f, ValidationFunction vf) {
+template<int CallingLine, typename T, typename DataGenerator, typename TestedFunction,
+         typename ValidationFunction>
+void test_nd_group_function_2d(size_t elements_per_thread, DataGenerator dg,
+                               TestedFunction f, ValidationFunction vf) {
 // currently only groupsizes between 128 and 256 are supportet for HIP
 #ifdef HIPSYCL_PLATFORM_ROCM
   std::vector<size_t> local_sizes  = {16};
@@ -334,7 +344,8 @@ void test_nd_group_function_2d(size_t elements_per_thread, DataGenerator dg, Tes
           [=](sycl::nd_item<2> item) {
           auto   g                = item.get_group();
           auto   sg               = item.get_sub_group();
-          size_t custom_linear_id = item.get_local_linear_id() + local_size * local_size * item.get_group_linear_id();
+          size_t custom_linear_id = item.get_local_linear_id() +
+                                    local_size * local_size * item.get_group_linear_id();
 
           T local_value = acc[custom_linear_id];
 

--- a/tests/sycl/group_functions/group_functions.hpp
+++ b/tests/sycl/group_functions/group_functions.hpp
@@ -135,7 +135,9 @@ bool compare_type(T x1, T x2) {
 
 template<typename T, typename std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
 HIPSYCL_KERNEL_TARGET
-T initialize_type(T init) { return init; }
+T initialize_type(T init) {
+  return init;
+}
 
 template<typename T, typename std::enable_if_t<!std::is_arithmetic_v<T>, int> = 0>
 HIPSYCL_KERNEL_TARGET

--- a/tests/sycl/group_functions/group_functions_binary_reduce.cpp
+++ b/tests/sycl/group_functions/group_functions_binary_reduce.cpp
@@ -7,27 +7,29 @@
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
-
 
 #include "../sycl_test_suite.hpp"
 #include "group_functions.hpp"
+#include <bits/types/locale_t.h>
+#include <cstddef>
 
 using namespace cl;
 
@@ -36,184 +38,170 @@ BOOST_FIXTURE_TEST_SUITE(group_functions_tests, reset_device_fixture)
 BOOST_AUTO_TEST_CASE(group_x_of_local) {
   using T = char;
 
-  const size_t local_size     = 256;
-  const size_t global_size    = 1024;
-  const size_t local_size_x   = 16;
-  const size_t local_size_y   = 16;
-  const size_t global_size_x  = 32;
-  const size_t global_size_y  = 32;
-  const size_t offset_margin  = global_size;
-  const size_t offset_divisor = 1;
-  const size_t buffer_size    = global_size;
-  const auto data_generator   = [](std::vector<T> &v) {
+  const size_t elements_per_thread = 1;
+  const auto data_generator = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     detail::create_bool_test_data(v, local_size, global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_any_of(g, static_cast<bool>(local_value));
+    const auto tested_function = [](auto acc, size_t global_linear_id,
+                                    sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_any_of(g, static_cast<bool>(local_value));
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{true, false, true, true},
-                                               "any_of");
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size,
+          std::vector<bool>{true, false, true, true}, "any_of");
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_all_of(g, static_cast<bool>(local_value));
+    const auto tested_function = [](auto acc, size_t global_linear_id,
+                                    sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_all_of(g, static_cast<bool>(local_value));
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{false, false, false, true},
-                                               "all_of");
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size,
+          std::vector<bool>{false, false, false, true}, "all_of");
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_none_of(g, static_cast<bool>(local_value));
+    const auto tested_function = [](auto acc, size_t global_linear_id,
+                                    sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_none_of(g, static_cast<bool>(local_value));
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{false, true, false, false},
-                                               "none_of");
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size,
+          std::vector<bool>{false, true, false, false}, "none_of");
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
 BOOST_AUTO_TEST_CASE(group_x_of_ptr) {
   using T = char;
 
-  const size_t local_size     = 256;
-  const size_t global_size    = 1024;
-  const size_t local_size_x   = 16;
-  const size_t local_size_y   = 16;
-  const size_t global_size_x  = 32;
-  const size_t global_size_y  = 32;
-  const size_t offset_margin  = global_size * 2;
-  const size_t offset_divisor = 1;
-  const size_t buffer_size    = global_size * 3;
-  const auto data_generator   = [](std::vector<T> &v) {
+  const size_t elements_per_thread = 3;
+  const auto data_generator = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     detail::create_bool_test_data(v, local_size * 2, global_size * 2);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id,
+                                    sycl::sub_group sg, auto g, T local_value) {
       auto local_size = g.get_local_range().size();
-      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end   = start + local_size * 2;
+      auto global_size = 4 * local_size;
+      auto start =
+          acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end = start + local_size * 2;
 
       auto local = sycl::detail::any_of(g, start.get(), end.get());
       sycl::group_barrier(g);
-      acc[global_linear_id + 2 * global_size] = local;
+      acc[global_linear_id + 2 * 4 * local_size] = local;
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{true, false, true, true},
-                                               "any_of", 0, 2 * global_size);
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size,
+          std::vector<bool>{true, false, true, true}, "any_of", 0,
+          2 * global_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id,
+                                    sycl::sub_group sg, auto g, T local_value) {
       auto local_size = g.get_local_range().size();
-      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end   = start + local_size * 2;
+      auto global_size = 4 * local_size;
+      auto start =
+          acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end = start + local_size * 2;
 
       auto local = sycl::detail::all_of(g, start.get(), end.get());
       sycl::group_barrier(g);
       acc[global_linear_id + 2 * global_size] = local;
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{false, false, false, true},
-                                               "all_of", 0, 2 * global_size);
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size,
+          std::vector<bool>{false, false, false, true}, "all_of", 0,
+          2 * global_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id,
+                                    sycl::sub_group sg, auto g, T local_value) {
       auto local_size = g.get_local_range().size();
-      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end   = start + local_size * 2;
+      auto global_size = 4 * local_size;
+      auto start =
+          acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end = start + local_size * 2;
 
       auto local = sycl::detail::none_of(g, start.get(), end.get());
       sycl::group_barrier(g);
       acc[global_linear_id + 2 * global_size] = local;
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{false, true, false, false},
-                                               "none_of", 0, 2 * global_size);
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size,
+          std::vector<bool>{false, true, false, false}, "none_of", 0,
+          2 * global_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
@@ -221,66 +209,68 @@ BOOST_AUTO_TEST_CASE(group_x_of_ptr) {
 BOOST_AUTO_TEST_CASE(sub_group_x_of_local) {
   using T = char;
 
-  const size_t local_size      = 256;
-  const size_t global_size     = 1024;
-  const size_t offset_margin   = global_size;
-  const size_t offset_divisor  = 1;
-  const size_t buffer_size     = global_size;
+  const size_t elements_per_thread = 1;
   const uint32_t subgroup_size = static_cast<uint32_t>(warpSize);
 
-  const auto data_generator = [](std::vector<T> &v) {
+  const auto data_generator = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     detail::create_bool_test_data(v, local_size, global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_any_of(sg, static_cast<bool>(local_value));
+    const auto tested_function = [](auto acc, size_t global_linear_id,
+                                    sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_any_of(sg, static_cast<bool>(local_value));
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{true, false, true, true},
-                                               "any_of", subgroup_size);
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size,
+          std::vector<bool>{true, false, true, true}, "any_of", subgroup_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_all_of(sg, static_cast<bool>(local_value));
+    const auto tested_function = [](auto acc, size_t global_linear_id,
+                                    sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_all_of(sg, static_cast<bool>(local_value));
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{false, false, false, true},
-                                               "all_of", subgroup_size);
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size,
+          std::vector<bool>{false, false, false, true}, "all_of",
+          subgroup_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_none_of(sg, static_cast<bool>(local_value));
+    const auto tested_function = [](auto acc, size_t global_linear_id,
+                                    sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_none_of(sg, static_cast<bool>(local_value));
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{false, true, false, false},
-                                               "none_of", subgroup_size);
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size,
+          std::vector<bool>{false, true, false, false}, "none_of",
+          subgroup_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 #endif
@@ -288,187 +278,173 @@ BOOST_AUTO_TEST_CASE(sub_group_x_of_local) {
 BOOST_AUTO_TEST_CASE(group_x_of_ptr_function) {
   using T = char;
 
-  const size_t local_size     = 256;
-  const size_t global_size    = 1024;
-  const size_t local_size_x   = 16;
-  const size_t local_size_y   = 16;
-  const size_t global_size_x  = 32;
-  const size_t global_size_y  = 32;
-  const size_t offset_margin  = global_size;
-  const size_t offset_divisor = 1;
-  const size_t buffer_size    = global_size * 3;
-  const auto data_generator   = [](std::vector<T> &v) {
+  const size_t elements_per_thread = 3;
+  const auto data_generator = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     detail::create_bool_test_data(v, local_size * 2, global_size * 2);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id,
+                                    sycl::sub_group sg, auto g, T local_value) {
       auto local_size = g.get_local_range().size();
-      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end   = start + local_size * 2;
+      auto global_size = 4 * local_size;
+      auto start =
+          acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end = start + local_size * 2;
 
-      auto local = sycl::detail::any_of(g, start.get(), end.get(), std::logical_not<T>());
+      auto local = sycl::detail::any_of(g, start.get(), end.get(),
+                                        std::logical_not<T>());
       sycl::group_barrier(g);
       acc[global_linear_id + 2 * global_size] = local;
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{true, true, true, false},
-                                               "any_of", 0, 2 * global_size);
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size,
+          std::vector<bool>{true, true, true, false}, "any_of", 0,
+          2 * global_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id,
+                                    sycl::sub_group sg, auto g, T local_value) {
       auto local_size = g.get_local_range().size();
-      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end   = start + local_size * 2;
+      auto global_size = 4 * local_size;
+      auto start =
+          acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end = start + local_size * 2;
 
-      auto local = sycl::detail::all_of(g, start.get(), end.get(), std::logical_not<T>());
+      auto local = sycl::detail::all_of(g, start.get(), end.get(),
+                                        std::logical_not<T>());
       sycl::group_barrier(g);
       acc[global_linear_id + 2 * global_size] = local;
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{false, true, false, false},
-                                               "all_of", 0, 2 * global_size);
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size,
+          std::vector<bool>{false, true, false, false}, "all_of", 0,
+          2 * global_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id,
+                                    sycl::sub_group sg, auto g, T local_value) {
       auto local_size = g.get_local_range().size();
-      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end   = start + local_size * 2;
+      auto global_size = 4 * local_size;
+      auto start =
+          acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end = start + local_size * 2;
 
-      auto local = sycl::detail::none_of(g, start.get(), end.get(), std::logical_not<T>());
+      auto local = sycl::detail::none_of(g, start.get(), end.get(),
+                                         std::logical_not<T>());
       sycl::group_barrier(g);
       acc[global_linear_id + 2 * global_size] = local;
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{false, false, false, true},
-                                               "none_of", 0, 2 * global_size);
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size,
+          std::vector<bool>{false, false, false, true}, "none_of", 0,
+          2 * global_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
 BOOST_AUTO_TEST_CASE(group_x_of_function) {
   using T = char;
 
-  const size_t local_size     = 256;
-  const size_t global_size    = 1024;
-  const size_t local_size_x   = 16;
-  const size_t local_size_y   = 16;
-  const size_t global_size_x  = 32;
-  const size_t global_size_y  = 32;
-  const size_t offset_margin  = global_size;
-  const size_t offset_divisor = 1;
-  const size_t buffer_size    = global_size;
-  const auto data_generator   = [](std::vector<T> &v) {
+  const size_t elements_per_thread = 1;
+  const auto data_generator = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     detail::create_bool_test_data(v, local_size, global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      acc[global_linear_id] =
-          sycl::group_any_of(g, static_cast<bool>(local_value), std::logical_not<T>());
+    const auto tested_function = [](auto acc, size_t global_linear_id,
+                                    sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_any_of(
+          g, static_cast<bool>(local_value), std::logical_not<T>());
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{true, true, true, false},
-                                               "any_of");
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size,
+          std::vector<bool>{true, true, true, false}, "any_of");
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      acc[global_linear_id] =
-          sycl::group_all_of(g, static_cast<bool>(local_value), std::logical_not<T>());
+    const auto tested_function = [](auto acc, size_t global_linear_id,
+                                    sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_all_of(
+          g, static_cast<bool>(local_value), std::logical_not<T>());
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{false, true, false, false},
-                                               "all_of");
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size,
+          std::vector<bool>{false, true, false, false}, "all_of");
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      acc[global_linear_id] =
-          sycl::group_none_of(g, static_cast<bool>(local_value), std::logical_not<T>());
+    const auto tested_function = [](auto acc, size_t global_linear_id,
+                                    sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_none_of(
+          g, static_cast<bool>(local_value), std::logical_not<T>());
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{false, false, false, true},
-                                               "none_of");
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size,
+          std::vector<bool>{false, false, false, true}, "none_of");
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
@@ -476,69 +452,68 @@ BOOST_AUTO_TEST_CASE(group_x_of_function) {
 BOOST_AUTO_TEST_CASE(sub_group_x_of_function) {
   using T = char;
 
-  const size_t local_size      = 256;
-  const size_t global_size     = 1024;
-  const size_t offset_margin   = global_size;
-  const size_t offset_divisor  = 1;
-  const size_t buffer_size     = global_size;
+  const size_t elements_per_thread = 1;
   const uint32_t subgroup_size = static_cast<uint32_t>(warpSize);
 
-  const auto data_generator = [](std::vector<T> &v) {
+  const auto data_generator = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     detail::create_bool_test_data(v, local_size, global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      acc[global_linear_id] =
-          sycl::group_any_of(sg, static_cast<bool>(local_value), std::logical_not<T>());
+    const auto tested_function = [](auto acc, size_t global_linear_id,
+                                    sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_any_of(
+          sg, static_cast<bool>(local_value), std::logical_not<T>());
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{true, true, true, false},
-                                               "any_of", subgroup_size);
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size,
+          std::vector<bool>{true, true, true, false}, "any_of", subgroup_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      acc[global_linear_id] =
-          sycl::group_all_of(sg, static_cast<bool>(local_value), std::logical_not<T>());
+    const auto tested_function = [](auto acc, size_t global_linear_id,
+                                    sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_all_of(
+          sg, static_cast<bool>(local_value), std::logical_not<T>());
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{false, true, false, false},
-                                               "all_of", subgroup_size);
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size,
+          std::vector<bool>{false, true, false, false}, "all_of",
+          subgroup_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      acc[global_linear_id] =
-          sycl::group_none_of(sg, static_cast<bool>(local_value), std::logical_not<T>());
+    const auto tested_function = [](auto acc, size_t global_linear_id,
+                                    sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_none_of(
+          sg, static_cast<bool>(local_value), std::logical_not<T>());
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{false, false, false, true},
-                                               "none_of", subgroup_size);
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size,
+          std::vector<bool>{false, false, false, true}, "none_of",
+          subgroup_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 #endif

--- a/tests/sycl/group_functions/group_functions_binary_reduce.cpp
+++ b/tests/sycl/group_functions/group_functions_binary_reduce.cpp
@@ -39,72 +39,53 @@ BOOST_AUTO_TEST_CASE(group_x_of_local) {
   using T = char;
 
   const size_t elements_per_thread = 1;
-  const auto data_generator = [](std::vector<T> &v, size_t local_size,
-                                 size_t global_size) {
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
     detail::create_bool_test_data(v, local_size, global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id,
-                                    sycl::sub_group sg, auto g, T local_value) {
-      acc[global_linear_id] =
-          sycl::group_any_of(g, static_cast<bool>(local_value));
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_any_of(g, static_cast<bool>(local_value));
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(
-          vIn, local_size, global_size,
-          std::vector<bool>{true, false, true, true}, "any_of");
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size, std::vector<bool>{true, false, true, true},
+                                               "any_of");
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id,
-                                    sycl::sub_group sg, auto g, T local_value) {
-      acc[global_linear_id] =
-          sycl::group_all_of(g, static_cast<bool>(local_value));
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_all_of(g, static_cast<bool>(local_value));
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(
-          vIn, local_size, global_size,
-          std::vector<bool>{false, false, false, true}, "all_of");
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{false, false, false, true}, "all_of");
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id,
-                                    sycl::sub_group sg, auto g, T local_value) {
-      acc[global_linear_id] =
-          sycl::group_none_of(g, static_cast<bool>(local_value));
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_none_of(g, static_cast<bool>(local_value));
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(
-          vIn, local_size, global_size,
-          std::vector<bool>{false, true, false, false}, "none_of");
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{false, true, false, false}, "none_of");
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
@@ -112,96 +93,74 @@ BOOST_AUTO_TEST_CASE(group_x_of_ptr) {
   using T = char;
 
   const size_t elements_per_thread = 3;
-  const auto data_generator = [](std::vector<T> &v, size_t local_size,
-                                 size_t global_size) {
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
     detail::create_bool_test_data(v, local_size * 2, global_size * 2);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id,
-                                    sycl::sub_group sg, auto g, T local_value) {
-      auto local_size = g.get_local_range().size();
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      auto local_size  = g.get_local_range().size();
       auto global_size = 4 * local_size;
-      auto start =
-          acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end = start + local_size * 2;
+      auto start       = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end         = start + local_size * 2;
 
       auto local = sycl::detail::any_of(g, start.get(), end.get());
       sycl::group_barrier(g);
       acc[global_linear_id + 2 * 4 * local_size] = local;
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(
-          vIn, local_size, global_size,
-          std::vector<bool>{true, false, true, true}, "any_of", 0,
-          2 * global_size);
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size, std::vector<bool>{true, false, true, true},
+                                               "any_of", 0, 2 * global_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id,
-                                    sycl::sub_group sg, auto g, T local_value) {
-      auto local_size = g.get_local_range().size();
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      auto local_size  = g.get_local_range().size();
       auto global_size = 4 * local_size;
-      auto start =
-          acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end = start + local_size * 2;
+      auto start       = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end         = start + local_size * 2;
 
       auto local = sycl::detail::all_of(g, start.get(), end.get());
       sycl::group_barrier(g);
       acc[global_linear_id + 2 * global_size] = local;
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       detail::check_binary_reduce<T, __LINE__>(
-          vIn, local_size, global_size,
-          std::vector<bool>{false, false, false, true}, "all_of", 0,
-          2 * global_size);
+          vIn, local_size, global_size, std::vector<bool>{false, false, false, true}, "all_of", 0, 2 * global_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id,
-                                    sycl::sub_group sg, auto g, T local_value) {
-      auto local_size = g.get_local_range().size();
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      auto local_size  = g.get_local_range().size();
       auto global_size = 4 * local_size;
-      auto start =
-          acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end = start + local_size * 2;
+      auto start       = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end         = start + local_size * 2;
 
       auto local = sycl::detail::none_of(g, start.get(), end.get());
       sycl::group_barrier(g);
       acc[global_linear_id + 2 * global_size] = local;
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       detail::check_binary_reduce<T, __LINE__>(
-          vIn, local_size, global_size,
-          std::vector<bool>{false, true, false, false}, "none_of", 0,
-          2 * global_size);
+          vIn, local_size, global_size, std::vector<bool>{false, true, false, false}, "none_of", 0, 2 * global_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
@@ -209,68 +168,50 @@ BOOST_AUTO_TEST_CASE(group_x_of_ptr) {
 BOOST_AUTO_TEST_CASE(sub_group_x_of_local) {
   using T = char;
 
-  const size_t elements_per_thread = 1;
-  const uint32_t subgroup_size = static_cast<uint32_t>(warpSize);
+  const size_t   elements_per_thread = 1;
+  const uint32_t subgroup_size       = static_cast<uint32_t>(warpSize);
 
-  const auto data_generator = [](std::vector<T> &v, size_t local_size,
-                                 size_t global_size) {
+  const auto data_generator = [](std::vector<T> &v, size_t local_size, size_t global_size) {
     detail::create_bool_test_data(v, local_size, global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id,
-                                    sycl::sub_group sg, auto g, T local_value) {
-      acc[global_linear_id] =
-          sycl::group_any_of(sg, static_cast<bool>(local_value));
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_any_of(sg, static_cast<bool>(local_value));
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(
-          vIn, local_size, global_size,
-          std::vector<bool>{true, false, true, true}, "any_of", subgroup_size);
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size, std::vector<bool>{true, false, true, true},
+                                               "any_of", subgroup_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id,
-                                    sycl::sub_group sg, auto g, T local_value) {
-      acc[global_linear_id] =
-          sycl::group_all_of(sg, static_cast<bool>(local_value));
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_all_of(sg, static_cast<bool>(local_value));
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(
-          vIn, local_size, global_size,
-          std::vector<bool>{false, false, false, true}, "all_of",
-          subgroup_size);
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{false, false, false, true}, "all_of", subgroup_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id,
-                                    sycl::sub_group sg, auto g, T local_value) {
-      acc[global_linear_id] =
-          sycl::group_none_of(sg, static_cast<bool>(local_value));
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_none_of(sg, static_cast<bool>(local_value));
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(
-          vIn, local_size, global_size,
-          std::vector<bool>{false, true, false, false}, "none_of",
-          subgroup_size);
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{false, true, false, false}, "none_of", subgroup_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 #endif
@@ -279,99 +220,74 @@ BOOST_AUTO_TEST_CASE(group_x_of_ptr_function) {
   using T = char;
 
   const size_t elements_per_thread = 3;
-  const auto data_generator = [](std::vector<T> &v, size_t local_size,
-                                 size_t global_size) {
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
     detail::create_bool_test_data(v, local_size * 2, global_size * 2);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id,
-                                    sycl::sub_group sg, auto g, T local_value) {
-      auto local_size = g.get_local_range().size();
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      auto local_size  = g.get_local_range().size();
       auto global_size = 4 * local_size;
-      auto start =
-          acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end = start + local_size * 2;
+      auto start       = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end         = start + local_size * 2;
 
-      auto local = sycl::detail::any_of(g, start.get(), end.get(),
-                                        std::logical_not<T>());
+      auto local = sycl::detail::any_of(g, start.get(), end.get(), std::logical_not<T>());
       sycl::group_barrier(g);
       acc[global_linear_id + 2 * global_size] = local;
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(
-          vIn, local_size, global_size,
-          std::vector<bool>{true, true, true, false}, "any_of", 0,
-          2 * global_size);
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size, std::vector<bool>{true, true, true, false},
+                                               "any_of", 0, 2 * global_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id,
-                                    sycl::sub_group sg, auto g, T local_value) {
-      auto local_size = g.get_local_range().size();
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      auto local_size  = g.get_local_range().size();
       auto global_size = 4 * local_size;
-      auto start =
-          acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end = start + local_size * 2;
+      auto start       = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end         = start + local_size * 2;
 
-      auto local = sycl::detail::all_of(g, start.get(), end.get(),
-                                        std::logical_not<T>());
+      auto local = sycl::detail::all_of(g, start.get(), end.get(), std::logical_not<T>());
       sycl::group_barrier(g);
       acc[global_linear_id + 2 * global_size] = local;
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       detail::check_binary_reduce<T, __LINE__>(
-          vIn, local_size, global_size,
-          std::vector<bool>{false, true, false, false}, "all_of", 0,
-          2 * global_size);
+          vIn, local_size, global_size, std::vector<bool>{false, true, false, false}, "all_of", 0, 2 * global_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id,
-                                    sycl::sub_group sg, auto g, T local_value) {
-      auto local_size = g.get_local_range().size();
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      auto local_size  = g.get_local_range().size();
       auto global_size = 4 * local_size;
-      auto start =
-          acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end = start + local_size * 2;
+      auto start       = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end         = start + local_size * 2;
 
-      auto local = sycl::detail::none_of(g, start.get(), end.get(),
-                                         std::logical_not<T>());
+      auto local = sycl::detail::none_of(g, start.get(), end.get(), std::logical_not<T>());
       sycl::group_barrier(g);
       acc[global_linear_id + 2 * global_size] = local;
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       detail::check_binary_reduce<T, __LINE__>(
-          vIn, local_size, global_size,
-          std::vector<bool>{false, false, false, true}, "none_of", 0,
-          2 * global_size);
+          vIn, local_size, global_size, std::vector<bool>{false, false, false, true}, "none_of", 0, 2 * global_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
@@ -379,72 +295,53 @@ BOOST_AUTO_TEST_CASE(group_x_of_function) {
   using T = char;
 
   const size_t elements_per_thread = 1;
-  const auto data_generator = [](std::vector<T> &v, size_t local_size,
-                                 size_t global_size) {
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
     detail::create_bool_test_data(v, local_size, global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id,
-                                    sycl::sub_group sg, auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_any_of(
-          g, static_cast<bool>(local_value), std::logical_not<T>());
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_any_of(g, static_cast<bool>(local_value), std::logical_not<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(
-          vIn, local_size, global_size,
-          std::vector<bool>{true, true, true, false}, "any_of");
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size, std::vector<bool>{true, true, true, false},
+                                               "any_of");
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id,
-                                    sycl::sub_group sg, auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_all_of(
-          g, static_cast<bool>(local_value), std::logical_not<T>());
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_all_of(g, static_cast<bool>(local_value), std::logical_not<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(
-          vIn, local_size, global_size,
-          std::vector<bool>{false, true, false, false}, "all_of");
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{false, true, false, false}, "all_of");
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id,
-                                    sycl::sub_group sg, auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_none_of(
-          g, static_cast<bool>(local_value), std::logical_not<T>());
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_none_of(g, static_cast<bool>(local_value), std::logical_not<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(
-          vIn, local_size, global_size,
-          std::vector<bool>{false, false, false, true}, "none_of");
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{false, false, false, true}, "none_of");
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
@@ -452,68 +349,50 @@ BOOST_AUTO_TEST_CASE(group_x_of_function) {
 BOOST_AUTO_TEST_CASE(sub_group_x_of_function) {
   using T = char;
 
-  const size_t elements_per_thread = 1;
-  const uint32_t subgroup_size = static_cast<uint32_t>(warpSize);
+  const size_t   elements_per_thread = 1;
+  const uint32_t subgroup_size       = static_cast<uint32_t>(warpSize);
 
-  const auto data_generator = [](std::vector<T> &v, size_t local_size,
-                                 size_t global_size) {
+  const auto data_generator = [](std::vector<T> &v, size_t local_size, size_t global_size) {
     detail::create_bool_test_data(v, local_size, global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id,
-                                    sycl::sub_group sg, auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_any_of(
-          sg, static_cast<bool>(local_value), std::logical_not<T>());
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_any_of(sg, static_cast<bool>(local_value), std::logical_not<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(
-          vIn, local_size, global_size,
-          std::vector<bool>{true, true, true, false}, "any_of", subgroup_size);
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size, std::vector<bool>{true, true, true, false},
+                                               "any_of", subgroup_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id,
-                                    sycl::sub_group sg, auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_all_of(
-          sg, static_cast<bool>(local_value), std::logical_not<T>());
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_all_of(sg, static_cast<bool>(local_value), std::logical_not<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(
-          vIn, local_size, global_size,
-          std::vector<bool>{false, true, false, false}, "all_of",
-          subgroup_size);
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{false, true, false, false}, "all_of", subgroup_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id,
-                                    sycl::sub_group sg, auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_none_of(
-          sg, static_cast<bool>(local_value), std::logical_not<T>());
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_none_of(sg, static_cast<bool>(local_value), std::logical_not<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(
-          vIn, local_size, global_size,
-          std::vector<bool>{false, false, false, true}, "none_of",
-          subgroup_size);
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{false, false, false, true}, "none_of", subgroup_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 #endif

--- a/tests/sycl/group_functions/group_functions_binary_reduce.cpp
+++ b/tests/sycl/group_functions/group_functions_binary_reduce.cpp
@@ -8,7 +8,7 @@
  * modification, are permitted provided that the following conditions are met:
  *
  * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
+ *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
@@ -39,53 +39,69 @@ BOOST_AUTO_TEST_CASE(group_x_of_local) {
   using T = char;
 
   const size_t elements_per_thread = 1;
-  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     detail::create_bool_test_data(v, local_size, global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
       acc[global_linear_id] = sycl::group_any_of(g, static_cast<bool>(local_value));
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size, std::vector<bool>{true, false, true, true},
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{true, false, true, true},
                                                "any_of");
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
       acc[global_linear_id] = sycl::group_all_of(g, static_cast<bool>(local_value));
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{false, false, false, true}, "all_of");
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size, std::vector<bool>{false, false, false, true},
+          "all_of");
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
       acc[global_linear_id] = sycl::group_none_of(g, static_cast<bool>(local_value));
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{false, true, false, false}, "none_of");
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size, std::vector<bool>{false, true, false, false},
+          "none_of");
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 }
 
@@ -93,74 +109,90 @@ BOOST_AUTO_TEST_CASE(group_x_of_ptr) {
   using T = char;
 
   const size_t elements_per_thread = 3;
-  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     detail::create_bool_test_data(v, local_size * 2, global_size * 2);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
       auto local_size  = g.get_local_range().size();
       auto global_size = 4 * local_size;
-      auto start       = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end         = start + local_size * 2;
+      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end   = start + local_size * 2;
 
       auto local = sycl::detail::any_of(g, start.get(), end.get());
       sycl::group_barrier(g);
       acc[global_linear_id + 2 * 4 * local_size] = local;
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size, std::vector<bool>{true, false, true, true},
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{true, false, true, true},
                                                "any_of", 0, 2 * global_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
       auto local_size  = g.get_local_range().size();
       auto global_size = 4 * local_size;
-      auto start       = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end         = start + local_size * 2;
+      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end   = start + local_size * 2;
 
       auto local = sycl::detail::all_of(g, start.get(), end.get());
       sycl::group_barrier(g);
       acc[global_linear_id + 2 * global_size] = local;
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       detail::check_binary_reduce<T, __LINE__>(
-          vIn, local_size, global_size, std::vector<bool>{false, false, false, true}, "all_of", 0, 2 * global_size);
+          vIn, local_size, global_size, std::vector<bool>{false, false, false, true},
+          "all_of", 0, 2 * global_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
       auto local_size  = g.get_local_range().size();
       auto global_size = 4 * local_size;
-      auto start       = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end         = start + local_size * 2;
+      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end   = start + local_size * 2;
 
       auto local = sycl::detail::none_of(g, start.get(), end.get());
       sycl::group_barrier(g);
       acc[global_linear_id + 2 * global_size] = local;
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       detail::check_binary_reduce<T, __LINE__>(
-          vIn, local_size, global_size, std::vector<bool>{false, true, false, false}, "none_of", 0, 2 * global_size);
+          vIn, local_size, global_size, std::vector<bool>{false, true, false, false},
+          "none_of", 0, 2 * global_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 }
 
@@ -171,47 +203,60 @@ BOOST_AUTO_TEST_CASE(sub_group_x_of_local) {
   const size_t   elements_per_thread = 1;
   const uint32_t subgroup_size       = static_cast<uint32_t>(warpSize);
 
-  const auto data_generator = [](std::vector<T> &v, size_t local_size, size_t global_size) {
+  const auto data_generator = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     detail::create_bool_test_data(v, local_size, global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
       acc[global_linear_id] = sycl::group_any_of(sg, static_cast<bool>(local_value));
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size, std::vector<bool>{true, false, true, true},
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{true, false, true, true},
                                                "any_of", subgroup_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
       acc[global_linear_id] = sycl::group_all_of(sg, static_cast<bool>(local_value));
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{false, false, false, true}, "all_of", subgroup_size);
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size, std::vector<bool>{false, false, false, true},
+          "all_of", subgroup_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
       acc[global_linear_id] = sycl::group_none_of(sg, static_cast<bool>(local_value));
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{false, true, false, false}, "none_of", subgroup_size);
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size, std::vector<bool>{false, true, false, false},
+          "none_of", subgroup_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 }
 #endif
@@ -220,74 +265,91 @@ BOOST_AUTO_TEST_CASE(group_x_of_ptr_function) {
   using T = char;
 
   const size_t elements_per_thread = 3;
-  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     detail::create_bool_test_data(v, local_size * 2, global_size * 2);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
       auto local_size  = g.get_local_range().size();
       auto global_size = 4 * local_size;
-      auto start       = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end         = start + local_size * 2;
+      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end   = start + local_size * 2;
 
       auto local = sycl::detail::any_of(g, start.get(), end.get(), std::logical_not<T>());
       sycl::group_barrier(g);
       acc[global_linear_id + 2 * global_size] = local;
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size, std::vector<bool>{true, true, true, false},
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{true, true, true, false},
                                                "any_of", 0, 2 * global_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
       auto local_size  = g.get_local_range().size();
       auto global_size = 4 * local_size;
-      auto start       = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end         = start + local_size * 2;
+      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end   = start + local_size * 2;
 
       auto local = sycl::detail::all_of(g, start.get(), end.get(), std::logical_not<T>());
       sycl::group_barrier(g);
       acc[global_linear_id + 2 * global_size] = local;
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       detail::check_binary_reduce<T, __LINE__>(
-          vIn, local_size, global_size, std::vector<bool>{false, true, false, false}, "all_of", 0, 2 * global_size);
+          vIn, local_size, global_size, std::vector<bool>{false, true, false, false},
+          "all_of", 0, 2 * global_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
       auto local_size  = g.get_local_range().size();
       auto global_size = 4 * local_size;
-      auto start       = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end         = start + local_size * 2;
+      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end   = start + local_size * 2;
 
-      auto local = sycl::detail::none_of(g, start.get(), end.get(), std::logical_not<T>());
+      auto local =
+          sycl::detail::none_of(g, start.get(), end.get(), std::logical_not<T>());
       sycl::group_barrier(g);
       acc[global_linear_id + 2 * global_size] = local;
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       detail::check_binary_reduce<T, __LINE__>(
-          vIn, local_size, global_size, std::vector<bool>{false, false, false, true}, "none_of", 0, 2 * global_size);
+          vIn, local_size, global_size, std::vector<bool>{false, false, false, true},
+          "none_of", 0, 2 * global_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 }
 
@@ -295,53 +357,72 @@ BOOST_AUTO_TEST_CASE(group_x_of_function) {
   using T = char;
 
   const size_t elements_per_thread = 1;
-  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     detail::create_bool_test_data(v, local_size, global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_any_of(g, static_cast<bool>(local_value), std::logical_not<T>());
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_any_of(g, static_cast<bool>(local_value), std::logical_not<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size, std::vector<bool>{true, true, true, false},
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{true, true, true, false},
                                                "any_of");
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_all_of(g, static_cast<bool>(local_value), std::logical_not<T>());
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_all_of(g, static_cast<bool>(local_value), std::logical_not<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{false, true, false, false}, "all_of");
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size, std::vector<bool>{false, true, false, false},
+          "all_of");
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_none_of(g, static_cast<bool>(local_value), std::logical_not<T>());
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_none_of(g, static_cast<bool>(local_value), std::logical_not<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{false, false, false, true}, "none_of");
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size, std::vector<bool>{false, false, false, true},
+          "none_of");
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 }
 
@@ -352,47 +433,63 @@ BOOST_AUTO_TEST_CASE(sub_group_x_of_function) {
   const size_t   elements_per_thread = 1;
   const uint32_t subgroup_size       = static_cast<uint32_t>(warpSize);
 
-  const auto data_generator = [](std::vector<T> &v, size_t local_size, size_t global_size) {
+  const auto data_generator = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     detail::create_bool_test_data(v, local_size, global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_any_of(sg, static_cast<bool>(local_value), std::logical_not<T>());
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_any_of(sg, static_cast<bool>(local_value), std::logical_not<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size, std::vector<bool>{true, true, true, false},
+      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
+                                               std::vector<bool>{true, true, true, false},
                                                "any_of", subgroup_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_all_of(sg, static_cast<bool>(local_value), std::logical_not<T>());
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_all_of(sg, static_cast<bool>(local_value), std::logical_not<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{false, true, false, false}, "all_of", subgroup_size);
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size, std::vector<bool>{false, true, false, false},
+          "all_of", subgroup_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_none_of(sg, static_cast<bool>(local_value), std::logical_not<T>());
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_none_of(sg, static_cast<bool>(local_value), std::logical_not<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
-      detail::check_binary_reduce<T, __LINE__>(vIn, local_size, global_size,
-                                               std::vector<bool>{false, false, false, true}, "none_of", subgroup_size);
+      detail::check_binary_reduce<T, __LINE__>(
+          vIn, local_size, global_size, std::vector<bool>{false, false, false, true},
+          "none_of", subgroup_size);
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 }
 #endif

--- a/tests/sycl/group_functions/group_functions_misc.cpp
+++ b/tests/sycl/group_functions/group_functions_misc.cpp
@@ -7,24 +7,24 @@
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
-
 
 #include "../sycl_test_suite.hpp"
 #include "group_functions.hpp"
@@ -34,21 +34,20 @@ BOOST_FIXTURE_TEST_SUITE(group_functions_tests, reset_device_fixture)
 BOOST_AUTO_TEST_CASE(group_barrier) {
   using T = int;
 
-  const size_t local_size     = 256;
-  const size_t global_size    = 1024;
-  const size_t offset_margin  = 0;
-  const size_t offset_divisor = 1;
-  const size_t buffer_size    = global_size;
-  const auto data_generator   = [](std::vector<T> &v) {
+  const size_t elements_per_thread = 1;
+  const auto data_generator = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     for (size_t i = 0; i < v.size(); ++i)
       v[i] = detail::initialize_type<T>(i);
   };
 
   {
     const auto tested_function = [=](auto acc, size_t global_linear_id,
-                                     sycl::sub_group sg, auto g, T local_value) {
-      int tmp             = -10000;
-      size_t local_id     = g.get_local_linear_id();
+                                     sycl::sub_group sg, auto g,
+                                     T local_value) {
+      int tmp = -10000;
+      size_t local_id = g.get_local_linear_id();
+      auto local_size = g.get_local_range().size();
       size_t group_offset = (global_linear_id / local_size) * local_size;
       for (int i = 0; i < local_size; ++i) {
         if (local_id == i) {
@@ -63,120 +62,122 @@ BOOST_AUTO_TEST_CASE(group_barrier) {
       }
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
         T expected = (i % local_size) * 10000;
         T computed = vIn[i];
 
         BOOST_TEST(detail::compare_type(expected, computed),
-                   detail::type_to_string(computed) << " at position " << i << " instead of "
-                                                    << detail::type_to_string(expected)
-                                                    << " for group: " << i / local_size);
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected)
+                       << " for group: " << i / local_size);
 
         //        if (!detail::compare_type(expected, computed))
         //          break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_broadcast, T, test_types) {
-  const size_t local_size     = 256;
-  const size_t global_size    = 1024;
-  const size_t local_size_x   = 16;
-  const size_t local_size_y   = 16;
-  const size_t global_size_x  = 32;
-  const size_t global_size_y  = 32;
-  const size_t offset_margin  = global_size;
-  const size_t offset_divisor = 1;
-  const size_t buffer_size    = global_size;
-  const auto data_generator   = [](std::vector<T> &v) {
+  const size_t elements_per_thread = 1;
+  const auto data_generator = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     for (size_t i = 0; i < v.size(); ++i)
       v[i] = detail::initialize_type<T>(i) + detail::get_offset<T>(global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
+    const auto tested_function = [=](auto acc, size_t global_linear_id,
+                                     sycl::sub_group sg, auto g,
+                                     T local_value) {
       acc[global_linear_id] = sycl::group_broadcast(g, local_value);
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
-        T expected = detail::initialize_type<T>(((int)i / local_size) * local_size) +
-                     detail::get_offset<T>(offset_margin, offset_divisor);
+        T expected =
+            detail::initialize_type<T>(((int)i / local_size) * local_size) +
+            detail::get_offset<T>(global_size, 1);
         T computed = vIn[i];
 
         BOOST_TEST(detail::compare_type(expected, computed),
                    detail::type_to_string(computed)
                        << " at position " << i << " instead of "
-                       << detail::type_to_string(expected) << " for case: no id");
+                       << detail::type_to_string(expected)
+                       << " for case: no id");
 
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
+    const auto tested_function = [=](auto acc, size_t global_linear_id,
+                                     sycl::sub_group sg, auto g,
+                                     T local_value) {
       acc[global_linear_id] = sycl::group_broadcast(g, local_value, 10);
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
-        T expected = detail::initialize_type<T>(((int)i / local_size) * local_size + 10) +
-                     detail::get_offset<T>(offset_margin, offset_divisor);
+        T expected = detail::initialize_type<T>(
+                         ((int)i / local_size) * local_size + 10) +
+                     detail::get_offset<T>(global_size, 1);
         T computed = vIn[i];
 
         BOOST_TEST(detail::compare_type(expected, computed),
                    detail::type_to_string(computed)
                        << " at position " << i << " instead of "
-                       << detail::type_to_string(expected) << " for case: linear id");
+                       << detail::type_to_string(expected)
+                       << " for case: linear id");
 
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
     const auto tested_function_1d = [](auto acc, size_t global_linear_id,
-                                       sycl::sub_group sg, auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_broadcast(g, local_value, sycl::id<1>(10));
+                                       sycl::sub_group sg, auto g,
+                                       T local_value) {
+      acc[global_linear_id] =
+          sycl::group_broadcast(g, local_value, sycl::id<1>(10));
     };
     const auto tested_function_2d = [](auto acc, size_t global_linear_id,
-                                       sycl::sub_group sg, auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_broadcast(g, local_value, sycl::id<2>(0, 10));
+                                       sycl::sub_group sg, auto g,
+                                       T local_value) {
+      acc[global_linear_id] =
+          sycl::group_broadcast(g, local_value, sycl::id<2>(0, 10));
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
-        T expected = detail::initialize_type<T>(((int)i / local_size) * local_size + 10) +
-                     detail::get_offset<T>(offset_margin, offset_divisor);
+        T expected = detail::initialize_type<T>(
+                         ((int)i / local_size) * local_size + 10) +
+                     detail::get_offset<T>(global_size, 1);
         T computed = vIn[i];
 
         BOOST_TEST(detail::compare_type(expected, computed),
@@ -189,97 +190,102 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_broadcast, T, test_types) {
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function_1d, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function_1d, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator,
-                                           tested_function_2d, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function_2d, validation_function);
   }
 }
 
 #if defined(HIPSYCL_PLATFORM_CUDA) || defined(HIPSYCL_PLATFORM_HIP)
 BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_broadcast, T, test_types) {
-  const size_t local_size      = 256;
-  const size_t global_size     = 1024;
-  const size_t offset_margin   = global_size;
-  const size_t offset_divisor  = 1;
-  const size_t buffer_size     = global_size;
+  const size_t elements_per_thread = 1;
   const uint32_t subgroup_size = static_cast<uint32_t>(warpSize);
 
-  const auto data_generator = [](std::vector<T> &v) {
+  const auto data_generator = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     for (size_t i = 0; i < v.size(); ++i)
       v[i] = detail::initialize_type<T>(i) + detail::get_offset<T>(global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id,
+                                    sycl::sub_group sg, auto g, T local_value) {
       acc[global_linear_id] = sycl::group_broadcast(sg, local_value);
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
-        T expected = detail::initialize_type<T>(((int)i / subgroup_size) * subgroup_size) +
-                     detail::get_offset<T>(offset_margin, offset_divisor);
+        int expected_base = i%local_size;
+        expected_base = ((int)expected_base/warpSize) * warpSize;
+        expected_base += ((int)i/local_size) * local_size;
+
+        T expected = detail::initialize_type<T>(expected_base) + detail::get_offset<T>(global_size);
         T computed = vIn[i];
 
         BOOST_TEST(detail::compare_type(expected, computed),
                    detail::type_to_string(computed)
                        << " at position " << i << " instead of "
-                       << detail::type_to_string(expected) << " for case: no id");
+                       << detail::type_to_string(expected)
+                       << " for case: no id");
 
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_broadcast(sg, local_value, 10);
+    const auto tested_function = [](auto acc, size_t global_linear_id,
+                                    sycl::sub_group sg, auto g, T local_value) {
+        acc[global_linear_id] = sycl::group_broadcast(sg, local_value, 10);
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
-        T expected =
-            detail::initialize_type<T>(((int)i / subgroup_size) * subgroup_size + 10) +
-            detail::get_offset<T>(offset_margin, offset_divisor);
+        int expected_base = i%local_size;
+        expected_base = ((int)expected_base/warpSize) * warpSize;
+        expected_base += ((int)i/local_size) * local_size + 10;
+
+        T expected = detail::initialize_type<T>(expected_base) + detail::get_offset<T>(global_size);
         T computed = vIn[i];
 
         BOOST_TEST(detail::compare_type(expected, computed),
                    detail::type_to_string(computed)
                        << " at position " << i << " instead of "
-                       << detail::type_to_string(expected) << " for case: linear id");
+                       << detail::type_to_string(expected)
+                       << " for case: linear id");
 
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_broadcast(sg, local_value, sycl::id<1>(10));
+    const auto tested_function = [](auto acc, size_t global_linear_id,
+                                    sycl::sub_group sg, auto g, T local_value) {
+        acc[global_linear_id] =
+            sycl::group_broadcast(sg, local_value, sycl::id<1>(10));
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
-        T expected =
-            detail::initialize_type<T>(((int)i / subgroup_size) * subgroup_size + 10) +
-            detail::get_offset<T>(offset_margin, offset_divisor);
+        int expected_base = i%local_size;
+        expected_base = ((int)expected_base/warpSize) * warpSize;
+        expected_base += ((int)i/local_size) * local_size + 10;
+
+        T expected = detail::initialize_type<T>(expected_base) + detail::get_offset<T>(global_size);
         T computed = vIn[i];
 
         BOOST_TEST(detail::compare_type(expected, computed),
@@ -292,9 +298,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_broadcast, T, test_types) {
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 #endif

--- a/tests/sycl/group_functions/group_functions_misc.cpp
+++ b/tests/sycl/group_functions/group_functions_misc.cpp
@@ -8,7 +8,7 @@
  * modification, are permitted provided that the following conditions are met:
  *
  * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
+ *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
@@ -35,13 +35,15 @@ BOOST_AUTO_TEST_CASE(group_barrier) {
   using T = int;
 
   const size_t elements_per_thread = 1;
-  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     for (size_t i = 0; i < v.size(); ++i)
       v[i] = detail::initialize_type<T>(i);
   };
 
   {
-    const auto tested_function = [=](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [=](auto acc, size_t global_linear_id,
+                                     sycl::sub_group sg, auto g, T local_value) {
       int    tmp          = -10000;
       size_t local_id     = g.get_local_linear_id();
       auto   local_size   = g.get_local_range().size();
@@ -58,111 +60,129 @@ BOOST_AUTO_TEST_CASE(group_barrier) {
         tmp = acc[group_offset + i];
       }
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
         T expected = (i % local_size) * 10000;
         T computed = vIn[i];
 
-        BOOST_TEST(detail::compare_type(expected, computed), detail::type_to_string(computed)
-                                                                 << " at position " << i << " instead of "
-                                                                 << detail::type_to_string(expected)
-                                                                 << " for group: " << i / local_size);
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected)
+                       << " for group: " << i / local_size);
 
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_broadcast, T, test_types) {
   const size_t elements_per_thread = 1;
-  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     for (size_t i = 0; i < v.size(); ++i)
       v[i] = detail::initialize_type<T>(i) + detail::get_offset<T>(global_size);
   };
 
   {
-    const auto tested_function = [=](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [=](auto acc, size_t global_linear_id,
+                                     sycl::sub_group sg, auto g, T local_value) {
       acc[global_linear_id] = sycl::group_broadcast(g, local_value);
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
-        T expected =
-            detail::initialize_type<T>(((int)i / local_size) * local_size) + detail::get_offset<T>(global_size, 1);
+        T expected = detail::initialize_type<T>(((int)i / local_size) * local_size) +
+                     detail::get_offset<T>(global_size, 1);
         T computed = vIn[i];
 
         BOOST_TEST(detail::compare_type(expected, computed),
-                   detail::type_to_string(computed) << " at position " << i << " instead of "
-                                                    << detail::type_to_string(expected) << " for case: no id");
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: no id");
 
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [=](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [=](auto acc, size_t global_linear_id,
+                                     sycl::sub_group sg, auto g, T local_value) {
       acc[global_linear_id] = sycl::group_broadcast(g, local_value, 10);
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
-        T expected =
-            detail::initialize_type<T>(((int)i / local_size) * local_size + 10) + detail::get_offset<T>(global_size, 1);
+        T expected = detail::initialize_type<T>(((int)i / local_size) * local_size + 10) +
+                     detail::get_offset<T>(global_size, 1);
         T computed = vIn[i];
 
         BOOST_TEST(detail::compare_type(expected, computed),
-                   detail::type_to_string(computed) << " at position " << i << " instead of "
-                                                    << detail::type_to_string(expected) << " for case: linear id");
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: linear id");
 
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 
   {
-    const auto tested_function_1d = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function_1d = [](auto acc, size_t global_linear_id,
+                                       sycl::sub_group sg, auto g, T local_value) {
       acc[global_linear_id] = sycl::group_broadcast(g, local_value, sycl::id<1>(10));
     };
-    const auto tested_function_2d = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function_2d = [](auto acc, size_t global_linear_id,
+                                       sycl::sub_group sg, auto g, T local_value) {
       acc[global_linear_id] = sycl::group_broadcast(g, local_value, sycl::id<2>(0, 10));
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
-        T expected =
-            detail::initialize_type<T>(((int)i / local_size) * local_size + 10) + detail::get_offset<T>(global_size, 1);
+        T expected = detail::initialize_type<T>(((int)i / local_size) * local_size + 10) +
+                     detail::get_offset<T>(global_size, 1);
         T computed = vIn[i];
 
         BOOST_TEST(detail::compare_type(expected, computed),
-                   detail::type_to_string(computed) << " at position " << i << " instead of "
-                                                    << detail::type_to_string(expected) << " for case: id");
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: id");
 
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function_1d,
-                                           validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function_1d, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function_2d,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function_2d, validation_function);
   }
 }
 
@@ -171,87 +191,103 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_broadcast, T, test_types) {
   const size_t   elements_per_thread = 1;
   const uint32_t subgroup_size       = static_cast<uint32_t>(warpSize);
 
-  const auto data_generator = [](std::vector<T> &v, size_t local_size, size_t global_size) {
+  const auto data_generator = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     for (size_t i = 0; i < v.size(); ++i)
       v[i] = detail::initialize_type<T>(i) + detail::get_offset<T>(global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
       acc[global_linear_id] = sycl::group_broadcast(sg, local_value);
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
         int expected_base = i % local_size;
         expected_base     = ((int)expected_base / warpSize) * warpSize;
         expected_base += ((int)i / local_size) * local_size;
 
-        T expected = detail::initialize_type<T>(expected_base) + detail::get_offset<T>(global_size);
+        T expected = detail::initialize_type<T>(expected_base) +
+                     detail::get_offset<T>(global_size);
         T computed = vIn[i];
 
         BOOST_TEST(detail::compare_type(expected, computed),
-                   detail::type_to_string(computed) << " at position " << i << " instead of "
-                                                    << detail::type_to_string(expected) << " for case: no id");
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: no id");
 
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
       acc[global_linear_id] = sycl::group_broadcast(sg, local_value, 10);
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
         int expected_base = i % local_size;
         expected_base     = ((int)expected_base / warpSize) * warpSize;
         expected_base += ((int)i / local_size) * local_size + 10;
 
-        T expected = detail::initialize_type<T>(expected_base) + detail::get_offset<T>(global_size);
+        T expected = detail::initialize_type<T>(expected_base) +
+                     detail::get_offset<T>(global_size);
         T computed = vIn[i];
 
         BOOST_TEST(detail::compare_type(expected, computed),
-                   detail::type_to_string(computed) << " at position " << i << " instead of "
-                                                    << detail::type_to_string(expected) << " for case: linear id");
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: linear id");
 
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
       acc[global_linear_id] = sycl::group_broadcast(sg, local_value, sycl::id<1>(10));
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
         int expected_base = i % local_size;
         expected_base     = ((int)expected_base / warpSize) * warpSize;
         expected_base += ((int)i / local_size) * local_size + 10;
 
-        T expected = detail::initialize_type<T>(expected_base) + detail::get_offset<T>(global_size);
+        T expected = detail::initialize_type<T>(expected_base) +
+                     detail::get_offset<T>(global_size);
         T computed = vIn[i];
 
         BOOST_TEST(detail::compare_type(expected, computed),
-                   detail::type_to_string(computed) << " at position " << i << " instead of "
-                                                    << detail::type_to_string(expected) << " for case: id");
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: id");
 
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 }
 #endif

--- a/tests/sycl/group_functions/group_functions_misc.cpp
+++ b/tests/sycl/group_functions/group_functions_misc.cpp
@@ -35,19 +35,16 @@ BOOST_AUTO_TEST_CASE(group_barrier) {
   using T = int;
 
   const size_t elements_per_thread = 1;
-  const auto data_generator = [](std::vector<T> &v, size_t local_size,
-                                 size_t global_size) {
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
     for (size_t i = 0; i < v.size(); ++i)
       v[i] = detail::initialize_type<T>(i);
   };
 
   {
-    const auto tested_function = [=](auto acc, size_t global_linear_id,
-                                     sycl::sub_group sg, auto g,
-                                     T local_value) {
-      int tmp = -10000;
-      size_t local_id = g.get_local_linear_id();
-      auto local_size = g.get_local_range().size();
+    const auto tested_function = [=](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      int    tmp          = -10000;
+      size_t local_id     = g.get_local_linear_id();
+      auto   local_size   = g.get_local_range().size();
       size_t group_offset = (global_linear_id / local_size) * local_size;
       for (int i = 0; i < local_size; ++i) {
         if (local_id == i) {
@@ -61,245 +58,200 @@ BOOST_AUTO_TEST_CASE(group_barrier) {
         tmp = acc[group_offset + i];
       }
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
         T expected = (i % local_size) * 10000;
         T computed = vIn[i];
 
-        BOOST_TEST(detail::compare_type(expected, computed),
-                   detail::type_to_string(computed)
-                       << " at position " << i << " instead of "
-                       << detail::type_to_string(expected)
-                       << " for group: " << i / local_size);
+        BOOST_TEST(detail::compare_type(expected, computed), detail::type_to_string(computed)
+                                                                 << " at position " << i << " instead of "
+                                                                 << detail::type_to_string(expected)
+                                                                 << " for group: " << i / local_size);
 
-        //        if (!detail::compare_type(expected, computed))
-        //          break;
+        if (!detail::compare_type(expected, computed))
+          break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_broadcast, T, test_types) {
   const size_t elements_per_thread = 1;
-  const auto data_generator = [](std::vector<T> &v, size_t local_size,
-                                 size_t global_size) {
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
     for (size_t i = 0; i < v.size(); ++i)
       v[i] = detail::initialize_type<T>(i) + detail::get_offset<T>(global_size);
   };
 
   {
-    const auto tested_function = [=](auto acc, size_t global_linear_id,
-                                     sycl::sub_group sg, auto g,
-                                     T local_value) {
+    const auto tested_function = [=](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
       acc[global_linear_id] = sycl::group_broadcast(g, local_value);
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
         T expected =
-            detail::initialize_type<T>(((int)i / local_size) * local_size) +
-            detail::get_offset<T>(global_size, 1);
+            detail::initialize_type<T>(((int)i / local_size) * local_size) + detail::get_offset<T>(global_size, 1);
         T computed = vIn[i];
 
         BOOST_TEST(detail::compare_type(expected, computed),
-                   detail::type_to_string(computed)
-                       << " at position " << i << " instead of "
-                       << detail::type_to_string(expected)
-                       << " for case: no id");
+                   detail::type_to_string(computed) << " at position " << i << " instead of "
+                                                    << detail::type_to_string(expected) << " for case: no id");
 
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [=](auto acc, size_t global_linear_id,
-                                     sycl::sub_group sg, auto g,
-                                     T local_value) {
+    const auto tested_function = [=](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
       acc[global_linear_id] = sycl::group_broadcast(g, local_value, 10);
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
-        T expected = detail::initialize_type<T>(
-                         ((int)i / local_size) * local_size + 10) +
-                     detail::get_offset<T>(global_size, 1);
+        T expected =
+            detail::initialize_type<T>(((int)i / local_size) * local_size + 10) + detail::get_offset<T>(global_size, 1);
         T computed = vIn[i];
 
         BOOST_TEST(detail::compare_type(expected, computed),
-                   detail::type_to_string(computed)
-                       << " at position " << i << " instead of "
-                       << detail::type_to_string(expected)
-                       << " for case: linear id");
+                   detail::type_to_string(computed) << " at position " << i << " instead of "
+                                                    << detail::type_to_string(expected) << " for case: linear id");
 
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function_1d = [](auto acc, size_t global_linear_id,
-                                       sycl::sub_group sg, auto g,
-                                       T local_value) {
-      acc[global_linear_id] =
-          sycl::group_broadcast(g, local_value, sycl::id<1>(10));
+    const auto tested_function_1d = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_broadcast(g, local_value, sycl::id<1>(10));
     };
-    const auto tested_function_2d = [](auto acc, size_t global_linear_id,
-                                       sycl::sub_group sg, auto g,
-                                       T local_value) {
-      acc[global_linear_id] =
-          sycl::group_broadcast(g, local_value, sycl::id<2>(0, 10));
+    const auto tested_function_2d = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_broadcast(g, local_value, sycl::id<2>(0, 10));
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
-        T expected = detail::initialize_type<T>(
-                         ((int)i / local_size) * local_size + 10) +
-                     detail::get_offset<T>(global_size, 1);
+        T expected =
+            detail::initialize_type<T>(((int)i / local_size) * local_size + 10) + detail::get_offset<T>(global_size, 1);
         T computed = vIn[i];
 
         BOOST_TEST(detail::compare_type(expected, computed),
-                   detail::type_to_string(computed)
-                       << " at position " << i << " instead of "
-                       << detail::type_to_string(expected) << " for case: id");
+                   detail::type_to_string(computed) << " at position " << i << " instead of "
+                                                    << detail::type_to_string(expected) << " for case: id");
 
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function_1d, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function_1d,
+                                           validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function_2d, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function_2d,
+                                           validation_function);
   }
 }
 
 #if defined(HIPSYCL_PLATFORM_CUDA) || defined(HIPSYCL_PLATFORM_HIP)
 BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_broadcast, T, test_types) {
-  const size_t elements_per_thread = 1;
-  const uint32_t subgroup_size = static_cast<uint32_t>(warpSize);
+  const size_t   elements_per_thread = 1;
+  const uint32_t subgroup_size       = static_cast<uint32_t>(warpSize);
 
-  const auto data_generator = [](std::vector<T> &v, size_t local_size,
-                                 size_t global_size) {
+  const auto data_generator = [](std::vector<T> &v, size_t local_size, size_t global_size) {
     for (size_t i = 0; i < v.size(); ++i)
       v[i] = detail::initialize_type<T>(i) + detail::get_offset<T>(global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id,
-                                    sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
       acc[global_linear_id] = sycl::group_broadcast(sg, local_value);
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
-        int expected_base = i%local_size;
-        expected_base = ((int)expected_base/warpSize) * warpSize;
-        expected_base += ((int)i/local_size) * local_size;
+        int expected_base = i % local_size;
+        expected_base     = ((int)expected_base / warpSize) * warpSize;
+        expected_base += ((int)i / local_size) * local_size;
 
         T expected = detail::initialize_type<T>(expected_base) + detail::get_offset<T>(global_size);
         T computed = vIn[i];
 
         BOOST_TEST(detail::compare_type(expected, computed),
-                   detail::type_to_string(computed)
-                       << " at position " << i << " instead of "
-                       << detail::type_to_string(expected)
-                       << " for case: no id");
+                   detail::type_to_string(computed) << " at position " << i << " instead of "
+                                                    << detail::type_to_string(expected) << " for case: no id");
 
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id,
-                                    sycl::sub_group sg, auto g, T local_value) {
-        acc[global_linear_id] = sycl::group_broadcast(sg, local_value, 10);
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_broadcast(sg, local_value, 10);
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
-        int expected_base = i%local_size;
-        expected_base = ((int)expected_base/warpSize) * warpSize;
-        expected_base += ((int)i/local_size) * local_size + 10;
+        int expected_base = i % local_size;
+        expected_base     = ((int)expected_base / warpSize) * warpSize;
+        expected_base += ((int)i / local_size) * local_size + 10;
 
         T expected = detail::initialize_type<T>(expected_base) + detail::get_offset<T>(global_size);
         T computed = vIn[i];
 
         BOOST_TEST(detail::compare_type(expected, computed),
-                   detail::type_to_string(computed)
-                       << " at position " << i << " instead of "
-                       << detail::type_to_string(expected)
-                       << " for case: linear id");
+                   detail::type_to_string(computed) << " at position " << i << " instead of "
+                                                    << detail::type_to_string(expected) << " for case: linear id");
 
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id,
-                                    sycl::sub_group sg, auto g, T local_value) {
-        acc[global_linear_id] =
-            sycl::group_broadcast(sg, local_value, sycl::id<1>(10));
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_broadcast(sg, local_value, sycl::id<1>(10));
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
-        int expected_base = i%local_size;
-        expected_base = ((int)expected_base/warpSize) * warpSize;
-        expected_base += ((int)i/local_size) * local_size + 10;
+        int expected_base = i % local_size;
+        expected_base     = ((int)expected_base / warpSize) * warpSize;
+        expected_base += ((int)i / local_size) * local_size + 10;
 
         T expected = detail::initialize_type<T>(expected_base) + detail::get_offset<T>(global_size);
         T computed = vIn[i];
 
         BOOST_TEST(detail::compare_type(expected, computed),
-                   detail::type_to_string(computed)
-                       << " at position " << i << " instead of "
-                       << detail::type_to_string(expected) << " for case: id");
+                   detail::type_to_string(computed) << " at position " << i << " instead of "
+                                                    << detail::type_to_string(expected) << " for case: id");
 
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 #endif

--- a/tests/sycl/group_functions/group_functions_reduce.cpp
+++ b/tests/sycl/group_functions/group_functions_reduce.cpp
@@ -269,7 +269,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_reduce, T, test_types) {
                        << " at position " << i << " instead of "
                        << detail::type_to_string(expected) << " for local_size " << local_size << " and case: no init");
         if (!detail::compare_type(expected, computed))
-          break;
+          ;//break;
       }
     };
 

--- a/tests/sycl/group_functions/group_functions_reduce.cpp
+++ b/tests/sycl/group_functions/group_functions_reduce.cpp
@@ -25,28 +25,24 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
 #include "../sycl_test_suite.hpp"
 #include "group_functions.hpp"
 
 BOOST_FIXTURE_TEST_SUITE(group_functions_tests, reset_device_fixture)
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce_mul, T, test_types) {
-  const size_t elements_per_thread    = 1;
-  const auto data_generator = [](std::vector<T> &v, size_t local_size,
-                                 size_t global_size) {
+  const size_t elements_per_thread = 1;
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
     for (size_t i = 0; i < v.size(); ++i)
       v[i] = (i % local_size == 0) ? T{static_cast<T>(2)} : T{static_cast<T>(1)};
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
       acc[global_linear_id] = sycl::group_reduce(g, local_value, std::multiplies<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       for (size_t i = 0; i < global_size / local_size; ++i) {
         T expected = vOrig[i * local_size];
         for (size_t j = 1; j < local_size; ++j)
@@ -56,40 +52,33 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce_mul, T, test_types) {
           T computed = vIn[i * local_size + j];
           BOOST_TEST(detail::compare_type(expected, computed),
                      detail::type_to_string(computed)
-                         << " at position " << j << " instead of "
-                         << detail::type_to_string(expected) << " for group " << i
-                         << " for local_size " << local_size << " and case: no init multiplication");
+                         << " at position " << j << " instead of " << detail::type_to_string(expected) << " for group "
+                         << i << " for local_size " << local_size << " and case: no init multiplication");
           if (!detail::compare_type(expected, computed))
             break;
         }
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce, T, test_types) {
-  const size_t elements_per_thread    = 1;
-  const auto data_generator = [](std::vector<T> &v, size_t local_size,
-                                 size_t global_size) {
+  const size_t elements_per_thread = 1;
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
     for (size_t i = 0; i < v.size(); ++i)
-      v[i] =
-          detail::initialize_type<T>(i) + detail::get_offset<T>(global_size, global_size);
+      v[i] = detail::initialize_type<T>(i) + detail::get_offset<T>(global_size, global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
       acc[global_linear_id] = sycl::group_reduce(g, local_value, std::plus<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       for (size_t i = 0; i < global_size / local_size; ++i) {
         T expected = T{};
         for (size_t j = 0; j < local_size; ++j)
@@ -99,32 +88,25 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce, T, test_types) {
           T computed = vIn[i * local_size + j];
           BOOST_TEST(detail::compare_type(expected, computed),
                      detail::type_to_string(computed)
-                         << " at position " << j << " instead of "
-                         << detail::type_to_string(expected) << " for group " << i
-                         << " for local_size " << local_size << " and case: no init");
+                         << " at position " << j << " instead of " << detail::type_to_string(expected) << " for group "
+                         << i << " for local_size " << local_size << " and case: no init");
           if (!detail::compare_type(expected, computed))
             break;
         }
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      acc[global_linear_id] =
-          sycl::group_reduce(g, local_value, detail::initialize_type<T>(10),
-                             std::plus<T>());
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_reduce(g, local_value, detail::initialize_type<T>(10), std::plus<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       for (size_t i = 0; i < global_size / local_size; ++i) {
         T expected = detail::initialize_type<T>(10);
         for (size_t j = 0; j < local_size; ++j)
@@ -134,47 +116,40 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce, T, test_types) {
           T computed = vIn[i * local_size + j];
           BOOST_TEST(detail::compare_type(expected, computed),
                      detail::type_to_string(computed)
-                         << " at position " << j << " instead of "
-                         << detail::type_to_string(expected) << " for group " << i
-                         << " for local_size " << local_size << " and case: init");
+                         << " at position " << j << " instead of " << detail::type_to_string(expected) << " for group "
+                         << i << " for local_size " << local_size << " and case: init");
           if (!detail::compare_type(expected, computed))
             break;
         }
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce_ptr, T, test_types) {
-  const size_t elements_per_thread    = 3;
-  const auto data_generator = [](std::vector<T> &v, size_t local_size,
-                                 size_t global_size) {
+  const size_t elements_per_thread = 3;
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
     for (size_t i = 0; i < v.size(); ++i)
-      v[i] = detail::initialize_type<T>(i) +
-             detail::get_offset<T>(global_size * elements_per_thread, local_size * 2);
+      v[i] = detail::initialize_type<T>(i) + detail::get_offset<T>(global_size * elements_per_thread, local_size * 2);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      auto local_size = g.get_local_range().size();
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      auto local_size  = g.get_local_range().size();
       auto global_size = local_size * 4;
-      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end   = start + local_size * 2;
+      auto start       = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end         = start + local_size * 2;
 
       T local = sycl::detail::reduce(g, start.get(), end.get(), std::plus<T>());
       sycl::group_barrier(g);
       acc[global_linear_id + 2 * global_size] = local;
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       for (size_t i = 0; i < global_size / local_size; ++i) {
         T expected = T{};
         for (size_t j = 0; j < local_size * 2; ++j)
@@ -183,37 +158,31 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce_ptr, T, test_types) {
         T computed = vIn[2 * global_size + i * local_size];
         BOOST_TEST(detail::compare_type(expected, computed),
                    detail::type_to_string(computed)
-                       << " at position " << i << " instead of "
-                       << detail::type_to_string(expected)
-                         << " for local_size " << local_size << " and case: no init");
+                       << " at position " << i << " instead of " << detail::type_to_string(expected)
+                       << " for local_size " << local_size << " and case: no init");
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      auto local_size = g.get_local_range().size();
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      auto local_size  = g.get_local_range().size();
       auto global_size = local_size * 4;
-      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end   = start + local_size * 2;
+      auto start       = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end         = start + local_size * 2;
 
-      T local = sycl::detail::reduce(g, start.get(), end.get(),
-                                     detail::initialize_type<T>(10), std::plus<T>());
+      T local = sycl::detail::reduce(g, start.get(), end.get(), detail::initialize_type<T>(10), std::plus<T>());
       sycl::group_barrier(g);
       acc[global_linear_id + 2 * global_size] = local;
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       for (size_t i = 0; i < global_size / local_size; ++i) {
         T expected = detail::initialize_type<T>(10);
         for (size_t j = 0; j < local_size * 2; ++j)
@@ -222,43 +191,36 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce_ptr, T, test_types) {
         T computed = vIn[i * local_size + 2 * global_size];
         BOOST_TEST(detail::compare_type(expected, computed),
                    detail::type_to_string(computed)
-                       << " at position " << i << " instead of "
-                       << detail::type_to_string(expected)
-                         << " for local_size " << local_size << " and case: init");
+                       << " at position " << i << " instead of " << detail::type_to_string(expected)
+                       << " for local_size " << local_size << " and case: init");
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
 #if defined(HIPSYCL_PLATFORM_CUDA) || defined(HIPSYCL_PLATFORM_HIP)
 BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_reduce, T, test_types) {
-  const uint32_t subgroup_size = static_cast<uint32_t>(warpSize);
-  const size_t elements_per_thread     = 1;
-  const auto data_generator = [](std::vector<T> &v, size_t local_size,
-                                 size_t global_size) {
+  const uint32_t subgroup_size       = static_cast<uint32_t>(warpSize);
+  const size_t   elements_per_thread = 1;
+  const auto     data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
     for (size_t i = 0; i < v.size(); ++i)
-      v[i] =
-          detail::initialize_type<T>(i) + detail::get_offset<T>(global_size, global_size);
+      v[i] = detail::initialize_type<T>(i) + detail::get_offset<T>(global_size, global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
       acc[global_linear_id] = sycl::group_reduce(sg, local_value, std::plus<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       for (size_t i = 0; i < global_size / local_size; ++i) {
-        T expected = T{};
+        T    expected         = T{};
         auto actual_warp_size = local_size < warpSize ? local_size : warpSize;
         for (size_t j = 0; j < actual_warp_size; ++j)
           expected = expected + vOrig[i * local_size + j];
@@ -266,45 +228,39 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_reduce, T, test_types) {
         T computed = vIn[i * local_size];
         BOOST_TEST(detail::compare_type(expected, computed),
                    detail::type_to_string(computed)
-                       << " at position " << i << " instead of "
-                       << detail::type_to_string(expected) << " for local_size " << local_size << " and case: no init");
-        if (!detail::compare_type(expected, computed))
-          ;//break;
-      }
-    };
-
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
-  }
-
-  {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      acc[global_linear_id] =
-          sycl::group_reduce(sg, local_value, detail::initialize_type<T>(10),
-                             std::plus<T>());
-    };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
-      for (size_t i = 0; i < global_size / local_size; ++i) {
-        T expected = detail::initialize_type<T>(10);
-        auto actual_warp_size = local_size < warpSize ? local_size : warpSize;
-        for (size_t j = 0; j < actual_warp_size; ++j)
-          expected = expected + vOrig[i * local_size + j];
-
-        T computed = vIn[i * local_size];
-        BOOST_TEST(detail::compare_type(expected, computed),
-                   detail::type_to_string(computed)
-                       << " at position " << i << " instead of "
-                       << detail::type_to_string(expected) << " for local_size " << local_size << " and case: init");
+                       << " at position " << i << " instead of " << detail::type_to_string(expected)
+                       << " for local_size " << local_size << " and case: no init");
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_reduce(sg, local_value, detail::initialize_type<T>(10), std::plus<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        T    expected         = detail::initialize_type<T>(10);
+        auto actual_warp_size = local_size < warpSize ? local_size : warpSize;
+        for (size_t j = 0; j < actual_warp_size; ++j)
+          expected = expected + vOrig[i * local_size + j];
+
+        T computed = vIn[i * local_size];
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of " << detail::type_to_string(expected)
+                       << " for local_size " << local_size << " and case: init");
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 #endif

--- a/tests/sycl/group_functions/group_functions_reduce.cpp
+++ b/tests/sycl/group_functions/group_functions_reduce.cpp
@@ -32,16 +32,19 @@ BOOST_FIXTURE_TEST_SUITE(group_functions_tests, reset_device_fixture)
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce_mul, T, test_types) {
   const size_t elements_per_thread = 1;
-  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     for (size_t i = 0; i < v.size(); ++i)
       v[i] = (i % local_size == 0) ? T{static_cast<T>(2)} : T{static_cast<T>(1)};
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
       acc[global_linear_id] = sycl::group_reduce(g, local_value, std::multiplies<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       for (size_t i = 0; i < global_size / local_size; ++i) {
         T expected = vOrig[i * local_size];
@@ -52,32 +55,40 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce_mul, T, test_types) {
           T computed = vIn[i * local_size + j];
           BOOST_TEST(detail::compare_type(expected, computed),
                      detail::type_to_string(computed)
-                         << " at position " << j << " instead of " << detail::type_to_string(expected) << " for group "
-                         << i << " for local_size " << local_size << " and case: no init multiplication");
+                         << " at position " << j << " instead of "
+                         << detail::type_to_string(expected) << " for group " << i
+                         << " for local_size " << local_size
+                         << " and case: no init multiplication");
           if (!detail::compare_type(expected, computed))
             break;
         }
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce, T, test_types) {
   const size_t elements_per_thread = 1;
-  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     for (size_t i = 0; i < v.size(); ++i)
-      v[i] = detail::initialize_type<T>(i) + detail::get_offset<T>(global_size, global_size);
+      v[i] =
+          detail::initialize_type<T>(i) + detail::get_offset<T>(global_size, global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
       acc[global_linear_id] = sycl::group_reduce(g, local_value, std::plus<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       for (size_t i = 0; i < global_size / local_size; ++i) {
         T expected = T{};
@@ -88,24 +99,30 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce, T, test_types) {
           T computed = vIn[i * local_size + j];
           BOOST_TEST(detail::compare_type(expected, computed),
                      detail::type_to_string(computed)
-                         << " at position " << j << " instead of " << detail::type_to_string(expected) << " for group "
-                         << i << " for local_size " << local_size << " and case: no init");
+                         << " at position " << j << " instead of "
+                         << detail::type_to_string(expected) << " for group " << i
+                         << " for local_size " << local_size << " and case: no init");
           if (!detail::compare_type(expected, computed))
             break;
         }
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_reduce(g, local_value, detail::initialize_type<T>(10), std::plus<T>());
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_reduce(
+          g, local_value, detail::initialize_type<T>(10), std::plus<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       for (size_t i = 0; i < global_size / local_size; ++i) {
         T expected = detail::initialize_type<T>(10);
@@ -116,39 +133,46 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce, T, test_types) {
           T computed = vIn[i * local_size + j];
           BOOST_TEST(detail::compare_type(expected, computed),
                      detail::type_to_string(computed)
-                         << " at position " << j << " instead of " << detail::type_to_string(expected) << " for group "
-                         << i << " for local_size " << local_size << " and case: init");
+                         << " at position " << j << " instead of "
+                         << detail::type_to_string(expected) << " for group " << i
+                         << " for local_size " << local_size << " and case: init");
           if (!detail::compare_type(expected, computed))
             break;
         }
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce_ptr, T, test_types) {
   const size_t elements_per_thread = 3;
-  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     for (size_t i = 0; i < v.size(); ++i)
-      v[i] = detail::initialize_type<T>(i) + detail::get_offset<T>(global_size * elements_per_thread, local_size * 2);
+      v[i] = detail::initialize_type<T>(i) +
+             detail::get_offset<T>(global_size * elements_per_thread, local_size * 2);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
       auto local_size  = g.get_local_range().size();
       auto global_size = local_size * 4;
-      auto start       = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end         = start + local_size * 2;
+      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end   = start + local_size * 2;
 
       T local = sycl::detail::reduce(g, start.get(), end.get(), std::plus<T>());
       sycl::group_barrier(g);
       acc[global_linear_id + 2 * global_size] = local;
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       for (size_t i = 0; i < global_size / local_size; ++i) {
         T expected = T{};
@@ -158,30 +182,36 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce_ptr, T, test_types) {
         T computed = vIn[2 * global_size + i * local_size];
         BOOST_TEST(detail::compare_type(expected, computed),
                    detail::type_to_string(computed)
-                       << " at position " << i << " instead of " << detail::type_to_string(expected)
-                       << " for local_size " << local_size << " and case: no init");
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for local_size "
+                       << local_size << " and case: no init");
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
       auto local_size  = g.get_local_range().size();
       auto global_size = local_size * 4;
-      auto start       = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end         = start + local_size * 2;
+      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end   = start + local_size * 2;
 
-      T local = sycl::detail::reduce(g, start.get(), end.get(), detail::initialize_type<T>(10), std::plus<T>());
+      T local = sycl::detail::reduce(g, start.get(), end.get(),
+                                     detail::initialize_type<T>(10), std::plus<T>());
       sycl::group_barrier(g);
       acc[global_linear_id + 2 * global_size] = local;
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       for (size_t i = 0; i < global_size / local_size; ++i) {
         T expected = detail::initialize_type<T>(10);
@@ -191,16 +221,19 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce_ptr, T, test_types) {
         T computed = vIn[i * local_size + 2 * global_size];
         BOOST_TEST(detail::compare_type(expected, computed),
                    detail::type_to_string(computed)
-                       << " at position " << i << " instead of " << detail::type_to_string(expected)
-                       << " for local_size " << local_size << " and case: init");
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for local_size "
+                       << local_size << " and case: init");
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 }
 
@@ -208,16 +241,20 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_reduce_ptr, T, test_types) {
 BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_reduce, T, test_types) {
   const uint32_t subgroup_size       = static_cast<uint32_t>(warpSize);
   const size_t   elements_per_thread = 1;
-  const auto     data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
+  const auto     data_generator      = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     for (size_t i = 0; i < v.size(); ++i)
-      v[i] = detail::initialize_type<T>(i) + detail::get_offset<T>(global_size, global_size);
+      v[i] =
+          detail::initialize_type<T>(i) + detail::get_offset<T>(global_size, global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
       acc[global_linear_id] = sycl::group_reduce(sg, local_value, std::plus<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       for (size_t i = 0; i < global_size / local_size; ++i) {
         T    expected         = T{};
@@ -228,21 +265,26 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_reduce, T, test_types) {
         T computed = vIn[i * local_size];
         BOOST_TEST(detail::compare_type(expected, computed),
                    detail::type_to_string(computed)
-                       << " at position " << i << " instead of " << detail::type_to_string(expected)
-                       << " for local_size " << local_size << " and case: no init");
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for local_size "
+                       << local_size << " and case: no init");
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_reduce(sg, local_value, detail::initialize_type<T>(10), std::plus<T>());
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
+                                    auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_reduce(
+          sg, local_value, detail::initialize_type<T>(10), std::plus<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       for (size_t i = 0; i < global_size / local_size; ++i) {
         T    expected         = detail::initialize_type<T>(10);
@@ -253,14 +295,16 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_reduce, T, test_types) {
         T computed = vIn[i * local_size];
         BOOST_TEST(detail::compare_type(expected, computed),
                    detail::type_to_string(computed)
-                       << " at position " << i << " instead of " << detail::type_to_string(expected)
-                       << " for local_size " << local_size << " and case: init");
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for local_size "
+                       << local_size << " and case: init");
         if (!detail::compare_type(expected, computed))
           break;
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
   }
 }
 #endif

--- a/tests/sycl/group_functions/group_functions_scan.cpp
+++ b/tests/sycl/group_functions/group_functions_scan.cpp
@@ -32,16 +32,9 @@
 BOOST_FIXTURE_TEST_SUITE(group_functions_tests, reset_device_fixture)
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan_mul, T, test_types) {
-  const size_t local_size     = 256;
-  const size_t global_size    = 1024;
-  const size_t local_size_x   = 16;
-  const size_t local_size_y   = 16;
-  const size_t global_size_x  = 32;
-  const size_t global_size_y  = 32;
-  const size_t offset_margin  = global_size;
-  const size_t offset_divisor = global_size;
-  const size_t buffer_size    = global_size;
-  const auto data_generator   = [](std::vector<T> &v) {
+  const size_t elements_per_thread    = 1;
+  const auto data_generator = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     for (size_t i = 0; i < global_size; ++i)
       v[i] = (i < 0) ? T{static_cast<T>(2)} : T{static_cast<T>(1)};
   };
@@ -54,7 +47,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan_mul, T, test_types) {
                                      std::multiplies<T>());
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
@@ -76,31 +70,21 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan_mul, T, test_types) {
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan, T, test_types) {
-  const size_t local_size     = 256;
-  const size_t global_size    = 1024;
-  const size_t local_size_x   = 16;
-  const size_t local_size_y   = 16;
-  const size_t global_size_x  = 32;
-  const size_t global_size_y  = 32;
-  const size_t offset_margin  = global_size;
-  const size_t offset_divisor = global_size;
-  const size_t buffer_size    = global_size;
-  const auto data_generator   = [](std::vector<T> &v) {
+  const size_t elements_per_thread    = 1;
+  const auto data_generator = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     for (size_t i = 0; i < global_size; ++i)
       v[i] = detail::initialize_type<T>(i) +
-             detail::get_offset<T>(offset_margin, offset_divisor);
+             detail::get_offset<T>(global_size, global_size);
   };
 
   {
@@ -109,7 +93,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan, T, test_types) {
       acc[global_linear_id] = sycl::group_exclusive_scan(g, local_value, std::plus<T>());
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
@@ -132,14 +117,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan, T, test_types) {
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
@@ -150,7 +132,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan, T, test_types) {
                                      std::plus<T>());
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
@@ -172,31 +155,21 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan, T, test_types) {
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan_ptr, T, test_types) {
-  const size_t local_size     = 256;
-  const size_t global_size    = 1024;
-  const size_t local_size_x   = 16;
-  const size_t local_size_y   = 16;
-  const size_t global_size_x  = 32;
-  const size_t global_size_y  = 32;
-  const size_t buffer_size    = global_size * 4;
-  const size_t offset_margin  = global_size;
-  const size_t offset_divisor = local_size * 2;
-  const auto data_generator   = [](std::vector<T> &v) {
+  const size_t elements_per_thread    = 4;
+  const auto data_generator = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     for (size_t i = 0; i < global_size; ++i)
       v[i] = detail::initialize_type<T>(i) +
-             detail::get_offset<T>(offset_margin, offset_divisor);
+             detail::get_offset<T>(global_size, local_size * 2);
   };
 
   {
@@ -211,7 +184,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan_ptr, T, test_types) {
       sycl::detail::exclusive_scan(g, start.get(), end.get(), out.get(), std::plus<T>());
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
@@ -234,14 +208,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan_ptr, T, test_types) {
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
@@ -257,7 +228,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan_ptr, T, test_types) {
                                    detail::initialize_type<T>(10), std::plus<T>());
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
@@ -279,29 +251,23 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan_ptr, T, test_types) {
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
 #if defined(HIPSYCL_PLATFORM_CUDA) || defined(HIPSYCL_PLATFORM_HIP)
 BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_exclusive_scan, T, test_types) {
   const uint32_t subgroup_size = static_cast<uint32_t>(warpSize);
-  const size_t local_size      = subgroup_size;
-  const size_t global_size     = subgroup_size * 4;
-  const size_t offset_margin   = global_size;
-  const size_t offset_divisor  = global_size;
-  const size_t buffer_size     = global_size;
-  const auto data_generator    = [](std::vector<T> &v) {
+  const size_t elements_per_thread     = 1;
+  const auto data_generator = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     for (size_t i = 0; i < global_size; ++i)
       v[i] = detail::initialize_type<T>(i) +
-             detail::get_offset<T>(offset_margin, offset_divisor);
+             detail::get_offset<T>(global_size, global_size);
   };
 
   {
@@ -310,22 +276,24 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_exclusive_scan, T, test_types) {
       acc[global_linear_id] = sycl::group_exclusive_scan(sg, local_value, std::plus<T>());
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * local_size] = T{};
-        for (size_t j = 1; j < local_size; ++j)
+        auto actual_warp_size = local_size < warpSize ? local_size : warpSize;
+        for (size_t j = 1; j < actual_warp_size; ++j)
           expected[i * local_size + j] =
               expected[i * local_size + j - 1] + vOrig[i * local_size + j - 1];
 
-        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
+        for (size_t j = i * local_size; j < (i + 1) * actual_warp_size; ++j) {
           T computed = vIn[j];
           BOOST_TEST(detail::compare_type(expected[j], computed),
                      detail::type_to_string(computed)
                          << " at position " << j << " instead of "
                          << detail::type_to_string(expected[j])
-                         << " for case: no init in group " << i);
+                       << " for local_size " << local_size << " and case: no init in group " << i);
 
           if (!detail::compare_type(expected[j], computed))
             break;
@@ -333,9 +301,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_exclusive_scan, T, test_types) {
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
@@ -346,46 +313,40 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_exclusive_scan, T, test_types) {
                                      std::plus<T>());
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * local_size] = detail::initialize_type<T>(10);
-        for (size_t j = 1; j < local_size; ++j)
+        auto actual_warp_size = local_size < warpSize ? local_size : warpSize;
+        for (size_t j = 1; j < actual_warp_size; ++j)
           expected[i * local_size + j] =
               expected[i * local_size + j - 1] + vOrig[i * local_size + j - 1];
 
-        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
+        for (size_t j = i * local_size; j < (i + 1) * actual_warp_size; ++j) {
           T computed = vIn[j];
           BOOST_TEST(detail::compare_type(expected[j], computed),
                      detail::type_to_string(computed)
                          << " at position " << j << " instead of "
                          << detail::type_to_string(expected[j])
-                         << " for case: init in group " << i);
+                       << " for local_size " << local_size << " and case: init in group " << i);
           if (!detail::compare_type(expected[j], computed))
             break;
         }
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 #endif
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan_mul, T, test_types) {
-  const size_t local_size     = 256;
-  const size_t global_size    = 1024;
-  const size_t local_size_x   = 16;
-  const size_t local_size_y   = 16;
-  const size_t global_size_x  = 32;
-  const size_t global_size_y  = 32;
-  const size_t offset_margin  = global_size;
-  const size_t offset_divisor = global_size;
-  const size_t buffer_size    = global_size;
-  const auto data_generator   = [](std::vector<T> &v) {
+  const size_t elements_per_thread    = 1;
+  const auto data_generator = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     for (size_t i = 0; i < global_size; ++i)
       v[i] = (i < 0) ? T{static_cast<T>(2)} : T{static_cast<T>(1)};
   };
@@ -397,7 +358,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan_mul, T, test_types) {
           sycl::group_inclusive_scan(g, local_value, std::multiplies<T>());
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
@@ -419,31 +381,21 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan_mul, T, test_types) {
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan, T, test_types) {
-  const size_t local_size     = 256;
-  const size_t global_size    = 1024;
-  const size_t local_size_x   = 16;
-  const size_t local_size_y   = 16;
-  const size_t global_size_x  = 32;
-  const size_t global_size_y  = 32;
-  const size_t offset_margin  = global_size;
-  const size_t offset_divisor = global_size;
-  const size_t buffer_size    = global_size;
-  const auto data_generator   = [](std::vector<T> &v) {
+  const size_t elements_per_thread    = 1;
+  const auto data_generator = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     for (size_t i = 0; i < global_size; ++i)
       v[i] = detail::initialize_type<T>(i) +
-             detail::get_offset<T>(offset_margin, offset_divisor);
+             detail::get_offset<T>(global_size, global_size);
   };
 
   {
@@ -452,7 +404,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan, T, test_types) {
       acc[global_linear_id] = sycl::group_inclusive_scan(g, local_value, std::plus<T>());
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
@@ -474,14 +427,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan, T, test_types) {
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
@@ -492,7 +442,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan, T, test_types) {
                                      std::plus<T>());
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
@@ -514,31 +465,21 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan, T, test_types) {
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan_ptr, T, test_types) {
-  const size_t local_size     = 256;
-  const size_t global_size    = 1024;
-  const size_t local_size_x   = 16;
-  const size_t local_size_y   = 16;
-  const size_t global_size_x  = 32;
-  const size_t global_size_y  = 32;
-  const size_t buffer_size    = global_size * 4;
-  const size_t offset_margin  = global_size;
-  const size_t offset_divisor = local_size * 2;
-  const auto data_generator   = [](std::vector<T> &v) {
+  const size_t elements_per_thread    = 4;
+  const auto data_generator = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     for (size_t i = 0; i < global_size; ++i)
       v[i] = detail::initialize_type<T>(i) +
-             detail::get_offset<T>(offset_margin, offset_divisor);
+             detail::get_offset<T>(global_size, local_size * 2);
   };
 
   {
@@ -553,7 +494,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan_ptr, T, test_types) {
       sycl::detail::inclusive_scan(g, start.get(), end.get(), out.get(), std::plus<T>());
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
@@ -568,21 +510,18 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan_ptr, T, test_types) {
                      detail::type_to_string(computed)
                          << " at position " << j << " instead of "
                          << detail::type_to_string(expected[j])
-                         << " for case: init in group " << i);
+                         << " for local_size " << local_size << " and case: no init in group " << i);
           if (!detail::compare_type(expected[j], computed))
             break;
         }
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
@@ -598,7 +537,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan_ptr, T, test_types) {
                                    detail::initialize_type<T>(10), std::plus<T>());
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
@@ -614,36 +554,30 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan_ptr, T, test_types) {
                      detail::type_to_string(computed)
                          << " at position " << j << " instead of "
                          << detail::type_to_string(expected[j])
-                         << " for case: init in group " << i);
+                         << " for local_size " << local_size << " and case: init in group " << i);
           if (!detail::compare_type(expected[j], computed))
             break;
         }
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(local_size_x, local_size_y, global_size_x,
-                                           global_size_y, offset_margin, offset_divisor,
-                                           buffer_size, data_generator, tested_function,
-                                           validation_function);
+    test_nd_group_function_2d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
 #if defined(HIPSYCL_PLATFORM_CUDA) || defined(HIPSYCL_PLATFORM_HIP)
 BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_inclusive_scan, T, test_types) {
   const uint32_t subgroup_size = static_cast<uint32_t>(warpSize);
-  const size_t local_size      = subgroup_size;
-  const size_t global_size     = subgroup_size * 4;
-  const size_t offset_margin   = global_size;
-  const size_t offset_divisor  = global_size;
-  const size_t buffer_size     = global_size;
-  const auto data_generator    = [](std::vector<T> &v) {
+  const size_t elements_per_thread     = 1;
+  const auto data_generator = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
     for (size_t i = 0; i < global_size; ++i)
       v[i] = detail::initialize_type<T>(i) +
-             detail::get_offset<T>(offset_margin, offset_divisor);
+             detail::get_offset<T>(global_size, global_size);
   };
 
   {
@@ -652,31 +586,32 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_inclusive_scan, T, test_types) {
       acc[global_linear_id] = sycl::group_inclusive_scan(sg, local_value, std::plus<T>());
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * local_size] = vOrig[i * local_size];
-        for (size_t j = 1; j < local_size; ++j)
+        auto actual_warp_size = local_size < warpSize ? local_size : warpSize;
+        for (size_t j = 1; j < actual_warp_size; ++j)
           expected[i * local_size + j] =
               expected[i * local_size + j - 1] + vOrig[i * local_size + j];
 
-        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
+        for (size_t j = i * local_size; j < (i + 1) * actual_warp_size; ++j) {
           T computed = vIn[j];
           BOOST_TEST(detail::compare_type(expected[j], computed),
                      detail::type_to_string(computed)
                          << " at position " << j << " instead of "
                          << detail::type_to_string(expected[j])
-                         << " for case: init in group " << i);
+                       << " for local_size " << local_size << " and case: no init in group " << i);
           if (!detail::compare_type(expected[j], computed))
             break;
         }
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
@@ -687,31 +622,32 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_inclusive_scan, T, test_types) {
                                      std::plus<T>());
     };
     const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig) {
+                                        const std::vector<T> &vOrig,
+                                        size_t local_size, size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * local_size] = vOrig[i * local_size] + detail::initialize_type<T>(10);
-        for (size_t j = 1; j < local_size; ++j)
+        auto actual_warp_size = local_size < warpSize ? local_size : warpSize;
+        for (size_t j = 1; j < actual_warp_size; ++j)
           expected[i * local_size + j] =
               expected[i * local_size + j - 1] + vOrig[i * local_size + j];
 
-        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
+        for (size_t j = i * local_size; j < (i + 1) * actual_warp_size; ++j) {
           T computed = vIn[j];
           BOOST_TEST(detail::compare_type(expected[j], computed),
                      detail::type_to_string(computed)
                          << " at position " << j << " instead of "
                          << detail::type_to_string(expected[j])
-                         << " for case: init in group " << i);
+                       << " for local_size " << local_size << " and case: init in group " << i);
           if (!detail::compare_type(expected[j], computed))
             break;
         }
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(local_size, global_size, offset_margin,
-                                           offset_divisor, buffer_size, data_generator,
-                                           tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(
+        elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 #endif

--- a/tests/sycl/group_functions/group_functions_scan.cpp
+++ b/tests/sycl/group_functions/group_functions_scan.cpp
@@ -25,44 +25,37 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
 #include "../sycl_test_suite.hpp"
 #include "group_functions.hpp"
 
 BOOST_FIXTURE_TEST_SUITE(group_functions_tests, reset_device_fixture)
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan_mul, T, test_types) {
-  const size_t elements_per_thread    = 1;
-  const auto data_generator = [](std::vector<T> &v, size_t local_size,
-                                 size_t global_size) {
+  const size_t elements_per_thread = 1;
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
     for (size_t i = 0; i < global_size; ++i)
       v[i] = (i < 0) ? T{static_cast<T>(2)} : T{static_cast<T>(1)};
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
       acc[global_linear_id] =
-          sycl::group_exclusive_scan(g, local_value, detail::initialize_type<T>(10),
-                                     std::multiplies<T>());
+          sycl::group_exclusive_scan(g, local_value, detail::initialize_type<T>(10), std::multiplies<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * local_size] = detail::initialize_type<T>(10);
         for (size_t j = 1; j < local_size; ++j)
-          expected[i * local_size + j] =
-              expected[i * local_size + j - 1] * vOrig[i * local_size + j - 1];
+          expected[i * local_size + j] = expected[i * local_size + j - 1] * vOrig[i * local_size + j - 1];
 
         for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
           T computed = vIn[j];
           BOOST_TEST(detail::compare_type(expected[j], computed),
                      detail::type_to_string(computed)
-                         << " at position " << j << " instead of "
-                         << detail::type_to_string(expected[j])
+                         << " at position " << j << " instead of " << detail::type_to_string(expected[j])
                          << " for case: init multiplication in group " << i);
           if (!detail::compare_type(expected[j], computed))
             break;
@@ -70,46 +63,38 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan_mul, T, test_types) {
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan, T, test_types) {
-  const size_t elements_per_thread    = 1;
-  const auto data_generator = [](std::vector<T> &v, size_t local_size,
-                                 size_t global_size) {
+  const size_t elements_per_thread = 1;
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
     for (size_t i = 0; i < global_size; ++i)
-      v[i] = detail::initialize_type<T>(i) +
-             detail::get_offset<T>(global_size, global_size);
+      v[i] = detail::initialize_type<T>(i) + detail::get_offset<T>(global_size, global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
       acc[global_linear_id] = sycl::group_exclusive_scan(g, local_value, std::plus<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * local_size] = T{};
         for (size_t j = 1; j < local_size; ++j)
-          expected[i * local_size + j] =
-              expected[i * local_size + j - 1] + vOrig[i * local_size + j - 1];
+          expected[i * local_size + j] = expected[i * local_size + j - 1] + vOrig[i * local_size + j - 1];
 
         for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
           T computed = vIn[j];
-          BOOST_TEST(detail::compare_type(expected[j], computed),
-                     detail::type_to_string(computed)
-                         << " at position " << j << " instead of "
-                         << detail::type_to_string(expected[j])
-                         << " for case: no init in group " << i);
+          BOOST_TEST(detail::compare_type(expected[j], computed), detail::type_to_string(computed)
+                                                                      << " at position " << j << " instead of "
+                                                                      << detail::type_to_string(expected[j])
+                                                                      << " for case: no init in group " << i);
 
           if (!detail::compare_type(expected[j], computed))
             break;
@@ -117,90 +102,74 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan, T, test_types) {
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
       acc[global_linear_id] =
-          sycl::group_exclusive_scan(g, local_value, detail::initialize_type<T>(10),
-                                     std::plus<T>());
+          sycl::group_exclusive_scan(g, local_value, detail::initialize_type<T>(10), std::plus<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * local_size] = detail::initialize_type<T>(10);
         for (size_t j = 1; j < local_size; ++j)
-          expected[i * local_size + j] =
-              expected[i * local_size + j - 1] + vOrig[i * local_size + j - 1];
+          expected[i * local_size + j] = expected[i * local_size + j - 1] + vOrig[i * local_size + j - 1];
 
         for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
           T computed = vIn[j];
-          BOOST_TEST(detail::compare_type(expected[j], computed),
-                     detail::type_to_string(computed)
-                         << " at position " << j << " instead of "
-                         << detail::type_to_string(expected[j])
-                         << " for case: init in group " << i);
+          BOOST_TEST(detail::compare_type(expected[j], computed), detail::type_to_string(computed)
+                                                                      << " at position " << j << " instead of "
+                                                                      << detail::type_to_string(expected[j])
+                                                                      << " for case: init in group " << i);
           if (!detail::compare_type(expected[j], computed))
             break;
         }
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan_ptr, T, test_types) {
-  const size_t elements_per_thread    = 4;
-  const auto data_generator = [](std::vector<T> &v, size_t local_size,
-                                 size_t global_size) {
+  const size_t elements_per_thread = 4;
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
     for (size_t i = 0; i < global_size; ++i)
-      v[i] = detail::initialize_type<T>(i) +
-             detail::get_offset<T>(global_size, local_size * 2);
+      v[i] = detail::initialize_type<T>(i) + detail::get_offset<T>(global_size, local_size * 2);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
       auto local_size = g.get_local_range().size();
-      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end   = start + local_size * 2;
-      auto out   = acc.get_pointer() + 2 * 4 * local_size +
-                 (global_linear_id / local_size) * local_size * 2;
+      auto start      = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end        = start + local_size * 2;
+      auto out        = acc.get_pointer() + 2 * 4 * local_size + (global_linear_id / local_size) * local_size * 2;
 
       sycl::detail::exclusive_scan(g, start.get(), end.get(), out.get(), std::plus<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * 2 * local_size] = T{};
         for (size_t j = 1; j < local_size * 2; ++j)
-          expected[i * 2 * local_size + j] =
-              expected[i * 2 * local_size + j - 1] + vOrig[i * 2 * local_size + j - 1];
+          expected[i * 2 * local_size + j] = expected[i * 2 * local_size + j - 1] + vOrig[i * 2 * local_size + j - 1];
 
         for (size_t j = i * 2 * local_size; j < (i + 1) * local_size * 2; ++j) {
           T computed = vIn[j + global_size * 2];
-          BOOST_TEST(detail::compare_type(expected[j], computed),
-                     detail::type_to_string(computed)
-                         << " at position " << j << " instead of "
-                         << detail::type_to_string(expected[j])
-                         << " for case: no init in group " << i);
+          BOOST_TEST(detail::compare_type(expected[j], computed), detail::type_to_string(computed)
+                                                                      << " at position " << j << " instead of "
+                                                                      << detail::type_to_string(expected[j])
+                                                                      << " for case: no init in group " << i);
 
           if (!detail::compare_type(expected[j], computed))
             break;
@@ -208,92 +177,77 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan_ptr, T, test_types) {
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
       auto local_size = g.get_local_range().size();
-      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end   = start + local_size * 2;
-      auto out   = acc.get_pointer() + 2 * 4 * local_size +
-                 (global_linear_id / local_size) * local_size * 2;
+      auto start      = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end        = start + local_size * 2;
+      auto out        = acc.get_pointer() + 2 * 4 * local_size + (global_linear_id / local_size) * local_size * 2;
 
-      sycl::detail::exclusive_scan(g, start.get(), end.get(), out.get(),
-                                   detail::initialize_type<T>(10), std::plus<T>());
+      sycl::detail::exclusive_scan(g, start.get(), end.get(), out.get(), detail::initialize_type<T>(10),
+                                   std::plus<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * 2 * local_size] = detail::initialize_type<T>(10);
         for (size_t j = 1; j < local_size * 2; ++j)
-          expected[i * 2 * local_size + j] =
-              expected[i * 2 * local_size + j - 1] + vOrig[i * 2 * local_size + j - 1];
+          expected[i * 2 * local_size + j] = expected[i * 2 * local_size + j - 1] + vOrig[i * 2 * local_size + j - 1];
 
         for (size_t j = i * 2 * local_size; j < (i + 1) * local_size * 2; ++j) {
           T computed = vIn[j + global_size * 2];
-          BOOST_TEST(detail::compare_type(expected[j], computed),
-                     detail::type_to_string(computed)
-                         << " at position " << j << " instead of "
-                         << detail::type_to_string(expected[j])
-                         << " for case: init in group " << i);
+          BOOST_TEST(detail::compare_type(expected[j], computed), detail::type_to_string(computed)
+                                                                      << " at position " << j << " instead of "
+                                                                      << detail::type_to_string(expected[j])
+                                                                      << " for case: init in group " << i);
           if (!detail::compare_type(expected[j], computed))
             break;
         }
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
 #if defined(HIPSYCL_PLATFORM_CUDA) || defined(HIPSYCL_PLATFORM_HIP)
 BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_exclusive_scan, T, test_types) {
-  const uint32_t subgroup_size = static_cast<uint32_t>(warpSize);
-  const size_t elements_per_thread     = 1;
-  const auto data_generator = [](std::vector<T> &v, size_t local_size,
-                                 size_t global_size) {
+  const uint32_t subgroup_size       = static_cast<uint32_t>(warpSize);
+  const size_t   elements_per_thread = 1;
+  const auto     data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
     for (size_t i = 0; i < global_size; ++i)
-      v[i] = detail::initialize_type<T>(i) +
-             detail::get_offset<T>(global_size, global_size);
+      v[i] = detail::initialize_type<T>(i) + detail::get_offset<T>(global_size, global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
       acc[global_linear_id] = sycl::group_exclusive_scan(sg, local_value, std::plus<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * local_size] = T{};
-        auto actual_warp_size = local_size < warpSize ? local_size : warpSize;
+        auto actual_warp_size    = local_size < warpSize ? local_size : warpSize;
         for (size_t j = 1; j < actual_warp_size; ++j)
-          expected[i * local_size + j] =
-              expected[i * local_size + j - 1] + vOrig[i * local_size + j - 1];
+          expected[i * local_size + j] = expected[i * local_size + j - 1] + vOrig[i * local_size + j - 1];
 
         for (size_t j = i * local_size; j < (i + 1) * actual_warp_size; ++j) {
           T computed = vIn[j];
           BOOST_TEST(detail::compare_type(expected[j], computed),
                      detail::type_to_string(computed)
-                         << " at position " << j << " instead of "
-                         << detail::type_to_string(expected[j])
-                       << " for local_size " << local_size << " and case: no init in group " << i);
+                         << " at position " << j << " instead of " << detail::type_to_string(expected[j])
+                         << " for local_size " << local_size << " and case: no init in group " << i);
 
           if (!detail::compare_type(expected[j], computed))
             break;
@@ -301,259 +255,29 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_exclusive_scan, T, test_types) {
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
       acc[global_linear_id] =
-          sycl::group_exclusive_scan(sg, local_value, detail::initialize_type<T>(10),
-                                     std::plus<T>());
+          sycl::group_exclusive_scan(sg, local_value, detail::initialize_type<T>(10), std::plus<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * local_size] = detail::initialize_type<T>(10);
-        auto actual_warp_size = local_size < warpSize ? local_size : warpSize;
+        auto actual_warp_size    = local_size < warpSize ? local_size : warpSize;
         for (size_t j = 1; j < actual_warp_size; ++j)
-          expected[i * local_size + j] =
-              expected[i * local_size + j - 1] + vOrig[i * local_size + j - 1];
+          expected[i * local_size + j] = expected[i * local_size + j - 1] + vOrig[i * local_size + j - 1];
 
         for (size_t j = i * local_size; j < (i + 1) * actual_warp_size; ++j) {
           T computed = vIn[j];
           BOOST_TEST(detail::compare_type(expected[j], computed),
                      detail::type_to_string(computed)
-                         << " at position " << j << " instead of "
-                         << detail::type_to_string(expected[j])
-                       << " for local_size " << local_size << " and case: init in group " << i);
-          if (!detail::compare_type(expected[j], computed))
-            break;
-        }
-      }
-    };
-
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
-  }
-}
-#endif
-
-BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan_mul, T, test_types) {
-  const size_t elements_per_thread    = 1;
-  const auto data_generator = [](std::vector<T> &v, size_t local_size,
-                                 size_t global_size) {
-    for (size_t i = 0; i < global_size; ++i)
-      v[i] = (i < 0) ? T{static_cast<T>(2)} : T{static_cast<T>(1)};
-  };
-
-  {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      acc[global_linear_id] =
-          sycl::group_inclusive_scan(g, local_value, std::multiplies<T>());
-    };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
-      std::vector<T> expected(vOrig.size());
-
-      for (size_t i = 0; i < global_size / local_size; ++i) {
-        expected[i * local_size] = vOrig[i * local_size];
-        for (size_t j = 1; j < local_size; ++j)
-          expected[i * local_size + j] =
-              expected[i * local_size + j - 1] * vOrig[i * local_size + j];
-
-        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
-          T computed = vIn[j];
-          BOOST_TEST(detail::compare_type(expected[j], computed),
-                     detail::type_to_string(computed)
-                         << " at position " << j << " instead of "
-                         << detail::type_to_string(expected[j])
-                         << " for case: no init multiplication in group " << i);
-          if (!detail::compare_type(expected[j], computed))
-            break;
-        }
-      }
-    };
-
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
-
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
-  }
-}
-
-BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan, T, test_types) {
-  const size_t elements_per_thread    = 1;
-  const auto data_generator = [](std::vector<T> &v, size_t local_size,
-                                 size_t global_size) {
-    for (size_t i = 0; i < global_size; ++i)
-      v[i] = detail::initialize_type<T>(i) +
-             detail::get_offset<T>(global_size, global_size);
-  };
-
-  {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      acc[global_linear_id] = sycl::group_inclusive_scan(g, local_value, std::plus<T>());
-    };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
-      std::vector<T> expected(vOrig.size());
-
-      for (size_t i = 0; i < global_size / local_size; ++i) {
-        expected[i * local_size] = vOrig[i * local_size];
-        for (size_t j = 1; j < local_size; ++j)
-          expected[i * local_size + j] =
-              expected[i * local_size + j - 1] + vOrig[i * local_size + j];
-
-        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
-          T computed = vIn[j];
-          BOOST_TEST(detail::compare_type(expected[j], computed),
-                     detail::type_to_string(computed)
-                         << " at position " << j << " instead of "
-                         << detail::type_to_string(expected[j])
-                         << " for case: no init in group " << i);
-          if (!detail::compare_type(expected[j], computed))
-            break;
-        }
-      }
-    };
-
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
-
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
-  }
-
-  {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      acc[global_linear_id] =
-          sycl::group_inclusive_scan(g, local_value, detail::initialize_type<T>(10),
-                                     std::plus<T>());
-    };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
-      std::vector<T> expected(vOrig.size());
-
-      for (size_t i = 0; i < global_size / local_size; ++i) {
-        expected[i * local_size] = vOrig[i * local_size] + detail::initialize_type<T>(10);
-        for (size_t j = 1; j < local_size; ++j)
-          expected[i * local_size + j] =
-              expected[i * local_size + j - 1] + vOrig[i * local_size + j];
-
-        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
-          T computed = vIn[j];
-          BOOST_TEST(detail::compare_type(expected[j], computed),
-                     detail::type_to_string(computed)
-                         << " at position " << j << " instead of "
-                         << detail::type_to_string(expected[j])
-                         << " for case: init in group " << i);
-          if (!detail::compare_type(expected[j], computed))
-            break;
-        }
-      }
-    };
-
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
-
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
-  }
-}
-
-BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan_ptr, T, test_types) {
-  const size_t elements_per_thread    = 4;
-  const auto data_generator = [](std::vector<T> &v, size_t local_size,
-                                 size_t global_size) {
-    for (size_t i = 0; i < global_size; ++i)
-      v[i] = detail::initialize_type<T>(i) +
-             detail::get_offset<T>(global_size, local_size * 2);
-  };
-
-  {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      auto local_size = g.get_local_range().size();
-      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end   = start + local_size * 2;
-      auto out   = acc.get_pointer() + 2 * 4 * local_size +
-                 (global_linear_id / local_size) * local_size * 2;
-
-      sycl::detail::inclusive_scan(g, start.get(), end.get(), out.get(), std::plus<T>());
-    };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
-      std::vector<T> expected(vOrig.size());
-
-      for (size_t i = 0; i < global_size / local_size; ++i) {
-        expected[i * 2 * local_size] = vOrig[i * 2 * local_size];
-        for (size_t j = 1; j < local_size * 2; ++j)
-          expected[i * 2 * local_size + j] =
-              expected[i * 2 * local_size + j - 1] + vOrig[i * 2 * local_size + j];
-
-        for (size_t j = i * 2 * local_size; j < (i + 1) * local_size * 2; ++j) {
-          T computed = vIn[j + 2 * global_size];
-          BOOST_TEST(detail::compare_type(expected[j], computed),
-                     detail::type_to_string(computed)
-                         << " at position " << j << " instead of "
-                         << detail::type_to_string(expected[j])
-                         << " for local_size " << local_size << " and case: no init in group " << i);
-          if (!detail::compare_type(expected[j], computed))
-            break;
-        }
-      }
-    };
-
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
-
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
-  }
-
-  {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
-      auto local_size = g.get_local_range().size();
-      auto start = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
-      auto end   = start + local_size * 2;
-      auto out   = acc.get_pointer() + 2 * 4 * local_size +
-                 (global_linear_id / local_size) * local_size * 2;
-
-      sycl::detail::inclusive_scan(g, start.get(), end.get(), out.get(),
-                                   detail::initialize_type<T>(10), std::plus<T>());
-    };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
-      std::vector<T> expected(vOrig.size());
-
-      for (size_t i = 0; i < global_size / local_size; ++i) {
-        expected[i * 2 * local_size] =
-            vOrig[i * 2 * local_size] + detail::initialize_type<T>(10);
-        for (size_t j = 1; j < local_size * 2; ++j)
-          expected[i * 2 * local_size + j] =
-              expected[i * 2 * local_size + j - 1] + vOrig[i * 2 * local_size + j];
-
-        for (size_t j = i * 2 * local_size; j < (i + 1) * local_size * 2; ++j) {
-          T computed = vIn[j + 2 * global_size];
-          BOOST_TEST(detail::compare_type(expected[j], computed),
-                     detail::type_to_string(computed)
-                         << " at position " << j << " instead of "
-                         << detail::type_to_string(expected[j])
+                         << " at position " << j << " instead of " << detail::type_to_string(expected[j])
                          << " for local_size " << local_size << " and case: init in group " << i);
           if (!detail::compare_type(expected[j], computed))
             break;
@@ -561,93 +285,263 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan_ptr, T, test_types) {
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+  }
+}
+#endif
 
-    test_nd_group_function_2d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan_mul, T, test_types) {
+  const size_t elements_per_thread = 1;
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
+    for (size_t i = 0; i < global_size; ++i)
+      v[i] = (i < 0) ? T{static_cast<T>(2)} : T{static_cast<T>(1)};
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_inclusive_scan(g, local_value, std::multiplies<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      std::vector<T> expected(vOrig.size());
+
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        expected[i * local_size] = vOrig[i * local_size];
+        for (size_t j = 1; j < local_size; ++j)
+          expected[i * local_size + j] = expected[i * local_size + j - 1] * vOrig[i * local_size + j];
+
+        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
+          T computed = vIn[j];
+          BOOST_TEST(detail::compare_type(expected[j], computed),
+                     detail::type_to_string(computed)
+                         << " at position " << j << " instead of " << detail::type_to_string(expected[j])
+                         << " for case: no init multiplication in group " << i);
+          if (!detail::compare_type(expected[j], computed))
+            break;
+        }
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+  }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan, T, test_types) {
+  const size_t elements_per_thread = 1;
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
+    for (size_t i = 0; i < global_size; ++i)
+      v[i] = detail::initialize_type<T>(i) + detail::get_offset<T>(global_size, global_size);
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::group_inclusive_scan(g, local_value, std::plus<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      std::vector<T> expected(vOrig.size());
+
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        expected[i * local_size] = vOrig[i * local_size];
+        for (size_t j = 1; j < local_size; ++j)
+          expected[i * local_size + j] = expected[i * local_size + j - 1] + vOrig[i * local_size + j];
+
+        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
+          T computed = vIn[j];
+          BOOST_TEST(detail::compare_type(expected[j], computed), detail::type_to_string(computed)
+                                                                      << " at position " << j << " instead of "
+                                                                      << detail::type_to_string(expected[j])
+                                                                      << " for case: no init in group " << i);
+          if (!detail::compare_type(expected[j], computed))
+            break;
+        }
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] =
+          sycl::group_inclusive_scan(g, local_value, detail::initialize_type<T>(10), std::plus<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      std::vector<T> expected(vOrig.size());
+
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        expected[i * local_size] = vOrig[i * local_size] + detail::initialize_type<T>(10);
+        for (size_t j = 1; j < local_size; ++j)
+          expected[i * local_size + j] = expected[i * local_size + j - 1] + vOrig[i * local_size + j];
+
+        for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
+          T computed = vIn[j];
+          BOOST_TEST(detail::compare_type(expected[j], computed), detail::type_to_string(computed)
+                                                                      << " at position " << j << " instead of "
+                                                                      << detail::type_to_string(expected[j])
+                                                                      << " for case: init in group " << i);
+          if (!detail::compare_type(expected[j], computed))
+            break;
+        }
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+  }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan_ptr, T, test_types) {
+  const size_t elements_per_thread = 4;
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
+    for (size_t i = 0; i < global_size; ++i)
+      v[i] = detail::initialize_type<T>(i) + detail::get_offset<T>(global_size, local_size * 2);
+  };
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      auto local_size = g.get_local_range().size();
+      auto start      = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end        = start + local_size * 2;
+      auto out        = acc.get_pointer() + 2 * 4 * local_size + (global_linear_id / local_size) * local_size * 2;
+
+      sycl::detail::inclusive_scan(g, start.get(), end.get(), out.get(), std::plus<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      std::vector<T> expected(vOrig.size());
+
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        expected[i * 2 * local_size] = vOrig[i * 2 * local_size];
+        for (size_t j = 1; j < local_size * 2; ++j)
+          expected[i * 2 * local_size + j] = expected[i * 2 * local_size + j - 1] + vOrig[i * 2 * local_size + j];
+
+        for (size_t j = i * 2 * local_size; j < (i + 1) * local_size * 2; ++j) {
+          T computed = vIn[j + 2 * global_size];
+          BOOST_TEST(detail::compare_type(expected[j], computed),
+                     detail::type_to_string(computed)
+                         << " at position " << j << " instead of " << detail::type_to_string(expected[j])
+                         << " for local_size " << local_size << " and case: no init in group " << i);
+          if (!detail::compare_type(expected[j], computed))
+            break;
+        }
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+  }
+
+  {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
+      auto local_size = g.get_local_range().size();
+      auto start      = acc.get_pointer() + (global_linear_id / local_size) * local_size * 2;
+      auto end        = start + local_size * 2;
+      auto out        = acc.get_pointer() + 2 * 4 * local_size + (global_linear_id / local_size) * local_size * 2;
+
+      sycl::detail::inclusive_scan(g, start.get(), end.get(), out.get(), detail::initialize_type<T>(10),
+                                   std::plus<T>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      std::vector<T> expected(vOrig.size());
+
+      for (size_t i = 0; i < global_size / local_size; ++i) {
+        expected[i * 2 * local_size] = vOrig[i * 2 * local_size] + detail::initialize_type<T>(10);
+        for (size_t j = 1; j < local_size * 2; ++j)
+          expected[i * 2 * local_size + j] = expected[i * 2 * local_size + j - 1] + vOrig[i * 2 * local_size + j];
+
+        for (size_t j = i * 2 * local_size; j < (i + 1) * local_size * 2; ++j) {
+          T computed = vIn[j + 2 * global_size];
+          BOOST_TEST(detail::compare_type(expected[j], computed),
+                     detail::type_to_string(computed)
+                         << " at position " << j << " instead of " << detail::type_to_string(expected[j])
+                         << " for local_size " << local_size << " and case: init in group " << i);
+          if (!detail::compare_type(expected[j], computed))
+            break;
+        }
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 
 #if defined(HIPSYCL_PLATFORM_CUDA) || defined(HIPSYCL_PLATFORM_HIP)
 BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_inclusive_scan, T, test_types) {
-  const uint32_t subgroup_size = static_cast<uint32_t>(warpSize);
-  const size_t elements_per_thread     = 1;
-  const auto data_generator = [](std::vector<T> &v, size_t local_size,
-                                 size_t global_size) {
+  const uint32_t subgroup_size       = static_cast<uint32_t>(warpSize);
+  const size_t   elements_per_thread = 1;
+  const auto     data_generator      = [](std::vector<T> &v, size_t local_size, size_t global_size) {
     for (size_t i = 0; i < global_size; ++i)
-      v[i] = detail::initialize_type<T>(i) +
-             detail::get_offset<T>(global_size, global_size);
+      v[i] = detail::initialize_type<T>(i) + detail::get_offset<T>(global_size, global_size);
   };
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
       acc[global_linear_id] = sycl::group_inclusive_scan(sg, local_value, std::plus<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * local_size] = vOrig[i * local_size];
-        auto actual_warp_size = local_size < warpSize ? local_size : warpSize;
+        auto actual_warp_size    = local_size < warpSize ? local_size : warpSize;
         for (size_t j = 1; j < actual_warp_size; ++j)
-          expected[i * local_size + j] =
-              expected[i * local_size + j - 1] + vOrig[i * local_size + j];
+          expected[i * local_size + j] = expected[i * local_size + j - 1] + vOrig[i * local_size + j];
 
         for (size_t j = i * local_size; j < (i + 1) * actual_warp_size; ++j) {
           T computed = vIn[j];
           BOOST_TEST(detail::compare_type(expected[j], computed),
                      detail::type_to_string(computed)
-                         << " at position " << j << " instead of "
-                         << detail::type_to_string(expected[j])
-                       << " for local_size " << local_size << " and case: no init in group " << i);
+                         << " at position " << j << " instead of " << detail::type_to_string(expected[j])
+                         << " for local_size " << local_size << " and case: no init in group " << i);
           if (!detail::compare_type(expected[j], computed))
             break;
         }
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 
   {
-    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
-                                    auto g, T local_value) {
+    const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg, auto g, T local_value) {
       acc[global_linear_id] =
-          sycl::group_inclusive_scan(sg, local_value, detail::initialize_type<T>(10),
-                                     std::plus<T>());
+          sycl::group_inclusive_scan(sg, local_value, detail::initialize_type<T>(10), std::plus<T>());
     };
-    const auto validation_function = [](const std::vector<T> &vIn,
-                                        const std::vector<T> &vOrig,
-                                        size_t local_size, size_t global_size) {
+    const auto validation_function = [](const std::vector<T> &vIn, const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
       std::vector<T> expected(vOrig.size());
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * local_size] = vOrig[i * local_size] + detail::initialize_type<T>(10);
-        auto actual_warp_size = local_size < warpSize ? local_size : warpSize;
+        auto actual_warp_size    = local_size < warpSize ? local_size : warpSize;
         for (size_t j = 1; j < actual_warp_size; ++j)
-          expected[i * local_size + j] =
-              expected[i * local_size + j - 1] + vOrig[i * local_size + j];
+          expected[i * local_size + j] = expected[i * local_size + j - 1] + vOrig[i * local_size + j];
 
         for (size_t j = i * local_size; j < (i + 1) * actual_warp_size; ++j) {
           T computed = vIn[j];
           BOOST_TEST(detail::compare_type(expected[j], computed),
                      detail::type_to_string(computed)
-                         << " at position " << j << " instead of "
-                         << detail::type_to_string(expected[j])
-                       << " for local_size " << local_size << " and case: init in group " << i);
+                         << " at position " << j << " instead of " << detail::type_to_string(expected[j])
+                         << " for local_size " << local_size << " and case: init in group " << i);
           if (!detail::compare_type(expected[j], computed))
             break;
         }
       }
     };
 
-    test_nd_group_function_1d<__LINE__, T>(
-        elements_per_thread, data_generator, tested_function, validation_function);
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator, tested_function, validation_function);
   }
 }
 #endif


### PR DESCRIPTION
optimized group_functions and fixed some bugs. Notable changes:
- subgroups are used to lessen local-memory-requirements
- static memory is used for CPU local-memory
- better memory accesses
- group-sizes that are not a multiple of the warpSize work now (not always the case before)
- shuffle-instruction abstraction added

Problems:
- [ ] inclusive_scan_ptr can use so many registers it doesn't run with 1024-threads and large sycl::vec (usually >=8 elements)
- [x] some renaming/refactoring is still incoming