### PR TITLE
Disable CUDA 10.0 in Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         clang_version: [11]
         os: [windows-latest]
-        cuda: ['10.0', '10.2', '11.0']
+        cuda: ['10.2', '11.0']
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
It seems it's no longer supported by Microsoft STL: https://github.com/microsoft/STL/pull/1544