### PR TITLE
Add script for publishing singularity containers

### DIFF
--- a/devops/repos/README.md
+++ b/devops/repos/README.md
@@ -42,6 +42,7 @@ bash update_repo.sh centos-7 deploy                        # deploy packages
 bash update_repo.sh centos-7 test 00                       # run build, add_repo install_dep run_test for the test
 bash update_repo.sh centos-7 test 00 build                 # build testing container
 bash update_repo.sh centos-7 test 00 add_repo               # Add hipSYCL repo to testing container
+bash update_repo.sh centos-7 pub_cont                      # Publish containers 
 ```
 
 

--- a/devops/repos/publish_test_container.sh
+++ b/devops/repos/publish_test_container.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -o xtrace
+set -e
+distro=$1
+cd $HIPSYCL_PKG_DEVOPS_DIR
+commit_hash=`git rev-parse --short HEAD`
+cd -
+date=`date -u +"%Y%m%d"`
+supported_backends="omp"
+HIPSYCL_PKG_PUBLIC_CONTAINER_DIR=${HIPSYCL_PKG_PUBLIC_CONTAINER_DIR:-/data/repos/singularity/}
+HIPSYCL_TEST_DIR=${HIPSYCL_TEST_DIR:-"/data/hipsyclbot/test-dir"}
+mkdir -p $HIPSYCL_PKG_PUBLIC_CONTAINER_DIR
+for backend in `ls $HIPSYCL_TEST_DIR | sed -n -e "s/^.*$distro-//p"`; do
+    if [[ ${backend:0:1} = "1" ]]; then supported_backends="${supported_backends}-rocm"; fi
+    if [[ ${backend:1:2} = "1" ]]; then supported_backends="${supported_backends}-cuda"; fi
+    container_name_base="hipSYCL-${HIPSYCL_PKG_TYPE}-${distro}-${supported_backends}"
+    container_name="${container_name_base}-${date}-${commit_hash}.sif"
+    singularity exec --fakeroot --writable $HIPSYCL_TEST_DIR/hipsycl-$distro-$backend rm -rf /opt/hipSYCL/cuda
+    #On arch these sockets cause a error while packing the container
+    singularity exec --fakeroot --writable $HIPSYCL_TEST_DIR/hipsycl-$distro-$backend rm -rf /etc/pacman.d/gnupg/S.gpg-agent.browser \
+            /etc/pacman.d/gnupg/S.gpg-agent.ssh /etc/pacman.d/gnupg/S.gpg-agent.extra  /etc/pacman.d/gnupg/S.gpg-agent
+    singularity build --force --fakeroot $HIPSYCL_PKG_PUBLIC_CONTAINER_DIR/$container_name $HIPSYCL_TEST_DIR/hipsycl-$distro-$backend
+    supported_backends="omp"
+    #Keep only the two latest container from each kind
+    ls -t $HIPSYCL_PKG_PUBLIC_CONTAINER_DIR | grep $container_name_base-[0-9] | tail -n +3 | xargs -I '_' rm -rf $HIPSYCL_PKG_PUBLIC_CONTAINER_DIR/_
+done
+
+
+
+
+

--- a/devops/repos/update_repo.sh
+++ b/devops/repos/update_repo.sh
@@ -26,6 +26,7 @@ HIPSYCL_PKG_SCRIPT_DIR=${HIPSYCL_PKG_SCRIPT_DIR:-../../install/scripts/}
 HIPSYCL_PKG_SCRIPT_DIR_ABS=$HIPSYCL_PKG_DEVOPS_DIR/$HIPSYCL_PKG_SCRIPT_DIR
 HIPSYCL_PKG_REPO_BASE_DIR=${HIPSYCL_PKG_REPO_BASE_DIR:-/data/repos/}
 HIPSYCL_PKG_REPO_BASE_DIR=$HIPSYCL_PKG_REPO_BASE_DIR/$HIPSYCL_PKG_REPO_BASE_DIR_SUFFIX
+HIPSYCL_PKG_PUBLIC_CONTAINER_DIR=${HIPSYCL_PKG_PUBLIC_CONTAINER_DIR:-/data/repos/singularity/}
 source $HIPSYCL_PKG_DEVOPS_DIR/common/init.sh
 
 HIPSYCL_TEST_DIR="/data/hipsyclbot/test-dir"
@@ -87,4 +88,9 @@ if [ "$action" = "test" ]; then
   else
     bash $HIPSYCL_PKG_DEVOPS_DIR/test-packages.sh $HIPSYCL_PKG_DEVOPS_DIR $distro $backend $option $4 $HIPSYCL_PKG_REPO_BASE_DIR_SUFFIX
   fi
+fi
+
+
+if [ "$action" = "pub_cont" ]; then
+   bash $HIPSYCL_PKG_DEVOPS_DIR/publish_test_container.sh $distro 
 fi

--- a/install/scripts/README.md
+++ b/install/scripts/README.md
@@ -4,6 +4,7 @@ We provide
 * Scripts to install hipSYCL and required LLVM, ROCm and CUDA stacks
 * Repositories for all supported distributions
 * Singularity definition files which allow to create singularity container images with hipSYCL
+* Pre-built singularity containers
 * Scripts to create binary packages of the entire stack for several distributions.
 
 Currently, we support
@@ -57,6 +58,19 @@ singularity exec hipsycl-ubuntu-18.04.def install-rocm.sh
 singularity exec hipsycl-ubuntu-18.04.def install-cuda.sh
 ```
 Note that there are two type of installation scripts available at the moment the regular ones loacted in the `install/scripts/` directory, and scripts that use spack to install the dependencies located in `install/scripts/spack-install/`. The spack install scripts are well tested, therfore we recommend using those for the installation. The regular install scripts might need some changes to work flawlessly.
+
+## Pre-built singularity containers
+
+We proved pre-built singularity images for all supported distributions (centos-7, ubuntu-18.04, ubuntu-20.04, archlinux). The containers are available through the following link: http://repo.urz.uni-heidelberg.de/sycl/singularity/ 
+
+We test the provided images by building the hipSYCL unit tests for all supported backend, and in the case of Cuda and omp executing them.
+
+Please note that due to legal reasons, the images do not contain the Cuda installation. Please use the `install/scripts/install-Cuda.sh` script to install it afterwards. Note that this is only possible in case the container is writable; therefore we recommend installing Cuda by executing the following commands:
+
+```
+singularity shell build --sandbox --fakeroot <container_name>.sif <container_name>
+singularity exec --writable --fakeroot <container_name> bash install/scripts/install-cuda.sh
+```
 
 ## Creating packages
 In order to create binary packages for your distribution, you will first have to create container images as described above. Then run (e.g., for Ubuntu):

--- a/install/scripts/README.md
+++ b/install/scripts/README.md
@@ -61,11 +61,11 @@ Note that there are two type of installation scripts available at the moment the
 
 ## Pre-built singularity containers
 
-We proved pre-built singularity images for all supported distributions (centos-7, ubuntu-18.04, ubuntu-20.04, archlinux). The containers are available through the following link: http://repo.urz.uni-heidelberg.de/sycl/singularity/ 
+We provide pre-built singularity images for all supported distributions. The containers are available here: http://repo.urz.uni-heidelberg.de/sycl/singularity/ 
 
-We test the provided images by building the hipSYCL unit tests for all supported backend, and in the case of Cuda and omp executing them.
+The images are validated by building the hipSYCL unit tests for all supported backends, and running them for OpenMP and CUDA.
 
-Please note that due to legal reasons, the images do not contain the Cuda installation. Please use the `install/scripts/install-Cuda.sh` script to install it afterwards. Note that this is only possible in case the container is writable; therefore we recommend installing Cuda by executing the following commands:
+Please note that due to legal reasons, the images do not contain the CUDA installation. Please use the `install/scripts/install-cuda.sh` script to install it afterwards. Note that this is only possible in case the container is writable; therefore we recommend installing CUDA by executing the following commands:
 
 ```
 singularity shell build --sandbox --fakeroot <container_name>.sif <container_name>


### PR DESCRIPTION
This script publishes the test hipSYCL containers. These singularity containers have everything necessary for running hipSYCL installed. 

TODO:
- [x] update readme