### PR TITLE
[SYCL 2020] Add joint_* interface for group algorithms

### DIFF
--- a/include/hipSYCL/sycl/libkernel/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/group_functions.hpp
@@ -30,6 +30,7 @@
 
 #include "backend.hpp"
 #include "group.hpp"
+#include "sub_group.hpp"
 #include <type_traits>
 
 #ifdef SYCL_DEVICE_ONLY
@@ -49,6 +50,18 @@
 
 namespace hipsycl {
 namespace sycl {
+
+template<class T>
+struct is_group : public std::false_type {};
+
+template<int Dim> 
+struct is_group<group<Dim>> : public std::true_type {};
+
+template<>
+struct is_group<sub_group> : public std::true_type {};
+
+template<class T>
+inline constexpr bool is_group_v = is_group<T>::value;
 
 // any_of
 template<typename Group, typename T, typename Predicate,
@@ -97,6 +110,81 @@ T group_inclusive_scan(Group g, V x, T init, BinaryOperation binary_op) {
   return binary_op(scan, init);
 }
 
+// SYCL 2020 final interface for InputIterator
+
+template <typename Group, typename Ptr, typename Predicate,
+          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
+HIPSYCL_KERNEL_TARGET bool joint_any_of(Group g, Ptr first, Ptr last,
+                                        Predicate pred) {
+  return detail::any_of(g, first, last, pred);
+}
+
+template <typename Group, typename Ptr, typename Predicate,
+          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
+HIPSYCL_KERNEL_TARGET bool joint_all_of(Group g, Ptr first, Ptr last,
+                                        Predicate pred) {
+  return detail::all_of(g, first, last, pred);
+}
+
+template <typename Group, typename Ptr, typename Predicate,
+          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
+HIPSYCL_KERNEL_TARGET bool joint_none_of(Group g, Ptr first, Ptr last,
+                                         Predicate pred) {
+  return detail::none_of(g, first, last, pred);
+}
+
+// *TODO*: Only make available for SYCL binary_op operators and
+// Pointers to fundamental types
+template <typename Group, typename Ptr, typename BinaryOperation,
+          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
+HIPSYCL_KERNEL_TARGET
+typename std::iterator_traits<Ptr>::value_type
+joint_reduce(Group g, Ptr first, Ptr last, BinaryOperation binary_op) {
+  return detail::reduce(g, first, last, binary_op);
+}
+
+template <typename Group, typename Ptr, typename T, typename BinaryOperation,
+          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
+HIPSYCL_KERNEL_TARGET
+T joint_reduce(Group g, Ptr first, Ptr last, T init, BinaryOperation binary_op) {
+  return detail::reduce(g, first, last, init, binary_op);
+}
+
+template <typename Group, typename InPtr, typename OutPtr,
+          typename BinaryOperation,
+          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
+HIPSYCL_KERNEL_TARGET
+OutPtr joint_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
+                            BinaryOperation binary_op) {
+  return detail::exclusive_scan(g, first, last, result, binary_op);
+}
+
+template <typename Group, typename InPtr, typename OutPtr, typename T,
+          typename BinaryOperation,
+          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
+HIPSYCL_KERNEL_TARGET
+T joint_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result, T init,
+                       BinaryOperation binary_op) {
+  return detail::exclusive_scan(g, first, last, result, init, binary_op);
+}
+
+template <typename Group, typename InPtr, typename OutPtr,
+          typename BinaryOperation,
+          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
+HIPSYCL_KERNEL_TARGET
+OutPtr joint_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
+                            BinaryOperation binary_op) {
+  return detail::inclusive_scan(g, first, last, result, binary_op);
+}
+
+template <typename Group, typename InPtr, typename OutPtr, typename T,
+          typename BinaryOperation,
+          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
+HIPSYCL_KERNEL_TARGET
+T joint_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
+                       BinaryOperation binary_op, T init) {
+  return detail::inclusive_scan(g, first, last, result, init, binary_op);
+}
 
 } // namespace sycl
 } // namespace hipsycl


### PR DESCRIPTION
Add `joint_*` name aliases for group algorithms accepting iterators. This functionality was already present, but with SYCL 2020 provisional interface withount `joint_` prefix.