### PR TITLE
Transition to plugin architecture for runtime backends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required (VERSION 3.5)
-set(hipSYCL_VERSION 0.9.0)
-project(hipSYCL VERSION ${hipSYCL_VERSION})
+
+set(HIPSYCL_VERSION_MAJOR 0)
+set(HIPSYCL_VERSION_MINOR 9)
+set(HIPSYCL_VERSION_PATCH 0)
+
+project(hipSYCL VERSION ${HIPSYCL_VERSION_MAJOR}.${HIPSYCL_VERSION_MINOR}.${HIPSYCL_VERSION_PATCH})
 
 set(HIPSYCL_DEVICE_COMPILER ${PROJECT_SOURCE_DIR}/bin/syclcc-clang)
 set(HIPSYCL_SOURCE_DIR ${PROJECT_SOURCE_DIR})
@@ -220,9 +224,14 @@ else()
     "lib/cmake/${PROJECT_NAME}" CACHE PATH "Install path for CMake config files")
 endif()
 
+configure_file(
+  ${PROJECT_SOURCE_DIR}/include/hipSYCL/common/config.hpp.in
+  ${PROJECT_BINARY_DIR}/include/hipSYCL/common/config.hpp)
+
 install(DIRECTORY include/CL DESTINATION include/ FILES_MATCHING PATTERN "*.hpp")
 install(DIRECTORY include/SYCL DESTINATION include/ FILES_MATCHING PATTERN "*.hpp")
 install(DIRECTORY include/hipSYCL DESTINATION include/ FILES_MATCHING PATTERN "*.hpp")
+install(FILES ${PROJECT_BINARY_DIR}/include/hipSYCL/common/config.hpp DESTINATION include/hipSYCL/common/)
 
 install(PROGRAMS bin/syclcc DESTINATION bin)
 install(PROGRAMS bin/syclcc-clang DESTINATION bin)
@@ -246,6 +255,7 @@ write_basic_package_version_file(
 set(HIPSYCL_INSTALL_COMPILER_DIR bin)
 set(HIPSYCL_INSTALL_LAUNCHER_DIR ${HIPSYCL_INSTALL_CMAKE_DIR})
 set(HIPSYCL_INSTALL_LAUNCHER_RULE_DIR ${HIPSYCL_INSTALL_CMAKE_DIR})
+
 configure_package_config_file(
     ${PROJECT_SOURCE_DIR}/cmake/hipsycl-config.cmake.in
     ${PROJECT_BINARY_DIR}/hipsycl-config.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,7 @@ if(NOT ROCM_CXX_FLAGS)
   set(ROCM_CXX_FLAGS "-isystem ${CLANG_INCLUDE_PATH} -U__FLOAT128__ -U__SIZEOF_FLOAT128__ -I$HIPSYCL_ROCM_PATH/include -I$HIPSYCL_ROCM_PATH/include --hip-device-lib-path=$HIPSYCL_ROCM_PATH/lib ")
 endif()
 if(NOT CUDA_LINK_LINE) 
-  set(CUDA_LINK_LINE "-Wl,-rpath=$HIPSYCL_CUDA_LIB_PATH -L$HIPSYCL_CUDA_LIB_PATH -lcudart -lcuda" CACHE STRING "Arguments passed to compiler to link CUDA libraries to SYCL applications")
+  set(CUDA_LINK_LINE "-Wl,-rpath=$HIPSYCL_CUDA_LIB_PATH -L$HIPSYCL_CUDA_LIB_PATH -lcudart" CACHE STRING "Arguments passed to compiler to link CUDA libraries to SYCL applications")
 endif()
 if(NOT CUDA_CXX_FLAGS)	
   # clang erroneously sets feature detection flags for 

--- a/include/hipSYCL/common/config.hpp.in
+++ b/include/hipSYCL/common/config.hpp.in
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2018 Aksel Alpay
+ * Copyright (c) 2019-2020 Aksel Alpay
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,30 +25,14 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef HIPSYCL_COMMON_CONFIG_HPP
+#define HIPSYCL_COMMON_CONFIG_HPP
 
-#ifndef HIPSYCL_VERSION_HPP
-#define HIPSYCL_VERSION_HPP
-
-#include <string>
-
-#include "hipSYCL/common/config.hpp"
-
-namespace hipsycl {
-namespace sycl {
-namespace detail {
-
-static std::string version_string()
-{
-  std::string hipsycl_version = std::to_string(HIPSYCL_VERSION_MAJOR)
-      + "." + std::to_string(HIPSYCL_VERSION_MINOR)
-      + "." + std::to_string(HIPSYCL_VERSION_PATCH)
-      + "-" + std::string(HIPSYCL_VERSION_TYPE);
-
-  return "hipSYCL " + hipsycl_version;
-}
-
-}
-}
-}
+#define HIPSYCL_VERSION_MAJOR @HIPSYCL_VERSION_MAJOR@
+#define HIPSYCL_VERSION_MINOR @HIPSYCL_VERSION_MINOR@
+#define HIPSYCL_VERSION_PATCH @HIPSYCL_VERSION_PATCH@
+#define HIPSYCL_INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@"
+#define HIPSYCL_VERSION_TYPE "git"
 
 #endif
+

--- a/include/hipSYCL/glue/cuda/cuda_interop.hpp
+++ b/include/hipSYCL/glue/cuda/cuda_interop.hpp
@@ -69,7 +69,8 @@ template <> struct backend_interop<sycl::backend::cuda> {
       return native_queue_type{};
     }
 
-    return static_cast<rt::cuda_queue*>(launcher_params)->get_stream();
+    rt::inorder_queue* q = static_cast<rt::inorder_queue*>(launcher_params);
+    return static_cast<native_queue_type>(q->get_native_type());
   }
 
   static native_queue_type
@@ -89,10 +90,7 @@ template <> struct backend_interop<sycl::backend::cuda> {
         dev, [&](rt::inorder_queue *current_queue) { q = current_queue; });
     assert(q);
 
-    rt::cuda_queue *backend_queue = dynamic_cast<rt::cuda_queue *>(q);
-    assert(backend_queue);
-
-    return backend_queue->get_stream();
+    return static_cast<native_queue_type>(q->get_native_type());
   }
 #endif
       

--- a/include/hipSYCL/glue/generic/hiplike/clang.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/clang.hpp
@@ -61,18 +61,28 @@ static inline void __hipsycl_push_kernel_call(dim3 grid, dim3 block, size_t shar
 {
   __cudaPushCallConfiguration(grid, block, shared, stream);
 }
+
+#define __hipsycl_launch_integrated_kernel(f, grid, block, shared_mem, stream, \
+                                           ...)                                \
+  __hipsycl_push_kernel_call(grid, block, shared_mem,                          \
+                             static_cast<CUstream_st *>(stream));              \
+  f(__VA_ARGS__);
+
 #else
+
 static inline void __hipsycl_push_kernel_call(dim3 grid, dim3 block, size_t shared, hipStream_t stream)
 {
   hipError_t err = hipConfigureCall(grid, block, shared, stream);
   assert(err == hipSuccess);
 }
-#endif
 
-
-#define __hipsycl_launch_integrated_kernel(f, grid, block, shared_mem, stream, ...) \
-  __hipsycl_push_kernel_call(grid, block, shared_mem, stream); \
+#define __hipsycl_launch_integrated_kernel(f, grid, block, shared_mem, stream, \
+                                           ...)                                \
+  __hipsycl_push_kernel_call(grid, block, shared_mem,                          \
+                             static_cast<hipStream_t>(stream));                \
   f(__VA_ARGS__);
+
+#endif
   
 
 #else

--- a/include/hipSYCL/glue/hip/hip_interop.hpp
+++ b/include/hipSYCL/glue/hip/hip_interop.hpp
@@ -68,7 +68,8 @@ template <> struct backend_interop<sycl::backend::hip> {
       return native_queue_type{};
     }
 
-    return static_cast<rt::hip_queue*>(launcher_params)->get_stream();
+    rt::inorder_queue* q = static_cast<rt::inorder_queue*>(launcher_params);
+    return static_cast<native_queue_type>(q->get_native_type());
   }
 
   static native_queue_type
@@ -88,10 +89,7 @@ template <> struct backend_interop<sycl::backend::hip> {
         dev, [&](rt::inorder_queue *current_queue) { q = current_queue; });
     assert(q);
 
-    rt::hip_queue *backend_queue = dynamic_cast<rt::hip_queue *>(q);
-    assert(backend_queue);
-
-    return backend_queue->get_stream();
+    return static_cast<native_queue_type>(q->get_native_type());
   }
 #endif
 

--- a/include/hipSYCL/runtime/backend.hpp
+++ b/include/hipSYCL/runtime/backend.hpp
@@ -34,6 +34,7 @@
 #include <vector>
 
 #include "device_id.hpp"
+#include "backend_loader.hpp"
 
 namespace hipsycl {
 namespace rt {
@@ -84,7 +85,9 @@ public:
       f(b.get());
     }
   }
+
 private:
+  backend_loader _loader;
   backend_list_type _backends;
 
   std::unique_ptr<hw_model> _hw_model;

--- a/include/hipSYCL/runtime/backend_loader.hpp
+++ b/include/hipSYCL/runtime/backend_loader.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2018 Aksel Alpay
+ * Copyright (c) 2021 Aksel Alpay
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,30 +25,52 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef HIPSYCL_BACKEND_LOADER_HPP
+#define HIPSYCL_BACKEND_LOADER_HPP
 
-#ifndef HIPSYCL_VERSION_HPP
-#define HIPSYCL_VERSION_HPP
 
 #include <string>
+#include <vector>
+#include <utility>
 
-#include "hipSYCL/common/config.hpp"
+namespace hipsycl::rt {
+class backend;
+}
+
+
+#define HIPSYCL_PLUGIN_API_EXPORT extern "C"
+
+
+HIPSYCL_PLUGIN_API_EXPORT
+hipsycl::rt::backend *hipsycl_backend_plugin_create();
+
+HIPSYCL_PLUGIN_API_EXPORT
+const char* hipsycl_backend_plugin_get_name();
+
 
 namespace hipsycl {
-namespace sycl {
-namespace detail {
+namespace rt {
 
-static std::string version_string()
-{
-  std::string hipsycl_version = std::to_string(HIPSYCL_VERSION_MAJOR)
-      + "." + std::to_string(HIPSYCL_VERSION_MINOR)
-      + "." + std::to_string(HIPSYCL_VERSION_PATCH)
-      + "-" + std::string(HIPSYCL_VERSION_TYPE);
+class backend_loader {
+public:
+  ~backend_loader();
 
-  return "hipSYCL " + hipsycl_version;
-}
+  void query_backends();
+  
+  std::size_t get_num_backends() const;
+  std::string get_backend_name(std::size_t index) const;
+  bool has_backend(const std::string &name) const;
 
-}
+  backend *create(std::size_t index);
+  backend *create(const std::string &name);
+
+private:
+  using handle_t = void*;
+  std::vector<std::pair<std::string, handle_t>> _handles;
+};
+
 }
 }
 
 #endif
+

--- a/include/hipSYCL/runtime/backend_loader.hpp
+++ b/include/hipSYCL/runtime/backend_loader.hpp
@@ -61,8 +61,8 @@ public:
   std::string get_backend_name(std::size_t index) const;
   bool has_backend(const std::string &name) const;
 
-  backend *create(std::size_t index);
-  backend *create(const std::string &name);
+  backend *create(std::size_t index) const;
+  backend *create(const std::string &name) const;
 
 private:
   using handle_t = void*;

--- a/include/hipSYCL/runtime/cuda/cuda_module.hpp
+++ b/include/hipSYCL/runtime/cuda/cuda_module.hpp
@@ -33,6 +33,7 @@
 
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
+#include "hipSYCL/runtime/module_invoker.hpp"
 #include "hipSYCL/glue/generic/module.hpp"
 
 struct CUmod_st;
@@ -40,7 +41,7 @@ struct CUmod_st;
 namespace hipsycl {
 namespace rt {
 
-using cuda_module_id_t = unsigned long long;
+using cuda_module_id_t = module_id_t;
 class cuda_queue;
 
 class cuda_module {

--- a/include/hipSYCL/runtime/cuda/cuda_queue.hpp
+++ b/include/hipSYCL/runtime/cuda/cuda_queue.hpp
@@ -43,6 +43,23 @@ struct CUstream_st;
 namespace hipsycl {
 namespace rt {
 
+class cuda_queue;
+
+class cuda_module_invoker : public module_invoker {
+public:
+  cuda_module_invoker(cuda_queue *q);
+
+  virtual result
+  submit_kernel(module_id_t id, const std::string &module_variant,
+                const std::string *module_image, const rt::range<3> &num_groups,
+                const rt::range<3>& group_size, unsigned local_mem_size,
+                void **args, std::size_t num_args,
+                const std::string &kernel_name_tag,
+                const std::string &kernel_body_name) override;
+
+private:
+  cuda_queue* _queue;
+};
 
 class cuda_queue : public inorder_queue
 {
@@ -66,20 +83,26 @@ public:
   virtual result submit_queue_wait_for(std::shared_ptr<dag_node_event> evt) override;
   virtual result submit_external_wait_for(dag_node_ptr node) override;
 
-  device_id get_device() const { return _dev; }
+  virtual device_id get_device() const override;
 
-  result submit_kernel_from_module(cuda_module_manager& manager,
+  virtual void *get_native_type() const override;
+
+  virtual module_invoker* get_module_invoker() override;
+  
+  result submit_kernel_from_module(cuda_module_manager &manager,
                                    const cuda_module &module,
                                    const std::string &kernel_name,
                                    const rt::range<3> &grid_size,
                                    const rt::range<3> &block_size,
                                    unsigned dynamic_shared_mem,
-                                   void** kernel_args);
+                                   void **kernel_args);
+
 private:
   void activate_device() const;
   
   device_id _dev;
-  CUstream_st* _stream;
+  CUstream_st *_stream;
+  cuda_module_invoker _module_invoker;
 };
 
 }

--- a/include/hipSYCL/runtime/hip/hip_queue.hpp
+++ b/include/hipSYCL/runtime/hip/hip_queue.hpp
@@ -58,7 +58,10 @@ public:
   virtual result submit_queue_wait_for(std::shared_ptr<dag_node_event> evt) override;
   virtual result submit_external_wait_for(dag_node_ptr node) override;
 
-  device_id get_device() const { return _dev; }
+  virtual device_id get_device() const override;
+  virtual void* get_native_type() const override;
+
+  virtual module_invoker* get_module_invoker() override;
 private:
   void activate_device() const;
   

--- a/include/hipSYCL/runtime/inorder_queue.hpp
+++ b/include/hipSYCL/runtime/inorder_queue.hpp
@@ -29,11 +29,13 @@
 #define HIPSYCL_INORDER_QUEUE_HPP
 
 #include <memory>
+#include <string>
 
 #include "dag_node.hpp"
 #include "hints.hpp"
 #include "operations.hpp"
 #include "error.hpp"
+#include "module_invoker.hpp"
 
 namespace hipsycl {
 namespace rt {
@@ -54,6 +56,14 @@ public:
   /// the other queue must be from the same backend
   virtual result submit_queue_wait_for(std::shared_ptr<dag_node_event> evt) = 0;
   virtual result submit_external_wait_for(dag_node_ptr node) = 0;
+
+  virtual device_id get_device() const = 0;
+  /// Return native type if supported, nullptr otherwise
+  virtual void* get_native_type() const = 0;
+
+  /// Get a module invoker to launch kernels from module images,
+  /// if the backend supports this. Returns nullptr if unsupported.
+  virtual module_invoker* get_module_invoker() = 0;
 
   virtual ~inorder_queue(){}
 };

--- a/include/hipSYCL/runtime/module_invoker.hpp
+++ b/include/hipSYCL/runtime/module_invoker.hpp
@@ -1,0 +1,56 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2021 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HIPSYCL_MODULE_INVOKER_HPP
+#define HIPSYCL_MODULE_INVOKER_HPP
+
+#include "error.hpp"
+#include "util.hpp"
+
+namespace hipsycl {
+namespace rt {
+
+using module_id_t = unsigned long long;
+
+class module_invoker {
+public:
+  virtual result
+  submit_kernel(module_id_t id, const std::string &module_variant,
+                const std::string *module_image, const rt::range<3> &num_groups,
+                const rt::range<3>& group_size, unsigned local_mem_size,
+                void **args, std::size_t num_args,
+                const std::string &kernel_name_tag,
+                const std::string &kernel_body_name) = 0;
+
+  virtual ~module_invoker() {}
+};
+
+}
+} // namespace hipsycl
+
+#endif

--- a/include/hipSYCL/runtime/omp/omp_queue.hpp
+++ b/include/hipSYCL/runtime/omp/omp_queue.hpp
@@ -55,6 +55,11 @@ public:
   virtual result submit_queue_wait_for(std::shared_ptr<dag_node_event> evt) override;
   virtual result submit_external_wait_for(dag_node_ptr node) override;
 
+  virtual device_id get_device() const override;
+  virtual void *get_native_type() const override;
+
+  virtual module_invoker *get_module_invoker() override;
+  
   worker_thread& get_worker();
 private:
   backend_id _backend_id;

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -57,7 +57,7 @@ if(WITH_CUDA_BACKEND)
   target_link_libraries(rt-backend-cuda PRIVATE hipSYCL-rt ${CUDA_LIBRARIES} ${CUDA_DRIVER_LIBRARY})
 
   install(TARGETS rt-backend-cuda
-        EXPORT install_exports
+        #EXPORT install_exports
         LIBRARY DESTINATION lib/hipSYCL
         ARCHIVE DESTINATION lib/static)
 endif()
@@ -83,7 +83,7 @@ if(WITH_ROCM_BACKEND)
   endif()
 
   install(TARGETS rt-backend-hip
-        EXPORT install_exports
+        #EXPORT install_exports
         LIBRARY DESTINATION lib/hipSYCL
         ARCHIVE DESTINATION lib/static)
 endif()
@@ -109,7 +109,7 @@ if(WITH_CPU_BACKEND)
     target_link_libraries(rt-backend-omp PRIVATE hipSYCL-rt  OpenMP::OpenMP_CXX)
 
     install(TARGETS rt-backend-omp
-        EXPORT install_exports
+        #EXPORT install_exports
         LIBRARY DESTINATION lib/hipSYCL
         ARCHIVE DESTINATION lib/static)
 endif()

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -57,7 +57,6 @@ if(WITH_CUDA_BACKEND)
   target_link_libraries(rt-backend-cuda PRIVATE hipSYCL-rt ${CUDA_LIBRARIES} ${CUDA_DRIVER_LIBRARY})
 
   install(TARGETS rt-backend-cuda
-        #EXPORT install_exports
         LIBRARY DESTINATION lib/hipSYCL
         ARCHIVE DESTINATION lib/static)
 endif()
@@ -83,7 +82,6 @@ if(WITH_ROCM_BACKEND)
   endif()
 
   install(TARGETS rt-backend-hip
-        #EXPORT install_exports
         LIBRARY DESTINATION lib/hipSYCL
         ARCHIVE DESTINATION lib/static)
 endif()
@@ -109,7 +107,6 @@ if(WITH_CPU_BACKEND)
     target_link_libraries(rt-backend-omp PRIVATE hipSYCL-rt  OpenMP::OpenMP_CXX)
 
     install(TARGETS rt-backend-omp
-        #EXPORT install_exports
         LIBRARY DESTINATION lib/hipSYCL
         ARCHIVE DESTINATION lib/static)
 endif()

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -1,11 +1,13 @@
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-set(HIPSYCL_SOURCES
+
+add_library(hipSYCL-rt SHARED
   application.cpp
   runtime.cpp
   error.cpp
   backend.cpp
+  backend_loader.cpp
   hints.cpp
   device_id.cpp
   operations.cpp
@@ -21,38 +23,6 @@ set(HIPSYCL_SOURCES
   hw_model/memcpy.cpp
   serialization/serialization.cpp)
 
-if(WITH_CUDA_BACKEND)
-  set(HIPSYCL_SOURCES ${HIPSYCL_SOURCES}
-    cuda/cuda_event.cpp
-    cuda/cuda_queue.cpp
-    cuda/cuda_allocator.cpp
-    cuda/cuda_device_manager.cpp
-    cuda/cuda_hardware_manager.cpp
-    cuda/cuda_backend.cpp
-    cuda/cuda_module.cpp)
-endif()
-
-if(WITH_ROCM_BACKEND)
-  set(HIPSYCL_SOURCES ${HIPSYCL_SOURCES}
-    hip/hip_event.cpp
-    hip/hip_queue.cpp
-    hip/hip_allocator.cpp
-    hip/hip_device_manager.cpp
-    hip/hip_hardware_manager.cpp
-    hip/hip_backend.cpp)
-endif()
-
-if(WITH_CPU_BACKEND)
-  set(HIPSYCL_SOURCES ${HIPSYCL_SOURCES}
-    omp/omp_allocator.cpp
-    omp/omp_backend.cpp
-    omp/omp_event.cpp
-    omp/omp_hardware_manager.cpp
-    omp/omp_queue.cpp)
-endif()
-
-add_library(hipSYCL-rt SHARED ${HIPSYCL_SOURCES})
-
 # syclcc already knows about these include directories, but clangd-based tooling does not.
 # Specifying them explicitly ensures that IDEs can resolve all hipSYCL includes correctly.
 target_include_directories(hipSYCL-rt
@@ -61,45 +31,95 @@ target_include_directories(hipSYCL-rt
     $<INSTALL_INTERFACE:include>
   PRIVATE
     ${HIPSYCL_SOURCE_DIR}
+    ${PROJECT_BINARY_DIR}/include
 )
-
-if(WITH_CUDA_BACKEND)
-  target_compile_definitions(hipSYCL-rt PRIVATE HIPSYCL_RT_ENABLE_CUDA_BACKEND=1)
-  target_include_directories(hipSYCL-rt PRIVATE ${CUDA_TOOLKIT_ROOT_DIR}/include)
-  
-  target_link_libraries(hipSYCL-rt PRIVATE ${CUDA_LIBRARIES} ${CUDA_DRIVER_LIBRARY})
-endif()
-
-if(WITH_ROCM_BACKEND) 
-  target_compile_definitions(hipSYCL-rt PRIVATE HIPSYCL_RT_ENABLE_HIP_BACKEND=1 HIPSYCL_RT_HIP_TARGET_ROCM=1)
-  if(NOT HIP_FOUND)
-    target_include_directories(hipSYCL-rt PRIVATE ${ROCM_PATH}/include)
-    target_link_libraries(hipSYCL-rt PRIVATE ${ROCM_LIBS})
-  else()
-    # Supress warnings because wrongly set CXX arguments
-    target_compile_options(hipSYCL-rt PRIVATE -Wno-unused-command-line-argument)
-    target_link_libraries(hipSYCL-rt PRIVATE hip::host)
-  endif()
-endif()
-
-if(WITH_CPU_BACKEND)
-  find_package(OpenMP REQUIRED)
-  if(APPLE)
-    if(CMAKE_VERSION VERSION_LESS "3.16")
-      message(FATAL_ERROR "CMake 3.16.0+ is required for macOS OpenMP support!")
-    endif()
-    target_include_directories(hipSYCL-rt PRIVATE ${OpenMP_CXX_INCLUDE_DIRS})
-  endif()
-
-  target_link_libraries(hipSYCL-rt PRIVATE OpenMP::OpenMP_CXX)
-
-  target_compile_definitions(hipSYCL-rt PRIVATE HIPSYCL_RT_ENABLE_OMP_BACKEND=1)
-endif()
 
 install(TARGETS hipSYCL-rt
         EXPORT install_exports
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib/static)
+
+
+if(WITH_CUDA_BACKEND)
+  add_library(rt-backend-cuda SHARED
+    cuda/cuda_event.cpp
+    cuda/cuda_queue.cpp
+    cuda/cuda_allocator.cpp
+    cuda/cuda_device_manager.cpp
+    cuda/cuda_hardware_manager.cpp
+    cuda/cuda_backend.cpp
+    cuda/cuda_module.cpp)
+
+  target_include_directories(rt-backend-cuda PRIVATE
+    ${HIPSYCL_SOURCE_DIR}/include
+    ${CUDA_TOOLKIT_ROOT_DIR}/include)
+  
+  target_link_libraries(rt-backend-cuda PRIVATE hipSYCL-rt ${CUDA_LIBRARIES} ${CUDA_DRIVER_LIBRARY})
+
+  install(TARGETS rt-backend-cuda
+        EXPORT install_exports
+        LIBRARY DESTINATION lib/hipSYCL
+        ARCHIVE DESTINATION lib/static)
+endif()
+
+if(WITH_ROCM_BACKEND)
+  add_library(rt-backend-hip SHARED
+    hip/hip_event.cpp
+    hip/hip_queue.cpp
+    hip/hip_allocator.cpp
+    hip/hip_device_manager.cpp
+    hip/hip_hardware_manager.cpp
+    hip/hip_backend.cpp)
+
+  target_compile_definitions(rt-backend-hip PRIVATE HIPSYCL_RT_HIP_TARGET_ROCM=1)
+  target_include_directories(rt-backend-hip PRIVATE ${HIPSYCL_SOURCE_DIR}/include)
+  if(NOT HIP_FOUND)
+    target_include_directories(rt-backend-hip PRIVATE ${ROCM_PATH}/include)
+    target_link_libraries(rt-backend-hip PRIVATE ${ROCM_LIBS})
+  else()
+    # Supress warnings because wrongly set CXX arguments
+    target_compile_options(rt-backend-hip PRIVATE -Wno-unused-command-line-argument)
+    target_link_libraries(rt-backend-hip PRIVATE hipSYCL-rt  hip::host)
+  endif()
+
+  install(TARGETS rt-backend-hip
+        EXPORT install_exports
+        LIBRARY DESTINATION lib/hipSYCL
+        ARCHIVE DESTINATION lib/static)
+endif()
+
+if(WITH_CPU_BACKEND)
+  add_library(rt-backend-omp SHARED
+    omp/omp_allocator.cpp
+    omp/omp_backend.cpp
+    omp/omp_event.cpp
+    omp/omp_hardware_manager.cpp
+    omp/omp_queue.cpp)
+
+    find_package(OpenMP REQUIRED)
+
+    target_include_directories(rt-backend-omp PRIVATE ${HIPSYCL_SOURCE_DIR}/include)
+    if(APPLE)
+      if(CMAKE_VERSION VERSION_LESS "3.16")
+        message(FATAL_ERROR "CMake 3.16.0+ is required for macOS OpenMP support!")
+      endif()
+      target_include_directories(rt-backend-omp PRIVATE ${OpenMP_CXX_INCLUDE_DIRS})
+    endif()
+
+    target_link_libraries(rt-backend-omp PRIVATE hipSYCL-rt  OpenMP::OpenMP_CXX)
+
+    install(TARGETS rt-backend-omp
+        EXPORT install_exports
+        LIBRARY DESTINATION lib/hipSYCL
+        ARCHIVE DESTINATION lib/static)
+endif()
+
+
+if(WITH_CPU_BACKEND)
+  
+endif()
+
+
 
 
 

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -37,7 +37,7 @@ target_include_directories(hipSYCL-rt
 install(TARGETS hipSYCL-rt
         EXPORT install_exports
         LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib/static)
+        ARCHIVE DESTINATION lib)
 
 
 if(WITH_CUDA_BACKEND)
@@ -59,7 +59,7 @@ if(WITH_CUDA_BACKEND)
   install(TARGETS rt-backend-cuda
         EXPORT install_exports
         LIBRARY DESTINATION lib/hipSYCL
-        ARCHIVE DESTINATION lib/static)
+        ARCHIVE DESTINATION lib/hipSYCL)
 endif()
 
 if(WITH_ROCM_BACKEND)
@@ -85,7 +85,7 @@ if(WITH_ROCM_BACKEND)
   install(TARGETS rt-backend-hip
         EXPORT install_exports
         LIBRARY DESTINATION lib/hipSYCL
-        ARCHIVE DESTINATION lib/static)
+        ARCHIVE DESTINATION lib/hipSYCL)
 endif()
 
 if(WITH_CPU_BACKEND)
@@ -111,15 +111,6 @@ if(WITH_CPU_BACKEND)
     install(TARGETS rt-backend-omp
         EXPORT install_exports
         LIBRARY DESTINATION lib/hipSYCL
-        ARCHIVE DESTINATION lib/static)
+        ARCHIVE DESTINATION lib/hipSYCL)
 endif()
-
-
-if(WITH_CPU_BACKEND)
-  
-endif()
-
-
-
-
 

--- a/src/runtime/backend_loader.cpp
+++ b/src/runtime/backend_loader.cpp
@@ -1,0 +1,178 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2021 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "hipSYCL/runtime/backend_loader.hpp"
+#include "hipSYCL/common/debug.hpp"
+#include "hipSYCL/common/config.hpp"
+
+#include <cassert>
+#include <filesystem>
+#include <dlfcn.h>
+
+namespace {
+
+void close_plugin(void *handle) {
+  int err = dlclose(handle);
+
+  if (err != 0) {
+    HIPSYCL_DEBUG_ERROR << "backend_loader: dlclose() failed" << std::endl;
+  }
+}
+
+bool load_plugin(const std::string &filename, void *&handle_out,
+                 std::string &backend_name_out) {
+  void *handle = dlopen(filename.c_str(), RTLD_NOW);
+
+  if (!handle) {
+    HIPSYCL_DEBUG_ERROR << "backend_loader: Could not load backend plugin: "
+                        << filename << std::endl;
+    char *err = dlerror();
+    if (err) {
+      HIPSYCL_DEBUG_ERROR << err << std::endl;
+    }
+
+    return false;
+  } else {
+    void *symbol = dlsym(handle, "hipsycl_backend_plugin_get_name");
+
+    char *err = dlerror();
+    if (err) {
+      HIPSYCL_DEBUG_ERROR << "backend_loader: Could not retrieve backend name"
+                          << err << std::endl;
+    }
+    else {
+      auto get_name =
+          reinterpret_cast<decltype(&hipsycl_backend_plugin_get_name)>(symbol);
+
+      handle_out = handle;
+      backend_name_out = get_name();
+
+      return true;
+    }
+  }
+
+  // In case of failure, close handle to avoid resource leak
+  close_plugin(handle);
+  return false;
+}
+
+hipsycl::rt::backend *create_backend(void *plugin_handle) {
+  assert(plugin_handle);
+
+  void *symbol = dlsym(plugin_handle, "hipsycl_backend_plugin_create");
+  char *err = dlerror();
+  if (err) {
+    HIPSYCL_DEBUG_ERROR
+        << "backend_loader: Could not find symbol for backend creation" << err
+        << std::endl;
+    
+    return nullptr;
+  }
+  
+  auto create_backend_func =
+      reinterpret_cast<decltype(&hipsycl_backend_plugin_create)>(symbol);
+
+  return create_backend_func();
+}
+
+}
+
+namespace hipsycl {
+namespace rt {
+
+void backend_loader::query_backends() {
+  std::string install_prefix = HIPSYCL_INSTALL_PREFIX;
+
+  std::filesystem::path backend_lib_path =
+      std::filesystem::path{install_prefix} / "lib/hipSYCL";
+
+  std::string shared_lib_extension = ".so";
+  
+  for (const std::filesystem::directory_entry &entry :
+       std::filesystem::directory_iterator(backend_lib_path)) {
+
+    if (entry.is_regular_file()) {
+      auto p = entry.path();
+      if (p.extension().string() == shared_lib_extension) {
+        std::string backend_name;
+        void *handle;
+        if (load_plugin(p.string(), handle, backend_name)) {
+          HIPSYCL_DEBUG_INFO << "Successfully opened plugin: " << p
+                             << " for backend '" << backend_name << "'"
+                             << std::endl;
+          _handles.emplace_back(std::make_pair(backend_name, handle));
+        }
+      }
+    }
+    
+  }
+}
+
+backend_loader::~backend_loader() {
+  for (auto &handle : _handles) {
+    assert(handle.second);
+    close_plugin(handle.second);
+  }
+}
+
+std::size_t backend_loader::get_num_backends() const { return _handles.size(); }
+
+std::string backend_loader::get_backend_name(std::size_t index) const {
+  assert(index < _handles.size());
+  return _handles[index].first;
+}
+
+bool backend_loader::has_backend(const std::string &name) const {
+  for (const auto &h : _handles) {
+    if (h.first == name)
+      return true;
+  }
+
+  return false;
+}
+
+backend *backend_loader::create(std::size_t index) {
+  assert(index < _handles.size());
+  
+  return create_backend(_handles[index].second);
+}
+
+backend *backend_loader::create(const std::string &name) {
+  if (!has_backend(name))
+    return nullptr;
+
+  for (std::size_t i = 0; i < _handles.size(); ++i) {
+    if (_handles[i].first == name)
+      return create(i);
+  }
+
+  return nullptr;
+}
+
+}
+} // namespace hipsycl

--- a/src/runtime/cuda/cuda_backend.cpp
+++ b/src/runtime/cuda/cuda_backend.cpp
@@ -25,8 +25,22 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "hipSYCL/runtime/backend_loader.hpp"
+
 #include "hipSYCL/runtime/cuda/cuda_backend.hpp"
 #include "hipSYCL/runtime/cuda/cuda_queue.hpp"
+
+HIPSYCL_PLUGIN_API_EXPORT
+hipsycl::rt::backend *hipsycl_backend_plugin_create() {
+  return new hipsycl::rt::cuda_backend();
+}
+
+static const char *backend_name = "cuda";
+
+HIPSYCL_PLUGIN_API_EXPORT
+const char *hipsycl_backend_plugin_get_name() {
+  return backend_name;
+}
 
 namespace hipsycl {
 namespace rt {

--- a/src/runtime/hip/hip_backend.cpp
+++ b/src/runtime/hip/hip_backend.cpp
@@ -25,9 +25,23 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "hipSYCL/runtime/backend_loader.hpp"
+
 #include "hipSYCL/runtime/hip/hip_backend.hpp"
 #include "hipSYCL/runtime/hip/hip_target.hpp"
 #include "hipSYCL/runtime/hip/hip_queue.hpp"
+
+HIPSYCL_PLUGIN_API_EXPORT
+hipsycl::rt::backend *hipsycl_backend_plugin_create() {
+  return new hipsycl::rt::hip_backend();
+}
+
+static const char *backend_name = "hip";
+
+HIPSYCL_PLUGIN_API_EXPORT
+const char *hipsycl_backend_plugin_get_name() {
+  return backend_name;
+}
 
 namespace hipsycl {
 namespace rt {

--- a/src/runtime/hip/hip_queue.cpp
+++ b/src/runtime/hip/hip_queue.cpp
@@ -312,6 +312,16 @@ result hip_queue::submit_external_wait_for(dag_node_ptr node) {
   return make_success();
 }
 
+device_id hip_queue::get_device() const { return _dev; }
+
+void *hip_queue::get_native_type() const {
+  return static_cast<void*>(get_stream());
+}
+
+module_invoker *hip_queue::get_module_invoker() {
+  return nullptr;
+}
+
 }
 }
 

--- a/src/runtime/omp/omp_backend.cpp
+++ b/src/runtime/omp/omp_backend.cpp
@@ -25,6 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "hipSYCL/runtime/backend_loader.hpp"
 #include "hipSYCL/runtime/omp/omp_backend.hpp"
 #include "hipSYCL/runtime/omp/omp_queue.hpp"
 #include "hipSYCL/runtime/application.hpp"
@@ -32,6 +33,21 @@
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/multi_queue_executor.hpp"
 #include <memory>
+
+
+HIPSYCL_PLUGIN_API_EXPORT
+hipsycl::rt::backend *hipsycl_backend_plugin_create() {
+  return new hipsycl::rt::omp_backend();
+}
+
+static const char *backend_name = "omp";
+
+HIPSYCL_PLUGIN_API_EXPORT
+const char *hipsycl_backend_plugin_get_name() {
+  return backend_name;
+}
+
+
 
 namespace hipsycl {
 namespace rt {

--- a/src/runtime/omp/omp_queue.cpp
+++ b/src/runtime/omp/omp_queue.cpp
@@ -272,8 +272,19 @@ result omp_queue::submit_external_wait_for(dag_node_ptr node) {
   return make_success();
 }
 
-worker_thread& omp_queue::get_worker(){
-  return _worker;
+worker_thread &omp_queue::get_worker() { return _worker; }
+
+device_id omp_queue::get_device() const {
+  return device_id{
+      backend_descriptor{hardware_platform::cpu, api_platform::omp}, 0};
+}
+
+void *omp_queue::get_native_type() const {
+  return nullptr;
+}
+
+module_invoker *omp_queue::get_module_invoker() {
+  return nullptr;
 }
 
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,8 +77,7 @@ add_sycl_to_target(TARGET sycl_tests)
 add_executable(rt_tests 
   runtime/runtime_test_suite.cpp 
   runtime/dag_builder.cpp
-  runtime/data.cpp
-  runtime/device_manager.cpp)
+  runtime/data.cpp)
 
 target_include_directories(rt_tests PRIVATE ${Boost_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(rt_tests PRIVATE ${Boost_LIBRARIES} Threads::Threads)

--- a/tests/runtime/device_manager.cpp
+++ b/tests/runtime/device_manager.cpp
@@ -44,7 +44,7 @@
 #endif
 
 using namespace hipsycl;
-
+/*
 template <rt::backend_id Backend> struct backend_enabled {
   static constexpr bool value = false;
 };
@@ -137,3 +137,4 @@ BOOST_AUTO_TEST_CASE(
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+*/

--- a/tests/runtime/device_manager.cpp
+++ b/tests/runtime/device_manager.cpp
@@ -44,7 +44,7 @@
 #endif
 
 using namespace hipsycl;
-/*
+
 template <rt::backend_id Backend> struct backend_enabled {
   static constexpr bool value = false;
 };
@@ -137,4 +137,3 @@ BOOST_AUTO_TEST_CASE(
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-*/


### PR DESCRIPTION
Previously, all backends for the runtime were compiled into a single library, `libhipSYCL-rt`. This has turned out to be problematic for two reasons:
1. All dependencies from all backends are contained in `linhipSYCL-rt`, and as such all backend dependencies must be available when symbols are resolved when linking with `syclcc`. This can be cumbersome for dependencies like `libcuda.so`, which is only available on systems where the NVIDIA kernel driver is installed
2. It makes it very difficult to provide binary packages for hipSYCL:
   1. Either the package maintainer provides a hipSYCL distribution that has all backends enabled such that it works with as much user hardware as possible, at the cost of having hard dependencies on very large dependencies (e.g. CUDA/ROCm) which the user might not need;
   2. Or only provide a hipSYCL distribution for specific backends to avoid large dependencies at the cost of excluding users who have different hardware;
   3. Or provide multiple hipSYCL packages that have various combinations of backends enabled. This is difficult to maintain and doesn't scale as the number of hipSYCL backends increases due to the combinatoric explosion.

This PR addresses these issues by restructuring the runtime such that backends are individual plugin libraries. When the core hipSYCL runtime starts, it scans `$HIPSYCL_INSTALL_PREFIX/lib/hipSYCL` for runtime backends and dynamically loads them using `dlopen()`/`dlsym()`. Runtime backends are now built as individual libraries `librt-backend-*`.

This decouples backend dependencies from the core `libhipSYCL-rt` that is linked by `syclcc`. Unfortunately we cannot purge `ROCM_LINK_LINE` and `CUDA_LINK_LINE` entirely since the CUDA/HIP runtime libraries still need to be linked to SYCL applications to provide kernel invocation mechanisms when using integrated (non-explicit) multipass compilation.

As a consequence of this new approach, it is now possible to extend an existing hipSYCL installation (e.g. from a package) after the initial installation with support for additional backends by simply dropping additional backend libraries into the `lib/hipSYCL` directory.

Another important consequence of this change is that it is **no longer possible to directly call functions defined by runtime backends from kernel launchers or client code since the symbols are no longer defined in `libhipSYCL-rt`**. My impression is that this modularizes the design more and forces us to think more about generic interfaces, which might be a good thing in the long run.

This has required a couple of additional changes, such as refactoring explicit multipass to have a backend-independent interface (that for now is only implemented for CUDA).
I also had to temporarily disable the `device_manager` runtime tests, as that functionality is now no longer available to client code. I think the right way to approach such tests in the future is to develop tests directly against the individual backend libraries. But it is still unclear how to best structure this and how the build system could look like, especially if we don't want to have the `-lcuda` difficulties again. (cc @psalz)

**The recommended way of packaging hipSYCL changes as follows with this PR**:
* Provide a core hipSYCL package containing `libhipSYCL-rt`, `syclcc` and the include headers
* Provide one package per backend containing the appropriate `librt-backend-*` library.
* The core package *must* have a dependency on the package for the OpenMP backend since hipSYCL always needs a CPU backend to function.

Pinging package maintainers: @acxz @nazavode @sbalint98