### PR TITLE
Add a placeholder for half

### DIFF
--- a/include/hipSYCL/sycl/types.hpp
+++ b/include/hipSYCL/sycl/types.hpp
@@ -103,6 +103,7 @@ using sp_float = float;
 using dp_float = double;
 } //detail
 
+using half = detail::hp_float;
 } // sycl
 } // hipsycl
 


### PR DESCRIPTION
In order to support libraries using half without major changes to their interface, we need to define half in hipSYCL. 

This change allows reducing the number of `#ifdefs` necessary when making oneMKL work with hipSYCL. see:  https://github.com/hipSYCL/oneMKL/pull/6