### PR TITLE
Implement queue::wait() using node group properties, optimize wait() in dag_submitted_ops

### DIFF
--- a/include/hipSYCL/runtime/dag_submitted_ops.hpp
+++ b/include/hipSYCL/runtime/dag_submitted_ops.hpp
@@ -44,7 +44,7 @@ public:
   void update_with_submission(dag_node_ptr single_node);
   
   void wait_for_all();
-
+  void wait_for_group(std::size_t node_group);
 private:
   std::vector<dag_node_ptr> _ops;
   std::mutex _lock;

--- a/include/hipSYCL/runtime/hints.hpp
+++ b/include/hipSYCL/runtime/hints.hpp
@@ -49,6 +49,7 @@ enum class execution_hint_type
   // mark a DAG node as bound to a particular device for execution
   bind_to_device,
   prefer_execution_lane,
+  node_group
 };
 
 class execution_hint
@@ -105,6 +106,22 @@ private:
   std::size_t _lane_id;
 };
 
+class node_group : public execution_hint
+{
+public:
+  static constexpr execution_hint_type type =
+      execution_hint_type::node_group;
+
+  node_group(std::size_t group_id)
+      : execution_hint{execution_hint_type::node_group}, _group_id{group_id} {}
+
+  std::size_t get_id() const {
+    return _group_id;
+  }
+private:
+  std::size_t _group_id;
+};
+
 } // hints
 
 
@@ -122,7 +139,10 @@ public:
   template<class Hint_type>
   Hint_type* get_hint() const
   {
-    return cast<Hint_type>(get_hint(Hint_type::type));
+    execution_hint* ptr = get_hint(Hint_type::type);
+    if(ptr)
+      return cast<Hint_type>(ptr);
+    return nullptr;
   }
 
   template <class Hint_type> bool has_hint() const {

--- a/include/hipSYCL/sycl/info/queue.hpp
+++ b/include/hipSYCL/sycl/info/queue.hpp
@@ -44,12 +44,14 @@ enum class queue : int
 {
   context,
   device,
-  reference_count
+  reference_count,
+  hipSYCL_node_group
 };
 
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(queue, queue::context, sycl::context);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(queue, queue::device, sycl::device);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(queue, queue::reference_count, detail::u_int);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(queue, queue::hipSYCL_node_group, std::size_t);
 
 }
 }

--- a/src/runtime/dag_manager.cpp
+++ b/src/runtime/dag_manager.cpp
@@ -138,6 +138,10 @@ void dag_manager::wait()
   this->_submitted_ops.wait_for_all();
 }
 
+void dag_manager::wait(std::size_t node_group_id) {
+  this->_submitted_ops.wait_for_group(node_group_id);
+}
+
 void dag_manager::register_submitted_ops(dag_node_ptr node) {
   this->_submitted_ops.update_with_submission(node);
 }

--- a/src/runtime/dag_submitted_ops.cpp
+++ b/src/runtime/dag_submitted_ops.cpp
@@ -81,9 +81,10 @@ void dag_submitted_ops::wait_for_group(std::size_t node_group) {
   // 1.) In dag_node::wait(), when the event turns complete the first time,
   // recursively mark all requirements as complete as well.
   // 2.) Reverse the iteration order here - this will cause us to handle the
-  // newest nodes first, which in general will depend on backend nodes.
-  // Since nodes cache their state when they complete, the wait() on most of
-  // the older nodes will become trivial and not require backend interaction.
+  // newest nodes first, which usually will depend on older nodes.
+  // Since nodes cache their state when they complete and because of 1), 
+  // the wait() on most of the older nodes will become trivial and not 
+  // require any backend interaction at all.
   for(dag_node_ptr node : current_ops) {
     assert(node->is_submitted());
     if (hints::node_group *g =

--- a/src/runtime/dag_submitted_ops.cpp
+++ b/src/runtime/dag_submitted_ops.cpp
@@ -29,6 +29,7 @@
 
 #include "hipSYCL/runtime/dag_submitted_ops.hpp"
 #include "hipSYCL/runtime/dag_node.hpp"
+#include "hipSYCL/runtime/hints.hpp"
 
 namespace hipsycl {
 namespace rt {
@@ -54,11 +55,46 @@ void dag_submitted_ops::update_with_submission(dag_node_ptr single_node) {
 }
 
 void dag_submitted_ops::wait_for_all() {
-  std::lock_guard lock{_lock};
-
-  for(dag_node_ptr node : _ops) {
+  std::vector<dag_node_ptr> current_ops;
+  {
+    std::lock_guard lock{_lock};
+    current_ops = _ops;
+  }
+  
+  for(dag_node_ptr node : current_ops) {
     assert(node->is_submitted());
     node->wait();
+  }
+}
+
+void dag_submitted_ops::wait_for_group(std::size_t node_group) {
+  HIPSYCL_DEBUG_INFO << "dag_submitted_ops: Waiting for node group "
+                     << node_group << std::endl;
+  
+  std::vector<dag_node_ptr> current_ops;
+  {
+    std::lock_guard lock{_lock};  
+    current_ops = _ops;
+  }
+
+  // TODO We can optimize this process by
+  // 1.) In dag_node::wait(), when the event turns complete the first time,
+  // recursively mark all requirements as complete as well.
+  // 2.) Reverse the iteration order here - this will cause us to handle the
+  // newest nodes first, which in general will depend on backend nodes.
+  // Since nodes cache their state when they complete, the wait() on most of
+  // the older nodes will become trivial and not require backend interaction.
+  for(dag_node_ptr node : current_ops) {
+    assert(node->is_submitted());
+    if (hints::node_group *g =
+            node->get_execution_hints().get_hint<hints::node_group>()) {
+      if (g->get_id() == node_group) {
+        HIPSYCL_DEBUG_INFO
+            << "dag_submitted_ops: Waiting for node group; current node: "
+            << node.get() << std::endl;
+        node->wait();
+      }
+    }
   }
 }
 

--- a/src/runtime/hints.cpp
+++ b/src/runtime/hints.cpp
@@ -61,16 +61,8 @@ void execution_hints::add_hint(execution_hint_ptr hint)
 
 void execution_hints::overwrite_with(const execution_hints& other)
 {
-  for(const auto& hint : other._hints)
-  {
-    execution_hint_type type = hint->get_hint_type();
-    auto it = std::find_if(_hints.begin(),_hints.end(),
-      [type](execution_hint_ptr h){
-      return type == h->get_hint_type();
-    });
-
-    if(it != _hints.end())
-      *it = hint;
+  for(const auto& hint : other._hints){
+    this->overwrite_with(hint);
   }
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,7 +71,8 @@ add_executable(sycl_tests
   sycl/sub_group.cpp
   sycl/sycl_test_suite.cpp 
   sycl/usm.cpp
-  sycl/vec.cpp)
+  sycl/vec.cpp
+  sycl/queue.cpp)
 
 target_include_directories(sycl_tests PRIVATE ${Boost_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(sycl_tests PRIVATE ${Boost_LIBRARIES})


### PR DESCRIPTION
* Introduce `node_group` execution hint in runtime
* Implement `queue::wait()` by generating a unique node group id for each queue, at submit attaching `node_group(id)` execution hint to nodes, and then only waiting for nodes with this node group id in `wait()`
* Optimize `dag_submitted_ops::wait()` by not locking until all waits have completed, instead only lock until a copy of the current node list could be created.
* Fix minor bugs in `execution_hints`

**This can boost performance considerably when working with multiple queues** because `queue::wait()` now waits selectively for nodes and also doesn't block runtime operations.