### PR TITLE
Allow selecting active backends via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Supported hardware:
 * NVIDIA CUDA GPUs. Note that clang, which hipSYCL relies on, may not always support the very latest CUDA version which may sometimes impact support for *very* new hardware. See the [clang documentation](https://www.llvm.org/docs/CompileCudaWithLLVM.html) for more details.
 * AMD GPUs that are [supported by ROCm](https://github.com/RadeonOpenCompute/ROCm#hardware-support)
 
-Operating system support currently strongly focuses on Linux. On Mac, only the CPU backend is expected to work. Windows is currently not supported.
+Operating system support currently strongly focuses on Linux. On Mac, only the CPU backend is expected to work. Windows support with CPU and CUDA backends is experimental, see [Using hipSYCL on Windows](https://github.com/illuhad/hipSYCL/wiki/Using-hipSYCL-on-Windows).
 
 ## Installing and using hipSYCL
 * [Building & Installing](doc/installing.md)
@@ -98,6 +98,7 @@ When targeting a GPU, you will need to provide a target GPU architecture. The ex
 * A simple SYCL example code for testing purposes can be found [here](doc/examples.md).
 * [SYCL Extensions implemented in hipSYCL](doc/extensions.md)
 * [Macros used by hipSYCL](doc/macros.md)
+* [Environment variables supported by hipSYCL](doc/env_variables.md)
 
 
 

--- a/doc/env_variables.md
+++ b/doc/env_variables.md
@@ -1,4 +1,4 @@
 # Environment variables used by hipSYCL
 
 * `HIPSYCL_DEBUG_LEVEL` - if set, overrides the output verbosity. `0`: none, `1`: error, `2`: warning, `3`: info, `4`: verbose, default is the value of `HIPSYCL_DEBUG_LEVEL` [macro](macros.md).
-* `HIPSYCL_VISIBILITY_MASK` - can be used to activate only a subset of backends. Syntax: `backend;backend2;..`. Possible values are the same as for the `HIPSYCL_TARGETS` CMake configuration option: `omp`, `cuda`, `hip` and `spirv`. `omp` will always be active as a CPU backend is required. Device level visibility has to be set via vendor specific variables for now, including `{CUDA,HIP}_VISIBLE_DEVICES` and `ZE_AFFINITY_MASK`.
+* `HIPSYCL_VISIBILITY_MASK` - can be used to activate only a subset of backends. Syntax: `backend;backend2;..`. Possible values are `omp`, `cuda`, `hip` and `ze` (as level zero is the backend and `spirv` in `HIPSYCL_TARGETS` just the target format). `omp` will always be active as a CPU backend is required. Device level visibility has to be set via vendor specific variables for now, including `{CUDA,HIP}_VISIBLE_DEVICES` and `ZE_AFFINITY_MASK`.

--- a/doc/env_variables.md
+++ b/doc/env_variables.md
@@ -1,0 +1,4 @@
+# Environment variables used by hipSYCL
+
+* `HIPSYCL_DEBUG_LEVEL` - if set, overrides the output verbosity. `0`: none, `1`: error, `2`: warning, `3`: info, `4`: verbose, default is the value of `HIPSYCL_DEBUG_LEVEL` [macro](macros.md).
+* `HIPSYCL_VISIBILITY_MASK` - can be used to activate only a subset of backends. Syntax: `backend;backend2;..`. Possible values are the same as for the `HIPSYCL_TARGETS` CMake configuration option: `omp`, `cuda`, `hip` and `spirv`. `omp` will always be active as a CPU backend is required. Device level visibility has to be set via vendor specific variables for now, including `{CUDA,HIP}_VISIBLE_DEVICES` and `ZE_AFFINITY_MASK`.

--- a/doc/macros.md
+++ b/doc/macros.md
@@ -20,3 +20,4 @@
 
 # Configuration macros
 * `HIPSYCL_ENABLE_UNIQUE_NAME_MANGLING` - define during compilation of the hipSYCL clang plugin to force enabling unique name mangling which is a requirement for explicit mulitpass compilation. This requires a clang that supports `__builting_unique_stable_name()`, and is automatically enabled on clang 11.
+* `HIPSYCL_DEBUG_LEVEL` - sets the output verbosity. `0`: none, `1`: error, `2`: warning, `3`: info, `4`: verbose, default is warning for Release and info for Debug builds.

--- a/include/hipSYCL/runtime/settings.hpp
+++ b/include/hipSYCL/runtime/settings.hpp
@@ -45,7 +45,7 @@ enum class scheduler_type { direct };
 std::istream &operator>>(std::istream &istr, scheduler_type &out);
 std::istream &operator>>(std::istream &istr, std::vector<rt::backend_id> &out);
 
-enum class setting { debug_level, scheduler_type, active_backends };
+enum class setting { debug_level, scheduler_type, visibility_mask };
 
 template <setting S> struct setting_trait {};
 
@@ -57,7 +57,7 @@ template <setting S> struct setting_trait {};
 
 HIPSYCL_RT_MAKE_SETTING_TRAIT(setting::debug_level, "debug_level", int)
 HIPSYCL_RT_MAKE_SETTING_TRAIT(setting::scheduler_type, "rt_scheduler", scheduler_type)
-HIPSYCL_RT_MAKE_SETTING_TRAIT(setting::active_backends, "active_backends", std::vector<rt::backend_id>)
+HIPSYCL_RT_MAKE_SETTING_TRAIT(setting::visibility_mask, "visibility_mask", std::vector<rt::backend_id>)
 
 class settings
 {
@@ -77,8 +77,8 @@ public:
       return _debug_level.value();
     } else if constexpr (S == setting::scheduler_type) {
       return _scheduler_type.value();
-    } else if constexpr (S == setting::active_backends) {
-      return _active_backends.value();
+    } else if constexpr (S == setting::visibility_mask) {
+      return _visibility_mask.value();
     }
     return typename setting_trait<S>::type{};
   }
@@ -97,8 +97,8 @@ public:
     _scheduler_type =
         get_environment_variable_or_default<setting::scheduler_type>(
             scheduler_type::direct);
-    _active_backends =
-        get_environment_variable_or_default<setting::active_backends>(
+    _visibility_mask =
+        get_environment_variable_or_default<setting::visibility_mask>(
             std::vector<rt::backend_id>{});
   }
 
@@ -139,7 +139,7 @@ private:
 
   std::optional<int> _debug_level;
   std::optional<scheduler_type> _scheduler_type;
-  std::optional<std::vector<rt::backend_id>> _active_backends;
+  std::optional<std::vector<rt::backend_id>> _visibility_mask;
 };
 
 }

--- a/include/hipSYCL/runtime/settings.hpp
+++ b/include/hipSYCL/runtime/settings.hpp
@@ -28,6 +28,7 @@
 #ifndef HIPSYCL_RT_SETTINGS_HPP
 #define HIPSYCL_RT_SETTINGS_HPP
 
+#include "hipSYCL/runtime/device_id.hpp"
 #include <ios>
 #include <optional>
 #include <string>
@@ -35,22 +36,16 @@
 #include <algorithm>
 #include <sstream>
 #include <iostream>
+#include <vector>
 namespace hipsycl {
 namespace rt {
 
 enum class scheduler_type { direct };
 
-inline std::istream &operator>>(std::istream &istr, scheduler_type &out) {
-  std::string str;
-  istr >> str;
-  if (str == "direct")
-    out = scheduler_type::direct;
-  else
-    istr.setstate(std::ios_base::failbit);
-  return istr;
-}
+std::istream &operator>>(std::istream &istr, scheduler_type &out);
+std::istream &operator>>(std::istream &istr, std::vector<rt::backend_id> &out);
 
-enum class setting { debug_level, scheduler_type };
+enum class setting { debug_level, scheduler_type, active_backends };
 
 template <setting S> struct setting_trait {};
 
@@ -62,6 +57,7 @@ template <setting S> struct setting_trait {};
 
 HIPSYCL_RT_MAKE_SETTING_TRAIT(setting::debug_level, "debug_level", int)
 HIPSYCL_RT_MAKE_SETTING_TRAIT(setting::scheduler_type, "rt_scheduler", scheduler_type)
+HIPSYCL_RT_MAKE_SETTING_TRAIT(setting::active_backends, "active_backends", std::vector<rt::backend_id>)
 
 class settings
 {
@@ -81,6 +77,8 @@ public:
       return _debug_level.value();
     } else if constexpr (S == setting::scheduler_type) {
       return _scheduler_type.value();
+    } else if constexpr (S == setting::active_backends) {
+      return _active_backends.value();
     }
     return typename setting_trait<S>::type{};
   }
@@ -99,6 +97,9 @@ public:
     _scheduler_type =
         get_environment_variable_or_default<setting::scheduler_type>(
             scheduler_type::direct);
+    _active_backends =
+        get_environment_variable_or_default<setting::active_backends>(
+            std::vector<rt::backend_id>{});
   }
 
 private:
@@ -138,6 +139,7 @@ private:
 
   std::optional<int> _debug_level;
   std::optional<scheduler_type> _scheduler_type;
+  std::optional<std::vector<rt::backend_id>> _active_backends;
 };
 
 }

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(hipSYCL-rt SHARED
   dag_direct_scheduler.cpp
   dag_manager.cpp
   dag_submitted_ops.cpp
+  settings.cpp
   generic/async_worker.cpp
   hw_model/memcpy.cpp
   serialization/serialization.cpp)

--- a/src/runtime/backend.cpp
+++ b/src/runtime/backend.cpp
@@ -29,7 +29,6 @@
 #include "hipSYCL/runtime/application.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
 #include "hipSYCL/runtime/error.hpp"
-#include "hipSYCL/sycl/exception.hpp"
 #include "hipSYCL/runtime/hw_model/hw_model.hpp"
 #include "hipSYCL/runtime/hardware.hpp"
 
@@ -58,12 +57,6 @@ backend_manager::backend_manager()
     }
   }
   
-
-#ifdef HIPSYCL_RT_ENABLE_LEVEL_ZERO_BACKEND
-  HIPSYCL_DEBUG_INFO << "backend_manager: Registering Level Zero backend..." << std::endl;
-  _backends.push_back(std::make_unique<ze_backend>());
-#endif
-
   this->for_each_backend([](backend *b) {
     HIPSYCL_DEBUG_INFO << "Discovered devices from backend '" << b->get_name()
                        << "': " << std::endl;

--- a/src/runtime/backend.cpp
+++ b/src/runtime/backend.cpp
@@ -86,8 +86,8 @@ backend_manager::backend_manager()
                     return b->get_hardware_platform() == hardware_platform::cpu;
                     }))
   {
-    HIPSYCL_DEBUG_ERROR << "No CPU backend has been loaded. Things will break." << std::endl;
-    throw sycl::runtime_error{"No CPU backend has been loaded."};
+    HIPSYCL_DEBUG_ERROR << "No CPU backend has been loaded. Terminating." << std::endl;
+    std::terminate();
   }
 }
 

--- a/src/runtime/backend.cpp
+++ b/src/runtime/backend.cpp
@@ -29,8 +29,10 @@
 #include "hipSYCL/runtime/application.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
 #include "hipSYCL/runtime/error.hpp"
+#include "hipSYCL/sycl/exception.hpp"
 #include "hipSYCL/runtime/hw_model/hw_model.hpp"
 #include "hipSYCL/runtime/hardware.hpp"
+
 #include <algorithm>
 
 namespace hipsycl {
@@ -78,6 +80,15 @@ backend_manager::backend_manager()
       }
     }
   });
+
+  if(std::none_of(_backends.cbegin(), _backends.cend(), 
+                  [](const std::unique_ptr<backend>& b){
+                    return b->get_hardware_platform() == hardware_platform::cpu;
+                    }))
+  {
+    HIPSYCL_DEBUG_ERROR << "No CPU backend has been loaded. Things will break." << std::endl;
+    throw sycl::runtime_error{"No CPU backend has been loaded."};
+  }
 }
 
 backend_manager::~backend_manager()

--- a/src/runtime/backend_loader.cpp
+++ b/src/runtime/backend_loader.cpp
@@ -58,10 +58,10 @@ void* load_library(const std::string &filename)
   if(void *handle = dlopen(filename.c_str(), RTLD_NOW)) {
     return handle;
   } else {
-    HIPSYCL_DEBUG_ERROR << "backend_loader: Could not load backend plugin: "
+    HIPSYCL_DEBUG_WARNING << "backend_loader: Could not load backend plugin: "
                         << filename << std::endl;
     if (char *err = dlerror()) {
-      HIPSYCL_DEBUG_ERROR << err << std::endl;
+      HIPSYCL_DEBUG_WARNING << err << std::endl;
     }
   }
 #else
@@ -70,7 +70,7 @@ void* load_library(const std::string &filename)
   } else {
     // too lazy to use FormatMessage bs right now, so look up the error at
     // https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes
-    HIPSYCL_DEBUG_ERROR << "backend_loader: Could not load backend plugin: "
+    HIPSYCL_DEBUG_WARNING << "backend_loader: Could not load backend plugin: "
                         << filename << " with: " << GetLastError() << std::endl;
   }
 #endif
@@ -82,9 +82,9 @@ void* get_symbol_from_library(void* handle, const std::string& symbolName)
 #ifndef _WIN32
   void *symbol = dlsym(handle, symbolName.c_str());
   if(char *err = dlerror()) {
-    HIPSYCL_DEBUG_ERROR << "backend_loader: Could not find symbol name: "
+    HIPSYCL_DEBUG_WARNING << "backend_loader: Could not find symbol name: "
                         << symbolName << std::endl;
-    HIPSYCL_DEBUG_ERROR << err << std::endl;
+    HIPSYCL_DEBUG_WARNING << err << std::endl;
   } else {
     return symbol;
   }
@@ -94,7 +94,7 @@ void* get_symbol_from_library(void* handle, const std::string& symbolName)
   } else {
     // too lazy to use FormatMessage bs right now, so look up the error at
     // https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes
-    HIPSYCL_DEBUG_ERROR << "backend_loader: Could not find symbol name: "
+    HIPSYCL_DEBUG_WARNING << "backend_loader: Could not find symbol name: "
                         << symbolName << " with: " << GetLastError() << std::endl;
   }
 #endif

--- a/src/runtime/backend_loader.cpp
+++ b/src/runtime/backend_loader.cpp
@@ -176,6 +176,8 @@ bool is_plugin_active(const std::string& name)
     id = hipsycl::rt::backend_id::cuda;
   } else if(name == "hip") {
     id = hipsycl::rt::backend_id::hip;
+  } else if(name == "spriv") {
+    id = hipsycl::rt::backend_id::level_zero;
   }
   return std::find(backends_active.cbegin(), backends_active.cend(), id) != backends_active.cend();
 }

--- a/src/runtime/backend_loader.cpp
+++ b/src/runtime/backend_loader.cpp
@@ -176,7 +176,7 @@ bool is_plugin_active(const std::string& name)
     id = hipsycl::rt::backend_id::cuda;
   } else if(name == "hip") {
     id = hipsycl::rt::backend_id::hip;
-  } else if(name == "spriv") {
+  } else if(name == "ze") {
     id = hipsycl::rt::backend_id::level_zero;
   }
   return std::find(backends_active.cbegin(), backends_active.cend(), id) != backends_active.cend();

--- a/src/runtime/backend_loader.cpp
+++ b/src/runtime/backend_loader.cpp
@@ -165,7 +165,7 @@ std::vector<std::filesystem::path> get_plugin_search_paths()
 
 bool is_plugin_active(const std::string& name)
 {
-  auto backends_active = hipsycl::rt::application::get_settings().get<hipsycl::rt::setting::active_backends>();
+  auto backends_active = hipsycl::rt::application::get_settings().get<hipsycl::rt::setting::visibility_mask>();
   if(backends_active.empty())
     return true;
   if(name == "omp") // we always need a cpu backend

--- a/src/runtime/settings.cpp
+++ b/src/runtime/settings.cpp
@@ -26,47 +26,48 @@
  */
 
 #include "hipSYCL/common/debug.hpp"
+#include "hipSYCL/runtime/settings.hpp"
 
 namespace hipsycl {
-  namespace rt {
+namespace rt {
 
-    std::istream &operator>>(std::istream &istr, scheduler_type &out) {
-      std::string str;
-      istr >> str;
-      if (str == "direct")
-        out = scheduler_type::direct;
-      else
-        istr.setstate(std::ios_base::failbit);
-      return istr;
-    }
+std::istream &operator>>(std::istream &istr, scheduler_type &out) {
+  std::string str;
+  istr >> str;
+  if (str == "direct")
+    out = scheduler_type::direct;
+  else
+    istr.setstate(std::ios_base::failbit);
+  return istr;
+}
 
-    std::istream &operator>>(std::istream &istr, std::vector<rt::backend_id> &out) {
-      std::string str;
-      istr >> str;
-      // have to copy, as otherweise might be interpreted as failing, although everything is fine.
-      std::istringstream istream{str};
+std::istream &operator>>(std::istream &istr, std::vector<rt::backend_id> &out) {
+  std::string str;
+  istr >> str;
+  // have to copy, as otherweise might be interpreted as failing, although everything is fine.
+  std::istringstream istream{str};
 
-      size_t offset = 0;
-      std::string name;
-      while(std::getline(istream, name, ';')) {
-        if(name.empty())
-          continue;
-        std::transform(name.cbegin(), name.cend(), name.begin(), ::tolower);
+  size_t offset = 0;
+  std::string name;
+  while(std::getline(istream, name, ';')) {
+    if(name.empty())
+      continue;
+    std::transform(name.cbegin(), name.cend(), name.begin(), ::tolower);
 
-        if (name == "cuda" || name == "nvidia") {
-          out.push_back(rt::backend_id::cuda);
-        } else if (name == "rocm" || name == "amd" || name == "hip") {
-          out.push_back(rt::backend_id::hip);
-        } else if(name == "host" || "cpu" || "hipcpu" || "omp") {
-          // looking for this, even though we have to allow it always.
-          out.push_back(rt::backend_id::omp);
-        } else {
-          istr.setstate(std::ios_base::failbit);
-          HIPSYCL_DEBUG_WARNING << "'" << name << "' is not a known backend name." << std::endl;
-          break;
-        }
-      }
-      return istr;
+    if (name == "cuda") {
+      out.push_back(rt::backend_id::cuda);
+    } else if (name == "hip") {
+      out.push_back(rt::backend_id::hip);
+    } else if("omp") {
+      // looking for this, even though we have to allow it always.
+      out.push_back(rt::backend_id::omp);
+    } else {
+      istr.setstate(std::ios_base::failbit);
+      HIPSYCL_DEBUG_WARNING << "'" << name << "' is not a known backend name." << std::endl;
+      break;
     }
   }
+  return istr;
+}
+}
 }

--- a/src/runtime/settings.cpp
+++ b/src/runtime/settings.cpp
@@ -58,6 +58,8 @@ std::istream &operator>>(std::istream &istr, std::vector<rt::backend_id> &out) {
       out.push_back(rt::backend_id::cuda);
     } else if (name == "hip") {
       out.push_back(rt::backend_id::hip);
+    } else if (name == "spirv") {
+      out.push_back(rt::backend_id::level_zero);
     } else if("omp") {
       // looking for this, even though we have to allow it always.
       out.push_back(rt::backend_id::omp);

--- a/src/runtime/settings.cpp
+++ b/src/runtime/settings.cpp
@@ -58,7 +58,7 @@ std::istream &operator>>(std::istream &istr, std::vector<rt::backend_id> &out) {
       out.push_back(rt::backend_id::cuda);
     } else if (name == "hip") {
       out.push_back(rt::backend_id::hip);
-    } else if (name == "spirv") {
+    } else if (name == "ze") {
       out.push_back(rt::backend_id::level_zero);
     } else if("omp") {
       // looking for this, even though we have to allow it always.

--- a/src/runtime/settings.cpp
+++ b/src/runtime/settings.cpp
@@ -1,0 +1,72 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2021 Aksel Alpay and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "hipSYCL/common/debug.hpp"
+
+namespace hipsycl {
+  namespace rt {
+
+    std::istream &operator>>(std::istream &istr, scheduler_type &out) {
+      std::string str;
+      istr >> str;
+      if (str == "direct")
+        out = scheduler_type::direct;
+      else
+        istr.setstate(std::ios_base::failbit);
+      return istr;
+    }
+
+    std::istream &operator>>(std::istream &istr, std::vector<rt::backend_id> &out) {
+      std::string str;
+      istr >> str;
+      // have to copy, as otherweise might be interpreted as failing, although everything is fine.
+      std::istringstream istream{str};
+
+      size_t offset = 0;
+      std::string name;
+      while(std::getline(istream, name, ';')) {
+        if(name.empty())
+          continue;
+        std::transform(name.cbegin(), name.cend(), name.begin(), ::tolower);
+
+        if (name == "cuda" || name == "nvidia") {
+          out.push_back(rt::backend_id::cuda);
+        } else if (name == "rocm" || name == "amd" || name == "hip") {
+          out.push_back(rt::backend_id::hip);
+        } else if(name == "host" || "cpu" || "hipcpu" || "omp") {
+          // looking for this, even though we have to allow it always.
+          out.push_back(rt::backend_id::omp);
+        } else {
+          istr.setstate(std::ios_base::failbit);
+          HIPSYCL_DEBUG_WARNING << "'" << name << "' is not a known backend name." << std::endl;
+          break;
+        }
+      }
+      return istr;
+    }
+  }
+}


### PR DESCRIPTION
Usage is as similar to `HIPSYCL_TARGETS` as possible: e.g. `HIPSYCL_ACTIVE_BACKENDS="omp;cuda"` would activate OpenMP and CUDA. No device selection is implemented here, so don't use `:` ..
OpenMP will always be active, as we need it as a host device.

Also, only output warnings, if a backend library failed to load as that might be the case if no CUDA driver is installed, e.g.. An error is output and an exception is thrown if no CPU backend was loaded, as we always need one.