### PR TITLE
Add queue::get_wait_list() extension

### DIFF
--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -49,6 +49,24 @@ public:
 }
 ```
 
+### `HIPSYCL_EXT_QUEUE_WAIT_LIST`
+
+Adds a `queue::get_wait_list()` method that returns a vector of `sycl::event` in analogy to `event::get_wait_list()`, such that waiting for all returned events guarantees that all operations submitted to the queue have completed. This can be used to express asynchronous barrier-like semantics when passing the returned vector into handler::depends_on().
+If the queue is an in-order queue, the returned vector will contain at most one event.
+
+Note that `queue::get_wait_list()` might not return an event for all submitted operations, e.g. completed operations or operations that are dependencies of others in the the dependency graphs may be optimized away in the returned set of events.
+
+#### API Reference
+
+```c++
+namespace sycl {
+class queue {
+public:
+  std::vector<event> get_wait_list() const;
+};
+}
+```
+
 ### `HIPSYCL_EXT_CG_PROPERTY_*`: Command group properties
 
 hipSYCL supports attaching special command group properties to individual command groups. This is done by passing a property list to the queue's `submit` member function:

--- a/include/hipSYCL/runtime/dag_manager.hpp
+++ b/include/hipSYCL/runtime/dag_manager.hpp
@@ -55,7 +55,9 @@ public:
   // Wait for completion of all submitted operations
   void wait();
   void wait(std::size_t node_group_id);
-  
+
+  std::vector<dag_node_ptr> get_group(std::size_t node_group_id);
+
   void register_submitted_ops(dag_node_ptr);
 private:
   void trigger_flush_opportunity();

--- a/include/hipSYCL/runtime/dag_submitted_ops.hpp
+++ b/include/hipSYCL/runtime/dag_submitted_ops.hpp
@@ -45,6 +45,7 @@ public:
   
   void wait_for_all();
   void wait_for_group(std::size_t node_group);
+  std::vector<dag_node_ptr> get_group(std::size_t node_group);
 private:
   std::vector<dag_node_ptr> _ops;
   std::mutex _lock;

--- a/include/hipSYCL/sycl/extensions.hpp
+++ b/include/hipSYCL/sycl/extensions.hpp
@@ -51,5 +51,6 @@
 #endif
 
 #define HIPSYCL_EXT_UPDATE_DEVICE
+#define HIPSYCL_EXT_QUEUE_WAIT_LIST
 
 #endif

--- a/src/runtime/dag_manager.cpp
+++ b/src/runtime/dag_manager.cpp
@@ -161,5 +161,9 @@ void dag_manager::trigger_flush_opportunity()
   }
 }
 
+std::vector<dag_node_ptr> dag_manager::get_group(std::size_t node_group_id) {
+  return _submitted_ops.get_group(node_group_id);
+}
+
 }
 }

--- a/src/runtime/dag_submitted_ops.cpp
+++ b/src/runtime/dag_submitted_ops.cpp
@@ -99,5 +99,23 @@ void dag_submitted_ops::wait_for_group(std::size_t node_group) {
   }
 }
 
+std::vector<dag_node_ptr> dag_submitted_ops::get_group(std::size_t node_group) {
+  
+  std::vector<dag_node_ptr> ops;
+  {
+    std::lock_guard lock{_lock};
+    for(dag_node_ptr node : _ops) {
+      assert(node->is_submitted());
+      if (hints::node_group *g =
+              node->get_execution_hints().get_hint<hints::node_group>()) {
+        if (g->get_id() == node_group) {
+          ops.push_back(node);
+        }
+      }
+    }
+  }
+  return ops;
+}
+
 }
 }


### PR DESCRIPTION
From documentation:

### `HIPSYCL_EXT_QUEUE_WAIT_LIST`

Adds a `queue::get_wait_list()` method that returns a vector of `sycl::event` in analogy to `event::get_wait_list()`, such that waiting for all returned events guarantees that all operations submitted to the queue have completed. This can be used to express asynchronous barrier-like semantics when passing the returned `vector` into `handler::depends_on()`.
If the queue is an in-order queue, the returned vector will contain at most one event.

Note that `queue::get_wait_list()` might not return an event for all submitted operations, e.g. completed operations or operations that are dependencies of others in the the dependency graphs may be optimized away in the returned set of events.

#### API Reference

```c++
namespace sycl {
class queue {
public:
  std::vector<event> get_wait_list() const;
};
}
```