### PR TITLE
Update archlinux docker image path

### DIFF
--- a/devops/repos/common/init.sh
+++ b/devops/repos/common/init.sh
@@ -26,7 +26,7 @@ declare -A cleanup_dep=( ["archlinux-rolling"]='pacman -Rsn --noconfirm $(pacman
                        )
 
 
-declare -A image_base=( ["archlinux-rolling"]="docker://archlinux/base" \
+declare -A image_base=( ["archlinux-rolling"]="docker://archlinux:base" \
                          ["centos-7"]="docker://centos:centos7" \
                          ["centos-8"]="docker://centos:centos8" \
                          ["ubuntu-18.04"]="docker://ubuntu:18.04" \

--- a/devops/repos/definitions-packaging-container/base-archlinux-rolling.def
+++ b/devops/repos/definitions-packaging-container/base-archlinux-rolling.def
@@ -1,5 +1,5 @@
 BootStrap: docker
-From: archlinux/base
+From: archlinux:base
 
 %setup
 

--- a/devops/repos/definitions-test-containers/archlinux-rolling.def
+++ b/devops/repos/definitions-test-containers/archlinux-rolling.def
@@ -1,5 +1,5 @@
 BootStrap: docker
-From: archlinux/base
+From: archlinux:base
 
 %setup
 

--- a/install/scripts/base-definitions/archlinux-rolling.def
+++ b/install/scripts/base-definitions/archlinux-rolling.def
@@ -1,5 +1,5 @@
 BootStrap: docker
-From: archlinux/base
+From: archlinux:base
 
 %setup
 


### PR DESCRIPTION
It turns out that the arch linux docker images are not available at archllinux/base anymore. This causes problems in our CI pipeline. This PR updates the install script so that they look for archlinux in the new path archlinux:base