### PR TITLE
adjusted the sub_group interface (purely cosmetic)

### DIFF
--- a/include/hipSYCL/sycl/libkernel/sub_group.hpp
+++ b/include/hipSYCL/sycl/libkernel/sub_group.hpp
@@ -62,19 +62,21 @@ public:
     return local_tid() & get_warp_mask();
   }
 
+  // always returns the maximum sub_group size
   HIPSYCL_KERNEL_TARGET
   range_type get_local_range() const {
     return warpSize;
   }
 
+  // always returns the maximum sub_group size
   HIPSYCL_KERNEL_TARGET
   linear_range_type get_local_linear_range() const {
     return warpSize;
   }
-  
+
   HIPSYCL_KERNEL_TARGET
   range_type get_max_local_range() const {
-    return get_local_range();
+    return warpSize;
   }
 
   HIPSYCL_KERNEL_TARGET
@@ -99,6 +101,7 @@ public:
     return range_type{get_group_linear_range()};
   }
 
+  [[deprecated]]
   HIPSYCL_KERNEL_TARGET
   range_type get_max_group_range() const {
     return get_group_range();

--- a/include/hipSYCL/sycl/libkernel/sub_group.hpp
+++ b/include/hipSYCL/sycl/libkernel/sub_group.hpp
@@ -190,9 +190,9 @@ public:
     return __spirv_BuiltInNumSubgroups;
   }
 
+  [[deprecated]]
   HIPSYCL_KERNEL_TARGET
   range_type get_max_group_range() const {
-    // TODO
     return __spirv_BuiltInNumSubgroups;
   }
 
@@ -268,6 +268,7 @@ public:
     return _group_size;
   }
 
+  [[deprecated]]
   HIPSYCL_KERNEL_TARGET
   range_type get_max_group_range() const {
     return _group_size;


### PR DESCRIPTION
I checked the sub_group-class, since I had a look at the group class.

`get_max_group_range` was deprecated, since it doesn't exist in the
specification and doesn't return the the maximum group range. It should
be removed completly in my opinion to reduce confusion.

Comments added to `get_local_range` and `get_local_linear_range`, to
make it clear they always return the maximum size.

`get_max_local_range` now returns `warpSize` instead of
`get_local_range`, as the maximum is returned, and it is easy to get the
wrong impression when looking at the code and it is likely to be
fogotten when `get_local_range` is changed at some point.

This commit doesn't contain any functional changes and is purely
cosmetic.