### PR TITLE
[Win][CI] Add a Windows CI using pre-built LLVM 11*.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         md -Force $env:GITHUB_WORKSPACE/install
         cd $env:GITHUB_WORKSPACE/install
-        Invoke-WebRequest -O llvm.7z https://ci-bot.joameyer.de/llvm.7z
+        Invoke-WebRequest -O llvm.7z http://repo.urz.uni-heidelberg.de/sycl/windows/llvm.7z
     - name: Extract LLVM
       shell: powershell
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,11 +54,10 @@ jobs:
     - name: install boost (from source)
       run: |
         $env:PATH="$env:GITHUB_WORKSPACE\install\bin;$env:PATH"
-        Invoke-WebRequest -O boost_1_75_0.7z https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.7z
-        7z.exe x boost_1_75_0.7z
+        md -Force boost_1_75_0
         cd boost_1_75_0
-        .\bootstrap.bat
-        .\b2 toolset=clang-win address-model=64 variant=release --build-type=complete stage --with-fiber --with-context --with-test
+        Invoke-WebRequest -O boost_1_75_0.7z http://repo.urz.uni-heidelberg.de/sycl/windows/boost_1_75_0.7z
+        7z.exe x boost_1_75_0.7z
         cd ..
     - name: build hipSYCL
       shell: cmd

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,103 @@
+name: Windows build and test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: clang ${{ matrix.clang_version }}, CUDA ${{matrix.cuda}}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        clang_version: [11]
+        os: [windows-latest]
+        cuda: ['10.0', '10.2', '11.0']
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - name: LLVM cache
+      id: llvm11-archive
+      uses: actions/cache@v2
+      with:
+        path: install/llvm.7z
+        key: ${{ runner.os }}-llvm11-7z
+    - name: Fetch LLVM
+      if: steps.llvm11-archive.outputs.cache-hit != 'true'
+      shell: powershell
+      run: |
+        md -Force $env:GITHUB_WORKSPACE/install
+        cd $env:GITHUB_WORKSPACE/install
+        Invoke-WebRequest -O llvm.7z https://ci-bot.joameyer.de/llvm.7z
+    - name: Extract LLVM
+      shell: powershell
+      run: |
+        cd $env:GITHUB_WORKSPACE/install
+        7z.exe x llvm.7z
+    - name: install CUDA 10.0
+      if: matrix.cuda == 10.0
+      shell: powershell
+      run: |
+        Invoke-WebRequest -O cuda.exe https://developer.nvidia.com/compute/cuda/10.0/Prod/network_installers/cuda_10.0.130_win10_network
+        Start-Process -FilePath "cuda.exe" -ArgumentList "-s nvcc_10.0 nvprune_10.0 cupti_10.0 cublas_10.0 cublas_dev_10.0 cudart_10.0 cufft_10.0 cufft_dev_10.0 curand_10.0 curand_dev_10.0 cusolver_10.0 cusolver_dev_10.0 cusparse_10.0 cusparse_dev_10.0 npp_10.0 npp_dev_10.0 nvrtc_10.0 nvrtc_dev_10.0 nvml_dev_10.0" -Wait -NoNewWindow
+    - name: install CUDA 10.2
+      if: matrix.cuda == 10.2
+      shell: powershell
+      run: |
+        Invoke-WebRequest -O cuda.exe https://developer.download.nvidia.com/compute/cuda/10.2/Prod/network_installers/cuda_10.2.89_win10_network.exe
+        Start-Process -FilePath "cuda.exe" -ArgumentList "-s nvcc_10.2 nvprune_10.2 cupti_10.2 cublas_10.2 cublas_dev_10.2 cudart_10.2 cufft_10.2 cufft_dev_10.2 curand_10.2 curand_dev_10.2 cusolver_10.2 cusolver_dev_10.2 cusparse_10.2 cusparse_dev_10.2 npp_10.2 npp_dev_10.2 nvrtc_10.2 nvrtc_dev_10.2 nvml_dev_10.2" -Wait -NoNewWindow
+    - name: install CUDA 11.0
+      if: matrix.cuda == 11.0
+      shell: powershell
+      run: |
+        Invoke-WebRequest -O cuda.exe https://developer.download.nvidia.com/compute/cuda/11.0.2/network_installers/cuda_11.0.2_win10_network.exe
+        Start-Process -FilePath "cuda.exe" -ArgumentList "-s nvcc_11.0 nvprune_11.0 cupti_11.0 cublas_11.0 cublas_dev_11.0 cudart_11.0 cufft_11.0 cufft_dev_11.0 curand_11.0 curand_dev_11.0 cusolver_11.0 cusolver_dev_11.0 cusparse_11.0 cusparse_dev_11.0 npp_11.0 npp_dev_11.0 nvrtc_11.0 nvrtc_dev_11.0 nvml_dev_11.0" -Wait -NoNewWindow
+    - name: install boost (from source)
+      run: |
+        $env:PATH="$env:GITHUB_WORKSPACE\install\bin;$env:PATH"
+        Invoke-WebRequest -O boost_1_75_0.7z https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.7z
+        7z.exe x boost_1_75_0.7z
+        cd boost_1_75_0
+        .\bootstrap.bat
+        .\b2 toolset=clang-win address-model=64 variant=release --build-type=complete stage --with-fiber --with-context --with-test
+        cd ..
+    - name: build hipSYCL
+      shell: cmd
+      env:
+        CUDA_PATH: "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v${{matrix.cuda}}"
+        CUDA_BIN_PATH: "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v${{matrix.cuda}}/bin"
+      run: |
+        set PATH=%GITHUB_WORKSPACE%\install\bin;C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja;%CUDA_BIN_PATH%;%PATH%
+        set GITHUB_WORKSPACE=%GITHUB_WORKSPACE:\=/%
+        mkdir "%GITHUB_WORKSPACE%/build/core"
+        cd "%GITHUB_WORKSPACE%/build/core"
+        cmake %GITHUB_WORKSPACE% -G Ninja -DCMAKE_C_COMPILER=%GITHUB_WORKSPACE%/install/bin/clang.exe -DCMAKE_CXX_COMPILER=%GITHUB_WORKSPACE%/install/bin/clang++.exe -DCLANG_EXECUTABLE_PATH=%GITHUB_WORKSPACE%/install/bin/clang++.exe -DLLVM_DIR=%GITHUB_WORKSPACE%/install/lib/cmake/llvm -DBOOST_ROOT=%GITHUB_WORKSPACE%/boost_1_75_0 -DWITH_CUDA_BACKEND=ON -DCMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%/install -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        ninja -j2 install
+    - name: build CPU tests
+      shell: cmd
+      env:
+        CUDA_BIN_PATH: "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v${{matrix.cuda}}/bin"
+      run: |
+        set PATH=%GITHUB_WORKSPACE%\install\bin;C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja;%CUDA_BIN_PATH%;%PATH%
+        set GITHUB_WORKSPACE=%GITHUB_WORKSPACE:\=/%
+        mkdir "%GITHUB_WORKSPACE%/build/tests-cpu"
+        cd "%GITHUB_WORKSPACE%/build/tests-cpu"
+        cmake -G Ninja -DHIPSYCL_TARGETS="omp" -DhipSYCL_DIR=%GITHUB_WORKSPACE%/install/lib/cmake/hipSYCL -DBOOST_ROOT=%GITHUB_WORKSPACE%/boost_1_75_0 -DCMAKE_BUILD_TYPE=RelWithDebInfo %GITHUB_WORKSPACE%/tests
+        ninja -j2
+    - name: build CUDA tests
+      shell: cmd
+      env:
+        CUDA_BIN_PATH: "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v${{matrix.cuda}}/bin"
+      run: |
+        set PATH=%GITHUB_WORKSPACE%\install\bin;C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja;%CUDA_BIN_PATH%;%PATH%
+        set GITHUB_WORKSPACE=%GITHUB_WORKSPACE:\=/%
+        mkdir "%GITHUB_WORKSPACE%/build/tests-cuda"
+        cd "%GITHUB_WORKSPACE%/build/tests-cuda"
+        cmake -G Ninja -DHIPSYCL_TARGETS="cuda:sm_60" -DhipSYCL_DIR=%GITHUB_WORKSPACE%/install/lib/cmake/hipSYCL -DBOOST_ROOT=%GITHUB_WORKSPACE%/boost_1_75_0 -DCMAKE_BUILD_TYPE=RelWithDebInfo %GITHUB_WORKSPACE%/tests
+        ninja -j2
+    - name: run CPU tests
+      shell: cmd
+      run: |
+        set PATH=%GITHUB_WORKSPACE%\install\bin;%PATH%
+        set GITHUB_WORKSPACE=%GITHUB_WORKSPACE:\=/%
+        cd "%GITHUB_WORKSPACE%/build/tests-cpu"
+        sycl_tests.exe

--- a/include/hipSYCL/glue/generic/host/collective_execution_engine.hpp
+++ b/include/hipSYCL/glue/generic/host/collective_execution_engine.hpp
@@ -28,7 +28,14 @@
 #ifndef HIPSYCL_COLLECTIVE_EXECUTION_ENGINE_HPP
 #define HIPSYCL_COLLECTIVE_EXECUTION_ENGINE_HPP
 
-#ifndef HIPSYCL_NO_FIBERS
+#include "hipSYCL/sycl/libkernel/backend.hpp"
+
+/**
+ * Due to an issue with Boost.Intrusive (used by Boost.Fiber), on Windows,
+ * which is triggered in device pass of Clang CUDA, we may only use this in host pass.
+ * This should not be a problem, as this implementation is anyways just required during host pass.
+ */
+#if !defined(HIPSYCL_NO_FIBERS) && !defined(SYCL_DEVICE_ONLY)
 #define HIPSYCL_HAS_FIBERS
 #endif
 


### PR DESCRIPTION
Just as with the Linux CI, CUDA and CPU tests are built, but only the CPU tests are actually executed.
* LLVM 11.1.0 was built with the required patch from https://reviews.llvm.org/D69322
It's using the action cache, as fetching of those >400MB would increase the overall build time heavily.

To fix an issue with Boost.Intrusive during device pass, the collective_execution_engine is ifdef'd away during device pass.