### PR TITLE
added shuffle algorithm equivalents

### DIFF
--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/warp_shuffle.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/warp_shuffle.hpp
@@ -71,6 +71,11 @@ __device__
 T shuffle_down_impl(T x, int offset) {
   return apply_on_data(x, [offset](int data) { return __shfl_down(data, offset); });
 }
+template<typename T>
+__device__
+T shuffle_xor_impl(T x, int lane_mask) {
+  return apply_on_data(x, [lane_mask](int data) { return __shfl_xor(data, lane_mask); });
+}
 
 // dpp sharing instruction abstraction based on rocPRIM
 // the dpp_ctrl can be found in the GCN3 ISA manual
@@ -148,6 +153,11 @@ template<typename T>
 __device__
 T shuffle_down_impl(T x, int offset) {
   return apply_on_data(x, [offset](int data) { return __shfl_down_sync(AllMask, data, offset); });
+}
+template<typename T>
+__device__
+T shuffle_xor_impl(T x, int lane_mask) {
+  return apply_on_data(x, [lane_mask](int data) { return __shfl_xor_sync(AllMask, data, lane_mask); });
 }
 
 #endif // HIPSYCL_PLATFORM_CUDA

--- a/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
@@ -552,11 +552,11 @@ T group_inclusive_scan(sub_group g, T x, BinaryOperation binary_op) {
 }
 
 // shift_left
-template <typename Group, typename T>
+template<typename Group, typename T>
 T shift_group_left(Group g, T x, typename Group::linear_id_type delta = 1) {
-  T *          scratch = static_cast<T *>(g.get_local_memory_ptr());
+  T *scratch = static_cast<T *>(g.get_local_memory_ptr());
 
-  typename Group::linear_id_type lid = g.get_local_linear_id();
+  typename Group::linear_id_type lid        = g.get_local_linear_id();
   typename Group::linear_id_type target_lid = lid + delta;
 
   scratch[lid] = x;
@@ -571,17 +571,17 @@ T shift_group_left(Group g, T x, typename Group::linear_id_type delta = 1) {
   return x;
 }
 
-template <typename T>
+template<typename T>
 T shift_group_left(sub_group g, T x, typename sub_group::linear_id_type delta = 1) {
   return x;
 }
 
 // shift_right
-template <typename Group, typename T>
+template<typename Group, typename T>
 T shift_group_right(Group g, T x, typename Group::linear_id_type delta = 1) {
-  T *          scratch = static_cast<T *>(g.get_local_memory_ptr());
+  T *scratch = static_cast<T *>(g.get_local_memory_ptr());
 
-  typename Group::linear_id_type lid = g.get_local_linear_id();
+  typename Group::linear_id_type lid        = g.get_local_linear_id();
   typename Group::linear_id_type target_lid = lid - delta;
 
   scratch[lid] = x;
@@ -597,17 +597,17 @@ T shift_group_right(Group g, T x, typename Group::linear_id_type delta = 1) {
   return x;
 }
 
-template <typename T>
+template<typename T>
 T shift_group_right(sub_group g, T x, typename sub_group::linear_id_type delta = 1) {
   return x;
 }
 
 // permute_group_by_xor
-template <typename Group, typename T>
+template<typename Group, typename T>
 T permute_group_by_xor(Group g, T x, typename Group::linear_id_type mask) {
-  T *          scratch = static_cast<T *>(g.get_local_memory_ptr());
+  T *scratch = static_cast<T *>(g.get_local_memory_ptr());
 
-  typename Group::linear_id_type lid = g.get_local_linear_id();
+  typename Group::linear_id_type lid        = g.get_local_linear_id();
   typename Group::linear_id_type target_lid = lid ^ mask;
 
   scratch[lid] = x;
@@ -624,18 +624,19 @@ T permute_group_by_xor(Group g, T x, typename Group::linear_id_type mask) {
 }
 
 // permute_group_by_xor
-template <typename T>
+template<typename T>
 T permute_group_by_xor(sub_group g, T x, typename sub_group::linear_id_type mask) {
   return x;
 }
 
 // select_from_group
-template <typename Group, typename T>
+template<typename Group, typename T>
 T select_from_group(Group g, T x, typename Group::id_type remote_local_id) {
-  T *          scratch = static_cast<T *>(g.get_local_memory_ptr());
+  T *scratch = static_cast<T *>(g.get_local_memory_ptr());
 
   typename Group::linear_id_type lid = g.get_local_linear_id();
-  typename Group::linear_id_type target_lid = detail::linear_id<g.dimensions>::get(remote_local_id, g.get_local_range());
+  typename Group::linear_id_type target_lid =
+      detail::linear_id<g.dimensions>::get(remote_local_id, g.get_local_range());
 
   scratch[lid] = x;
   group_barrier(g);
@@ -650,7 +651,7 @@ T select_from_group(Group g, T x, typename Group::id_type remote_local_id) {
   return x;
 }
 
-template <typename T>
+template<typename T>
 T select_from_group(sub_group g, T x, typename sub_group::id_type remote_local_id) {
   return x;
 }

--- a/tests/sycl/group_functions/group_functions.hpp
+++ b/tests/sycl/group_functions/group_functions.hpp
@@ -261,6 +261,17 @@ void check_binary_reduce(std::vector<T> buffer, size_t local_size, size_t global
   }
 }
 
+inline size_t compute_subgroup_size(int i, size_t local_size) {
+  size_t warp_start = static_cast<int>((i % local_size) / warpSize) * warpSize;
+  return (warpSize < (local_size - warp_start)) ? warpSize : (local_size - warp_start);
+}
+
+inline bool last_in_subgroup(int i, size_t local_size) {
+  size_t index_in_work_group = i % local_size;
+  size_t warp_size = compute_subgroup_size(i, local_size);
+  return ((index_in_work_group % warpSize) + 1  == warp_size);
+}
+
 } // namespace detail
 
 template<int N, int M, typename T>

--- a/tests/sycl/group_functions/group_functions.hpp
+++ b/tests/sycl/group_functions/group_functions.hpp
@@ -261,19 +261,6 @@ void check_binary_reduce(std::vector<T> buffer, size_t local_size, size_t global
   }
 }
 
-#if defined(HIPSYCL_PLATFORM_CUDA) || defined(HIPSYCL_PLATFORM_HIP)
-inline size_t compute_subgroup_size(int i, size_t local_size) {
-  size_t warp_start = static_cast<int>((i % local_size) / warpSize) * warpSize;
-  return (warpSize < (local_size - warp_start)) ? warpSize : (local_size - warp_start);
-}
-
-inline bool last_in_subgroup(int i, size_t local_size) {
-  size_t index_in_work_group = i % local_size;
-  size_t warp_size = compute_subgroup_size(i, local_size);
-  return ((index_in_work_group % warpSize) + 1  == warp_size);
-}
-#endif
-
 } // namespace detail
 
 template<int N, int M, typename T>

--- a/tests/sycl/group_functions/group_functions.hpp
+++ b/tests/sycl/group_functions/group_functions.hpp
@@ -261,6 +261,7 @@ void check_binary_reduce(std::vector<T> buffer, size_t local_size, size_t global
   }
 }
 
+#if defined(HIPSYCL_PLATFORM_CUDA) || defined(HIPSYCL_PLATFORM_HIP)
 inline size_t compute_subgroup_size(int i, size_t local_size) {
   size_t warp_start = static_cast<int>((i % local_size) / warpSize) * warpSize;
   return (warpSize < (local_size - warp_start)) ? warpSize : (local_size - warp_start);
@@ -271,6 +272,7 @@ inline bool last_in_subgroup(int i, size_t local_size) {
   size_t warp_size = compute_subgroup_size(i, local_size);
   return ((index_in_work_group % warpSize) + 1  == warp_size);
 }
+#endif
 
 } // namespace detail
 

--- a/tests/sycl/group_functions/group_functions_misc.cpp
+++ b/tests/sycl/group_functions/group_functions_misc.cpp
@@ -460,7 +460,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(subgroup_shuffle_like, T, test_types) {
                      detail::get_offset<T>(global_size, 1);
 
         // output only defined if target is in group
-        if (i % warpSize + 1 == warpSize)
+        if (detail::last_in_subgroup(i, local_size))
           continue;
 
         T computed = vIn[i];
@@ -468,7 +468,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(subgroup_shuffle_like, T, test_types) {
         BOOST_TEST(detail::compare_type(expected, computed),
                    detail::type_to_string(computed)
                        << " at position " << i << " instead of "
-                       << detail::type_to_string(expected) << " for case: sub_group, shift left");
+                       << detail::type_to_string(expected) << " for case: sub_group, shift left, local size: " << local_size);
 
         if (!detail::compare_type(expected, computed))
           break;
@@ -488,11 +488,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(subgroup_shuffle_like, T, test_types) {
                                         const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
+        size_t warp_size = detail::compute_subgroup_size(i, local_size);
         T expected = detail::initialize_type<T>(i - 1) +
                      detail::get_offset<T>(global_size, 1);
 
         // output only defined if target is in group
-        if (i % warpSize == 0)
+        if ((i % local_size) % warp_size == 0)
           continue;
 
         T computed = vIn[i];
@@ -500,7 +501,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(subgroup_shuffle_like, T, test_types) {
         BOOST_TEST(detail::compare_type(expected, computed),
                    detail::type_to_string(computed)
                        << " at position " << i << " instead of "
-                       << detail::type_to_string(expected) << " for case: sub_group, shift right");
+                       << detail::type_to_string(expected) << " for case: sub_group, shift right, local size: " << local_size);
 
         if (!detail::compare_type(expected, computed))
           break;
@@ -532,7 +533,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(subgroup_shuffle_like, T, test_types) {
         BOOST_TEST(detail::compare_type(expected, computed),
                    detail::type_to_string(computed)
                        << " at position " << i << " instead of "
-                       << detail::type_to_string(expected) << " for case: sub_group, permute xor");
+                       << detail::type_to_string(expected) << " for case: sub_group, permute xor, local size: " << local_size);
 
         if (!detail::compare_type(expected, computed))
           break;
@@ -552,7 +553,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(subgroup_shuffle_like, T, test_types) {
                                         const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       for (size_t i = 0; i < vIn.size(); ++i) {
-        T expected = detail::initialize_type<T>(static_cast<int>(i / warpSize) * warpSize) +
+        T expected = detail::initialize_type<T>(static_cast<int>((i % local_size) / warpSize) * warpSize + (static_cast<int>(i / local_size) * local_size)) +
                      detail::get_offset<T>(global_size, 1);
 
         T computed = vIn[i];
@@ -560,7 +561,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(subgroup_shuffle_like, T, test_types) {
         BOOST_TEST(detail::compare_type(expected, computed),
                    detail::type_to_string(computed)
                        << " at position " << i << " instead of "
-                       << detail::type_to_string(expected) << " for case: sub_group, select");
+                       << detail::type_to_string(expected) << " for case: sub_group, select, local size: " << local_size);
 
         if (!detail::compare_type(expected, computed))
           break;

--- a/tests/sycl/group_functions/group_functions_misc.cpp
+++ b/tests/sycl/group_functions/group_functions_misc.cpp
@@ -293,6 +293,286 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_broadcast, T, test_types) {
   }
 }
 #endif
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(group_shuffle_like, T, test_types) {
+  const size_t elements_per_thread = 1;
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
+    for (size_t i = 0; i < v.size(); ++i)
+      v[i] = detail::initialize_type<T>(i) + detail::get_offset<T>(global_size);
+  };
+  {
+    const auto tested_function = [=](auto acc, size_t global_linear_id,
+                                     sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::shift_group_left(g, local_value, 1);
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      for (size_t i = 0; i < vIn.size(); ++i) {
+        T expected = detail::initialize_type<T>(i + 1) +
+                     detail::get_offset<T>(global_size, 1);
+
+        // output only defined if target is in group
+        if (static_cast<int>((i + 1) / local_size) + 1 > 1)
+          continue;
+
+        T computed = vIn[i];
+
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: group, shift left");
+
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
+  }
+
+  {
+    const auto tested_function = [=](auto acc, size_t global_linear_id,
+                                     sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::shift_group_right(g, local_value, 1);
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      for (size_t i = 0; i < vIn.size(); ++i) {
+        T expected = detail::initialize_type<T>(i - 1) +
+                     detail::get_offset<T>(global_size, 1);
+
+        // output only defined if target is in group
+        if (i % local_size == 0)
+          continue;
+
+        T computed = vIn[i];
+
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: group, shift right");
+
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
+  }
+
+  {
+    const auto tested_function = [=](auto acc, size_t global_linear_id,
+                                     sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::permute_group_by_xor(g, local_value, 1);
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      for (size_t i = 0; i < vIn.size(); ++i) {
+        T expected = detail::initialize_type<T>(i ^ 1) +
+                     detail::get_offset<T>(global_size, 1);
+
+        // output only defined if target is in group
+        if (static_cast<int>((i + 1) / local_size) + 1 > 1)
+          continue;
+
+        T computed = vIn[i];
+
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: group, permute xor");
+
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
+  }
+
+  {
+    const auto tested_function = [=](auto acc, size_t global_linear_id,
+                                     sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::select_from_group(g, local_value, sycl::id<g.dimensions>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      for (size_t i = 0; i < vIn.size(); ++i) {
+        T expected = detail::initialize_type<T>(static_cast<int>(i / local_size) * local_size) +
+                     detail::get_offset<T>(global_size, 1);
+
+        T computed = vIn[i];
+
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: group, select");
+
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
+
+    test_nd_group_function_2d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
+  }
+}
+
+#if defined(HIPSYCL_PLATFORM_CUDA) || defined(HIPSYCL_PLATFORM_HIP)
+BOOST_AUTO_TEST_CASE_TEMPLATE(subgroup_shuffle_like, T, test_types) {
+  const size_t elements_per_thread = 1;
+  const auto   data_generator      = [](std::vector<T> &v, size_t local_size,
+                                 size_t global_size) {
+    for (size_t i = 0; i < v.size(); ++i)
+      v[i] = detail::initialize_type<T>(i) + detail::get_offset<T>(global_size);
+  };
+
+  {
+    const auto tested_function = [=](auto acc, size_t global_linear_id,
+                                     sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::shift_group_left(sg, local_value, 1);
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      for (size_t i = 0; i < vIn.size(); ++i) {
+        T expected = detail::initialize_type<T>(i + 1) +
+                     detail::get_offset<T>(global_size, 1);
+
+        // output only defined if target is in group
+        if (i % warpSize + 1 == warpSize)
+          continue;
+
+        T computed = vIn[i];
+
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: sub_group, shift left");
+
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
+  }
+
+  {
+    const auto tested_function = [=](auto acc, size_t global_linear_id,
+                                     sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::shift_group_right(sg, local_value, 1);
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      for (size_t i = 0; i < vIn.size(); ++i) {
+        T expected = detail::initialize_type<T>(i - 1) +
+                     detail::get_offset<T>(global_size, 1);
+
+        // output only defined if target is in group
+        if (i % warpSize == 0)
+          continue;
+
+        T computed = vIn[i];
+
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: sub_group, shift right");
+
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
+  }
+
+  {
+    const auto tested_function = [=](auto acc, size_t global_linear_id,
+                                     sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::permute_group_by_xor(sg, local_value, 1);
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      for (size_t i = 0; i < vIn.size(); ++i) {
+        T expected = detail::initialize_type<T>(i ^ 1) +
+                     detail::get_offset<T>(global_size, 1);
+
+        // output only defined if target is in group
+        if (static_cast<int>((i + 1) / local_size) + 1 > 1)
+          continue;
+
+        T computed = vIn[i];
+
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: sub_group, permute xor");
+
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
+  }
+
+  {
+    const auto tested_function = [=](auto acc, size_t global_linear_id,
+                                     sycl::sub_group sg, auto g, T local_value) {
+      acc[global_linear_id] = sycl::select_from_group(sg, local_value, sycl::id<1>());
+    };
+    const auto validation_function = [](const std::vector<T> &vIn,
+                                        const std::vector<T> &vOrig, size_t local_size,
+                                        size_t global_size) {
+      for (size_t i = 0; i < vIn.size(); ++i) {
+        T expected = detail::initialize_type<T>(static_cast<int>(i / warpSize) * warpSize) +
+                     detail::get_offset<T>(global_size, 1);
+
+        T computed = vIn[i];
+
+        BOOST_TEST(detail::compare_type(expected, computed),
+                   detail::type_to_string(computed)
+                       << " at position " << i << " instead of "
+                       << detail::type_to_string(expected) << " for case: sub_group, select");
+
+        if (!detail::compare_type(expected, computed))
+          break;
+      }
+    };
+
+    test_nd_group_function_1d<__LINE__, T>(elements_per_thread, data_generator,
+                                           tested_function, validation_function);
+  }
+}
+#endif
+
 BOOST_AUTO_TEST_SUITE_END()
 
 #endif

--- a/tests/sycl/group_functions/group_functions_misc.cpp
+++ b/tests/sycl/group_functions/group_functions_misc.cpp
@@ -461,8 +461,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(subgroup_shuffle_like, T, test_types) {
                                         const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       for (size_t i = 0; i < global_size / local_size; ++i) {
-        for (size_t j = 0; j < (local_size / warpSize - 1) / warpSize; ++i) {
-          for (size_t k = 0; j < warpSize; ++i) {
+        for (size_t j = 0; j < (local_size + warpSize - 1) / warpSize; ++j) {
+          for (size_t k = 0; k < warpSize; ++k) {
             size_t local_index  = j * warpSize + k;
             size_t global_index = i * local_size + local_index;
 
@@ -476,17 +476,17 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(subgroup_shuffle_like, T, test_types) {
                 k == warpSize - 1) // not defined for last work item
               continue;
 
-            T computed = vIn[i];
+            T computed = vIn[global_index];
 
             BOOST_TEST(detail::compare_type(expected, computed),
                        detail::type_to_string(computed)
-                           << " at position " << i << " instead of "
+                           << " at position " << global_index << " instead of "
                            << detail::type_to_string(expected)
                            << " for case: sub_group, shift left, local size: "
                            << local_size);
 
             if (!detail::compare_type(expected, computed))
-              break;
+              return;
           }
         }
       }
@@ -505,8 +505,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(subgroup_shuffle_like, T, test_types) {
                                         const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       for (size_t i = 0; i < global_size / local_size; ++i) {
-        for (size_t j = 0; j < (local_size / warpSize - 1) / warpSize; ++i) {
-          for (size_t k = 0; j < warpSize; ++i) {
+        for (size_t j = 0; j < (local_size + warpSize - 1) / warpSize; ++j) {
+          for (size_t k = 0; k < warpSize; ++k) {
             size_t local_index  = j * warpSize + k;
             size_t global_index = i * local_size + local_index;
 
@@ -519,17 +519,17 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(subgroup_shuffle_like, T, test_types) {
             if (k == 0) // not defined for first work item
               continue;
 
-            T computed = vIn[i];
+            T computed = vIn[global_index];
 
             BOOST_TEST(detail::compare_type(expected, computed),
                        detail::type_to_string(computed)
-                           << " at position " << i << " instead of "
+                           << " at position " << global_index << " instead of "
                            << detail::type_to_string(expected)
                            << " for case: sub_group, shift right, local size: "
                            << local_size);
 
             if (!detail::compare_type(expected, computed))
-              break;
+              return;
           }
         }
       }
@@ -548,26 +548,26 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(subgroup_shuffle_like, T, test_types) {
                                         const std::vector<T> &vOrig, size_t local_size,
                                         size_t global_size) {
       for (size_t i = 0; i < global_size / local_size; ++i) {
-        for (size_t j = 0; j < (local_size / warpSize - 1) / warpSize; ++i) {
-          for (size_t k = 0; j < warpSize; ++i) {
+        for (size_t j = 0; j < (local_size + warpSize - 1) / warpSize; ++j) {
+          for (size_t k = 0; k < warpSize; ++k) {
             size_t local_index  = j * warpSize + k;
             size_t global_index = i * local_size + local_index;
 
             if (local_index >= local_size) // keep to work group size
               break;
 
-            T expected = detail::initialize_type<T>(global_index ^ 1) +
+            T expected = detail::initialize_type<T>(i*local_size + (local_index ^ 1)) +
                          detail::get_offset<T>(global_size, 1);
 
-            if ((local_index ^ 1) >= local_size - 1 ||
+            if ((local_index ^ 1) >= local_size ||
                 (k ^ 1) >= warpSize) // only defined if target is in subgroup
               continue;
 
-            T computed = vIn[i];
+            T computed = vIn[global_index];
 
             BOOST_TEST(detail::compare_type(expected, computed),
                        detail::type_to_string(computed)
-                           << " at position " << i << " instead of "
+                           << " at position " << global_index << " instead of "
                            << detail::type_to_string(expected)
                            << " for case: sub_group, permute xor, local size: "
                            << local_size);
@@ -592,8 +592,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(subgroup_shuffle_like, T, test_types) {
                                       const std::vector<T> &vOrig, size_t local_size,
                                       size_t global_size) {
       for (size_t i = 0; i < global_size / local_size; ++i) {
-        for (size_t j = 0; j < (local_size / warpSize - 1) / warpSize; ++i) {
-          for (size_t k = 0; j < warpSize; ++i) {
+        for (size_t j = 0; j < (local_size + warpSize - 1) / warpSize; ++j) {
+          for (size_t k = 0; k < warpSize; ++k) {
             size_t local_index  = j * warpSize + k;
             size_t global_index = i * local_size + local_index;
 
@@ -603,17 +603,17 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(subgroup_shuffle_like, T, test_types) {
             T expected = detail::initialize_type<T>(i*local_size + j*warpSize) +
                          detail::get_offset<T>(global_size, 1);
 
-            T computed = vIn[i];
+            T computed = vIn[global_index];
 
             BOOST_TEST(detail::compare_type(expected, computed),
                        detail::type_to_string(computed)
-                           << " at position " << i << " instead of "
+                           << " at position " << global_index << " instead of "
                            << detail::type_to_string(expected)
                            << " for case: sub_group, select, local size: "
                            << local_size);
 
             if (!detail::compare_type(expected, computed))
-              break;
+              return;
           }
         }
       }


### PR DESCRIPTION
contains algorithms and tests for:
- shift_left
- shift_right
- permute
- select

The functions on work-groups need enough local memory for 1024 elements, the subgroup versions use the appropriately shuffle instructions.