### PR TITLE
Add support for multi-device queue/automatic system-wide work distribution API

### DIFF
--- a/doc/env_variables.md
+++ b/doc/env_variables.md
@@ -8,3 +8,7 @@
 * `HIPSYCL_RT_SCHEDULER`: Set scheduler type. Allowed values: 
     * `direct` is a low-latency direct-submission scheduler. 
     * `unbound` is the default scheduler and supports automatic work distribution across multiple devices. If the `HIPSYCL_EXT_MULTI_DEVICE_QUEUE` extension is used, the scheduler must be `unbound`.
+* `HIPSYCL_DEFAULT_SELECTOR_BEHAVIOR`: Set behavior of default selector. Allowed values:
+    * `strict` (default): Strictly behave as defined by the SYCL specification
+    * `multigpu`: Makes default selector behave like a multigpu selector from the `HIPSYCL_EXT_MULTI_DEVICE_QUEUE` extension
+    * `system`: Makes default selector behave like a system selector from the `HIPSYCL_EXT_MULTI_DEVICE_QUEUE` extension

--- a/doc/env_variables.md
+++ b/doc/env_variables.md
@@ -5,3 +5,6 @@
 * `HIPSYCL_RT_DAG_REQ_OPTIMIZATION_DEPTH`: maximum depth when descending the DAG requirement tree to look for DAG optimization opportunities, such as eliding unnecessary dependencies.
 * `HIPSYCL_RT_MQE_LANE_STATISTICS_MAX_SIZE`: For the `multi_queue_executor`, the maximum size of entries in the lane statistics, i.e. the maximum number of submissions to retain statistical information about. This information is used to estimate execution lane utilization.
 * `HIPSYCL_RT_MQE_LANE_STATISTICS_DECAY_TIME_SEC`: The time in seconds (floating point value) after which to forget information about old submissions.
+* `HIPSYCL_RT_SCHEDULER`: Set scheduler type. Allowed values: 
+    * `direct` is a low-latency direct-submission scheduler. 
+    * `unbound` is the default scheduler and supports automatic work distribution across multiple devices. If the `HIPSYCL_EXT_MULTI_DEVICE_QUEUE` extension is used, the scheduler must be `unbound`.

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -22,6 +22,10 @@ hipSYCL supports interoperability between `sycl::buffer` and USM pointers. See [
 
 An extension that allows to eplicitly set view/non-view semantics for buffers as well as enable some behaviors that cannot be expressed in regular SYCL such as buffers that do not block in the destructor. See [here](explicit-buffer-policies.md) for details.
 
+### `HIPSYCL_EXT_MULTI_DEVICE_QUEUE`
+
+Allows constructing a queue that automatically distributes work across multiple devices, or even the entire system. See [here](multi-device-queue.md) for details.
+
 ### `HIPSYCL_EXT_ACCESSOR_VARIANTS` and `HIPSYCL_EXT_ACCESSOR_VARIANT_DEDUCTION`
 
 hipSYCL supports various flavors of accessors that encode the purpose and feature set of the accessor (e.g. placeholder, ranged, unranged) in the accessor type. Based on this information, the size of the accessor is optimized by eliding unneeded information at compile time. This can be beneficial for performance in kernels bound by register pressure.

--- a/doc/multi-device-queue.md
+++ b/doc/multi-device-queue.md
@@ -1,0 +1,95 @@
+# `HIPSYCL_EXT_MULTI_DEVICE_QUEUE`
+
+This extension allows `sycl::queue` to automatically distribute work across multiple devices.
+
+**Note:** This is highly experimental, not performance-optimized, the current work distribution algorithm is extremely primitive and a placeholder for a proper scheduling algorithm. This extension should not yet be used for any production workloads.
+
+A multi-device queue can be constructed either by passing a vector of `sycl::device` to the queue constructor, or by using the new device selectors, such as `system_selector_v`. See the API reference below for details.
+
+## Example
+
+```c++
+sycl::queue q{sycl::system_selector_v};
+q.single_task([=](){
+  // may be executed on any device inside the system
+  // as automatically decided by the scheduler
+}).wait();
+```
+
+## Restrictions
+
+In multi-device mode, the following operations are currently unsupported, although support may be partially or fully added in the future:
+
+* `queue::get_device()`;
+* Overloads for USM memory management functions that are provided the queue as argument;
+* the USM-related member functions of `sycl::handler` such as `memcpy`, `memset`, `fill`, `prefetch` and `prefetch_host`;
+* If kernels use USM pointers, the user is responsible for making sure that the USM pointer is valid on all devices that the queue might dispatch to;
+* All variants of `handler::copy()`;
+* `handler::update()` from the `HIPSYCL_EXT_UPDATE_DEVICE` extension
+
+## API Reference
+
+```c++
+namespace sycl {
+
+enum class selection_policy {
+  all,
+  best
+};
+
+// A wrapper class that turns a regular selector into a multi-device
+// selector. 
+// If selection policy is selection_policy::all, then
+// all devices are selected for which the provided selector returns a
+// non-negative number.
+// If selection policy is selection_policy::best, then
+// only devices with the best score are selected. Multiple devices are
+// only selected in this case if the same top score is returned
+// for multiple devices.
+template <class Selector, selection_policy P = selection_policy::all>
+class multi_device_selector {
+public:
+  constexpr multi_device_selector(const Selector& s = Selector{});
+
+  int operator()(const device& dev);
+};
+
+inline constexpr multi_device_selector<cpu_selector,selection_policy::best>
+    multi_cpu_selector_v;
+
+// Returns all GPUs that have been targeted at compile time.
+inline constexpr multi_device_selector<gpu_selector, selection_policy::best>
+    multi_gpu_selector_v;
+
+// Returns all devices in the system that have been targeted at
+// compile time.
+inline constexpr multi_device_selector<default_selector, selection_policy::all>
+    system_selector_v;
+
+class queue {
+public:
+  // New constructors that accept a vector of device.
+  // Alternatively, an appropriate multi-device selector
+  // can be provided to the queue.
+  explicit queue(const std::vector<device> &devices,
+                 const async_handler &handler,
+                 const property_list &propList = {});
+
+  explicit queue(const std::vector<device>& devices, 
+                const property_list& propList = {});
+
+  explicit queue(const context &syclContext,
+                const std::vector<device> &devices,
+                const property_list &propList = {});
+
+  explicit queue(const context &syclContext,
+                 const std::vector<device> &devices,
+                 const async_handler &asyncHandler,
+                 const property_list &propList = {});
+
+  // Returns all devices that this queue might dispatch to
+  std::vector<device> get_devices() const;
+};
+
+}
+```

--- a/doc/multi-device-queue.md
+++ b/doc/multi-device-queue.md
@@ -1,10 +1,12 @@
 # `HIPSYCL_EXT_MULTI_DEVICE_QUEUE`
 
-This extension allows `sycl::queue` to automatically distribute work across multiple devices.
+This extension allows `sycl::queue` to automatically distribute work across multiple devices. The funcionality from this extension requires that the scheduler type is set to `unbound` (default).
 
 **Note:** This is highly experimental, not performance-optimized, the current work distribution algorithm is extremely primitive and a placeholder for a proper scheduling algorithm. This extension should not yet be used for any production workloads.
 
 A multi-device queue can be constructed either by passing a vector of `sycl::device` to the queue constructor, or by using the new device selectors, such as `system_selector_v`. See the API reference below for details.
+
+Additionally, the behavior of the default selector can be modified to behave like a system selector or a multi-gpu selector. See the documentation on environment variables for more details.
 
 ## Example
 

--- a/include/hipSYCL/runtime/dag_manager.hpp
+++ b/include/hipSYCL/runtime/dag_manager.hpp
@@ -31,6 +31,7 @@
 #include "dag.hpp"
 #include "dag_builder.hpp"
 #include "dag_direct_scheduler.hpp"
+#include "dag_unbound_scheduler.hpp"
 #include "dag_submitted_ops.hpp"
 #include "generic/async_worker.hpp"
 
@@ -68,6 +69,7 @@ private:
   worker_thread _worker;
   
   dag_direct_scheduler _direct_scheduler;
+  dag_unbound_scheduler _unbound_scheduler;
   dag_submitted_ops _submitted_ops;
 };
 

--- a/include/hipSYCL/runtime/dag_unbound_scheduler.hpp
+++ b/include/hipSYCL/runtime/dag_unbound_scheduler.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2019 Aksel Alpay
+ * Copyright (c) 2021 Aksel Alpay
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,33 +25,27 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef HIPSYCL_EXTENSIONS_HPP
-#define HIPSYCL_EXTENSIONS_HPP
 
-#ifdef HIPSYCL_EXT_ENABLE_ALL
- #define HIPSYCL_EXT_FP_ATOMICS
-#endif
+#ifndef HIPSYCL_DAG_UNBOUND_SCHEDULER_HPP
+#define HIPSYCL_DAG_UNBOUND_SCHEDULER_HPP
 
-#define HIPSYCL_EXT_AUTO_PLACEHOLDER_REQUIRE
-#define HIPSYCL_EXT_CUSTOM_PFWI_SYNCHRONIZATION
-#define HIPSYCL_EXT_SCOPED_PARALLELISM
-#define HIPSYCL_EXT_ENQUEUE_CUSTOM_OPERATION
-#define HIPSYCL_EXT_CG_PROPERTY_RETARGET
-#define HIPSYCL_EXT_CG_PROPERTY_PREFER_GROUP_SIZE
-#define HIPSYCL_EXT_CG_PROPERTY_PREFER_EXECUTION_LANE
-#define HIPSYCL_EXT_BUFFER_USM_INTEROP
-#define HIPSYCL_EXT_PREFETCH_HOST
-#define HIPSYCL_EXT_SYNCHRONOUS_MEM_ADVISE
-#define HIPSYCL_EXT_BUFFER_PAGE_SIZE
-#define HIPSYCL_EXT_EXPLICIT_BUFFER_POLICIES
-#define HIPSYCL_EXT_ACCESSOR_VARIANTS
+#include "dag_node.hpp"
+#include "dag_direct_scheduler.hpp"
 
-#ifndef HIPSYCL_STRICT_ACCESSOR_DEDUCTION
- #define HIPSYCL_EXT_ACCESSOR_VARIANT_DEDUCTION
-#endif
+namespace hipsycl {
+namespace rt {
 
-#define HIPSYCL_EXT_UPDATE_DEVICE
-#define HIPSYCL_EXT_QUEUE_WAIT_LIST
-#define HIPSYCL_EXT_MULTI_DEVICE_QUEUE
+class dag_unbound_scheduler {
+public:
+  dag_unbound_scheduler();
+
+  void submit(dag_node_ptr node);
+private:
+  std::vector<device_id> _devices;
+  rt::dag_direct_scheduler _direct_scheduler;
+};
+
+}
+}
 
 #endif

--- a/include/hipSYCL/runtime/hints.hpp
+++ b/include/hipSYCL/runtime/hints.hpp
@@ -48,6 +48,7 @@ enum class execution_hint_type
 {
   // mark a DAG node as bound to a particular device for execution
   bind_to_device,
+  bind_to_device_group,
   prefer_execution_lane,
   node_group
 };
@@ -88,6 +89,25 @@ public:
 private:
   device_id _dev;
 };
+
+
+class bind_to_device_group : public execution_hint
+{
+public:
+  static constexpr execution_hint_type type = 
+    execution_hint_type::bind_to_device_group;
+
+  bind_to_device_group(const std::vector<device_id> &devs)
+      : execution_hint{execution_hint_type::bind_to_device_group}, _devs{devs} {
+  }
+
+  const std::vector<device_id>& get_devices() const {
+    return _devs;
+  }
+private:
+  std::vector<device_id> _devs;
+};
+
 
 class prefer_execution_lane : public execution_hint
 {

--- a/include/hipSYCL/runtime/settings.hpp
+++ b/include/hipSYCL/runtime/settings.hpp
@@ -41,9 +41,11 @@ namespace hipsycl {
 namespace rt {
 
 enum class scheduler_type { direct, unbound };
+enum class default_selector_behavior { strict, multigpu, system };
 
 std::istream &operator>>(std::istream &istr, scheduler_type &out);
 std::istream &operator>>(std::istream &istr, std::vector<rt::backend_id> &out);
+std::istream &operator>>(std::istream &istr, default_selector_behavior& out);
 
 enum class setting {
   debug_level,
@@ -51,7 +53,8 @@ enum class setting {
   visibility_mask,
   dag_req_optimization_depth,
   mqe_lane_statistics_max_size,
-  mqe_lane_statistics_decay_time_sec
+  mqe_lane_statistics_decay_time_sec,
+  default_selector_behavior
 };
 
 template <setting S> struct setting_trait {};
@@ -71,6 +74,8 @@ HIPSYCL_RT_MAKE_SETTING_TRAIT(setting::mqe_lane_statistics_max_size,
                               "rt_mqe_lane_statistics_max_size", std::size_t);
 HIPSYCL_RT_MAKE_SETTING_TRAIT(setting::mqe_lane_statistics_decay_time_sec,
                               "rt_mqe_lane_statistics_decay_time_sec", double);
+HIPSYCL_RT_MAKE_SETTING_TRAIT(setting::default_selector_behavior,
+                              "default_selector_behavior", default_selector_behavior);
 
 class settings
 {
@@ -89,6 +94,8 @@ public:
       return _mqe_lane_statistics_max_size;
     } else if constexpr (S == setting::mqe_lane_statistics_decay_time_sec) {
       return _mqe_lane_statistics_decay_time_sec;
+    } else if constexpr (S == setting::default_selector_behavior) {
+      return _default_selector_behavior;
     }
     return typename setting_trait<S>::type{};
   }
@@ -112,6 +119,9 @@ public:
         setting::mqe_lane_statistics_max_size>(100);
     _mqe_lane_statistics_decay_time_sec = get_environment_variable_or_default<
         setting::mqe_lane_statistics_decay_time_sec>(10.0);
+    _default_selector_behavior =
+        get_environment_variable_or_default<setting::default_selector_behavior>(
+            default_selector_behavior::strict);
   }
 
 private:
@@ -147,6 +157,7 @@ private:
   std::size_t _dag_requirement_optimization_depth;
   std::size_t _mqe_lane_statistics_max_size;
   double _mqe_lane_statistics_decay_time_sec;
+  default_selector_behavior _default_selector_behavior;
 };
 
 }

--- a/include/hipSYCL/runtime/settings.hpp
+++ b/include/hipSYCL/runtime/settings.hpp
@@ -40,7 +40,7 @@
 namespace hipsycl {
 namespace rt {
 
-enum class scheduler_type { direct };
+enum class scheduler_type { direct, unbound };
 
 std::istream &operator>>(std::istream &istr, scheduler_type &out);
 std::istream &operator>>(std::istream &istr, std::vector<rt::backend_id> &out);
@@ -102,7 +102,7 @@ public:
         default_debug_level);
     _scheduler_type =
         get_environment_variable_or_default<setting::scheduler_type>(
-            scheduler_type::direct);
+            scheduler_type::unbound);
     _visibility_mask =
         get_environment_variable_or_default<setting::visibility_mask>(
             std::vector<rt::backend_id>{});

--- a/include/hipSYCL/sycl/context.hpp
+++ b/include/hipSYCL/sycl/context.hpp
@@ -61,9 +61,7 @@ public:
 
   explicit context(async_handler handler = [](exception_list e) {
     glue::default_async_handler(e);
-  }) {
-    this->init(handler, detail::select_device(default_selector_v));
-  }
+  }) : context{detail::select_devices(default_selector_v), handler} {}
 
   explicit context(
       const device &dev, async_handler handler = [](exception_list e) {

--- a/include/hipSYCL/sycl/device_selector.hpp
+++ b/include/hipSYCL/sycl/device_selector.hpp
@@ -164,7 +164,7 @@ std::vector<device> select_devices(const Selector &s) {
   std::vector<device> result;
   assert(!dev_indices.empty());
 
-  int best_score = dev_scores[dev_indices[0]];
+  const int best_score = dev_scores[dev_indices[0]];
   for(int i = 0; i < dev_indices.size(); ++i) {
     // Only include devices with positive scores, no more than max_devs.
     // If we are not in multi device selection mode, max_devs is 1

--- a/include/hipSYCL/sycl/platform.hpp
+++ b/include/hipSYCL/sycl/platform.hpp
@@ -55,7 +55,7 @@ public:
 
   template<class DeviceSelector>
   explicit platform(const DeviceSelector &deviceSelector) {
-    auto dev = detail::select_device(deviceSelector);
+    auto dev = detail::select_devices(deviceSelector)[0];
     this->_platform = rt::platform_id{dev._device_id};
   }
 

--- a/include/hipSYCL/sycl/queue.hpp
+++ b/include/hipSYCL/sycl/queue.hpp
@@ -197,6 +197,10 @@ public:
       : detail::property_carrying_object{propList}, _ctx{syclContext},
         _handler{asyncHandler} {
 
+    if(devices.empty()) {
+      throw invalid_parameter_error{"queue: No devices in device list"};
+    }
+
     for(const auto& dev : devices)
       if (!is_device_in_context(dev, syclContext))
         throw invalid_object_error{"queue: Device is not in context"};
@@ -271,7 +275,7 @@ public:
     }
     return true;
   }
-  
+
   bool is_in_order() const {
     return _is_in_order;
   }

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(hipSYCL-rt SHARED
   dag_node.cpp
   dag_builder.cpp
   dag_direct_scheduler.cpp
+  dag_unbound_scheduler.cpp
   dag_manager.cpp
   dag_submitted_ops.cpp
   settings.cpp

--- a/src/runtime/dag_manager.cpp
+++ b/src/runtime/dag_manager.cpp
@@ -119,6 +119,8 @@ void dag_manager::flush_async()
           _unbound_scheduler.submit(node);
         }
       }
+      HIPSYCL_DEBUG_INFO << "dag_manager [async]: DAG flush complete."
+                         << std::endl;
     } else {
       HIPSYCL_DEBUG_INFO << "dag_manager [async]: Nothing to do" << std::endl;
     }

--- a/src/runtime/dag_unbound_scheduler.cpp
+++ b/src/runtime/dag_unbound_scheduler.cpp
@@ -25,8 +25,6 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
-
 #include "hipSYCL/runtime/dag_unbound_scheduler.hpp"
 #include "hipSYCL/runtime/application.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
@@ -53,9 +51,7 @@ void dag_unbound_scheduler::submit(dag_node_ptr node) {
     });
   }
 
-  if(node->get_execution_hints().has_hint<hints::bind_to_device>()){
-    _direct_scheduler.submit(node);
-  } else {
+  if(!node->get_execution_hints().has_hint<hints::bind_to_device>()){
     std::vector<rt::device_id> eligible_devices;
     if(node->get_execution_hints().has_hint<hints::bind_to_device_group>()) {
       eligible_devices = node->get_execution_hints()
@@ -82,9 +78,9 @@ void dag_unbound_scheduler::submit(dag_node_ptr node) {
     rt::device_id target_dev = eligible_devices[dev % eligible_devices.size()];
     node->get_execution_hints().add_hint(
         make_execution_hint<rt::hints::bind_to_device>(target_dev));
-
-    _direct_scheduler.submit(node);
   }
+
+  _direct_scheduler.submit(node);
 }
 
 }

--- a/src/runtime/dag_unbound_scheduler.cpp
+++ b/src/runtime/dag_unbound_scheduler.cpp
@@ -30,6 +30,7 @@
 #include "hipSYCL/runtime/dag_unbound_scheduler.hpp"
 #include "hipSYCL/runtime/application.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
+#include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/hints.hpp"
 #include "hipSYCL/runtime/hardware.hpp"
 
@@ -64,6 +65,15 @@ void dag_unbound_scheduler::submit(dag_node_ptr node) {
       eligible_devices = _devices;
     }
 
+    if(eligible_devices.empty()) {
+      register_error(
+          __hipsycl_here(),
+          error_info{"dag_unbound_scheduler: No devices available to "
+                     "dispatch operation; this indicates that the "
+                     "device selector did not find appropriate devices."});
+      node->cancel();
+      return;
+    }
     // Round-robin as placeholder. This is not intended
     // for anything practical, it's a _placeholder_
     static std::size_t dev = 0;

--- a/src/runtime/dag_unbound_scheduler.cpp
+++ b/src/runtime/dag_unbound_scheduler.cpp
@@ -1,0 +1,82 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2021 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+
+#include "hipSYCL/runtime/dag_unbound_scheduler.hpp"
+#include "hipSYCL/runtime/application.hpp"
+#include "hipSYCL/runtime/device_id.hpp"
+#include "hipSYCL/runtime/hints.hpp"
+#include "hipSYCL/runtime/hardware.hpp"
+
+namespace hipsycl {
+namespace rt {
+
+dag_unbound_scheduler::dag_unbound_scheduler() {}
+
+void dag_unbound_scheduler::submit(dag_node_ptr node) {
+  if(_devices.empty()) {
+    // We cannot query this in the constructor, because
+    // when schedulers are constructed the runtime is typically
+    // locked because it is just starting up, so this would
+    // create a deadlock
+    application::backends().for_each_backend([this](backend *b) {
+      std::size_t num_devs = b->get_hardware_manager()->get_num_devices();
+      for (std::size_t i = 0; i < num_devs; ++i) {
+        this->_devices.push_back(b->get_hardware_manager()->get_device_id(i));
+      }
+    });
+  }
+
+  if(node->get_execution_hints().has_hint<hints::bind_to_device>()){
+    _direct_scheduler.submit(node);
+  } else {
+    std::vector<rt::device_id> eligible_devices;
+    if(node->get_execution_hints().has_hint<hints::bind_to_device_group>()) {
+      eligible_devices = node->get_execution_hints()
+                             .get_hint<hints::bind_to_device_group>()
+                             ->get_devices();
+    } else {
+      eligible_devices = _devices;
+    }
+
+    // Round-robin as placeholder. This is not intended
+    // for anything practical, it's a _placeholder_
+    static std::size_t dev = 0;
+    ++dev;
+
+    rt::device_id target_dev = eligible_devices[dev % eligible_devices.size()];
+    node->get_execution_hints().add_hint(
+        make_execution_hint<rt::hints::bind_to_device>(target_dev));
+
+    _direct_scheduler.submit(node);
+  }
+}
+
+}
+}
+

--- a/src/runtime/settings.cpp
+++ b/src/runtime/settings.cpp
@@ -36,6 +36,8 @@ std::istream &operator>>(std::istream &istr, scheduler_type &out) {
   istr >> str;
   if (str == "direct")
     out = scheduler_type::direct;
+  else if (str == "unbound")
+    out = scheduler_type::unbound;
   else
     istr.setstate(std::ios_base::failbit);
   return istr;

--- a/src/runtime/settings.cpp
+++ b/src/runtime/settings.cpp
@@ -73,5 +73,20 @@ std::istream &operator>>(std::istream &istr, std::vector<rt::backend_id> &out) {
   }
   return istr;
 }
+
+std::istream &operator>>(std::istream &istr, default_selector_behavior& out) {
+  std::string str;
+  istr >> str;
+  if (str == "strict")
+    out = default_selector_behavior::strict;
+  else if (str == "multigpu")
+    out = default_selector_behavior::multigpu;
+  else if (str == "system")
+    out = default_selector_behavior::system;
+  else
+    istr.setstate(std::ios_base::failbit);
+  return istr;
+}
+
 }
 }

--- a/tests/sycl/extensions.cpp
+++ b/tests/sycl/extensions.cpp
@@ -879,5 +879,36 @@ BOOST_AUTO_TEST_CASE(queue_wait_list) {
 }
 
 #endif
+#ifdef HIPSYCL_EXT_MULTI_DEVICE_QUEUE
+
+BOOST_AUTO_TEST_CASE(multi_device_queue) {
+  using namespace cl;
+  sycl::queue q{sycl::system_selector_v};
+
+  sycl::buffer<int> buff{sycl::range{1}};
+
+  q.submit([&](sycl::handler& cgh){
+    sycl::accessor acc{buff, cgh, sycl::no_init};
+    cgh.single_task([=](){
+      acc[0] = 1;
+    });
+  });
+  q.submit([&](sycl::handler& cgh){
+    sycl::accessor acc{buff, cgh};
+    cgh.single_task([=](){
+      acc[0] += 100;
+    });
+  });
+  q.submit([&](sycl::handler& cgh){
+    sycl::accessor acc{buff, cgh};
+    cgh.single_task([=](){
+      acc[0]++;
+    });
+  });
+
+  sycl::host_accessor hacc{buff};
+  BOOST_CHECK(hacc[0] == 102);
+}
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/sycl/extensions.cpp
+++ b/tests/sycl/extensions.cpp
@@ -888,19 +888,19 @@ BOOST_AUTO_TEST_CASE(multi_device_queue) {
   sycl::buffer<int> buff{sycl::range{1}};
 
   q.submit([&](sycl::handler& cgh){
-    sycl::accessor acc{buff, cgh, sycl::no_init};
+    sycl::accessor<int> acc{buff, cgh, sycl::no_init};
     cgh.single_task([=](){
       acc[0] = 1;
     });
   });
   q.submit([&](sycl::handler& cgh){
-    sycl::accessor acc{buff, cgh};
+    sycl::accessor<int> acc{buff, cgh};
     cgh.single_task([=](){
       acc[0] += 100;
     });
   });
   q.submit([&](sycl::handler& cgh){
-    sycl::accessor acc{buff, cgh};
+    sycl::accessor<int> acc{buff, cgh};
     cgh.single_task([=](){
       acc[0]++;
     });


### PR DESCRIPTION
This adds support for the multi device queue extension, multi-device and system device selector, and initial API for automatic work distribution across the system. **The current scheduler for automatic work distribution is a placeholder and WILL NOT BE EFFICIENT, please don't use it for any production workloads!** The point of this PR is rather to add a base from which we can start improving in an incremental fashion.

From the documentation:

# `HIPSYCL_EXT_MULTI_DEVICE_QUEUE`

This extension allows `sycl::queue` to automatically distribute work across multiple devices.

**Note:** This is highly experimental, not performance-optimized, the current work distribution algorithm is extremely primitive and a placeholder for a proper scheduling algorithm. This extension should not yet be used for any production workloads.

A multi-device queue can be constructed either by passing a vector of `sycl::device` to the queue constructor, or by using the new device selectors, such as `system_selector_v`. See the API reference below for details.

## Example

```c++
sycl::queue q{sycl::system_selector_v};
q.single_task([=](){
  // may be executed on any device inside the system
  // as automatically decided by the scheduler
}).wait();
```

## Restrictions

In multi-device mode, the following operations are currently unsupported, although support may be partially or fully added in the future:

* `queue::get_device()`;
* Overloads for USM memory management functions that are provided the queue as argument;
* the USM-related member functions of `sycl::handler` such as `memcpy`, `memset`, `fill`, `prefetch` and `prefetch_host`;
* If kernels use USM pointers, the user is responsible for making sure that the USM pointer is valid on all devices that the queue might dispatch to;
* All variants of `handler::copy()`;
* `handler::update()` from the `HIPSYCL_EXT_UPDATE_DEVICE` extension

## API Reference

```c++
namespace sycl {

enum class selection_policy {
  all,
  best
};

// A wrapper class that turns a regular selector into a multi-device
// selector. 
// If selection policy is selection_policy::all, then
// all devices are selected for which the provided selector returns a
// non-negative number.
// If selection policy is selection_policy::best, then
// only devices with the best score are selected. Multiple devices are
// only selected in this case if the same top score is returned
// for multiple devices.
template <class Selector, selection_policy P = selection_policy::all>
class multi_device_selector {
public:
  constexpr multi_device_selector(const Selector& s = Selector{});

  int operator()(const device& dev);
};

inline constexpr multi_device_selector<cpu_selector,selection_policy::best>
    multi_cpu_selector_v;

// Returns all GPUs that have been targeted at compile time.
inline constexpr multi_device_selector<gpu_selector, selection_policy::best>
    multi_gpu_selector_v;

// Returns all devices in the system that have been targeted at
// compile time.
inline constexpr multi_device_selector<default_selector, selection_policy::all>
    system_selector_v;

class queue {
public:
  // New constructors that accept a vector of device.
  // Alternatively, an appropriate multi-device selector
  // can be provided to the queue.
  explicit queue(const std::vector<device> &devices,
                 const async_handler &handler,
                 const property_list &propList = {});

  explicit queue(const std::vector<device>& devices, 
                const property_list& propList = {});

  explicit queue(const context &syclContext,
                const std::vector<device> &devices,
                const property_list &propList = {});

  explicit queue(const context &syclContext,
                 const std::vector<device> &devices,
                 const async_handler &asyncHandler,
                 const property_list &propList = {});

  // Returns all devices that this queue might dispatch to
  std::vector<device> get_devices() const;
};

}
```