### PR TITLE
usm_allocator copy constructor cannot access private members

### DIFF
--- a/include/hipSYCL/sycl/usm.hpp
+++ b/include/hipSYCL/sycl/usm.hpp
@@ -331,6 +331,8 @@ public:
   }
 
 private:
+  template <class U, usm::alloc AllocKindU, size_t AlignmentU>
+  friend class usm_allocator;
   context _ctx;
   device _dev;
 };


### PR DESCRIPTION
Fixes bug https://github.com/illuhad/hipSYCL/issues/538