### PR TITLE
Don't override explicit __host__ and __device__ attributes

### DIFF
--- a/include/hipSYCL/compiler/Frontend.hpp
+++ b/include/hipSYCL/compiler/Frontend.hpp
@@ -359,10 +359,11 @@ public:
     {
       // Strictly speaking, setting these attributes is not even necessary!
       // It's only important that the kernel has the right attribute.
-      if (!F->hasAttr<clang::CUDAHostAttr>())
+      if (!F->hasAttr<clang::CUDAHostAttr>() && !F->hasAttr<clang::CUDADeviceAttr>())
+      {
         F->addAttr(clang::CUDAHostAttr::CreateImplicit(Instance.getASTContext()));
-      if (!F->hasAttr<clang::CUDADeviceAttr>())
         F->addAttr(clang::CUDADeviceAttr::CreateImplicit(Instance.getASTContext()));
+      }
     }
 
     for(auto F : MarkedKernels)
@@ -387,10 +388,11 @@ public:
         HIPSYCL_DEBUG_INFO << "AST processing: Marking function as __host__ __device__: "
                            << RD->getQualifiedNameAsString() << std::endl;
         markAsHostDevice(RD);
-        if (!RD->hasAttr<clang::CUDAHostAttr>())
+        if (!RD->hasAttr<clang::CUDAHostAttr>() && !RD->hasAttr<clang::CUDADeviceAttr>())
+        {
           RD->addAttr(clang::CUDAHostAttr::CreateImplicit(Instance.getASTContext()));
-        if (!RD->hasAttr<clang::CUDADeviceAttr>())
           RD->addAttr(clang::CUDADeviceAttr::CreateImplicit(Instance.getASTContext()));
+        }
       }
     }
   }


### PR DESCRIPTION
Previously, hipSYCL internally marked all functions called from a kernel
as `__host__ __device__`. This leads to unintended side-effects when the
code has separately defined `__host__ foo()` and `__device__ foo()`
functions.

With this patch, we only add CUDAHostAttr and CUDADeviceAttr if neither of
them is specified. If at least one is explicitly present, we respect the
user code and leave the attributes as-is.

Closes #550