### PR TITLE
Add accessor variants aliases, forbid invalid conversions

### DIFF
--- a/include/hipSYCL/sycl/libkernel/accessor.hpp
+++ b/include/hipSYCL/sycl/libkernel/accessor.hpp
@@ -537,9 +537,8 @@ class accessor
     else if(is_std_accessor_variant(dest))
       // Can always convert to regular accessors from non-raw accessors
       return true;
-    //else if(is_std_accessor_variant(src) && !is_std_accessor_variant(dest))
-    // TODO: This case should be prevented unless dest is ranged?
-    else if(is_unranged_variant(dest) && is_ranged_variant(src))
+    else if (is_unranged_variant(dest) &&
+             (is_ranged_variant(src) || is_std_accessor_variant(src)))
       // Allowing this would expose an accessor that has forgotten its
       // correct access range, using the subscript operators would potentially
       // access memory outside of the allowed range
@@ -1194,6 +1193,32 @@ template <class T, int Dim = 1,
                                               : access_mode::read_write),
           target Tgt = target::device>
 using raw_accessor = accessor<T, Dim, M, Tgt, accessor_variant::raw>;
+
+template <class T, int Dim = 1,
+          access_mode M = (std::is_const_v<T> ? access_mode::read
+                                              : access_mode::read_write),
+          target Tgt = target::device>
+using ranged_accessor = accessor<T, Dim, M, Tgt, accessor_variant::ranged>;
+
+template <class T, int Dim = 1,
+          access_mode M = (std::is_const_v<T> ? access_mode::read
+                                              : access_mode::read_write),
+          target Tgt = target::device>
+using unranged_accessor = accessor<T, Dim, M, Tgt, accessor_variant::unranged>;
+
+template <class T, int Dim = 1,
+          access_mode M = (std::is_const_v<T> ? access_mode::read
+                                              : access_mode::read_write),
+          target Tgt = target::device>
+using ranged_placeholder_accessor =
+    accessor<T, Dim, M, Tgt, accessor_variant::ranged_placeholder>;
+
+template <class T, int Dim = 1,
+          access_mode M = (std::is_const_v<T> ? access_mode::read
+                                              : access_mode::read_write),
+          target Tgt = target::device>
+using unranged_placeholder_accessor =
+    accessor<T, Dim, M, Tgt, accessor_variant::unranged_placeholder>;
 
 // Accessor deduction guides
 #ifdef HIPSYCL_EXT_ACCESSOR_VARIANT_DEDUCTION

--- a/tests/sycl/accessor.cpp
+++ b/tests/sycl/accessor.cpp
@@ -300,12 +300,20 @@ BOOST_AUTO_TEST_CASE(accessor_simplifications) {
   q.submit([&](s::handler& cgh){
     s::accessor acc1{buff, cgh, s::read_only};
     BOOST_CHECK(!acc1.is_placeholder());
+    
+#ifdef HIPSYCL_EXT_ACCESSOR_VARIANT_DEDUCTION
+    // Conversion rw accessor<int> -> accessor<const int>, read-only
+    s::accessor<const int> acc2 = s::accessor<int>{buff, cgh};
+    s::accessor acc3{buff, cgh, s::read_only};
+    // Conversion read-write to non-const read-only accessor
+    acc3 = s::accessor{buff, cgh, s::read_write};
+#else
     // Conversion rw accessor<int> -> accessor<const int>, read-only
     s::accessor<const int> acc2 = s::accessor{buff, cgh, s::read_write};
-    
     s::accessor acc3{buff, cgh, s::read_only};
     // Conversion read-write to non-const read-only accessor
     acc3 = s::accessor<int>{buff, cgh};
+#endif
     BOOST_CHECK(!acc3.is_placeholder());
 
     // Deduction based on constness of argument


### PR DESCRIPTION
* Describe `raw_accessor operator[]` behavior better in documentation
* Forbid conversion from standard accessor to `ranged` variants because of potentially incorrect semantics
* Add `ranged_accessor`, `unranged_accessor` etc aliases