### PR TITLE
Implement buffer writeback to external locations/set_final_data()

### DIFF
--- a/tests/sycl/buffer.cpp
+++ b/tests/sycl/buffer.cpp
@@ -26,6 +26,7 @@
  */
 
 
+#include "hipSYCL/sycl/access.hpp"
 #include "sycl_test_suite.hpp"
 #include <boost/test/unit_test_suite.hpp>
 
@@ -90,6 +91,32 @@ BOOST_AUTO_TEST_CASE(buffer_update_host) {
   }).wait();
 
   BOOST_CHECK(host_buf == (std::vector{0, 1, 2, 3}));
+}
+
+BOOST_AUTO_TEST_CASE(buffer_external_writeback) {
+  cl::sycl::queue q;
+
+  std::size_t size = 1024;
+  std::vector<int> host_buff(size);
+  {
+    cl::sycl::buffer<int> buff{size};
+
+    buff.set_final_data(host_buff.data());
+
+    q.submit([&](cl::sycl::handler &cgh) {
+      auto acc =
+          buff.get_access<cl::sycl::access::mode::discard_read_write>(cgh);
+
+      cgh.parallel_for<class buffer_external_writeback_test>(
+          cl::sycl::range{size}, [=](cl::sycl::id<1> idx) {
+            acc[idx.get(0)] = static_cast<int>(idx.get(0));
+          });
+    });
+  }
+
+  for(int i = 0; i < host_buff.size(); ++i) {
+    BOOST_CHECK(host_buff[i] == i);
+  }
 }
 
 


### PR DESCRIPTION
This implements the previously unimplemented buffer writeback to external locations, i.e. pointers not passed to the buffer at construction, but using the `set_final_data()` interface.