### PR TITLE
Add requirement to data users even if the same operation is already a user

### DIFF
--- a/src/runtime/dag_builder.cpp
+++ b/src/runtime/dag_builder.cpp
@@ -57,11 +57,17 @@ void add_to_data_users(dag_node_ptr node, memory_requirement *mem_req) {
                            ->get_data_region()
                            ->get_users();
 
-    if (!data_users.has_user(node)) {
-      data_users.add_user(
-          node, mem_req->get_access_mode(), mem_req->get_access_target(),
-          mem_req->get_access_offset3d(), mem_req->get_access_range3d());
-    }
+    // We need to add the user unconditionally, whether the user
+    // is already registered or not. This is to cover the case
+    // where we have multiple requirements (potentially with different access
+    // modes or ranges) on the same operation.
+    // This cannot introduce duplicate dependency edges in the DAG because
+    // dag_node::add_requirement() only inserts requirements to nodes
+    // that are not listed yet as requirement. 
+    data_users.add_user(
+        node, mem_req->get_access_mode(), mem_req->get_access_target(),
+        mem_req->get_access_offset3d(), mem_req->get_access_range3d());
+  
   } else
     assert(false && "dag: Image requirements are not yet implemented");
 }

--- a/src/runtime/data.cpp
+++ b/src/runtime/data.cpp
@@ -99,7 +99,6 @@ void data_user_tracker::add_user(
   id<3> offset, 
   range<3> range)
 {
-  assert(!has_user(user));
   std::lock_guard<std::mutex> lock{_lock};
 
   _users.push_back(


### PR DESCRIPTION
Fixes #464 

We need to add an operation to data users even if the same operation is already listed as a user, because the access mode might be different. This in turn can affect conflict detection in the `dag_builder`. In certain scenarios, this can lead to missing dependencies (and hence missing synchronization) in the DAG.

This does not introduce additional synchronization due to potential duplicate DAG edges, because `dag_node::add_requirement()` still only inserts a requirement to a node if is a new one.