### PR TITLE
Ignore default constructed/invalid events in depends_on()

### DIFF
--- a/include/hipSYCL/sycl/handler.hpp
+++ b/include/hipSYCL/sycl/handler.hpp
@@ -116,7 +116,11 @@ public:
   }
 
   void depends_on(event e) {
-    _requirements.add_node_requirement(e._node);
+    // No need to consider default constructed events that are
+    // not bound to a node
+    if(e._node) {
+      _requirements.add_node_requirement(e._node);
+    }
   }
 
   void depends_on(const std::vector<event> &events) {

--- a/src/runtime/operations.cpp
+++ b/src/runtime/operations.cpp
@@ -71,12 +71,14 @@ void requirements_list::add_requirement(std::unique_ptr<requirement> req)
     std::vector<dag_node_ptr>{},
     std::move(req));
   
-  _reqs.push_back(node);
+  add_node_requirement(node);
 }
 
 void requirements_list::add_node_requirement(dag_node_ptr node)
 {
-  _reqs.push_back(node);
+  // Don't store invalid requirements
+  if(node)
+    _reqs.push_back(node);
 }
 
 const std::vector<dag_node_ptr>& requirements_list::get() const


### PR DESCRIPTION
Passing default constructed arguments to `depends_on()` is legal, but these events don't have an associated dag node - just ignore them to avoid having to deal with null pointers later.