### PR TITLE
[SYCL 2020] Install SYCL/sycl.hpp also to sycl/sycl.hpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,6 +278,9 @@ install(FILES ${PROJECT_BINARY_DIR}/include/hipSYCL/common/config.hpp DESTINATIO
 
 if(NOT WIN32)
 install(PROGRAMS bin/syclcc DESTINATION bin)
+# Windows is case-insensitive, so don't copy to sycl/sycl.hpp as
+# we already have SYCL/sycl.hpp
+install(FILES include/SYCL/sycl.hpp DESTINATION include/sycl/)
 else()
 install(PROGRAMS bin/syclcc-clang DESTINATION bin RENAME syclcc)
 endif()


### PR DESCRIPTION
SYCL 2020 final has changed the header location to `sycl/sycl.hpp`. For compatibility, we still provide `SYCL/sycl.hpp`.

On Windows, don't install `sycl/sycl.hpp` as filesystems are case-insensitive (? cc @fodinabor)