### PR TITLE
Fix initialization of accessors used inside reduction objects

### DIFF
--- a/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
@@ -581,7 +581,7 @@ public:
             typename... Reductions>
   void bind(sycl::id<Dim> offset, sycl::range<Dim> global_range,
             sycl::range<Dim> local_range, std::size_t dynamic_local_memory,
-            Kernel kernel, Reductions... reductions) {
+            Kernel k, Reductions... reductions) {
     
     this->_type = type;
 
@@ -602,11 +602,11 @@ public:
                          << effective_local_range.size() << std::endl;
     }
 
-    _invoker = [=](rt::dag_node* node) {
+    _invoker = [=](rt::dag_node* node) mutable {
       assert(_queue != nullptr);
-      Kernel k = kernel;
+      
       static_cast<rt::kernel_operation *>(node->get_operation())
-          ->initialize_embedded_pointers(k);
+          ->initialize_embedded_pointers(k, reductions...);
 
       // Simple cases first: Kernel types that don't support
       // reductions

--- a/include/hipSYCL/glue/omp/omp_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/omp/omp_kernel_launcher.hpp
@@ -354,7 +354,7 @@ public:
             typename... Reductions>
   void bind(sycl::id<Dim> offset, sycl::range<Dim> global_range,
             sycl::range<Dim> local_range, std::size_t dynamic_local_memory,
-            Kernel kernel_body, Reductions... reductions) {
+            Kernel k, Reductions... reductions) {
 
     this->_type = type;
 
@@ -377,10 +377,10 @@ public:
     }
 #endif
     
-    this->_invoker = [=](rt::dag_node* node) {
-      Kernel k = kernel_body;
+    this->_invoker = [=] (rt::dag_node* node) mutable {
+
       static_cast<rt::kernel_operation *>(node->get_operation())
-          ->initialize_embedded_pointers(k);
+          ->initialize_embedded_pointers(k, reductions...);
 
       bool is_with_offset = false;
       for (std::size_t i = 0; i < Dim; ++i)

--- a/include/hipSYCL/glue/ze/ze_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/ze/ze_kernel_launcher.hpp
@@ -193,14 +193,14 @@ public:
             typename... Reductions>
   void bind(sycl::id<Dim> offset, sycl::range<Dim> global_range,
             sycl::range<Dim> local_range, std::size_t dynamic_local_memory,
-            Kernel kernel_body, Reductions... reductions) {
+            Kernel k, Reductions... reductions) {
 
     this->_type = type;
     
-    this->_invoker = [=](rt::dag_node* node) {
-      Kernel k = kernel_body;
+    this->_invoker = [=](rt::dag_node* node) mutable {
+      
       static_cast<rt::kernel_operation *>(node->get_operation())
-          ->initialize_embedded_pointers(k);
+          ->initialize_embedded_pointers(k, reductions...);
 
       sycl::range<Dim> effective_local_range = local_range;
       if constexpr (type == rt::kernel_type::basic_parallel_for) {


### PR DESCRIPTION
Since PR #499, it is required that all objects that are used inside kernels and might contain accessors are scanned explicitly for accessors such that they can be initialized. Previously this was not done for `reduction` objects, causing reduction failure if the reduction object was initialized with an accessor because the accessor was not initialized. This PR fixes this.

Also adds test case for accessor reductions based on a similar code pattern as mentioned in #527.

Resolves #527 