### PR TITLE
[HIP] Use new HIP launch API and define __HIP_ROCclr__

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,7 @@ if(NOT ROCM_CXX_FLAGS)
   # __float128 even though it is not supported for CUDA / HIP,
   # see https://bugs.llvm.org/show_bug.cgi?id=47559.
 
-  set(ROCM_CXX_FLAGS "-isystem ${CLANG_INCLUDE_PATH} -U__FLOAT128__ -U__SIZEOF_FLOAT128__ -I$HIPSYCL_ROCM_PATH/include -I$HIPSYCL_ROCM_PATH/include --rocm-device-lib-path=$HIPSYCL_ROCM_PATH/amdgcn/bitcode --rocm-path=$HIPSYCL_ROCM_PATH" CACHE STRING "Arguments passed to compiler to compile SYCL applications with ROCm")
+  set(ROCM_CXX_FLAGS "-isystem ${CLANG_INCLUDE_PATH} -U__FLOAT128__ -U__SIZEOF_FLOAT128__ -I$HIPSYCL_ROCM_PATH/include -I$HIPSYCL_ROCM_PATH/include --rocm-device-lib-path=$HIPSYCL_ROCM_PATH/amdgcn/bitcode --rocm-path=$HIPSYCL_ROCM_PATH -fhip-new-launch-api -D__HIP_ROCclr__" CACHE STRING "Arguments passed to compiler to compile SYCL applications with ROCm")
 endif()
 
 if(NOT CUDA_CXX_FLAGS)	

--- a/include/hipSYCL/glue/generic/hiplike/clang.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/clang.hpp
@@ -48,11 +48,7 @@ extern "C" unsigned __cudaPushCallConfiguration(dim3 gridDim, dim3 blockDim,
                                                 size_t sharedMem,
                                                 void *stream);
 
-extern "C" unsigned __cudaPopCallConfiguration();
-
 #else // compiling for __HIP__
-
-hipError_t hipConfigureCall(dim3 gridDim, dim3 blockDim, size_t sharedMem, hipStream_t stream);
 
 extern "C" hipError_t __hipPushCallConfiguration(dim3 gridDim, dim3 blockDim,
                                                  size_t sharedMem,

--- a/include/hipSYCL/glue/generic/hiplike/clang.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/clang.hpp
@@ -54,6 +54,10 @@ extern "C" unsigned __cudaPopCallConfiguration();
 
 hipError_t hipConfigureCall(dim3 gridDim, dim3 blockDim, size_t sharedMem, hipStream_t stream);
 
+extern "C" hipError_t __hipPushCallConfiguration(dim3 gridDim, dim3 blockDim,
+                                                 size_t sharedMem,
+                                                 hipStream_t stream);
+
 #endif // __CUDA__
 
 #ifdef __CUDA__
@@ -72,7 +76,7 @@ static inline void __hipsycl_push_kernel_call(dim3 grid, dim3 block, size_t shar
 
 static inline void __hipsycl_push_kernel_call(dim3 grid, dim3 block, size_t shared, hipStream_t stream)
 {
-  hipError_t err = hipConfigureCall(grid, block, shared, stream);
+  hipError_t err = __hipPushCallConfiguration(grid, block, shared, stream);
   assert(err == hipSuccess);
 }
 

--- a/include/hipSYCL/runtime/hip/hip_target.hpp
+++ b/include/hipSYCL/runtime/hip/hip_target.hpp
@@ -42,6 +42,7 @@
 #elif defined(HIPSYCL_RT_HIP_TARGET_ROCM)
 #ifndef __HIP_PLATFORM_HCC__
 #define __HIP_PLATFORM_HCC__
+#define __HIP_ROCclr__ (1)
 #endif
 #include <hip/hip_runtime.h>
 #elif defined(HIPSYCL_RT_HIP_TARGET_HIPCPU)


### PR DESCRIPTION
* Use new HIP push call configuration kernel launch API
* Compile with `__HIP_ROCclr__`

Aligns `syclcc` compilation with current `hipcc` compilation.

Draft because first needs AMD runtime testing