### PR TITLE
[SYCL 2020] Add accessor simplifications/deduction guides, host_accessor

### DIFF
--- a/include/hipSYCL/sycl/access.hpp
+++ b/include/hipSYCL/sycl/access.hpp
@@ -32,20 +32,13 @@
 
 namespace hipsycl {
 namespace sycl {
-namespace access {
-
-enum class mode {
-  read = 1024,
-  write,
-  read_write,
-  discard_write,
-  discard_read_write,
-  atomic
-};
 
 enum class target {
-  global_buffer = 2014,
-  constant_buffer,
+  device,
+  host_task,
+  global_buffer = device,
+  // Deprecated targets
+  constant_buffer = 2,
   local,
   image,
   host_buffer,
@@ -53,37 +46,37 @@ enum class target {
   image_array
 };
 
-enum class placeholder {
-  false_t,
-  true_t
+enum class access_mode {
+  read,
+  write,
+  read_write,
+  // Deprecated access modes
+  discard_write,
+  discard_read_write,
+  atomic
 };
 
-enum class fence_space : char {
-  local_space,
-  global_space,
-  global_and_local
-};
 
 // TODO these should be moved to a common/serialization.hpp?
-inline std::ostream &operator<<(std::ostream &out, const sycl::access::mode value)
+inline std::ostream &operator<<(std::ostream &out, const sycl::access_mode value)
 {
   switch (value) {
-  case sycl::access::mode::read:
+  case sycl::access_mode::read:
     out << "R";
     break;
-  case sycl::access::mode::write:
+  case sycl::access_mode::write:
     out << "W";
     break;
-  case sycl::access::mode::atomic:
+  case sycl::access_mode::atomic:
     out << "atomic";
     break;
-  case sycl::access::mode::read_write:
+  case sycl::access_mode::read_write:
     out << "RW";
     break;
-  case sycl::access::mode::discard_write:
+  case sycl::access_mode::discard_write:
     out << "Discard W";
     break;
-  case sycl::access::mode::discard_read_write:
+  case sycl::access_mode::discard_read_write:
     out << "Discard RW";
     break;
   default:
@@ -94,28 +87,31 @@ inline std::ostream &operator<<(std::ostream &out, const sycl::access::mode valu
 }
 
 inline std::ostream &operator<<(std::ostream &out,
-                                const sycl::access::target value) {
+                                const sycl::target value) {
   switch (value) {
-  case sycl::access::target::image:
+  case sycl::target::image:
     out << "image";
     break;
-  case sycl::access::target::constant_buffer:
+  case sycl::target::constant_buffer:
     out << "constant_buffer";
     break;
-  case sycl::access::target::global_buffer:
-    out << "global_buffer";
+  case sycl::target::device:
+    out << "device";
     break;
-  case sycl::access::target::host_buffer:
+  case sycl::target::host_buffer:
     out << "host_buffer";
     break;
-  case sycl::access::target::host_image:
+  case sycl::target::host_image:
     out << "host_image";
     break;
-  case sycl::access::target::image_array:
+  case sycl::target::image_array:
     out << "Image_array";
     break;
-  case sycl::access::target::local:
+  case sycl::target::local:
     out << "local";
+    break;
+  case sycl::target::host_task:
+    out << "host_task";
     break;
   default:
     throw "Target enum cannot be serialized";
@@ -123,6 +119,24 @@ inline std::ostream &operator<<(std::ostream &out,
   }
   return out;
 }
+
+namespace access {
+
+// SYCL 1.2.1 compatibility
+using sycl::target;
+using mode = sycl::access_mode;
+
+// Deprecated
+enum class placeholder {
+  false_t,
+  true_t
+};
+
+enum class fence_space : char {
+  local_space,
+  global_space,
+  global_and_local
+};
 
 inline std::ostream &operator<<(std::ostream &out,
                          const sycl::access::placeholder value)
@@ -161,7 +175,7 @@ inline std::ostream &operator<<(std::ostream &out,
   return out;
 }
 
-}
+} // access
 }
 }
 

--- a/include/hipSYCL/sycl/buffer.hpp
+++ b/include/hipSYCL/sycl/buffer.hpp
@@ -480,11 +480,9 @@ public:
     return accessor{*this, args...};
   }
 
-  // TODO
   template<typename... Args>
   auto get_host_access(Args... args) {
-    assert(false && "unimplemented");
-    return nullptr;
+    return host_accessor{*this, args...};
   }
 
   void set_final_data(std::shared_ptr<T> finalData)

--- a/include/hipSYCL/sycl/buffer.hpp
+++ b/include/hipSYCL/sycl/buffer.hpp
@@ -63,20 +63,20 @@ namespace sycl {
 
 namespace property::buffer {
 
-class use_host_ptr : public detail::property
+class use_host_ptr : public detail::buffer_property
 {
 public:
   use_host_ptr() = default;
 };
 
-class use_mutex : public detail::property
+class use_mutex : public detail::buffer_property
 {
 public:
   use_mutex(mutex_class& ref);
   mutex_class* get_mutex_ptr() const;
 };
 
-class context_bound : public detail::property
+class context_bound : public detail::buffer_property
 {
 public:
   context_bound(context bound_context)
@@ -91,14 +91,14 @@ private:
   context _ctx;
 };
 
-class use_optimized_host_memory : public detail::property
+class use_optimized_host_memory : public detail::buffer_property
 {};
 
 } // property::buffer
 
 namespace detail::buffer_policy {
 
-class destructor_waits : public property
+class destructor_waits : public buffer_property
 { 
 public: 
   destructor_waits(bool v): _v{v}{} 
@@ -107,7 +107,7 @@ private:
   bool _v;
 };
 
-class writes_back : public property
+class writes_back : public buffer_property
 { 
 public: 
   writes_back(bool v): _v{v}{} 
@@ -116,7 +116,7 @@ private:
   bool _v;
 };
 
-class use_external_storage : public property
+class use_external_storage : public buffer_property
 { 
 public: 
   use_external_storage(bool v): _v{v}{} 
@@ -230,8 +230,7 @@ template <class T> struct buffer_allocation {
 
 // Default template arguments for the buffer class
 // are defined when forward-declaring the buffer in accessor.hpp
-template <typename T, int dimensions,
-          typename AllocatorT>
+template <typename T, int dimensions, typename AllocatorT>
 class buffer : public detail::property_carrying_object
 {
 public:
@@ -279,7 +278,7 @@ public:
     : buffer(bufferRange, propList)
   { _alloc = allocator; }
 
-  buffer(T *hostData, const range<dimensions> &bufferRange,
+  buffer(std::remove_const_t<T> *hostData, const range<dimensions> &bufferRange,
          const property_list &propList = {})
     : detail::property_carrying_object{propList}
   {
@@ -300,17 +299,16 @@ public:
     }
   }
 
-  buffer(T *hostData, const range<dimensions> &bufferRange,
+  buffer(std::remove_const_t<T> *hostData, const range<dimensions> &bufferRange,
          AllocatorT allocator, const property_list &propList = {})
-    : buffer{hostData, bufferRange, propList}
-  {
+      : buffer{hostData, bufferRange, propList} {
     _alloc = allocator;
   }
 
+  template <class t = T, std::enable_if_t<!std::is_const_v<t>, bool> = true>
   buffer(const T *hostData, const range<dimensions> &bufferRange,
          const property_list &propList = {})
-    : detail::property_carrying_object{propList}
-  {
+      : detail::property_carrying_object{propList} {
     _impl = std::make_shared<detail::buffer_impl>();
 
     default_policies dpol;
@@ -417,6 +415,12 @@ public:
     assert(false && "subbuffer is unimplemented");
   }
 
+  // Allow conversion to buffer<const T> from buffer<T>
+  template <class t = T, std::enable_if_t<std::is_const_v<t>, bool> = true>
+  buffer(const buffer<std::remove_const_t<T>, dimensions, AllocatorT> &other)
+      : _alloc{other._alloc}, _range{other._range}, _impl{other._impl},
+        detail::property_carrying_object{other} {}
+
   range<dimensions> get_range() const
   {
     return _range;
@@ -437,28 +441,31 @@ public:
     return _alloc;
   }
 
-  template <access::mode mode, access::target target = access::target::global_buffer>
-  accessor<T, dimensions, mode, target> get_access(handler &commandGroupHandler)
-  {
+  template <access_mode mode = access_mode::read_write,
+            access::target target = access::target::device>
+  accessor<T, dimensions, mode, target>
+  get_access(handler &commandGroupHandler) {
     return accessor<T, dimensions, mode, target>{*this, commandGroupHandler};
   }
 
+  // Deprecated
   template <access::mode mode>
   accessor<T, dimensions, mode, access::target::host_buffer> get_access()
   {
     return accessor<T, dimensions, mode, access::target::host_buffer>{*this};
   }
 
-  template <access::mode mode, access::target target = access::target::global_buffer>
-  accessor<T, dimensions, mode, target> get_access(
-      handler &commandGroupHandler, range<dimensions> accessRange,
-      id<dimensions> accessOffset = {})
-  {
+  template <access_mode mode = access_mode::read_write,
+            access::target target = access::target::device>
+  accessor<T, dimensions, mode, target>
+  get_access(handler &commandGroupHandler, range<dimensions> accessRange,
+             id<dimensions> accessOffset = {}) {
     return accessor<T, dimensions, mode, target>{
       *this, commandGroupHandler, accessRange, accessOffset
     };
   }
 
+  // Deprecated
   template <access::mode mode>
   accessor<T, dimensions, mode, access::target::host_buffer> get_access(
       range<dimensions> accessRange, id<dimensions> accessOffset = {})
@@ -466,6 +473,18 @@ public:
     return accessor<T, dimensions, mode, access::target::host_buffer>{
       *this, accessRange, accessOffset
     };
+  }
+
+  template<typename... Args>
+  auto get_access(Args... args) {
+    return accessor{*this, args...};
+  }
+
+  // TODO
+  template<typename... Args>
+  auto get_host_access(Args... args) {
+    assert(false && "unimplemented");
+    return nullptr;
   }
 
   void set_final_data(std::shared_ptr<T> finalData)

--- a/include/hipSYCL/sycl/handler.hpp
+++ b/include/hipSYCL/sycl/handler.hpp
@@ -74,7 +74,7 @@ public:
   {
   }
 
-  template <typename dataT, int dimensions, access::mode accessMode,
+  template <typename dataT, int dimensions, access_mode accessMode,
             access::target accessTarget, access::placeholder isPlaceholder>
   void
   require(accessor<dataT, dimensions, accessMode, accessTarget, isPlaceholder>&
@@ -85,6 +85,12 @@ public:
     // Construct requirement descriptor
     std::shared_ptr<rt::buffer_data_region> data_region = acc._buff.get_shared_ptr();
     
+    if(!data_region) {
+      throw invalid_parameter_error{
+          "handler: require(): accessor is illegal paramater for require() "
+          "because it is not bound to a buffer."};
+    }
+
     auto offset = acc.get_offset();
     auto range = acc.get_range();
     size_t element_size = data_region->get_element_size();
@@ -94,8 +100,11 @@ public:
                       "not yet supported");
     }
 
+    // Translate no_init property and host_task modes
+    access_mode mode = acc.get_effective_access_mode();
+
     auto req = std::make_unique<rt::buffer_memory_requirement>(
-        data_region, rt::make_id(offset), rt::make_range(range), accessMode,
+        data_region, rt::make_id(offset), rt::make_range(range), mode,
         accessTarget);
 
     // Bind the accessor's deferred pointer to the requirement, such that

--- a/include/hipSYCL/sycl/libkernel/accessor.hpp
+++ b/include/hipSYCL/sycl/libkernel/accessor.hpp
@@ -46,8 +46,11 @@
 #include "hipSYCL/sycl/device.hpp"
 #include "hipSYCL/sycl/buffer_allocator.hpp"
 #include "hipSYCL/sycl/access.hpp"
+#include "hipSYCL/sycl/property.hpp"
 #include "hipSYCL/sycl/libkernel/backend.hpp"
 
+#include "hipSYCL/sycl/libkernel/host/host_backend.hpp"
+#include "hipSYCL/sycl/property.hpp"
 #include "range.hpp"
 #include "item.hpp"
 #include "multi_ptr.hpp"
@@ -58,9 +61,48 @@
 namespace hipsycl {
 namespace sycl {
 
+namespace detail {
+
+struct read_only_tag_t {};
+struct read_write_tag_t {};
+struct write_only_tag_t {};
+struct read_only_host_task_tag_t {};
+struct read_write_host_task_tag_t {};
+struct write_only_host_task_tag_t {};
+
+template <typename TagT> constexpr access_mode deduce_access_mode() {
+  if constexpr (std::is_same_v<TagT, read_only_tag_t> ||
+                std::is_same_v<TagT, read_only_host_task_tag_t>) {
+    return access_mode::read;
+  } else if constexpr (std::is_same_v<TagT, read_write_tag_t> ||
+                       std::is_same_v<TagT, read_write_host_task_tag_t>) {
+    return access_mode::read_write;
+  } else {
+    return access_mode::write;
+  }
+}
+
+template<typename TagT> constexpr target deduce_access_target() {
+  if constexpr (std::is_same_v<TagT, read_only_tag_t> ||
+                std::is_same_v<TagT, read_write_tag_t> ||
+                std::is_same_v<TagT, write_only_tag_t>) {
+    return target::device;
+  } else {
+    return target::host_task;
+  }
+}
+
+}
+
+inline constexpr detail::read_only_tag_t read_only;
+inline constexpr detail::read_write_tag_t read_write;
+inline constexpr detail::write_only_tag_t write_only;
+inline constexpr detail::read_only_host_task_tag_t read_only_host_task;
+inline constexpr detail::read_write_host_task_tag_t read_write_host_task;
+inline constexpr detail::write_only_host_task_tag_t write_only_host_task;
 
 template <typename T, int dimensions = 1,
-          typename AllocatorT = sycl::buffer_allocator<T>>
+          typename AllocatorT = buffer_allocator<std::remove_const_t<T>>>
 class buffer;
 
 class handler;
@@ -82,21 +124,18 @@ detail::local_memory::address allocate_local_mem(sycl::handler&,
 
 namespace detail::accessor {
 
-template<class T, access::mode m>
-struct accessor_pointer_type
-{
-  using value = T*;
+template<class T, access_mode M>
+struct accessor_data_type {
+  using value = T;
 };
 
 template<class T>
-struct accessor_pointer_type<T, access::mode::read>
-{
-  using value = const T*;
+struct accessor_data_type<T, access_mode::read> {
+  using value = const T;
 };
 
-
-template <typename dataT, int dimensions, access::mode accessmode,
-          access::target accessTarget, access::placeholder isPlaceholder,
+template <typename dataT, int dimensions, access_mode accessmode,
+          target accessTarget, access::placeholder isPlaceholder,
           int current_dimension = 1>
 class subscript_proxy
 {
@@ -131,10 +170,10 @@ public:
 
   template <int D = dimensions,
             int C = current_dimension,
-            access::mode M = accessmode,
+            access_mode M = accessmode,
             std::enable_if_t<can_invoke_access(C, D) && 
-                            (M == access::mode::read || 
-                             M == access::mode::atomic)> * = nullptr>
+                            (M == access_mode::read || 
+                             M == access_mode::atomic)> * = nullptr>
   HIPSYCL_UNIVERSAL_TARGET
   auto operator[](size_t index) const {
     return invoke_value_access(index);
@@ -142,10 +181,10 @@ public:
 
   template <int D = dimensions,
             int C = current_dimension,
-            access::mode M = accessmode,
+            access_mode M = accessmode,
             std::enable_if_t<can_invoke_access(C, D) && 
-                            (M != access::mode::read &&
-                             M != access::mode::atomic)> * = nullptr>
+                            (M != access_mode::read &&
+                             M != access_mode::atomic)> * = nullptr>
   HIPSYCL_UNIVERSAL_TARGET
   auto& operator[](size_t index) const {
     return invoke_ref_access(index);
@@ -235,159 +274,231 @@ protected:
 
 } // detail
 
-template<typename dataT, int dimensions,
-         access::mode accessmode,
-         access::target accessTarget = access::target::global_buffer,
-         access::placeholder isPlaceholder = access::placeholder::false_t>
-class accessor : public detail::accessor_base<dataT>
-{
+namespace property {
+
+struct no_init : public detail::property {};
+
+} // property
+
+inline constexpr property::no_init no_init;
+
+template <typename dataT, int dimensions = 1,
+          access_mode accessmode =
+              (std::is_const_v<dataT> ? access_mode::read
+                                      : access_mode::read_write),
+          target accessTarget = target::device,
+          access::placeholder isPlaceholder = access::placeholder::false_t>
+class accessor : public detail::accessor_base<std::remove_const_t<dataT>> {
+
+  static_assert(!std::is_const_v<dataT> || accessmode == access_mode::read,
+    "const accessors are only allowed for read-only accessors");
+
   template<class AccessorType, class BufferType, int Dim>
   friend void detail::accessor::bind_to_buffer(
     AccessorType& acc, BufferType& buff, 
     sycl::id<Dim> accessOffset, sycl::range<Dim> accessRange);
+
+  // Need to be friends with other accessors for implicit
+  // conversion rules
+  template <class Data2, int Dim2, access_mode M2, target Tgt2,
+            access::placeholder P2>
+  friend class accessor;
+
+  friend class sycl::handler;
+
 public:
-  using value_type = dataT;
-  using reference = dataT &;
+  using value_type =
+      typename detail::accessor::accessor_data_type<dataT, accessmode>::value;
+  using reference = value_type &;
   using const_reference = const dataT &;
+  // TODO accessor_ptr
+  // TODO iterator, const_interator, reverse_iterator, const_reverse_iterator
+  // TODO difference_type
+  using size_type = size_t;
 
-  using pointer_type =
-    typename detail::accessor::accessor_pointer_type<dataT, accessmode>::value;
+  using pointer_type = value_type*;
 
-  /* Available only when: (isPlaceholder == access::placeholder::false_t &&
-accessTarget == access::target::host_buffer) ||
-(isPlaceholder ==
-access::placeholder::true_t && (accessTarget == access::target::global_buffer
-|| accessTarget == access::target::constant_buffer)) && dimensions == 0 */
-  template<access::placeholder P = isPlaceholder,
-           access::target T = accessTarget,
-           int D = dimensions,
-           std::enable_if_t<((P == access::placeholder::false_t &&
-                              T == access::target::host_buffer) ||
-                             (P == access::placeholder::true_t  &&
-                             (T == access::target::global_buffer ||
-                              T == access::target::constant_buffer))) &&
-                              D == 0 >* = nullptr>
-  accessor(buffer<dataT, 1> &bufferRef)
-  {
-    throw unimplemented{"0-dimensional accessors are not yet implemented"};
+  accessor() = default;
+
+  // 0D accessors
+  template <typename AllocatorT, int D = dimensions,
+            std::enable_if_t<D == 0> * = nullptr>
+  accessor(buffer<dataT, 1, AllocatorT> &bufferRef,
+           const property_list &prop_list = {}) {
+
+    _is_placeholder = true;
+    
+    init_properties(prop_list);
+    
     detail::accessor::bind_to_buffer(*this, bufferRef);
 
-    if(T == access::target::host_buffer) {
+    if(accessTarget == access::target::host_buffer) {
       init_host_buffer();
     }
   }
 
-  /* Available only when: (isPlaceholder == access::placeholder::false_t &&
-(accessTarget == access::target::global_buffer || accessTarget ==
-access::target::constant_buffer)) && dimensions == 0 */
-  template<access::placeholder P = isPlaceholder,
-           access::target T = accessTarget,
-           int D = dimensions,
-           std::enable_if_t<(P == access::placeholder::false_t &&
-                            (T == access::target::global_buffer ||
-                             T == access::target::constant_buffer )) &&
-                             D == 0 >* = nullptr>
-  accessor(buffer<dataT, 1> &bufferRef, handler &commandGroupHandlerRef)
-  {
-    throw unimplemented{"0-dimensional accessors are not yet implemented"};
+  template <typename AllocatorT, int D = dimensions,
+            std::enable_if_t<D == 0> * = nullptr>
+  accessor(buffer<dataT, 1, AllocatorT> &bufferRef,
+           handler &commandGroupHandlerRef,
+           const property_list &prop_list = {}) {
+    init_properties(prop_list);
+    
     detail::accessor::bind_to_buffer(*this, bufferRef);
   }
 
-  /* Available only when: (isPlaceholder == access::placeholder::false_t &&
-accessTarget == access::target::host_buffer) ||
-(isPlaceholder ==
-access::placeholder::true_t && (accessTarget == access::target::global_buffer
-|| accessTarget == access::target::constant_buffer)) && dimensions > 0 */
+  // Non 0-dimensional accessors
+  template <typename AllocatorT, int D = dimensions,
+            std::enable_if_t<(D > 0)> * = nullptr>
+  accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
+           const property_list &prop_list = {}) {
+    
+    _is_placeholder = true;
 
-  template<access::placeholder P = isPlaceholder,
-           access::target T = accessTarget,
-           int D = dimensions,
-           std::enable_if_t<((P == access::placeholder::false_t &&
-                              T == access::target::host_buffer) ||
-                             (P == access::placeholder::true_t &&
-                             (T == access::target::global_buffer ||
-                              T == access::target::constant_buffer))) &&
-                             (D > 0)>* = nullptr>
-  accessor(buffer<dataT, dimensions> &bufferRef)
-  {
+    init_properties(prop_list);
     detail::accessor::bind_to_buffer(*this, bufferRef);
 
-    if(T == access::target::host_buffer) {
+    if(accessTarget == access::target::host_buffer) {
       init_host_buffer();
     }
   }
 
-  /* Available only when: (isPlaceholder == access::placeholder::false_t &&
-(accessTarget == access::target::global_buffer || accessTarget ==
-access::target::constant_buffer)) && dimensions > 0 */
-  template<access::placeholder P = isPlaceholder,
-           access::target T = accessTarget,
-           int D = dimensions,
-           std::enable_if_t<(P == access::placeholder::false_t &&
-                            (T == access::target::global_buffer ||
-                             T == access::target::constant_buffer)) &&
-                            (D > 0)>* = nullptr>
-  accessor(buffer<dataT, dimensions> &bufferRef,
-           handler &commandGroupHandlerRef)
-  {
+  template <typename AllocatorT, typename TagT, int D = dimensions,
+            std::enable_if_t<(D > 0)> * = nullptr>
+  accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef, TagT tag,
+           const property_list &prop_list = {}) 
+  : accessor{bufferRef, prop_list} {}
+
+  template <typename AllocatorT, int D = dimensions,
+            std::enable_if_t<(D > 0)> * = nullptr>
+  accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
+           handler &commandGroupHandlerRef,
+           const property_list &prop_list = {}) {
+
+    init_properties(prop_list);
     detail::accessor::bind_to_buffer(*this, bufferRef);
     detail::accessor::bind_to_handler(*this, commandGroupHandlerRef);
   }
 
-  /// Creates an accessor for a partial range of the buffer, described by an offset
-  /// and range.
-  ///
-  ///
-  /// Available only when: (isPlaceholder == access::placeholder::false_t &&
-  /// accessTarget == access::target::host_buffer) || (isPlaceholder ==
-  /// access::placeholder::true_t && (accessTarget == access::target::global_buffer
-  /// || accessTarget == access::target::constant_buffer)) && dimensions > 0 */
-  template<access::placeholder P = isPlaceholder,
-           access::target T = accessTarget,
-           int D = dimensions,
-           std::enable_if_t<(P == access::placeholder::false_t &&
-                             T == access::target::host_buffer) ||
-                            ((P == access::placeholder::true_t &&
-                            (T == access::target::global_buffer ||
-                             T == access::target::constant_buffer)) &&
-                            (D > 0)) >* = nullptr>
-  accessor(buffer<dataT, dimensions> &bufferRef,
-           range<dimensions> accessRange,
-           id<dimensions> accessOffset = {})
-  {
+  template <typename AllocatorT, typename TagT, int D = dimensions,
+            std::enable_if_t<(D > 0)> * = nullptr>
+  accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
+           handler &commandGroupHandlerRef, TagT tag,
+           const property_list &prop_list = {})
+      : accessor{bufferRef, commandGroupHandlerRef, prop_list} {}
+
+  /* Ranged accessors */
+
+  template <typename AllocatorT, int D = dimensions,
+            std::enable_if_t<(D > 0)> * = nullptr>
+  accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
+           range<dimensions> accessRange, const property_list &propList = {})
+  : accessor{bufferRef, accessRange, id<dimensions>{}, propList} {}
+
+  template <typename AllocatorT, typename TagT, int D = dimensions,
+            std::enable_if_t<(D > 0)> * = nullptr>
+  accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
+           range<dimensions> accessRange, TagT tag,
+           const property_list &propList = {})
+  : accessor{bufferRef, accessRange, id<dimensions>{}, tag, propList} {}
+
+  template <typename AllocatorT, int D = dimensions,
+            std::enable_if_t<(D > 0)> * = nullptr>
+  accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
+           range<dimensions> accessRange, id<dimensions> accessOffset,
+           const property_list &propList = {}) {
+    
+    _is_placeholder = true;
+
+    init_properties(propList);
     detail::accessor::bind_to_buffer(*this, bufferRef, accessOffset,
                                      accessRange);
 
-    if(T == access::target::host_buffer) {
+    if (accessTarget == access::target::host_buffer) {
       init_host_buffer();
     }
   }
 
-  /* Available only when: (isPlaceholder == access::placeholder::false_t &&
-(accessTarget == access::target::global_buffer || accessTarget ==
-access::target::constant_buffer)) && dimensions > 0 */
-  template<access::placeholder P = isPlaceholder,
-           access::target T = accessTarget,
-           int D = dimensions,
-           std::enable_if_t<(P == access::placeholder::false_t &&
-                            (T == access::target::global_buffer ||
-                             T == access::target::constant_buffer)) &&
-                            (D > 0)>* = nullptr>
-  accessor(buffer<dataT, dimensions> &bufferRef,
+  template <typename AllocatorT, typename TagT, int D = dimensions,
+            std::enable_if_t<(D > 0)> * = nullptr>
+  accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
+           range<dimensions> accessRange, id<dimensions> accessOffset, TagT tag,
+           const property_list &propList = {})
+      : accessor{bufferRef, accessRange, accessOffset, propList} {}
+
+  template <typename AllocatorT, int D = dimensions,
+            std::enable_if_t<(D > 0)> * = nullptr>
+  accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
            handler &commandGroupHandlerRef, range<dimensions> accessRange,
-           id<dimensions> accessOffset = {})
-  {
-    detail::accessor::bind_to_buffer(*this, bufferRef, accessOffset, accessRange);
+           const property_list &propList = {})
+      : accessor{bufferRef, commandGroupHandlerRef, accessRange,
+                 id<dimensions>{}, propList} {}
+
+  template <typename AllocatorT, typename TagT, int D = dimensions,
+            std::enable_if_t<(D > 0)> * = nullptr>
+  accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
+           handler &commandGroupHandlerRef, range<dimensions> accessRange,
+           TagT tag, const property_list &propList = {})
+      : accessor{bufferRef, commandGroupHandlerRef, accessRange, propList} {}
+
+  template <typename AllocatorT, int D = dimensions,
+            std::enable_if_t<(D > 0)> * = nullptr>
+  accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
+           handler &commandGroupHandlerRef, range<dimensions> accessRange,
+           id<dimensions> accessOffset, const property_list &propList = {}) {
+
+    init_properties(propList);
+    detail::accessor::bind_to_buffer(*this, bufferRef, accessOffset,
+                                     accessRange);
     detail::accessor::bind_to_handler(*this, commandGroupHandlerRef);
+
+    if (accessTarget == access::target::host_buffer) {
+      init_host_buffer();
+    }
   }
 
+  template <typename AllocatorT, typename TagT, int D = dimensions,
+            std::enable_if_t<(D > 0)> * = nullptr>
+  accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
+           handler &commandGroupHandlerRef, range<dimensions> accessRange,
+           id<dimensions> accessOffset, TagT tag,
+           const property_list &propList = {})
+      : accessor{bufferRef, commandGroupHandlerRef, accessRange, accessOffset,
+                 propList} {}
+
+  HIPSYCL_UNIVERSAL_TARGET
   accessor(const accessor& other) = default;
+
+  HIPSYCL_UNIVERSAL_TARGET
   accessor& operator=(const accessor& other) = default;
 
+  // Implicit conversion between accessor of type T and const T
+  // if access_mode is read
+  template <typename T = dataT,
+            std::enable_if_t<std::is_const_v<T> &&
+                             accessmode == access_mode::read> * = nullptr>
+  HIPSYCL_UNIVERSAL_TARGET
+  accessor(const accessor<std::remove_const_t<T>, dimensions, accessmode,
+                          accessTarget> &other)
+      : detail::accessor_base<std::remove_const_t<T>>{other},
+        _buffer_range{other._buffer_range}, _range{other._range},
+        _offset{other._offset}, _is_no_init{other._is_no_init},
+        _is_placeholder{other._is_placeholder} {}
+
+  template <typename T = dataT,
+            std::enable_if_t<!std::is_const_v<T> &&
+                             accessmode == access_mode::read> * = nullptr>
+  HIPSYCL_UNIVERSAL_TARGET
+  accessor(const accessor<const T, dimensions, accessmode,
+                          accessTarget> &other)
+    : detail::accessor_base<std::remove_const_t<T>>{other},
+        _buffer_range{other._buffer_range}, _range{other._range},
+        _offset{other._offset}, _is_no_init{other._is_no_init},
+        _is_placeholder{other._is_placeholder} {}
 
   /* -- common interface members -- */
-  HIPSYCL_UNIVERSAL_TARGET
-  friend bool operator==(const accessor &lhs, const accessor &rhs) {
+  HIPSYCL_UNIVERSAL_TARGET friend bool operator==(const accessor &lhs,
+                                                  const accessor &rhs) {
     bool buffer_same = true;
 
 #ifndef SYCL_DEVICE_ONLY
@@ -405,9 +516,9 @@ access::target::constant_buffer)) && dimensions > 0 */
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  constexpr bool is_placeholder() const
+  bool is_placeholder() const
   {
-    return isPlaceholder == access::placeholder::true_t;
+    return _is_placeholder;
   }
 
   HIPSYCL_UNIVERSAL_TARGET
@@ -600,6 +711,24 @@ accessMode == access::mode::discard_read_write) && dimensions == 1) */
   }
 private:
 
+  access_mode get_effective_access_mode() const {
+    access_mode mode = accessmode;
+
+    if(mode == access_mode::atomic){
+      mode = access_mode::read_write;
+    }
+
+    if(_is_no_init) {
+      if(mode == access_mode::write) {
+        mode = access_mode::discard_write;
+      } else if(mode == access_mode::read_write) {
+        mode = access_mode::discard_read_write;
+      }
+    }
+
+    return mode;
+  }
+
   void init_host_buffer() {
     // TODO: Maybe unify code with handler::update_host()?
     HIPSYCL_DEBUG_INFO << "accessor [host]: Initializing host access" << std::endl;
@@ -617,8 +746,8 @@ private:
 
       auto explicit_requirement =
           rt::make_operation<rt::buffer_memory_requirement>(
-              data, rt::make_id(_offset), rt::make_range(_range), accessmode,
-              accessTarget);
+              data, rt::make_id(_offset), rt::make_range(_range),
+              get_effective_access_mode(), accessTarget);
 
       this->bind_to(
           rt::cast<rt::buffer_memory_requirement>(explicit_requirement.get()));
@@ -659,14 +788,197 @@ private:
     }
     // TODO Need to lock execution of DAG
   }
-  
-  HIPSYCL_UNIVERSAL_TARGET
-  accessor(){}
+
+  void init_properties() {
+    if(accessmode == access_mode::discard_write ||
+       accessmode == access_mode::discard_read_write) {
+      _is_no_init = true;
+    }
+  }
+
+  void init_properties(const property_list& prop_list) {
+    init_properties();
+    if(prop_list.has_property<property::no_init>()) {
+      _is_no_init = true;
+    }
+  }
 
   range<dimensions> _buffer_range;
   range<dimensions> _range;
   id<dimensions> _offset;
+  bool _is_no_init = false;
+  bool _is_placeholder = false;
 };
+
+// Accessor deduction guides
+
+template <typename T, int Dim, typename AllocatorT, typename TagT>
+accessor(buffer<T, Dim, AllocatorT> &bufferRef, TagT tag,
+          const property_list &prop_list = {})
+    -> accessor<T, Dim, detail::deduce_access_mode<TagT>(),
+                detail::deduce_access_target<TagT>(),
+                access::placeholder::true_t>;
+
+template <typename T, int Dim, typename AllocatorT, typename TagT>
+accessor(buffer<T, Dim, AllocatorT> &bufferRef, handler &commandGroupHandlerRef,
+         TagT tag, const property_list &prop_list = {})
+    -> accessor<T, Dim, detail::deduce_access_mode<TagT>(),
+                detail::deduce_access_target<TagT>(),
+                access::placeholder::false_t>;
+
+template <typename T, int Dim, typename AllocatorT, typename TagT>
+accessor(buffer<T, Dim, AllocatorT> &bufferRef, range<Dim> accessRange,
+         TagT tag, const property_list &propList = {})
+    -> accessor<T, Dim, detail::deduce_access_mode<TagT>(),
+                detail::deduce_access_target<TagT>(),
+                access::placeholder::true_t>;
+
+template <typename T, int Dim, typename AllocatorT, typename TagT>
+accessor(buffer<T, Dim, AllocatorT> &bufferRef, range<Dim> accessRange,
+         id<Dim> accessOffset, TagT tag, const property_list &propList = {})
+    -> accessor<T, Dim, detail::deduce_access_mode<TagT>(),
+                detail::deduce_access_target<TagT>(),
+                access::placeholder::true_t>;
+
+template <typename T, int Dim, typename AllocatorT, typename TagT>
+accessor(buffer<T, Dim, AllocatorT> &bufferRef, handler &commandGroupHandlerRef,
+         range<Dim> accessRange, TagT tag, const property_list &propList = {})
+    -> accessor<T, Dim, detail::deduce_access_mode<TagT>(),
+                detail::deduce_access_target<TagT>(),
+                access::placeholder::false_t>;
+
+template <typename T, int Dim, typename AllocatorT, typename TagT>
+accessor(buffer<T, Dim, AllocatorT> &bufferRef, handler &commandGroupHandlerRef,
+         range<Dim> accessRange, id<Dim> accessOffset, TagT tag,
+         const property_list &propList = {})
+    -> accessor<T, Dim, detail::deduce_access_mode<TagT>(),
+                detail::deduce_access_target<TagT>(),
+                access::placeholder::false_t>;
+
+// host_accessor implementation
+
+// template <typename dataT, int dimensions = 1,
+//           access_mode accessMode =
+//               (std::is_const_v<dataT> ? access_mode::read
+//                                       : access_mode::read_write)>
+// class host_accessor : public detail::accessor_base<std::remove_const_t<dataT>> {
+  
+//   static_assert(!std::is_const_v<dataT> || accessMode == access_mode::read,
+//     "const accessors are only allowed for read-only accessors");
+
+//   template<class AccessorType, class BufferType, int Dim>
+//   friend void detail::accessor::bind_to_buffer(
+//     AccessorType& acc, BufferType& buff, 
+//     sycl::id<Dim> accessOffset, sycl::range<Dim> accessRange);
+
+// public:
+//   using value_type =
+//       typename detail::accessor::accessor_data_type<dataT, accessMode>::value;
+//   using reference = value_type &;
+//   using const_reference = const dataT &;
+//   // using iterator = __unspecified_iterator__<value_type>;
+//   // using const_iterator = __unspecified_iterator__<const value_type>;
+//   // using reverse_iterator = std::reverse_iterator<iterator>;
+//   // using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+//   // using difference_type = typename
+//   // std::iterator_traits<iterator>::difference_type;
+//   using size_type = size_t;
+
+//   host_accessor() = default;
+
+//   /* Available only when: (dimensions == 0) */
+//   template <typename AllocatorT>
+//   host_accessor(buffer<dataT, 1, AllocatorT> &bufferRef,
+//                 const property_list &propList = {});
+
+//   /* Available only when: (dimensions > 0) */
+//   template <typename AllocatorT>
+//   host_accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
+//                 const property_list &propList = {});
+
+//   /* Available only when: (dimensions > 0) */
+//   template <typename AllocatorT, typename TagT>
+//   host_accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef, TagT tag,
+//                 const property_list &propList = {});
+
+//   /* Available only when: (dimensions > 0) */
+//   template <typename AllocatorT>
+//   host_accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
+//                 range<dimensions> accessRange,
+//                 const property_list &propList = {});
+
+//   /* Available only when: (dimensions > 0) */
+//   template <typename AllocatorT, typename TagT>
+//   host_accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
+//                 range<dimensions> accessRange, TagT tag,
+//                 const property_list &propList = {});
+
+//   /* Available only when: (dimensions > 0) */
+//   template <typename AllocatorT>
+//   host_accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
+//                 range<dimensions> accessRange, id<dimensions> accessOffset,
+//                 const property_list &propList = {});
+
+//   /* Available only when: (dimensions > 0) */
+//   template <typename AllocatorT, typename TagT>
+//   host_accessor(buffer<dataT, dimensions, AllocatorT> &bufferRef,
+//                 range<dimensions> accessRange, id<dimensions> accessOffset,
+//                 TagT tag, const property_list &propList = {});
+
+//   /* -- common interface members -- */
+
+//   void swap(host_accessor &other);
+
+//   size_type byte_size() const noexcept;
+
+//   size_type size() const noexcept;
+
+//   size_type max_size() const noexcept;
+
+//   bool empty() const noexcept;
+
+//   /* Available only when: (dimensions > 0) */
+//   range<dimensions> get_range() const;
+
+//   /* Available only when: (dimensions > 0) */
+//   id<dimensions> get_offset() const;
+
+//   /* Available only when: (dimensions == 0) */
+//   operator reference() const;
+
+//   /* Available only when: (dimensions > 0) */
+//   reference operator[](id<dimensions> index) const;
+
+//   /* Available only when: (dimensions > 1) */
+//   __unspecified__ &operator[](size_t index) const;
+
+//   /* Available only when: (dimensions == 1) */
+//   reference operator[](size_t index) const;
+
+//   std::add_pointer_t<value_type> get_pointer() const noexcept;
+
+//   iterator begin() const noexcept;
+
+//   iterator end() const noexcept;
+
+//   const_iterator cbegin() const noexcept;
+
+//   const_iterator cend() const noexcept;
+
+//   reverse_iterator rbegin() const noexcept;
+
+//   reverse_iterator rend() const noexcept;
+
+//   const_reverse_iterator crbegin() const noexcept;
+
+//   const_reverse_iterator crend() const noexcept;
+
+// private:
+//   range<dimensions> _buffer_range;
+//   range<dimensions> _range;
+//   id<dimensions> _offset;
+//   bool _is_no_init = false;
+// };
 
 /// Accessor specialization for local memory
 template <typename dataT,

--- a/include/hipSYCL/sycl/property.hpp
+++ b/include/hipSYCL/sycl/property.hpp
@@ -29,78 +29,156 @@
 #ifndef HIPSYCL_PROPERTY_HPP
 #define HIPSYCL_PROPERTY_HPP
 
+#include <type_traits>
+#include <memory>
+
+#include "access.hpp"
 #include "types.hpp"
 #include "exception.hpp"
 
 namespace hipsycl {
 namespace sycl {
+
+class queue;
+class context;
+class handler;
+
+template<class T, int Dim, class AllocatorT>
+class buffer;
+
+template <typename T, int Dim, access_mode M, target Tgt, access::placeholder P>
+class accessor;
+
 namespace detail {
 
-class property {
-public:
-  virtual ~property() {};
+class property {};
+class queue_property : public property {};
+class context_property : public property {};
+class buffer_property : public property {};
+class accessor_property : public property {};
+class cg_property : public property {};
+class unknown_property : public property {};
+
+template<class SyclObjectT>
+struct associated_property_base {
+  using type = unknown_property;
 };
 
-using property_ptr = shared_ptr_class<property>;
+template<>
+struct associated_property_base<queue> {
+  using type = queue_property;
+};
 
-}
+template<>
+struct associated_property_base<context> {
+  using type = context_property;
+};
+
+template<class T, int Dim, class AllocatorT>
+struct associated_property_base<buffer<T, Dim, AllocatorT>> {
+  using type = buffer_property;
+};
+// TODO: host_accessor
+template<typename T, int Dim, access_mode M, target Tgt, access::placeholder P>
+struct associated_property_base<accessor<T, Dim, M, Tgt, P>> {
+  using type = accessor_property;
+};
+
+template <class SyclObjectT>
+using associated_property_base_t =
+    typename associated_property_base<SyclObjectT>::type;
+
+} // detail
+
+template <typename PropertyT>
+struct is_property : public std::integral_constant<
+                         bool, std::is_base_of_v<detail::property, PropertyT>> {
+};
+
+template<typename PropertyT>
+inline constexpr bool is_property_v = is_property<PropertyT>::value;
+
+template <typename PropertyT, typename SyclObjectT>
+struct is_property_of
+    : public std::integral_constant<
+          bool,
+          std::is_base_of_v<detail::associated_property_base_t<SyclObjectT>,
+                            PropertyT>> {};
+
+template <typename PropertyT, typename SyclObjectT>
+inline constexpr bool is_property_of_v =
+    is_property_of<PropertyT, SyclObjectT>::value;
 
 class property_list
 {
 public:
 
-  template <typename... propertyTN>
+  template <typename... propertyTN,
+    std::enable_if_t<(is_property_v<propertyTN> && ...), bool> = true>
   property_list(propertyTN... props)
   {
     init(props...);
   }
 
   template <typename propertyT>
-  bool has_property() const
+  bool has_property() const noexcept
   {
-    for(const auto& property_ptr: _props)
-    {
-      if(dynamic_cast<propertyT*>(property_ptr.get()) != nullptr)
+    std::size_t id = typeid(propertyT).hash_code();
+    for(std::size_t i = 0; i < _props.size(); ++i) {
+      if(_props[i]->type_hash == id) {
         return true;
+      }
     }
+    
     return false;
   }
 
   template <typename propertyT>
   propertyT get_property() const
   {
-    for(const auto& property_ptr: _props)
-    {
-      propertyT* prop = dynamic_cast<propertyT*>(property_ptr.get());
-      if(prop != nullptr)
-        return *prop;
+    std::size_t id = typeid(propertyT).hash_code();
+    for(std::size_t i = 0; i < _props.size(); ++i) {
+      if(_props[i]->type_hash == id) {
+        return static_cast<property_wrapper<propertyT> *>(_props[i].get())
+            ->property;
+      }
     }
+
     throw invalid_object_error{"Property not found"};
   }
 private:
-  void init() {}
 
-  template<class T, typename... Other>
-  void init(const T& current, Other... others)
-  {
-    add_property(current);
-    init(others...);
-  }
+  struct type_erased_property {
+    type_erased_property(std::size_t id)
+    : type_hash{id} {}
 
-  template<class T>
-  void init(const T& current)
-  {
-    add_property(current);
+    std::size_t type_hash;
+    virtual ~type_erased_property(){}
+  };
+
+  template<class PropT>
+  struct property_wrapper : public type_erased_property {
+    property_wrapper(const PropT &p)
+        : property{p}, type_erased_property{typeid(PropT).hash_code()} {}
+
+    PropT property;
+  };
+
+  using property_ptr = std::shared_ptr<type_erased_property>;
+
+  template<typename... Props>
+  void init(Props... props){
+    (add_property(props), ...);
   }
 
   template<class T>
   void add_property(const T& prop)
   {
-    auto ptr = detail::property_ptr{new T{prop}};
+    auto ptr = property_ptr{new property_wrapper<T>{prop}};
     _props.push_back(ptr);
   }
 
-  vector_class<detail::property_ptr> _props;
+  std::vector<property_ptr> _props;
 };
 
 

--- a/include/hipSYCL/sycl/property.hpp
+++ b/include/hipSYCL/sycl/property.hpp
@@ -49,6 +49,9 @@ class buffer;
 template <typename T, int Dim, access_mode M, target Tgt, access::placeholder P>
 class accessor;
 
+template<typename T, int Dim, access_mode M>
+class host_accessor;
+
 namespace detail {
 
 class property {};
@@ -78,9 +81,14 @@ template<class T, int Dim, class AllocatorT>
 struct associated_property_base<buffer<T, Dim, AllocatorT>> {
   using type = buffer_property;
 };
-// TODO: host_accessor
+
 template<typename T, int Dim, access_mode M, target Tgt, access::placeholder P>
 struct associated_property_base<accessor<T, Dim, M, Tgt, P>> {
+  using type = accessor_property;
+};
+
+template<typename T, int Dim, access_mode M>
+struct associated_property_base<host_accessor<T, Dim, M>> {
   using type = accessor_property;
 };
 

--- a/include/hipSYCL/sycl/queue.hpp
+++ b/include/hipSYCL/sycl/queue.hpp
@@ -71,14 +71,14 @@ using queue_submission_hooks_ptr =
 namespace property::command_group {
 
 template<int Dim>
-struct hipSYCL_prefer_group_size : public detail::property{
+struct hipSYCL_prefer_group_size : public detail::cg_property{
   hipSYCL_prefer_group_size(range<Dim> r)
   : size{r} {}
 
   range<Dim> size;
 };
 
-struct hipSYCL_retarget : public detail::property{
+struct hipSYCL_retarget : public detail::cg_property{
   hipSYCL_retarget(const device& d)
   : dev{d} {}
 
@@ -90,7 +90,7 @@ struct hipSYCL_retarget : public detail::property{
 
 namespace property::queue {
 
-class in_order : public detail::property
+class in_order : public detail::queue_property
 {};
 
 }

--- a/tests/sycl/accessor.cpp
+++ b/tests/sycl/accessor.cpp
@@ -26,6 +26,8 @@
  */
 
 
+#include "hipSYCL/sycl/libkernel/accessor.hpp"
+#include "hipSYCL/sycl/access.hpp"
 #include "sycl_test_suite.hpp"
 
 BOOST_FIXTURE_TEST_SUITE(accessor_tests, reset_device_fixture)
@@ -230,6 +232,95 @@ BOOST_AUTO_TEST_CASE(nested_subscript) {
         BOOST_CHECK(host_acc3d.get_pointer()[linear_id3d] == linear_id3d);
       }
     }
+}
+
+template <class T, int Dim, cl::sycl::access_mode M, cl::sycl::target Tgt,
+          cl::sycl::access::placeholder P>
+constexpr cl::sycl::access_mode
+get_access_mode(cl::sycl::accessor<T, Dim, M, Tgt, P>) {
+  return M;
+}
+
+template <class T, int Dim, cl::sycl::access_mode M, cl::sycl::target Tgt,
+          cl::sycl::access::placeholder P>
+constexpr cl::sycl::target
+get_access_target(cl::sycl::accessor<T, Dim, M, Tgt, P>) {
+  return Tgt;
+}
+
+template <class Acc>
+void validate_accessor_deduction(Acc acc, cl::sycl::access_mode expected_mode,
+                                 cl::sycl::target expected_target) {
+  BOOST_CHECK(get_access_mode(acc) == expected_mode);
+  BOOST_CHECK(get_access_target(acc) == expected_target);
+}
+
+BOOST_AUTO_TEST_CASE(accessor_simplifications) {
+  namespace s = cl::sycl;
+  s::queue q;
+
+  s::range size{1024};
+  s::buffer<int> buff{size};
+
+  s::accessor placeholder{buff, s::read_only};
+  BOOST_CHECK(placeholder.is_placeholder());
+
+  q.submit([&](s::handler& cgh){
+    s::accessor acc1{buff, cgh, s::read_only};
+    BOOST_CHECK(!acc1.is_placeholder());
+    // Conversion accessor<int> -> accessor<const int>
+    s::accessor<const int> acc2 = s::accessor{buff, cgh, s::read_only};
+
+    s::accessor acc3{buff, cgh, s::read_only};
+    // Conversion const int -> int for read-only accessors
+    acc3 = acc2;
+    BOOST_CHECK(!acc3.is_placeholder());
+
+    // Deduction based on constness of argument
+    // First employ implicit conversion to const int buff -
+    // it is curently unclear whether it should also work
+    // on non-const buffer, and if so, how.
+    s::buffer<const int> buff2 = buff;
+    s::accessor<const int> acc4{buff2, cgh};
+    BOOST_CHECK(get_access_mode(acc4) == s::access_mode::read);
+    s::accessor<int> acc5{buff, cgh};
+    BOOST_CHECK(get_access_mode(acc5) == s::access_mode::read_write);
+
+    // Deduction Tags
+    validate_accessor_deduction(s::accessor{buff, cgh, s::read_only},
+                                s::access_mode::read, s::target::device);
+    validate_accessor_deduction(s::accessor{buff, cgh, s::read_only, s::no_init},
+                                s::access_mode::read, s::target::device);
+
+    validate_accessor_deduction(s::accessor{buff, cgh, s::read_write},
+                                s::access_mode::read_write, s::target::device);
+    validate_accessor_deduction(s::accessor{buff, cgh, s::read_write, s::no_init},
+                                s::access_mode::read_write, s::target::device);
+
+    validate_accessor_deduction(s::accessor{buff, cgh, s::write_only},
+                                s::access_mode::write, s::target::device);
+    validate_accessor_deduction(s::accessor{buff, cgh, s::write_only, s::no_init},
+                            s::access_mode::write, s::target::device);
+
+    validate_accessor_deduction(s::accessor{buff, cgh, s::read_only_host_task},
+                                s::access_mode::read, s::target::host_task);
+    validate_accessor_deduction(s::accessor{buff, cgh, s::read_only_host_task, s::no_init},
+                                s::access_mode::read, s::target::host_task);
+
+    validate_accessor_deduction(s::accessor{buff, cgh, s::read_write_host_task},
+                                s::access_mode::read_write, s::target::host_task);
+    validate_accessor_deduction(s::accessor{buff, cgh, s::read_write_host_task, s::no_init},
+                                s::access_mode::read_write, s::target::host_task);
+
+    validate_accessor_deduction(s::accessor{buff, cgh, s::write_only_host_task},
+                                s::access_mode::write, s::target::host_task);
+    validate_accessor_deduction(s::accessor{buff, cgh, s::write_only_host_task, s::no_init},
+                                s::access_mode::write, s::target::host_task);
+
+    cgh.single_task([=](){});
+  });
+
+  q.wait();
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
(cc @tomdeakin)

Initial implementation of
* Accessor simplifications, deduction guides and `no_init` property
* host_accessor (partial implementation)
* Redesigned `property_list` which was required by the new accessor interface.

Allows code patterns such as
```c++
q.submit([&](sycl::handler& cgh){
  // read-write default for non-const buffer type
  sycl::accessor acc{buff, cgh};
  // Using deduction guides and no_init property
  sycl::accessor acc2{buff, cgh, sycl::read_only, sycl::no_init};
});
sycl::host_accessor hacc{buff, sycl::read_only};
```

*Note*: This PR does not yet contain additional changes/additions to the members of accessors, such as the iterator interface.


The only thing I'm not sure about is the pattern:
```
sycl::buffer<int> buff {...};
// construct read-only accessor
sycl::accessor<const int> acc{buff};
```
I think originally the intent was to allow this pattern in order to make read-write/read-only expressible only with accessor const-ness, but I don't see how the interface in the spec allows for that, and the wording in the spec appears pretty vague to me.
The spec hardcodes that the buffer arguments to the `accessor<T>` constructors is of type `buffer<T>`. 

We would need additional `accessor(buffer<std::remove_const_t<T>>&)` constructors to make constructing `accessor<const T>` from `buffer<T>` work, which the spec does not seem to anticipate (which would also double the number of constructors because we don't have enough yet ;-) )