### PR TITLE
Only set policy CMP0074 if cmake >= 3.12 in root cMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required (VERSION 3.5)
-cmake_policy(SET CMP0074 NEW) # Don't complain about using BOOST_ROOT...
+if(NOT CMAKE_VERSION VERSION_LESS 3.12)
+  cmake_policy(SET CMP0074 NEW) # Don't complain about using BOOST_ROOT...
+endif()
 
 set(HIPSYCL_VERSION_MAJOR 0)
 set(HIPSYCL_VERSION_MINOR 9)


### PR DESCRIPTION
This policy has been added to cmake 3.12 first, therefore it should only be set in case cmake is more recent than 3.12. 