### PR TITLE
Fix ambiguity of atomic accessor operator[].

### DIFF
--- a/include/hipSYCL/sycl/libkernel/accessor.hpp
+++ b/include/hipSYCL/sycl/libkernel/accessor.hpp
@@ -537,7 +537,8 @@ public:
   }
 
   template<int D = dimensions,
-            std::enable_if_t<(D > 0), bool> = true>
+            access::mode M = accessmode,
+            std::enable_if_t<(D > 0) && (M != access::mode::atomic), bool> = true>
   HIPSYCL_UNIVERSAL_TARGET
   reference operator[](id<dimensions> index) const
   {
@@ -545,7 +546,8 @@ public:
   }
 
   template<int D = dimensions,
-            std::enable_if_t<(D == 1), bool> = true>
+            access::mode M = accessmode,
+            std::enable_if_t<(D == 1) && (M != access::mode::atomic), bool> = true>
   HIPSYCL_UNIVERSAL_TARGET
   reference operator[](size_t index) const
   {

--- a/include/hipSYCL/sycl/libkernel/atomic.hpp
+++ b/include/hipSYCL/sycl/libkernel/atomic.hpp
@@ -52,8 +52,8 @@ enum class memory_order : int
     std::enable_if_t<std::is_integral<template_param>::value>* = nullptr
 #endif
 
-/// \todo Atomics are only partially implemented. In particular, there's no
-/// code path on host at the moment!
+/// \todo Atomics are only partially implemented.
+/// In particular, load / store are unimplemented on GPU.
 template <typename T, access::address_space addressSpace =
           access::address_space::global_space>
 class atomic {

--- a/tests/sycl/accessor.cpp
+++ b/tests/sycl/accessor.cpp
@@ -161,6 +161,17 @@ BOOST_AUTO_TEST_CASE(accessor_api) {
     cgh.single_task<class accessor_api_device_accessors>([](){});
   });
 
+  queue.submit([&](s::handler& cgh) {
+    run_test([&](auto buf, auto... args) {
+      return buf.template get_access<s::access::mode::atomic>(cgh, args...);
+    });
+    // mostly compilation test
+    auto atomicAcc = buf_a.template get_access<s::access::mode::atomic>(cgh);
+    cgh.single_task<class accessor_api_atomic_device_accessors>([atomicAcc](){
+      atomicAcc[0].exchange(0);
+    });
+  });
+
   // Test local accessors
   queue.submit([&](s::handler& cgh) {
     s::accessor<int, 1, s::access::mode::read_write, s::access::target::local> acc_a(32, cgh);

--- a/tests/sycl/accessor.cpp
+++ b/tests/sycl/accessor.cpp
@@ -171,11 +171,13 @@ BOOST_AUTO_TEST_CASE(accessor_api) {
     auto atomicAcc3D = buf_d.template get_access<s::access::mode::atomic>(cgh);
     auto localAtomic = s::accessor<int, 1, s::access::mode::atomic, s::access::target::local>{s::range<1>{2}, cgh};
     auto localAtomic3D = s::accessor<int, 3, s::access::mode::atomic, s::access::target::local>{s::range<3>{2, 2, 2}, cgh};
-    cgh.single_task<class accessor_api_atomic_device_accessors>([=](){
-      atomicAcc[0].exchange(0);
-      atomicAcc3D[0][1][0].exchange(0);
-      localAtomic[0].exchange(0);
-      localAtomic3D[0][1][0].exchange(0);
+    cgh.parallel_for<class accessor_api_atomic_device_accessors>(
+        cl::sycl::nd_range<1>{2, 2},
+        [=](cl::sycl::nd_item<1> item) {
+          atomicAcc[0].exchange(0);
+          atomicAcc3D[0][1][0].exchange(0);
+          localAtomic[0].exchange(0);
+          localAtomic3D[0][1][0].exchange(0);
     });
   });
 

--- a/tests/sycl/accessor.cpp
+++ b/tests/sycl/accessor.cpp
@@ -121,6 +121,7 @@ BOOST_AUTO_TEST_CASE(accessor_api) {
 
   s::buffer<int, 1> buf_a(32);
   s::buffer<int, 1> buf_b(32);
+  s::buffer<int, 3> buf_d(s::range<3>{4, 4, 4});
   auto buf_c = buf_a;
 
   const auto run_test = [&](auto get_access) {
@@ -167,8 +168,14 @@ BOOST_AUTO_TEST_CASE(accessor_api) {
     });
     // mostly compilation test
     auto atomicAcc = buf_a.template get_access<s::access::mode::atomic>(cgh);
-    cgh.single_task<class accessor_api_atomic_device_accessors>([atomicAcc](){
+    auto atomicAcc3D = buf_d.template get_access<s::access::mode::atomic>(cgh);
+    auto localAtomic = s::accessor<int, 1, s::access::mode::atomic, s::access::target::local>{s::range<1>{2}, cgh};
+    auto localAtomic3D = s::accessor<int, 3, s::access::mode::atomic, s::access::target::local>{s::range<3>{2, 2, 2}, cgh};
+    cgh.single_task<class accessor_api_atomic_device_accessors>([=](){
       atomicAcc[0].exchange(0);
+      atomicAcc3D[0][1][0].exchange(0);
+      localAtomic[0].exchange(0);
+      localAtomic3D[0][1][0].exchange(0);
     });
   });
 


### PR DESCRIPTION
As reported in https://github.com/illuhad/hipSYCL/issues/380#issuecomment-803572968 [1], the `operator[]` is ambiguous, if using an atomic accessor.