### PR TITLE
Add missing logical_vector_op_result<char> specialization.

### DIFF
--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -151,6 +151,9 @@ template<class T>
 struct logical_vector_op_result
 {};
 
+template<> struct logical_vector_op_result<char>
+{ using type = int8_t; };
+
 template<> struct logical_vector_op_result<int8_t>
 { using type = int8_t; };
 


### PR DESCRIPTION
Which is not a typedef of `int8_t` for some reason (https://godbolt.org/z/fGEqcr).
Reported by @zjin-lcf in https://github.com/illuhad/hipSYCL/issues/380#issuecomment-803572968 [4]