### PR TITLE
Support new ROCm versions by default

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        clang_version: [10, 11]
-        rocm_version: [3.8]
+        clang_version: [11]
+        rocm_version: ['4.0.1']
         os: [ubuntu-20.04, ubuntu-18.04]
         cuda: [10.0, 10.2, 11.0]
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,8 @@ if(NOT ROCM_CXX_FLAGS)
   # clang erroneously sets feature detection flags for 
   # __float128 even though it is not supported for CUDA / HIP,
   # see https://bugs.llvm.org/show_bug.cgi?id=47559.
-  set(ROCM_CXX_FLAGS "-isystem ${CLANG_INCLUDE_PATH} -U__FLOAT128__ -U__SIZEOF_FLOAT128__ -I$HIPSYCL_ROCM_PATH/include -I$HIPSYCL_ROCM_PATH/include --hip-device-lib-path=$HIPSYCL_ROCM_PATH/lib " CACHE STRING "Arguments passed to compiler to compile SYCL applications with ROCm")
+
+  set(ROCM_CXX_FLAGS "-isystem ${CLANG_INCLUDE_PATH} -U__FLOAT128__ -U__SIZEOF_FLOAT128__ -I$HIPSYCL_ROCM_PATH/include -I$HIPSYCL_ROCM_PATH/include --rocm-device-lib-path=$HIPSYCL_ROCM_PATH/amdgcn/bitcode --rocm-path=$HIPSYCL_ROCM_PATH" CACHE STRING "Arguments passed to compiler to compile SYCL applications with ROCm")
 endif()
 
 if(NOT CUDA_CXX_FLAGS)	

--- a/doc/install-rocm.md
+++ b/doc/install-rocm.md
@@ -3,9 +3,10 @@
 In general, hipSYCL on ROCm requires a clang installation that satisfies the following conditions:
 * clang must **not** be compiled with the `_DEBUG` macro enabled (otherwise, hipSYCL triggers incorrect `assert()` statements inside clang due to the, from clang's perpective, unusual way in which it employs the HIP/CUDA toolchain). Regular clang release builds as they can be found in distributions usually meet this requirement.
 * clang versions older than 8 are not supported because HIP support was introduced in 8.
+* By default, hipSYCL uses `--rocm-path` and `--rocm-device-lib-path` clang flags which were introduced in clang 11. You will have to change hipSYCL's `ROCM_CXX_FLAGS` manually to use older clang versions.
 * clang must have been built with the AMDGPU backend enabled (which is usually the case)
 * lld is also required.
-* ROCm versions older than 2.6 cannot work, but recent hipSYCL distributions may or may not work with such old ROCm stacks. It is recommended to use a recent ROCm version.
+* By default, hipSYCL uses ROCm features that are only available in recent ROCm versions (e.g. >=4.0) such as the managed memory API. You can build against an older ROCm version, but will have to define `HIPSYCL_RT_NO_HIP_MANAGED_MEMORY` when compiling hipSYCL.
 
 Additionally, please take note of the following:
 * **regular LLVM/clang distributions:** hipSYCL can run with regular clang/LLVM distributions, as long as you have matching ROCm device and runtime libraries installed. This is usually **the easiest way and therefore recommended.**

--- a/src/runtime/hip/hip_allocator.cpp
+++ b/src/runtime/hip/hip_allocator.cpp
@@ -139,7 +139,7 @@ result hip_allocator::query_pointer(const void *ptr, pointer_info &out) const
   out.dev = rt::device_id{_backend_descriptor, attribs.device};
   out.is_from_host_backend = false;
   out.is_optimized_host = attribs.memoryType == hipMemoryTypeHost;
-#ifdef HIPSYCL_RT_HIP_SUPPORTS_UNIFIED_MEMORY
+#ifndef HIPSYCL_RT_NO_HIP_MANAGED_MEMORY
   out.is_usm = attribs.isManaged;
 #else
   // query for hipMemoryTypeUnified as dummy; this is not actually
@@ -154,7 +154,7 @@ result hip_allocator::query_pointer(const void *ptr, pointer_info &out) const
 
 result hip_allocator::mem_advise(const void *addr, std::size_t num_bytes,
                                 int advise) const {
-#ifdef HIPSYCL_RT_HIP_SUPPORTS_UNIFIED_MEMORY
+#ifndef HIPSYCL_RT_NO_HIP_MANAGED_MEMORY
   hipError_t err = hipMemAdvise(addr, num_bytes,
                                 static_cast<hipMemoryAdvise>(advise), _dev);
   if(err != hipSuccess) {

--- a/src/runtime/hip/hip_queue.cpp
+++ b/src/runtime/hip/hip_queue.cpp
@@ -237,7 +237,7 @@ result hip_queue::submit_kernel(const kernel_operation &op) {
 
 result hip_queue::submit_prefetch(const prefetch_operation& op) {
 
-#ifdef HIPSYCL_RT_HIP_SUPPORTS_UNIFIED_MEMORY
+#ifndef HIPSYCL_RT_NO_HIP_MANAGED_MEMORY
   hipError_t err = hipSuccess;
   
   if (op.get_target().is_host()) {


### PR DESCRIPTION
Support newer ROCm versions (>= 4.0) by default:
* Enable HIP managed memory API for `hipMemPrefetchAsync()` and `hipMemAdvise()` by default
* Use new `--rocm-path` and `--rocm-device-lib-path` flags (from clang >= 11)
* Adapt default ROCm device library path to the location used by ROCm since 3.9 (`$PREFIX/amdgcn/bitcode`)

With this PR, hipSYCL should be able to compile out-of-the-box against clang 11 and ROCm 4.0.

Because we now use clang 11 specific flags in the ROCm path, I had to disable clang 10 in CI.