### PR TITLE
Install correct libomp in CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -52,7 +52,7 @@ jobs:
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
         sudo ./llvm.sh ${{matrix.clang_version}}
-        sudo apt install libclang-${{matrix.clang_version}}-dev clang-tools-${{matrix.clang_version}}
+        sudo apt install libclang-${{matrix.clang_version}}-dev clang-tools-${{matrix.clang_version}} libomp-${{matrix.clang_version}}-dev
     - name: install boost (from source)
       if: matrix.os == 'ubuntu-18.04'
       run: |


### PR DESCRIPTION
For whatever reason, the LLVM apt packages in CI always installed `libomp-12`. This PR causes them to install a libomp matching the clang version. This fixes the issue where `-lomp` fails during linking in CI.