### PR TITLE
Add workaround for libstdc++ 11 clang CUDA issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,14 +243,14 @@ if(NOT ROCM_CXX_FLAGS)
   # __float128 even though it is not supported for CUDA / HIP,
   # see https://bugs.llvm.org/show_bug.cgi?id=47559.
 
-  set(ROCM_CXX_FLAGS "-isystem ${CLANG_INCLUDE_PATH} -U__FLOAT128__ -U__SIZEOF_FLOAT128__ -I$HIPSYCL_ROCM_PATH/include -I$HIPSYCL_ROCM_PATH/include --rocm-device-lib-path=$HIPSYCL_ROCM_PATH/amdgcn/bitcode --rocm-path=$HIPSYCL_ROCM_PATH -fhip-new-launch-api -D__HIP_ROCclr__" CACHE STRING "Arguments passed to compiler to compile SYCL applications with ROCm")
+  set(ROCM_CXX_FLAGS "-isystem $HIPSYCL_PATH/include/hipSYCL/std/hiplike -isystem ${CLANG_INCLUDE_PATH} -U__FLOAT128__ -U__SIZEOF_FLOAT128__ -I$HIPSYCL_ROCM_PATH/include -I$HIPSYCL_ROCM_PATH/include --rocm-device-lib-path=$HIPSYCL_ROCM_PATH/amdgcn/bitcode --rocm-path=$HIPSYCL_ROCM_PATH -fhip-new-launch-api -D__HIP_ROCclr__" CACHE STRING "Arguments passed to compiler to compile SYCL applications with ROCm")
 endif()
 
 if(NOT CUDA_CXX_FLAGS)	
   # clang erroneously sets feature detection flags for 
   # __float128 even though it is not supported for CUDA / HIP,
   # see https://bugs.llvm.org/show_bug.cgi?id=47559.
-  set(CUDA_CXX_FLAGS "-U__FLOAT128__ -U__SIZEOF_FLOAT128__" CACHE STRING "Arguments passed to compiler to compile SYCL applications with CUDA")
+  set(CUDA_CXX_FLAGS "-U__FLOAT128__ -U__SIZEOF_FLOAT128__ -isystem $HIPSYCL_PATH/include/hipSYCL/std/hiplike" CACHE STRING "Arguments passed to compiler to compile SYCL applications with CUDA")
 endif()
 
 if(NOT OMP_CXX_FLAGS) 
@@ -297,6 +297,7 @@ configure_file(
 install(DIRECTORY include/CL DESTINATION include/ FILES_MATCHING PATTERN "*.hpp")
 install(DIRECTORY include/SYCL DESTINATION include/ FILES_MATCHING PATTERN "*.hpp")
 install(DIRECTORY include/hipSYCL DESTINATION include/ FILES_MATCHING PATTERN "*.hpp")
+install(DIRECTORY include/hipSYCL/std DESTINATION include/hipSYCL/ )
 install(FILES ${PROJECT_BINARY_DIR}/include/hipSYCL/common/config.hpp DESTINATION include/hipSYCL/common/)
 
 if(NOT WIN32)

--- a/include/hipSYCL/std/hiplike/complex
+++ b/include/hipSYCL/std/hiplike/complex
@@ -1,0 +1,37 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2021 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#if defined(__clang__) && (defined(__CUDACC__) || defined(__HIP__))
+#pragma push_macro("__failed_assertion")
+#define __failed_assertion __cuda_failed_assertion
+#include_next <complex>
+#pragma pop_macro("__failed_assertion")
+#else
+#error This file requires clang CUDA/HIP
+#endif

--- a/include/hipSYCL/std/hiplike/complex
+++ b/include/hipSYCL/std/hiplike/complex
@@ -26,8 +26,17 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-
 #if defined(__clang__) && (defined(__CUDACC__) || defined(__HIP__))
+
+#ifdef _WIN32
+#include <cmath>
+
+namespace std {
+  __device__
+  inline bool signbit(long double v) { return signbit(static_cast<double>(v)); }
+}
+#endif
+
 #pragma push_macro("__failed_assertion")
 #define __failed_assertion __cuda_failed_assertion
 #include_next <complex>

--- a/tests/device_compilation_tests.cpp
+++ b/tests/device_compilation_tests.cpp
@@ -25,6 +25,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// Test workaround for https://bugs.llvm.org/show_bug.cgi?id=50383
+#include <atomic>
+#include <complex>
+
 #define BOOST_TEST_MODULE device compilation tests
 #if !defined(_WIN32) || defined(__MINGW32__)
 #define BOOST_TEST_DYN_LINK


### PR DESCRIPTION
This adds a workaround for https://bugs.llvm.org/show_bug.cgi?id=50383 - an incompatibility between clang CUDA/HIP and libstdc++ 11.1. This is not specific to hipSYCL; with libstdc++ 11.1.0 any code including `complex` fails compilation with clang CUDA or HIP.

This is already fixed in libstdc++ and clang upstream, but the problematic releases are already out there. In particular, our CI pipeline is affected, so currently this issue breaks our CI.

This PR adds a workaround by introducing our own std header wrappers with the same compatibility workarounds that the upstream clang patch uses. Currently we fix `complex` and `atomic`, for which this issue was reported. I don't know if other headers might be affected as well.

At the moment this workaround is always active. I'm not sure if there's harm in doing that and we should only conditionally enable it.