### PR TITLE
Fix signature of joint_* functions due to typo in spec

### DIFF
--- a/include/hipSYCL/sycl/libkernel/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/group_functions.hpp
@@ -163,7 +163,7 @@ template <typename Group, typename InPtr, typename OutPtr, typename T,
           typename BinaryOperation,
           std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
 HIPSYCL_KERNEL_TARGET
-T joint_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result, T init,
+OutPtr joint_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result, T init,
                        BinaryOperation binary_op) {
   return detail::exclusive_scan(g, first, last, result, init, binary_op);
 }
@@ -181,7 +181,7 @@ template <typename Group, typename InPtr, typename OutPtr, typename T,
           typename BinaryOperation,
           std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
 HIPSYCL_KERNEL_TARGET
-T joint_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
+OutPtr joint_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
                        BinaryOperation binary_op, T init) {
   return detail::inclusive_scan(g, first, last, result, init, binary_op);
 }


### PR DESCRIPTION
The SYCL 2020 spec says that the joint scan functions should return data type `T`. This does not make any sense, and the description specifies that indeed a pointer should be returned. This PR fixes the interface.