### PR TITLE
Implement basic vendor_id 

### DIFF
--- a/include/hipSYCL/runtime/hardware.hpp
+++ b/include/hipSYCL/runtime/hardware.hpp
@@ -95,7 +95,9 @@ enum class device_uint_property {
   local_mem_size,
 
   printf_buffer_size,
-  partition_max_sub_devices
+  partition_max_sub_devices,
+
+  vendor_id
 };
 
 enum class device_uint_list_property {

--- a/include/hipSYCL/sycl/device.hpp
+++ b/include/hipSYCL/sycl/device.hpp
@@ -234,7 +234,10 @@ HIPSYCL_SPECIALIZE_GET_INFO(device, device_type) {
 
 /// \todo Return different id for amd and nvidia
 HIPSYCL_SPECIALIZE_GET_INFO(device, vendor_id)
-{ return 1; }
+{ 
+  return get_rt_device()->get_property(
+      rt::device_uint_property::vendor_id); 
+}
 
 HIPSYCL_SPECIALIZE_GET_INFO(device, max_compute_units)
 {

--- a/src/runtime/cuda/cuda_hardware_manager.cpp
+++ b/src/runtime/cuda/cuda_hardware_manager.cpp
@@ -295,6 +295,9 @@ cuda_hardware_context::get_property(device_uint_property prop) const {
   case device_uint_property::partition_max_sub_devices:
     return 0;
     break;
+  case device_uint_property::vendor_id:
+    return 4318;
+    break;
   }
   assert(false && "Invalid device property");
   std::terminate();

--- a/src/runtime/hip/hip_hardware_manager.cpp
+++ b/src/runtime/hip/hip_hardware_manager.cpp
@@ -304,6 +304,9 @@ hip_hardware_context::get_property(device_uint_property prop) const {
   case device_uint_property::partition_max_sub_devices:
     return 0;
     break;
+  case device_uint_property::vendor_id:
+    return 1022;
+    break;
   }
   assert(false && "Invalid device property");
   std::terminate();

--- a/src/runtime/omp/omp_hardware_manager.cpp
+++ b/src/runtime/omp/omp_hardware_manager.cpp
@@ -237,6 +237,9 @@ omp_hardware_context::get_property(device_uint_property prop) const {
   case device_uint_property::partition_max_sub_devices:
     return 0;
     break;
+  case device_uint_property::vendor_id:
+    return std::numeric_limits<std::size_t>::max();
+    break;
   }
   assert(false && "Invalid device property");
   return 0;

--- a/src/runtime/ze/ze_hardware_manager.cpp
+++ b/src/runtime/ze/ze_hardware_manager.cpp
@@ -416,6 +416,9 @@ std::size_t ze_hardware_context::get_property(device_uint_property prop) const {
   case device_uint_property::partition_max_sub_devices:
     return 0;
     break;
+  case device_uint_property::vendor_id:
+    return _props.vendorId;
+    break;
   }
   assert(false && "Invalid device property");
   std::terminate();


### PR DESCRIPTION
The vendor id, as in dpc++, is assumed to be the PCI address vendor-prefix.
It is furthermore assumed that the HIP backend runs on AMD, and the CUDA backend runs on NVIDIA devices.