### PR TITLE
[SYCL 2020] Initial implementation of device aspect API

### DIFF
--- a/include/hipSYCL/runtime/hardware.hpp
+++ b/include/hipSYCL/runtime/hardware.hpp
@@ -44,7 +44,13 @@ enum class device_support_aspect {
   global_mem_cache_read_only,
   global_mem_cache_write_only,
   emulated_local_memory,
-  sub_group_independent_forward_progress
+  sub_group_independent_forward_progress,
+  usm_device_allocations,
+  usm_host_allocations,
+  usm_atomic_host_allocations,
+  usm_shared_allocations,
+  usm_atomic_shared_allocations,
+  usm_system_allocations
 };
 
 enum class device_uint_property {

--- a/include/hipSYCL/sycl/aspect.hpp
+++ b/include/hipSYCL/sycl/aspect.hpp
@@ -1,0 +1,86 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2021 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HIPSYCL_SYCL_ASPECT_HPP
+#define HIPSYCL_SYCL_ASPECT_HPP
+
+#include <type_traits>
+
+namespace hipsycl {
+namespace sycl {
+
+enum class aspect {
+  cpu,
+  gpu,
+  accelerator,
+  custom,
+  emulated,
+  host_debuggable,
+  fp16,
+  fp64,
+  atomic64,
+  image,
+  online_compiler,
+  online_linker,
+  queue_profiling,
+  usm_device_allocations,
+  usm_host_allocations,
+  usm_atomic_host_allocations,
+  usm_shared_allocations,
+  usm_atomic_shared_allocations,
+  usm_system_allocations
+};
+
+template <aspect Aspect> struct any_device_has : public std::true_type {};
+template <aspect Aspect> struct all_devices_have : public std::false_type {};
+
+// We always have a CPU device that is host debuggable
+template <>
+struct any_device_has<aspect::host_debuggable> : public std::true_type {};
+
+// Images are unsupported
+template <>
+struct any_device_has<aspect::image> : public std::false_type {};
+
+// All backends in hipSYCL must support at least explicit USM by design
+template <>
+struct all_devices_have<aspect::usm_device_allocations>
+    : public std::true_type {};
+template <>
+struct all_devices_have<aspect::usm_atomic_host_allocations>
+    : public std::true_type {};
+
+template <aspect A>
+inline constexpr bool any_device_has_v = any_device_has<A>::value;
+
+template <aspect A>
+inline constexpr bool all_devices_have_v = all_devices_have<A>::value;
+
+}
+}
+
+#endif

--- a/include/hipSYCL/sycl/device.hpp
+++ b/include/hipSYCL/sycl/device.hpp
@@ -34,6 +34,7 @@
 #include <type_traits>
 
 #include "types.hpp"
+#include "aspect.hpp"
 #include "info/info.hpp"
 #include "libkernel/backend.hpp"
 #include "exception.hpp"
@@ -87,19 +88,65 @@ public:
 
   bool is_cpu() const
   {
-    return _device_id.get_full_backend_descriptor().hw_platform ==
-           rt::hardware_platform::cpu;
+    return get_rt_device()->is_cpu();
   }
 
   bool is_gpu() const
   {
-    return rt::application::get_backend(_device_id.get_backend())
-        .get_hardware_manager()
-        ->get_device(_device_id.get_id())
-        ->is_gpu();
+    return get_rt_device()->is_gpu();
   }
 
   bool is_accelerator() const { return !is_cpu(); }
+
+  bool has(aspect asp) const {
+    if(asp == aspect::cpu) {
+      return is_cpu();
+    } else if(asp == aspect::gpu) {
+      return is_gpu();
+    } else if(asp == aspect::accelerator) {
+      return is_accelerator();
+    } else if(asp == aspect::custom) {
+      return false;
+    } else if(asp == aspect::emulated) {
+      return false;
+    } else if(asp == aspect::host_debuggable) {
+      return _device_id.get_full_backend_descriptor().hw_platform ==
+           rt::hardware_platform::cpu;
+    } else if(asp == aspect::fp16) {
+      // fp16 is only partially supported in hipSYCL
+      return false;
+    } else if(asp == aspect::fp64) {
+      return true;
+    } else if(asp == aspect::atomic64) {
+      return true;
+    } else if(asp == aspect::image) {
+      return get_rt_device()->has(
+      rt::device_support_aspect::sub_group_independent_forward_progress);
+    } else if(asp == aspect::online_compiler) {
+      return false;
+    } else if(asp == aspect::online_linker) {
+      return false;
+    } else if(asp == aspect::queue_profiling) {
+      return false;
+    } else if(asp == aspect::usm_device_allocations) {
+      return get_rt_device()->has(
+          rt::device_support_aspect::usm_device_allocations);
+    } else if(asp == aspect::usm_host_allocations) {
+      return get_rt_device()->has(
+          rt::device_support_aspect::usm_host_allocations);
+    } else if(asp == aspect::usm_atomic_host_allocations) {
+      return get_rt_device()->has(
+          rt::device_support_aspect::usm_atomic_host_allocations);
+    } else if(asp == aspect::usm_shared_allocations) {
+      return get_rt_device()->has(
+          rt::device_support_aspect::usm_shared_allocations);
+    } else if(asp == aspect::usm_system_allocations) {
+      return get_rt_device()->has(
+          rt::device_support_aspect::usm_system_allocations);
+    }
+
+    return false;
+  }
 
   bool hipSYCL_has_compiled_kernels() const {
 #if defined(__HIPSYCL_ENABLE_OMPHOST_TARGET__)
@@ -582,6 +629,39 @@ HIPSYCL_SPECIALIZE_GET_INFO(device, version) {
 
 HIPSYCL_SPECIALIZE_GET_INFO(device, opencl_c_version)
 { return "1.2 HIPSYCL"; }
+
+HIPSYCL_SPECIALIZE_GET_INFO(device, aspects)
+{
+  std::array aspects = {aspect::cpu,
+                        aspect::gpu,
+                        aspect::accelerator,
+                        aspect::custom,
+                        aspect::emulated,
+                        aspect::host_debuggable,
+                        aspect::fp16,
+                        aspect::fp64,
+                        aspect::atomic64,
+                        aspect::image,
+                        aspect::online_compiler,
+                        aspect::online_linker,
+                        aspect::queue_profiling,
+                        aspect::usm_device_allocations,
+                        aspect::usm_host_allocations,
+                        aspect::usm_atomic_host_allocations,
+                        aspect::usm_shared_allocations,
+                        aspect::usm_atomic_shared_allocations,
+                        aspect::usm_system_allocations};
+
+  std::vector<aspect> result;
+  
+  for(auto asp : aspects) {
+    if(this->has(asp)){
+      result.push_back(asp);
+    }
+  }
+
+  return result;
+}
 
 HIPSYCL_SPECIALIZE_GET_INFO(device, extensions)
 {

--- a/include/hipSYCL/sycl/info/device.hpp
+++ b/include/hipSYCL/sycl/info/device.hpp
@@ -31,8 +31,10 @@
 
 #include <cstddef>
 
+#include "hipSYCL/sycl/aspect.hpp"
 #include "param_traits.hpp"
 #include "../types.hpp"
+#include "../aspect.hpp"
 
 namespace hipsycl {
 namespace sycl {
@@ -113,6 +115,7 @@ enum class device : int {
   profile,
   version,
   opencl_c_version,
+  aspects,
   extensions,
   printf_buffer_size,
   preferred_interop_user_sync,
@@ -252,6 +255,7 @@ HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::driver_version, string_class);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::profile, string_class);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::version, string_class);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::opencl_c_version, string_class);
+HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::aspects, std::vector<aspect>);
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::extensions, std::vector<string_class>);
 
 HIPSYCL_PARAM_TRAIT_RETURN_VALUE(device, device::printf_buffer_size, size_t);

--- a/include/hipSYCL/sycl/platform.hpp
+++ b/include/hipSYCL/sycl/platform.hpp
@@ -102,6 +102,16 @@ public:
                .hw_platform == rt::hardware_platform::cpu;
   }
 
+  /// Returns true if all devices in this platform have the
+  /// specified aspect
+  bool has(aspect asp) const {
+    auto devs = get_devices();
+    for(const device& d : devs) {
+      if(!d.has(asp))
+        return false;
+    }
+    return true;
+  }
 
   static std::vector<platform> get_platforms() {
     std::vector<platform> result;

--- a/src/runtime/cuda/cuda_hardware_manager.cpp
+++ b/src/runtime/cuda/cuda_hardware_manager.cpp
@@ -158,6 +158,26 @@ bool cuda_hardware_context::has(device_support_aspect aspect) const {
   case device_support_aspect::sub_group_independent_forward_progress:
     return true;
     break;
+  case device_support_aspect::usm_device_allocations:
+    return true;
+    break;
+  case device_support_aspect::usm_host_allocations:
+    return true;
+    break;
+  case device_support_aspect::usm_atomic_host_allocations:
+    // TODO actually query this
+    return false;
+    break;
+  case device_support_aspect::usm_shared_allocations:
+    return true;
+    break;
+  case device_support_aspect::usm_atomic_shared_allocations:
+    // TODO actually query this
+    return false;
+    break;
+  case device_support_aspect::usm_system_allocations:
+    return false;
+    break;
   }
   assert(false && "Unknown device aspect");
   std::terminate();

--- a/src/runtime/hip/hip_hardware_manager.cpp
+++ b/src/runtime/hip/hip_hardware_manager.cpp
@@ -167,6 +167,26 @@ bool hip_hardware_context::has(device_support_aspect aspect) const {
   case device_support_aspect::sub_group_independent_forward_progress:
     return true;
     break;
+  case device_support_aspect::usm_device_allocations:
+    return true;
+    break;
+  case device_support_aspect::usm_host_allocations:
+    return true;
+    break;
+  case device_support_aspect::usm_atomic_host_allocations:
+    // TODO actually query this
+    return false;
+    break;
+  case device_support_aspect::usm_shared_allocations:
+    return true;
+    break;
+  case device_support_aspect::usm_atomic_shared_allocations:
+    // TODO actually query this
+    return false;
+    break;
+  case device_support_aspect::usm_system_allocations:
+    return false;
+    break;
   }
   assert(false && "Unknown device aspect");
   std::terminate();

--- a/src/runtime/omp/omp_hardware_manager.cpp
+++ b/src/runtime/omp/omp_hardware_manager.cpp
@@ -100,6 +100,24 @@ bool omp_hardware_context::has(device_support_aspect aspect) const {
   case device_support_aspect::sub_group_independent_forward_progress:
     return false;
     break;
+  case device_support_aspect::usm_device_allocations:
+    return true;
+    break;
+  case device_support_aspect::usm_host_allocations:
+    return true;
+    break;
+  case device_support_aspect::usm_atomic_host_allocations:
+    return true;
+    break;
+  case device_support_aspect::usm_shared_allocations:
+    return true;
+    break;
+  case device_support_aspect::usm_atomic_shared_allocations:
+    return true;
+    break;
+  case device_support_aspect::usm_system_allocations:
+    return true;
+    break;
   }
   assert(false && "Unknown device aspect");
   return false;

--- a/src/runtime/ze/ze_hardware_manager.cpp
+++ b/src/runtime/ze/ze_hardware_manager.cpp
@@ -273,6 +273,26 @@ bool ze_hardware_context::has(device_support_aspect aspect) const {
   case device_support_aspect::sub_group_independent_forward_progress:
     return true;
     break;
+  case device_support_aspect::usm_device_allocations:
+    return true;
+    break;
+  case device_support_aspect::usm_host_allocations:
+    return true;
+    break;
+  case device_support_aspect::usm_atomic_host_allocations:
+    // TODO actually query this
+    return false;
+    break;
+  case device_support_aspect::usm_shared_allocations:
+    return true;
+    break;
+  case device_support_aspect::usm_atomic_shared_allocations:
+    // TODO actually query this
+    return false;
+    break;
+  case device_support_aspect::usm_system_allocations:
+    return false;
+    break;
   }
   assert(false && "Unknown device aspect");
   std::terminate();


### PR DESCRIPTION
This adds the initial SYCL 2020 aspect API to query device properties. In particular this allows querying USM support.