### PR TITLE
Add missing `group_barrier`s at the end of host scans.

### DIFF
--- a/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
@@ -511,8 +511,8 @@ T group_exclusive_scan(Group g, V x, T init, BinaryOperation binary_op) {
   }
 
   group_barrier(g);
-
   T tmp = scratch[lid];
+  group_barrier(g);
 
   return tmp;
 }
@@ -539,8 +539,8 @@ T group_inclusive_scan(Group g, T x, BinaryOperation binary_op) {
   }
 
   group_barrier(g);
-
   T tmp = scratch[lid];
+  group_barrier(g);
 
   return tmp;
 }


### PR DESCRIPTION
This is required as the scratch memory might be reused with a different access pattern.