### PR TITLE
Update reduction variables to SYCL 2020 spec behavior

### DIFF
--- a/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
@@ -413,7 +413,7 @@ public:
       const ReductionDescriptor& desc,
       rt::device_id dev, const std::vector<ReductionStage> &stages,
       std::vector<void *> &managed_scratch_memory)
-      : _descriptor{desc}, _is_final{false}, _scratch_memory_in{nullptr},
+      : _descriptor{desc}, _is_final_stage{false}, _scratch_memory_in{nullptr},
         _scratch_memory_out{nullptr} {
     
     assert(stages.size() > 0);
@@ -456,61 +456,13 @@ public:
                                   stage.allocated_local_memory);
 
     if (stage_index + 1 == num_stages)
-      _is_final = true;
+      _is_final_stage = true;
   
     if (stage_index > 0) {
       std::swap(_scratch_memory_in, _scratch_memory_out);
     }
   }
 
-  // Must be __host__ __device__ in order to be able to call
-  // hiplike_dynamic_local_memory()
-  __host__ __device__ void *get_local_scratch_mem() const {
-#ifdef SYCL_DEVICE_ONLY
-    return static_cast<void *>(
-        static_cast<char *>(sycl::detail::hiplike_dynamic_local_memory()) +
-        _local_memory_offset);
-#else
-    return nullptr;
-#endif
-  }
-
-  // Must be __host__ __device__ in order to be able to call
-  // hiplike_dynamic_local_memory()
-  __host__ __device__ void *get_local_scratch_mem_initialized() const {
-#ifdef SYCL_DEVICE_ONLY
-    return static_cast<void *>(
-        static_cast<char *>(sycl::detail::hiplike_dynamic_local_memory()) +
-        _local_memory_offset + work_group_size() * sizeof(value_type));
-#else
-    return nullptr;
-#endif
-  }
-
-  __host__ __device__
-  void* get_reduction_output_buffer() const {
-#ifdef SYCL_DEVICE_ONLY
-    if(!_is_final)
-      return _scratch_memory_out;
-    else
-      return _descriptor.get_pointer();
-#else
-    return nullptr;
-#endif
-  }
-
-  __host__ __device__ 
-  void* get_reduction_output_initialized_buffer() const {
-#ifdef SYCL_DEVICE_ONLY
-    if(!_is_final)
-      return static_cast<value_type*>(_scratch_memory_out) + work_group_size();
-    // hiplike::local_reduction_accumulator will only write the output initialized flag
-    // for intermediate stages
-#endif
-    return nullptr;
-  }
-
-#ifdef SYCL_DEVICE_ONLY
   __device__ hiplike::local_reducer<ReductionDescriptor>
   construct_reducer() const {
     int my_local_id = __hipsycl_lid_z * __hipsycl_lsize_y * __hipsycl_lsize_x +
@@ -519,47 +471,21 @@ public:
         __hipsycl_gid_z * __hipsycl_ngroups_y * __hipsycl_ngroups_x +
         __hipsycl_gid_y * __hipsycl_ngroups_x + __hipsycl_gid_x;
 
-    auto private_accumulator = sequential_reduction_accumulator<ReductionDescriptor>{_descriptor};
-    auto group_scratch_ptr = static_cast<value_type *>(get_local_scratch_mem());
-    value_type *group_output_ptr =
-        static_cast<value_type *>(get_reduction_output_buffer()) + my_group_id;
-    value_type* global_input_ptr =
-        static_cast<value_type*>(get_reduction_input_buffer());
-
-    if constexpr (ReductionDescriptor::has_identity) {
+    if constexpr(ReductionDescriptor::has_identity) {
       return hiplike::local_reducer<ReductionDescriptor>{
-          _descriptor, my_local_id, private_accumulator,
-          hiplike::local_reduction_accumulator<ReductionDescriptor>{group_scratch_ptr,
-              group_output_ptr, global_input_ptr},
-          _is_final};
+          _descriptor, my_local_id,
+          hiplike::local_reduction_accumulator<ReductionDescriptor>{get_scratch_value_buffer(),
+              get_output_value_buffer() + my_group_id, get_input_value_buffer()},
+          _is_final_stage};
     } else {
-      auto group_scratch_initialized_ptr = reinterpret_cast<hiplike::local_memory_flag*>(
-          get_local_scratch_mem_initialized());
-      auto group_output_initialized_ptr =
-          static_cast<hiplike::local_memory_flag *>(get_reduction_output_initialized_buffer()) + my_group_id;
-      auto global_input_initialized_ptr =
-          static_cast<hiplike::local_memory_flag *>(get_reduction_input_initialized_buffer());
       return hiplike::local_reducer<ReductionDescriptor>{
-          _descriptor, my_local_id, private_accumulator,
-          hiplike::local_reduction_accumulator<ReductionDescriptor>{group_scratch_ptr,
-              group_scratch_initialized_ptr, group_output_ptr, group_output_initialized_ptr,
-              global_input_ptr, global_input_initialized_ptr},
-          _is_final};
+          _descriptor, my_local_id,
+          hiplike::local_reduction_accumulator<ReductionDescriptor>{get_scratch_value_buffer(),
+              get_scratch_initialized_flag_buffer(), get_output_value_buffer() + my_group_id,
+              get_output_initialized_flag_buffer() + my_group_id,
+              get_input_value_buffer(), get_input_initialized_flag_buffer()},
+          _is_final_stage};
     }
-  }
-#endif
-
-  __device__ void *get_reduction_input_buffer() const {
-    return _scratch_memory_in;
-  }
-
-  __device__ void *get_reduction_input_initialized_buffer() const {
-    return static_cast<value_type*>(_scratch_memory_in) + work_group_size();
-  }
-
-  __host__ __device__
-  const ReductionDescriptor& get_descriptor() const {
-    return _descriptor;
   }
 
 private:
@@ -579,11 +505,49 @@ private:
         work_group_size * (sizeof(value_type) + sizeof_initialized_flag);
   }
 
+  __device__ value_type *get_input_value_buffer() const {
+    return static_cast<value_type*>(_scratch_memory_in);
+  }
+
+  __device__ hiplike::local_memory_flag *get_input_initialized_flag_buffer() const {
+    return reinterpret_cast<hiplike::local_memory_flag*>(
+        static_cast<value_type*>(_scratch_memory_in) + work_group_size());
+  }
+
+  __device__ value_type* get_scratch_value_buffer() const {
+    return reinterpret_cast<value_type *>(
+        static_cast<char *>(sycl::detail::hiplike_dynamic_local_memory()) +
+            _local_memory_offset);
+  }
+
+  __device__ hiplike::local_memory_flag* get_scratch_initialized_flag_buffer() const {
+    return reinterpret_cast<hiplike::local_memory_flag *>(
+        static_cast<char *>(sycl::detail::hiplike_dynamic_local_memory()) +
+            _local_memory_offset + work_group_size() * sizeof(value_type));
+  }
+
+  __device__ value_type* get_output_value_buffer() const {
+    if(!_is_final_stage)
+      return static_cast<value_type*>(_scratch_memory_out);
+    else
+      return _descriptor.get_pointer();
+  }
+
+  __device__ hiplike::local_memory_flag* get_output_initialized_flag_buffer() const {
+    // hiplike::local_reduction_accumulator will only write the output initialized flag
+    // for intermediate stages
+    if(!_is_final_stage)
+      return reinterpret_cast<hiplike::local_memory_flag*>(
+          static_cast<value_type*>(_scratch_memory_out) + work_group_size());
+    else
+      return nullptr;
+  }
+
   static __device__ int work_group_size() {
     return __hipsycl_lsize_x * __hipsycl_lsize_y * __hipsycl_lsize_z;
   }
 
-  bool _is_final;
+  bool _is_final_stage;
 
   void* _scratch_memory_in;
   void* _scratch_memory_out;

--- a/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
@@ -503,8 +503,8 @@ private:
         ceil_division(allocated_local_mem_size, alignment) *
         alignment;
 
-    // Dynamic local memory layout, reduction known:   [values...]
-    // Dynamic local memory layout, reduction unknown: [values...][initialized_flags...]
+    // Dynamic local memory layout, identity known:   [values...]
+    // Dynamic local memory layout, identity unknown: [values...][initialized_flags...]
     allocated_local_mem_size = _local_memory_offset +
         work_group_size * (sizeof(value_type) + sizeof_initialized_flag);
   }

--- a/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
@@ -420,7 +420,7 @@ public:
 
     std::size_t num_scratch_elements = stages[0].num_groups.size();
     std::size_t scratch_memory_size =
-        sizeof(value_type) * num_scratch_elements;
+        (sizeof(value_type) + sizeof_initialized_flag) * num_scratch_elements;
 
     auto allocator =
         rt::application::get_backend(dev.get_backend()).get_allocator(dev);
@@ -475,7 +475,19 @@ public:
 #endif
   }
 
-  __host__ __device__ 
+  // Must be __host__ __device__ in order to be able to call
+  // hiplike_dynamic_local_memory()
+  __host__ __device__ void *get_local_scratch_mem_initialized() const {
+#ifdef SYCL_DEVICE_ONLY
+    return static_cast<void *>(
+        static_cast<char *>(sycl::detail::hiplike_dynamic_local_memory()) +
+        _local_memory_offset + work_group_size() * sizeof(value_type));
+#else
+    return nullptr;
+#endif
+  }
+
+  __host__ __device__
   void* get_reduction_output_buffer() const {
 #ifdef SYCL_DEVICE_ONLY
     if(!_is_final)
@@ -487,6 +499,17 @@ public:
 #endif
   }
 
+  __host__ __device__ 
+  void* get_reduction_output_initialized_buffer() const {
+#ifdef SYCL_DEVICE_ONLY
+    if(!_is_final)
+      return static_cast<value_type*>(_scratch_memory_out) + work_group_size();
+    // hiplike::local_reduction_accumulator will only write the output initialized flag
+    // for intermediate stages
+#endif
+    return nullptr;
+  }
+
 #ifdef SYCL_DEVICE_ONLY
   __device__ hiplike::local_reducer<ReductionDescriptor>
   construct_reducer() const {
@@ -496,21 +519,42 @@ public:
         __hipsycl_gid_z * __hipsycl_ngroups_y * __hipsycl_ngroups_x +
         __hipsycl_gid_y * __hipsycl_ngroups_x + __hipsycl_gid_x;
 
+    auto private_accumulator = sequential_reduction_accumulator<ReductionDescriptor>{_descriptor};
+    auto group_scratch_ptr = static_cast<value_type *>(get_local_scratch_mem());
     value_type *group_output_ptr =
         static_cast<value_type *>(get_reduction_output_buffer()) + my_group_id;
-
     value_type* global_input_ptr =
         static_cast<value_type*>(get_reduction_input_buffer());
 
-    return hiplike::local_reducer<ReductionDescriptor>{
-        _descriptor, my_local_id,
-        static_cast<value_type *>(get_local_scratch_mem()), group_output_ptr,
-        global_input_ptr, _is_final};
+    if constexpr (ReductionDescriptor::has_identity) {
+      return hiplike::local_reducer<ReductionDescriptor>{
+          _descriptor, my_local_id, private_accumulator,
+          hiplike::local_reduction_accumulator<ReductionDescriptor>{group_scratch_ptr,
+              group_output_ptr, global_input_ptr},
+          _is_final};
+    } else {
+      auto group_scratch_initialized_ptr = reinterpret_cast<hiplike::local_memory_flag*>(
+          get_local_scratch_mem_initialized());
+      auto group_output_initialized_ptr =
+          static_cast<hiplike::local_memory_flag *>(get_reduction_output_initialized_buffer()) + my_group_id;
+      auto global_input_initialized_ptr =
+          static_cast<hiplike::local_memory_flag *>(get_reduction_input_initialized_buffer());
+      return hiplike::local_reducer<ReductionDescriptor>{
+          _descriptor, my_local_id, private_accumulator,
+          hiplike::local_reduction_accumulator<ReductionDescriptor>{group_scratch_ptr,
+              group_scratch_initialized_ptr, group_output_ptr, group_output_initialized_ptr,
+              global_input_ptr, global_input_initialized_ptr},
+          _is_final};
+    }
   }
 #endif
-  
+
   __device__ void *get_reduction_input_buffer() const {
     return _scratch_memory_in;
+  }
+
+  __device__ void *get_reduction_input_initialized_buffer() const {
+    return static_cast<value_type*>(_scratch_memory_in) + work_group_size();
   }
 
   __host__ __device__
@@ -518,9 +562,10 @@ public:
     return _descriptor;
   }
 
-  
 private:
-  
+  constexpr static std::size_t sizeof_initialized_flag
+      = ReductionDescriptor::has_identity ? 0 : sizeof(hiplike::local_memory_flag);
+
   __host__ void initialize_local_memory(int work_group_size,
                                         int &allocated_local_mem_size) {
     
@@ -531,11 +576,15 @@ private:
         alignment;
 
     allocated_local_mem_size = _local_memory_offset + 
-        work_group_size * sizeof(value_type);
+        work_group_size * (sizeof(value_type) + sizeof_initialized_flag);
+  }
+
+  static __device__ int work_group_size() {
+    return __hipsycl_lsize_x * __hipsycl_lsize_y * __hipsycl_lsize_z;
   }
 
   bool _is_final;
-  
+
   void* _scratch_memory_in;
   void* _scratch_memory_out;
 

--- a/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
@@ -505,7 +505,7 @@ public:
     return hiplike::local_reducer<ReductionDescriptor>{
         _descriptor, my_local_id,
         static_cast<value_type *>(get_local_scratch_mem()), group_output_ptr,
-        global_input_ptr};
+        global_input_ptr, _is_final};
   }
 #endif
   

--- a/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
@@ -489,8 +489,10 @@ public:
   }
 
 private:
+  // For reductions without a known identity, we need to allocate additional space to store flags indicating
+  // whether each reduction input/output has been is initialized
   constexpr static std::size_t sizeof_initialized_flag
-      = ReductionDescriptor::has_identity ? 0 : sizeof(hiplike::local_memory_flag);
+      = ReductionDescriptor::has_identity ? 0 : sizeof(hiplike::initialized_flag);
 
   __host__ void initialize_local_memory(int work_group_size,
                                         int &allocated_local_mem_size) {
@@ -501,7 +503,9 @@ private:
         ceil_division(allocated_local_mem_size, alignment) *
         alignment;
 
-    allocated_local_mem_size = _local_memory_offset + 
+    // Dynamic local memory layout, reduction known:   [values...]
+    // Dynamic local memory layout, reduction unknown: [values...][initialized_flags...]
+    allocated_local_mem_size = _local_memory_offset +
         work_group_size * (sizeof(value_type) + sizeof_initialized_flag);
   }
 
@@ -509,8 +513,8 @@ private:
     return static_cast<value_type*>(_scratch_memory_in);
   }
 
-  __device__ hiplike::local_memory_flag *get_input_initialized_flag_buffer() const {
-    return reinterpret_cast<hiplike::local_memory_flag*>(
+  __device__ hiplike::initialized_flag *get_input_initialized_flag_buffer() const {
+    return reinterpret_cast<hiplike::initialized_flag*>(
         static_cast<value_type*>(_scratch_memory_in) + work_group_size());
   }
 
@@ -520,8 +524,8 @@ private:
             _local_memory_offset);
   }
 
-  __device__ hiplike::local_memory_flag* get_scratch_initialized_flag_buffer() const {
-    return reinterpret_cast<hiplike::local_memory_flag *>(
+  __device__ hiplike::initialized_flag* get_scratch_initialized_flag_buffer() const {
+    return reinterpret_cast<hiplike::initialized_flag *>(
         static_cast<char *>(sycl::detail::hiplike_dynamic_local_memory()) +
             _local_memory_offset + work_group_size() * sizeof(value_type));
   }
@@ -533,11 +537,11 @@ private:
       return _descriptor.get_pointer();
   }
 
-  __device__ hiplike::local_memory_flag* get_output_initialized_flag_buffer() const {
+  __device__ hiplike::initialized_flag* get_output_initialized_flag_buffer() const {
     // hiplike::local_reduction_accumulator will only write the output initialized flag
     // for intermediate stages
     if(!_is_final_stage)
-      return reinterpret_cast<hiplike::local_memory_flag*>(
+      return reinterpret_cast<hiplike::initialized_flag*>(
           static_cast<value_type*>(_scratch_memory_out) + work_group_size());
     else
       return nullptr;

--- a/include/hipSYCL/glue/generic/hiplike/hiplike_reducer.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/hiplike_reducer.hpp
@@ -218,6 +218,11 @@ public:
     _private_accumulator.combine_with(_desc, _local_accumulator.get_global_input(my_global_id));
 #endif
   }
+
+  __host__ __device__ value_type identity() const {
+    return _desc.identity;
+  }
+
 private:
   const ReductionDescriptor &_desc;
   const int _my_lid;

--- a/include/hipSYCL/glue/generic/hiplike/hiplike_reducer.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/hiplike_reducer.hpp
@@ -28,39 +28,140 @@
 #ifndef HIPSYCL_GLUE_HIPLIKE_REDUCER_HPP
 #define HIPSYCL_GLUE_HIPLIKE_REDUCER_HPP
 
+#include "hipSYCL/glue/generic/reduction_accumulator.hpp"
 #include "hipSYCL/sycl/libkernel/backend.hpp"
 
 namespace hipsycl {
 namespace glue {
 namespace hiplike {
 
+using local_memory_flag = bool;
+
 template<class ReductionDescriptor, class Enable = void>
-class local_reducer;
+class local_reduction_accumulator;
 
 template<class ReductionDescriptor>
-class local_reducer<ReductionDescriptor, std::enable_if_t<ReductionDescriptor::has_identity>> {
+class local_reduction_accumulator<ReductionDescriptor,
+    std::enable_if_t<ReductionDescriptor::has_identity>> {
+public:
+  using value_type = typename ReductionDescriptor::value_type;
+  using private_accumulator_type = sequential_reduction_accumulator<ReductionDescriptor>;
+
+  __host__ __device__ local_reduction_accumulator(value_type *local_memory,
+      value_type *local_output, value_type *global_input)
+      : _local_memory{local_memory}, _local_output{local_output}, _global_input{global_input} {}
+
+  __host__ __device__ void init_value(int my_lid,
+      const private_accumulator_type &private_accumulator) {
+    _local_memory[my_lid] = private_accumulator.value;
+  }
+
+  __host__ __device__ void combine_with(const ReductionDescriptor &desc,
+      int my_lid, int other_lid) {
+    _local_memory[my_lid] = desc.combiner(_local_memory[my_lid], _local_memory[other_lid]);
+  }
+
+  __host__ __device__ void store_intermediate_output() {
+    *_local_output = _local_memory[0];
+  }
+
+  __host__ __device__ void combine_final_output(const ReductionDescriptor &desc) {
+     if (!desc.initialize_to_identity) {
+       *_local_output = desc.combiner(*_local_output, _local_memory[0]);
+     } else {
+       *_local_output = _local_memory[0];
+     }
+  }
+
+  __host__ __device__ private_accumulator_type get_global_input(int my_global_id) {
+    return private_accumulator_type{_global_input[my_global_id]};
+  }
+
+private:
+  value_type *_local_memory;
+  value_type *_local_output;
+  value_type *_global_input;
+};
+
+template<class ReductionDescriptor>
+class local_reduction_accumulator<ReductionDescriptor,
+    std::enable_if_t<!ReductionDescriptor::has_identity>> {
+public:
+  using value_type = typename ReductionDescriptor::value_type;
+  using private_accumulator_type = sequential_reduction_accumulator<ReductionDescriptor>;
+
+  __host__ __device__ local_reduction_accumulator(
+      value_type *local_memory, local_memory_flag *memory_initialized,
+      value_type *local_output, local_memory_flag *output_initialized,
+      value_type *global_input, local_memory_flag *input_initialized)
+    : _local_memory{local_memory}, _memory_initialized{memory_initialized}
+    , _local_output{local_output}, _output_initialized{output_initialized}
+    , _global_input{global_input}, _input_initialized{input_initialized} {}
+
+  __host__ __device__ void init_value(int my_lid,
+      const private_accumulator_type &private_accumulator) {
+    _local_memory[my_lid] = private_accumulator.value;
+    _memory_initialized[my_lid] = private_accumulator.initialized;
+  }
+
+  __host__ __device__ void combine_with(const ReductionDescriptor &desc,
+      int my_lid, int other_lid) {
+    if (!_memory_initialized[other_lid]) return;
+    _local_memory[my_lid] = _memory_initialized[my_lid]
+        ? desc.combiner(_local_memory[my_lid], _local_memory[other_lid])
+        : _local_memory[other_lid];
+    _memory_initialized[my_lid] = true;
+  }
+
+  __host__ __device__ void store_intermediate_output() {
+    *_local_output = _local_memory[0];
+    *_output_initialized = _memory_initialized[0];
+  }
+
+  __host__ __device__ void combine_final_output(const ReductionDescriptor &desc) {
+    if (_memory_initialized[0]) {
+      *_local_output = desc.combiner(*_local_output, _local_memory[0]);
+    }
+  }
+
+  __host__ __device__ private_accumulator_type get_global_input(int my_global_id) {
+    return private_accumulator_type{_global_input[my_global_id], _input_initialized[my_global_id]};
+  }
+
+private:
+  value_type *_local_memory;
+  local_memory_flag *_memory_initialized;
+  value_type *_local_output;
+  local_memory_flag *_output_initialized;
+  value_type *_global_input;
+  local_memory_flag *_input_initialized;
+};
+
+template<class ReductionDescriptor>
+class local_reducer {
 public:
   using value_type = typename ReductionDescriptor::value_type;
   using combiner_type = typename ReductionDescriptor::combiner_type;
+  using private_accumulator_type = sequential_reduction_accumulator<ReductionDescriptor>;
+  using local_accumulator_type = local_reduction_accumulator<ReductionDescriptor>;
 
   __host__ __device__ local_reducer(const ReductionDescriptor &desc, int my_lid,
-                                    value_type *local_memory,
-                                    value_type *local_output,
-                                    value_type *global_input, bool is_final_stage)
-      : _desc{desc}, _my_lid{my_lid}, _my_value{desc.identity},
-        _local_memory{local_memory}, _local_output{local_output},
-        _global_input{global_input}, _is_final_stage{is_final_stage} {}
+                                    const private_accumulator_type &private_accumulator,
+                                    const local_accumulator_type &local_accumulator,
+                                    bool is_final_stage)
+      : _desc{desc}, _my_lid{my_lid},
+        _private_accumulator{private_accumulator}, _local_accumulator{local_accumulator},
+        _is_final_stage{is_final_stage} {}
 
   __host__ __device__
   void combine(const value_type& v) {
-    _my_value = _desc.combiner(_my_value, v);
+    _private_accumulator.combine_with(_desc, v);
   }
 
   __host__ __device__
   void finalize_result() {
-    _local_memory[_my_lid] = _my_value;
-    // TODO Optimize this - may be able to share
-    // code with group algorithms
+    _local_accumulator.init_value(_my_lid, _private_accumulator);
+    // TODO Optimize this - may be able to share code with group algorithms
     // TODO What if local size is not power of two?
 #ifdef SYCL_DEVICE_ONLY
     __syncthreads();
@@ -68,15 +169,14 @@ public:
         __hipsycl_lsize_x * __hipsycl_lsize_y * __hipsycl_lsize_z;
     for (int i = local_size / 2; i > 0; i /= 2) {
       if(_my_lid < i)
-        _local_memory[_my_lid] =
-            _desc.combiner(_local_memory[_my_lid], _local_memory[_my_lid + i]);
+        _local_accumulator.combine_with(_desc, _my_lid, _my_lid + i);
       __syncthreads();
     }
     if (_my_lid == 0) {
-      if (_is_final_stage && !_desc.initialize_to_identity) {
-        *_local_output = _desc.combiner(*_local_output, _local_memory[0]);
+      if (_is_final_stage) {
+        _local_accumulator.combine_final_output(_desc);
       } else {
-        *_local_output = _local_memory[0];
+        _local_accumulator.store_intermediate_output();
       }
     }
 #endif
@@ -84,16 +184,14 @@ public:
 
   __host__ __device__ void combine_global_input(int my_global_id) {
 #ifdef SYCL_DEVICE_ONLY
-    combine(_global_input[my_global_id]);
+    _private_accumulator.combine_with(_desc, _local_accumulator.get_global_input(my_global_id));
 #endif
   }
 private:
   const ReductionDescriptor &_desc;
   const int _my_lid;
-  value_type _my_value;
-  value_type* _local_memory;
-  value_type* _local_output;
-  value_type* _global_input;
+  private_accumulator_type _private_accumulator;
+  local_accumulator_type _local_accumulator;
   bool _is_final_stage;
 };
 

--- a/include/hipSYCL/glue/generic/hiplike/hiplike_reducer.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/hiplike_reducer.hpp
@@ -146,11 +146,10 @@ public:
   using local_accumulator_type = local_reduction_accumulator<ReductionDescriptor>;
 
   __host__ __device__ local_reducer(const ReductionDescriptor &desc, int my_lid,
-                                    const private_accumulator_type &private_accumulator,
                                     const local_accumulator_type &local_accumulator,
                                     bool is_final_stage)
       : _desc{desc}, _my_lid{my_lid},
-        _private_accumulator{private_accumulator}, _local_accumulator{local_accumulator},
+        _private_accumulator{desc}, _local_accumulator{local_accumulator},
         _is_final_stage{is_final_stage} {}
 
   __host__ __device__

--- a/include/hipSYCL/glue/generic/host/sequential_reducer.hpp
+++ b/include/hipSYCL/glue/generic/host/sequential_reducer.hpp
@@ -87,6 +87,10 @@ public:
     *(_desc.get_pointer()) = accumulator.value;
   }
 
+  value_type identity() const {
+    return _desc.identity;
+  }
+
 private:
   ReductionDescriptor &_desc;
   // TODO: new does not necessarily respect over-aligned alignas requirements.

--- a/include/hipSYCL/glue/generic/host/sequential_reducer.hpp
+++ b/include/hipSYCL/glue/generic/host/sequential_reducer.hpp
@@ -54,6 +54,49 @@ template <class T> struct cache_line_aligned {
   alignas(cache_line_size) T value;
 };
 
+template<class ReductionDescriptor, class Enable = void>
+struct reduction_accumulator;
+
+template<class ReductionDescriptor>
+struct alignas(cache_line_size) reduction_accumulator<ReductionDescriptor,
+    std::enable_if_t<ReductionDescriptor::has_identity>> {
+  using value_type = typename ReductionDescriptor::value_type;
+
+  value_type value;
+
+  explicit reduction_accumulator(ReductionDescriptor &desc): value(desc.identity) {}
+
+  void combine_with(ReductionDescriptor &desc, const value_type &v) {
+    value = desc.combiner(value, v);
+  }
+
+  void combine_with(ReductionDescriptor &desc, const reduction_accumulator &v) {
+    value = desc.combiner(value, v.value);
+  }
+};
+
+template<class ReductionDescriptor>
+struct alignas(cache_line_size) reduction_accumulator<ReductionDescriptor,
+    std::enable_if_t<!ReductionDescriptor::has_identity>> {
+  using value_type = typename ReductionDescriptor::value_type;
+
+  value_type value;
+  bool initialized = false;
+
+  explicit reduction_accumulator(ReductionDescriptor &) {}
+
+  void combine_with(ReductionDescriptor &desc, const value_type &v) {
+    value = initialized ? desc.combiner(value, v) : v;
+    initialized = true;
+  }
+
+  void combine_with(ReductionDescriptor &desc, const reduction_accumulator &v) {
+    if (!v.initialized) return;
+    value = initialized ? desc.combiner(value, v.value) : v.value;
+    initialized = true;
+  }
+};
+
 template<class ReductionDescriptor>
 class sequential_reducer {
 public:
@@ -61,35 +104,36 @@ public:
   using combiner_type = typename ReductionDescriptor::combiner_type;
 
   sequential_reducer(int num_threads, ReductionDescriptor &desc)
-      : _desc{desc},
-        _per_thread_results(num_threads,
-                            cache_line_aligned<value_type>{identity()}) {}
-
-  value_type identity() const { return _desc.identity; }
+      : _desc{desc}, _per_thread_results(num_threads, reduction_accumulator<ReductionDescriptor>{desc}) {}
 
   void combine(int my_thread_id, const value_type& v) {
     assert(my_thread_id < _per_thread_results.size());
-    _per_thread_results[my_thread_id].value =
-        _desc.combiner(_per_thread_results[my_thread_id].value, v);
+    _per_thread_results[my_thread_id].combine_with(_desc, v);
   }
 
   // This should be executed in a single threaded scope.
   // Sums up all the partial results and stores in the result data buffer
   void finalize_result() {
-    for (std::size_t i = 1; i < _per_thread_results.size(); ++i) {
-      _per_thread_results[0].value = _desc.combiner(
-          _per_thread_results[0].value, _per_thread_results[i].value);
+    bool initialize_from_dest = true;
+    if constexpr (ReductionDescriptor::has_identity) {
+      initialize_from_dest = !_desc.initialize_to_identity;
     }
-    
-    *(_desc.get_pointer()) = _per_thread_results[0].value;
+    reduction_accumulator<ReductionDescriptor> accumulator(_desc);
+    if (initialize_from_dest) {
+      accumulator.combine_with(_desc, *_desc.get_pointer());
+    }
+    for (std::size_t i = 0; i < _per_thread_results.size(); ++i) {
+      accumulator.combine_with(_desc, _per_thread_results[i]);
+    }
+    *(_desc.get_pointer()) = accumulator.value;
   }
+
 private:
   ReductionDescriptor &_desc;
   // TODO: new does not necessarily respect over-aligned alignas requirements.
   // Depending on the value of std::max_align_t and cache_line_size,
   // alignment may be off and not match cache lines.
-  std::vector<cache_line_aligned<value_type>> _per_thread_results;
-
+  std::vector<reduction_accumulator<ReductionDescriptor>> _per_thread_results;
 };
 
 }

--- a/include/hipSYCL/glue/generic/reduction_accumulator.hpp
+++ b/include/hipSYCL/glue/generic/reduction_accumulator.hpp
@@ -1,0 +1,93 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2021 Aksel Alpay and Contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HIPSYCL_GLUE_REDUCTION_ACCUMULATOR_H
+#define HIPSYCL_GLUE_REDUCTION_ACCUMULATOR_H
+
+#include "hipSYCL/sycl/libkernel/backend.hpp"
+
+namespace hipsycl {
+namespace glue {
+
+template<class ReductionDescriptor, class Enable = void>
+struct sequential_reduction_accumulator;
+
+template<class ReductionDescriptor>
+struct sequential_reduction_accumulator<ReductionDescriptor,
+    std::enable_if_t<ReductionDescriptor::has_identity>> {
+  using value_type = typename ReductionDescriptor::value_type;
+
+  value_type value;
+
+  explicit HIPSYCL_UNIVERSAL_TARGET sequential_reduction_accumulator(
+      const ReductionDescriptor &desc)
+    : value(desc.identity) {}
+
+  explicit HIPSYCL_UNIVERSAL_TARGET sequential_reduction_accumulator(value_type value)
+    : value{value} {}
+
+  HIPSYCL_UNIVERSAL_TARGET void combine_with(const ReductionDescriptor &desc, const value_type &v) {
+    value = desc.combiner(value, v);
+  }
+
+  HIPSYCL_UNIVERSAL_TARGET void combine_with(const ReductionDescriptor &desc,
+      const sequential_reduction_accumulator &v) {
+    value = desc.combiner(value, v.value);
+  }
+};
+
+template<class ReductionDescriptor>
+struct sequential_reduction_accumulator<ReductionDescriptor,
+    std::enable_if_t<!ReductionDescriptor::has_identity>> {
+  using value_type = typename ReductionDescriptor::value_type;
+
+  value_type value;
+  bool initialized = false;
+
+  explicit HIPSYCL_UNIVERSAL_TARGET sequential_reduction_accumulator(const ReductionDescriptor &) {}
+
+  explicit HIPSYCL_UNIVERSAL_TARGET sequential_reduction_accumulator(value_type value,
+      bool initialized)
+    : value{value}, initialized{initialized} {}
+
+  HIPSYCL_UNIVERSAL_TARGET void combine_with(const ReductionDescriptor &desc, const value_type &v) {
+    value = initialized ? desc.combiner(value, v) : v;
+    initialized = true;
+  }
+
+  HIPSYCL_UNIVERSAL_TARGET void combine_with(const ReductionDescriptor &desc,
+      const sequential_reduction_accumulator &v) {
+    if (!v.initialized) return;
+    value = initialized ? desc.combiner(value, v.value) : v.value;
+    initialized = true;
+  }
+};
+
+}
+}
+
+#endif

--- a/include/hipSYCL/glue/generic/reduction_accumulator.hpp
+++ b/include/hipSYCL/glue/generic/reduction_accumulator.hpp
@@ -33,9 +33,12 @@
 namespace hipsycl {
 namespace glue {
 
+// Common interface for accumulating values in a reduction variable, for both the known-identity and the
+// unknown-identity cases.
 template<class ReductionDescriptor, class Enable = void>
 struct sequential_reduction_accumulator;
 
+// In the common case, the accumulator is initialized to the known identity.
 template<class ReductionDescriptor>
 struct sequential_reduction_accumulator<ReductionDescriptor,
     std::enable_if_t<ReductionDescriptor::has_identity>> {
@@ -60,6 +63,8 @@ struct sequential_reduction_accumulator<ReductionDescriptor,
   }
 };
 
+// When the identity is unknown, the accumulator is effectively a std::optional, remembering whether at least one
+// value has been combine()d.
 template<class ReductionDescriptor>
 struct sequential_reduction_accumulator<ReductionDescriptor,
     std::enable_if_t<!ReductionDescriptor::has_identity>> {

--- a/include/hipSYCL/sycl/libkernel/detail/local_memory_allocator.hpp
+++ b/include/hipSYCL/sycl/libkernel/detail/local_memory_allocator.hpp
@@ -168,9 +168,8 @@ private:
 #pragma omp threadprivate(_origin)
 };
 
-HIPSYCL_KERNEL_TARGET
-inline void* hiplike_dynamic_local_memory() {
-#ifdef SYCL_DEVICE_ONLY
+#if defined(HIPSYCL_PLATFORM_HIP) || defined(HIPSYCL_PLATFORM_CUDA)
+__device__ inline void* hiplike_dynamic_local_memory() {
   #ifdef HIPSYCL_PLATFORM_CUDA
     extern __shared__ int local_mem [];
     return static_cast<void*>(local_mem);
@@ -178,11 +177,8 @@ inline void* hiplike_dynamic_local_memory() {
   #ifdef HIPSYCL_PLATFORM_ROCM
     return __amdgcn_get_dynamicgroupbaseptr();
   #endif
-#else
-  assert(false && "this function should only be called on device");
-  return nullptr;
-#endif
 }
+#endif
 
 class local_memory
 {

--- a/include/hipSYCL/sycl/libkernel/functional.hpp
+++ b/include/hipSYCL/sycl/libkernel/functional.hpp
@@ -79,6 +79,39 @@ template <typename T> struct maximum {
   T operator()(const T &x, const T &y) const { return (x > y) ? x : y; }
 };
 
+
+template<typename BinaryOperation, typename AccumulatorT>
+struct known_identity;
+
+template <typename BinaryOperation, typename AccumulatorT>
+inline constexpr AccumulatorT known_identity_v = known_identity<BinaryOperation, AccumulatorT>::value;
+
+template<typename BinaryOperation, typename AccumulatorT>
+struct has_known_identity {
+    static constexpr bool value = false;
+};
+
+template <typename BinaryOperation, typename AccumulatorT>
+inline constexpr bool has_known_identity_v = has_known_identity<BinaryOperation, AccumulatorT>::value;
+
+#define HIPSYCL_DEFINE_IDENTITY(op, identity) \
+    template<typename T> \
+    struct known_identity<op<T>, T> { \
+        inline static constexpr T value = (identity); \
+    }; \
+    template<typename T> \
+    struct has_known_identity<op<T>, T> { \
+        static constexpr bool value = true; \
+    };
+
+HIPSYCL_DEFINE_IDENTITY(plus, 0);
+HIPSYCL_DEFINE_IDENTITY(multiplies, 1);
+HIPSYCL_DEFINE_IDENTITY(bit_or, T{});
+HIPSYCL_DEFINE_IDENTITY(bit_and, ~T{});
+HIPSYCL_DEFINE_IDENTITY(bit_xor, T{});
+HIPSYCL_DEFINE_IDENTITY(logical_or, T{0});
+HIPSYCL_DEFINE_IDENTITY(logical_and, ~T{});
+
 } // namespace sycl
 }
 

--- a/include/hipSYCL/sycl/libkernel/functional.hpp
+++ b/include/hipSYCL/sycl/libkernel/functional.hpp
@@ -99,6 +99,19 @@ struct known_identity_trait {
         inline static constexpr acc known_identity = (identity); \
     };
 
+template<typename T, typename Enable=void>
+struct minmax_identity {
+    inline static constexpr T max_id = std::numeric_limits<T>::lowest();
+    inline static constexpr T min_id = std::numeric_limits<T>::max();
+};
+
+template<typename T>
+struct minmax_identity<T, std::enable_if_t<std::numeric_limits<T>::has_infinity>> {
+    inline static constexpr T max_id = -std::numeric_limits<T>::infinity();
+    inline static constexpr T min_id = std::numeric_limits<T>::infinity();
+};
+
+// TODO is_arithmetic implicitly covers the current pseudo half = ushort type, resolve once half is implemented
 HIPSYCL_DEFINE_IDENTITY(plus, typename T, T, T{0}, std::enable_if_t<std::is_arithmetic_v<T>>)
 HIPSYCL_DEFINE_IDENTITY(multiplies, typename T, T, T{1}, std::enable_if_t<std::is_arithmetic_v<T>>)
 HIPSYCL_DEFINE_IDENTITY(bit_or, typename T, T, T{}, std::enable_if_t<std::is_integral_v<T>>)
@@ -106,6 +119,8 @@ HIPSYCL_DEFINE_IDENTITY(bit_and, typename T, T, ~T{}, std::enable_if_t<std::is_i
 HIPSYCL_DEFINE_IDENTITY(bit_xor, typename T, T, T{}, std::enable_if_t<std::is_integral_v<T>>)
 HIPSYCL_DEFINE_IDENTITY(logical_or, , bool, false, void)
 HIPSYCL_DEFINE_IDENTITY(logical_and, , bool, true, void)
+HIPSYCL_DEFINE_IDENTITY(minimum, typename T, T, minmax_identity<T>::min_id, std::enable_if_t<std::is_arithmetic_v<T>>);
+HIPSYCL_DEFINE_IDENTITY(maximum, typename T, T, minmax_identity<T>::max_id, std::enable_if_t<std::is_arithmetic_v<T>>);
 
 #undef HIPSYCL_DEFINE_IDENTITY
 

--- a/include/hipSYCL/sycl/libkernel/functional.hpp
+++ b/include/hipSYCL/sycl/libkernel/functional.hpp
@@ -73,14 +73,14 @@ template <typename T = void> struct bit_or {
 };
 
 template <> struct bit_or<void> {
-    template<typename T>
-    HIPSYCL_KERNEL_TARGET
-    T operator()(const T &x, const T &y) const { return x | y; }
+  template<typename T>
+  HIPSYCL_KERNEL_TARGET
+  T operator()(const T &x, const T &y) const { return x | y; }
 };
 
 template <typename T = void> struct bit_xor {
-    HIPSYCL_KERNEL_TARGET
-    T operator()(const T &x, const T &y) const { return x ^ y; }
+  HIPSYCL_KERNEL_TARGET
+  T operator()(const T &x, const T &y) const { return x ^ y; }
 };
 
 template <> struct bit_xor<void> {
@@ -117,14 +117,14 @@ template <typename T = void> struct minimum {
 };
 
 template <> struct minimum<void> {
-    template<typename T>
-    HIPSYCL_KERNEL_TARGET
-    T operator()(const T &x, const T &y) const { return (x < y) ? x : y; }
+  template<typename T>
+  HIPSYCL_KERNEL_TARGET
+  T operator()(const T &x, const T &y) const { return (x < y) ? x : y; }
 };
 
 template <typename T = void> struct maximum {
-    HIPSYCL_KERNEL_TARGET
-    T operator()(const T &x, const T &y) const { return (x > y) ? x : y; }
+  HIPSYCL_KERNEL_TARGET
+  T operator()(const T &x, const T &y) const { return (x > y) ? x : y; }
 };
 
 template <> struct maximum<void> {
@@ -138,32 +138,37 @@ namespace detail {
 
 template<typename BinaryOperation, typename AccumulatorT, typename Enable = void>
 struct known_identity_trait {
-    static constexpr bool has_known_identity = false; \
+  static constexpr bool has_known_identity = false; \
+};
+
+template<typename T, typename Enable=void>
+struct minmax_identity {
+  inline static constexpr T max_id = std::numeric_limits<T>::lowest();
+  inline static constexpr T min_id = std::numeric_limits<T>::max();
+};
+
+template<typename T>
+struct minmax_identity<T, std::enable_if_t<std::numeric_limits<T>::has_infinity>> {
+  inline static constexpr T max_id = -std::numeric_limits<T>::infinity();
+  inline static constexpr T min_id = std::numeric_limits<T>::infinity();
 };
 
 #define HIPSYCL_DEFINE_IDENTITY(op, cond, identity) \
     template<typename T, typename U> \
     struct known_identity_trait<op<T>, U, std::enable_if_t<cond>> { \
-        static constexpr bool has_known_identity = true; \
-        inline static constexpr T known_identity = (identity); \
+        inline static constexpr bool has_known_identity = true; \
+        inline static constexpr std::remove_cv_t<T> known_identity = (identity); \
     }; \
     template<typename T> \
     struct known_identity_trait<op<void>, T, std::enable_if_t<cond>> { \
         inline static constexpr bool has_known_identity = true; \
-        inline static constexpr T known_identity = (identity); \
+        inline static constexpr std::remove_cv_t<T> known_identity = (identity); \
     }
 
-template<typename T, typename Enable=void>
-struct minmax_identity {
-    inline static constexpr T max_id = std::numeric_limits<T>::lowest();
-    inline static constexpr T min_id = std::numeric_limits<T>::max();
-};
-
-template<typename T>
-struct minmax_identity<T, std::enable_if_t<std::numeric_limits<T>::has_infinity>> {
-    inline static constexpr T max_id = -std::numeric_limits<T>::infinity();
-    inline static constexpr T min_id = std::numeric_limits<T>::infinity();
-};
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wbool-operation"  // allow ~bool, bool & bool
+#endif
 
 // TODO is_arithmetic implicitly covers the current pseudo half = ushort type, resolve once half is implemented
 HIPSYCL_DEFINE_IDENTITY(plus, std::is_arithmetic_v<T>, T{});
@@ -171,10 +176,14 @@ HIPSYCL_DEFINE_IDENTITY(multiplies, std::is_arithmetic_v<T>, T{1});
 HIPSYCL_DEFINE_IDENTITY(bit_or, std::is_integral_v<T>, T{});
 HIPSYCL_DEFINE_IDENTITY(bit_and, std::is_integral_v<T>, ~T{});
 HIPSYCL_DEFINE_IDENTITY(bit_xor, std::is_integral_v<T>, T{});
-HIPSYCL_DEFINE_IDENTITY(logical_or, (std::is_same_v<T, bool>), false);
-HIPSYCL_DEFINE_IDENTITY(logical_and, (std::is_same_v<T, bool>), true);
-HIPSYCL_DEFINE_IDENTITY(minimum, std::is_arithmetic_v<T>, minmax_identity<T>::min_id);
-HIPSYCL_DEFINE_IDENTITY(maximum, std::is_arithmetic_v<T>, minmax_identity<T>::max_id);
+HIPSYCL_DEFINE_IDENTITY(logical_or, (std::is_same_v<std::remove_cv_t<T>, bool>), false);
+HIPSYCL_DEFINE_IDENTITY(logical_and, (std::is_same_v<std::remove_cv_t<T>, bool>), true);
+HIPSYCL_DEFINE_IDENTITY(minimum, std::is_arithmetic_v<T>, minmax_identity<std::remove_cv_t<T>>::min_id);
+HIPSYCL_DEFINE_IDENTITY(maximum, std::is_arithmetic_v<T>, minmax_identity<std::remove_cv_t<T>>::max_id);
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 #undef HIPSYCL_DEFINE_IDENTITY
 
@@ -182,8 +191,8 @@ HIPSYCL_DEFINE_IDENTITY(maximum, std::is_arithmetic_v<T>, minmax_identity<T>::ma
 
 template<typename BinaryOperation, typename AccumulatorT>
 struct known_identity {
-    static constexpr AccumulatorT value = detail::known_identity_trait<
-        BinaryOperation, AccumulatorT>::known_identity;
+  static constexpr AccumulatorT value = detail::known_identity_trait<
+      BinaryOperation, AccumulatorT>::known_identity;
 };
 
 template <typename BinaryOperation, typename AccumulatorT>
@@ -191,8 +200,8 @@ inline constexpr AccumulatorT known_identity_v = known_identity<BinaryOperation,
 
 template<typename BinaryOperation, typename AccumulatorT>
 struct has_known_identity {
-    static constexpr bool value = detail::known_identity_trait<
-        BinaryOperation, AccumulatorT>::has_known_identity;
+  static constexpr bool value = detail::known_identity_trait<
+      BinaryOperation, AccumulatorT>::has_known_identity;
 };
 
 template <typename BinaryOperation, typename AccumulatorT>

--- a/include/hipSYCL/sycl/libkernel/functional.hpp
+++ b/include/hipSYCL/sycl/libkernel/functional.hpp
@@ -156,13 +156,13 @@ struct minmax_identity<T, std::enable_if_t<std::numeric_limits<T>::has_infinity>
 #define HIPSYCL_DEFINE_IDENTITY(op, cond, identity) \
     template<typename T, typename U> \
     struct known_identity_trait<op<T>, U, std::enable_if_t<cond>> { \
-        inline static constexpr bool has_known_identity = true; \
-        inline static constexpr std::remove_cv_t<T> known_identity = (identity); \
+      inline static constexpr bool has_known_identity = true; \
+      inline static constexpr std::remove_cv_t<T> known_identity = (identity); \
     }; \
     template<typename T> \
     struct known_identity_trait<op<void>, T, std::enable_if_t<cond>> { \
-        inline static constexpr bool has_known_identity = true; \
-        inline static constexpr std::remove_cv_t<T> known_identity = (identity); \
+      inline static constexpr bool has_known_identity = true; \
+      inline static constexpr std::remove_cv_t<T> known_identity = (identity); \
     }
 
 #ifdef __GNUC__

--- a/include/hipSYCL/sycl/libkernel/reduction.hpp
+++ b/include/hipSYCL/sycl/libkernel/reduction.hpp
@@ -264,6 +264,19 @@ auto reduction(BufferT vars, handler &cgh, const typename BufferT::value_type &i
       initialize_to_identity};
 }
 
+template <typename AccessorT, typename BinaryOperation>
+[[deprecated("Use the sycl::reduction() overload taking a buffer instead")]]
+auto reduction(AccessorT vars, BinaryOperation combiner) {
+  auto identity = typename AccessorT::value_type{};
+  return detail::accessor_reduction_descriptor{vars, identity, combiner, true /* initialize_to_identity */};
+}
+
+template <typename AccessorT, typename BinaryOperation>
+[[deprecated("Use the sycl::reduction() overload taking a buffer instead")]]
+auto reduction(AccessorT vars, const typename AccessorT::value_type &identity, BinaryOperation combiner) {
+  return detail::accessor_reduction_descriptor{vars, identity, combiner, true /* initialize_to_identity */};
+}
+
 template <typename T, typename BinaryOperation>
 auto reduction(T *var, BinaryOperation combiner, property_list prop_list = {}) {
   bool initialize_to_identity = prop_list.has_property<property::reduction::initialize_to_identity>();

--- a/include/hipSYCL/sycl/libkernel/reduction.hpp
+++ b/include/hipSYCL/sycl/libkernel/reduction.hpp
@@ -185,7 +185,7 @@ private:
 
 #define HIPSYCL_ENABLE_REDUCER_OP_IF_TYPE(T)                                   \
   class Op = typename reducer<BackendReducerImpl>::combiner_type,              \
-  std::enable_if_t<std::is_same_v<                                             \
+  std::enable_if_t<std::is_same_v<Op, T<void>> || std::is_same_v<              \
             Op, T<typename reducer<BackendReducerImpl>::value_type>>> * =      \
             nullptr
 

--- a/include/hipSYCL/sycl/libkernel/reduction.hpp
+++ b/include/hipSYCL/sycl/libkernel/reduction.hpp
@@ -43,30 +43,30 @@ struct reduction_descriptor_base;
 
 template<typename T, typename BinaryOperation>
 struct reduction_descriptor_base<T, BinaryOperation, false> {
-    using value_type = T;
-    using combiner_type = BinaryOperation;
+  using value_type = T;
+  using combiner_type = BinaryOperation;
 
-    constexpr static bool has_identity = false;
+  constexpr static bool has_identity = false;
 
-    BinaryOperation combiner;
+  BinaryOperation combiner;
 
-    explicit reduction_descriptor_base(BinaryOperation combiner)
-        : combiner(combiner) {}
+  explicit reduction_descriptor_base(BinaryOperation combiner)
+      : combiner(combiner) {}
 };
 
 template<typename T, typename BinaryOperation>
 struct reduction_descriptor_base<T, BinaryOperation, true> {
-    using value_type = T;
-    using combiner_type = BinaryOperation;
+  using value_type = T;
+  using combiner_type = BinaryOperation;
 
-    constexpr static bool has_identity = true;
+  constexpr static bool has_identity = true;
 
-    BinaryOperation combiner;
-    T identity;
-    bool initialize_to_identity;
+  BinaryOperation combiner;
+  T identity;
+  bool initialize_to_identity;
 
-    explicit reduction_descriptor_base(BinaryOperation combiner, T identity, bool initialize_to_identity)
-        : combiner(combiner), identity(identity), initialize_to_identity(initialize_to_identity) {}
+  explicit reduction_descriptor_base(BinaryOperation combiner, T identity, bool initialize_to_identity)
+      : combiner(combiner), identity(identity), initialize_to_identity(initialize_to_identity) {}
 };
 
 template <class T, typename BinaryOperation, bool KnownIdentity>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ add_executable(sycl_tests
   sycl/explicit_copy.cpp
   sycl/extensions.cpp
   sycl/fill.cpp
+  sycl/functional.cpp
   sycl/group_functions/group_functions_misc.cpp
   sycl/group_functions/group_functions_binary_reduce.cpp
   sycl/group_functions/group_functions_reduce.cpp

--- a/tests/sycl/functional.cpp
+++ b/tests/sycl/functional.cpp
@@ -1,0 +1,98 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018, 2019 Aksel Alpay and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sycl_test_suite.hpp"
+
+namespace s = cl::sycl;
+
+BOOST_FIXTURE_TEST_SUITE(functional_tests, reset_device_fixture)
+
+// list of types classified as "genfloat" in the SYCL standard
+using known_identity_types = boost::mpl::list<float, double, char, signed char, unsigned char,
+    int, long, unsigned int, unsigned long, bool>;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(known_identities, T, known_identity_types::type) {
+  static_assert(s::has_known_identity_v<s::minimum<T>, T>);
+  static_assert(s::has_known_identity_v<s::minimum<>, T>);
+  static_assert(s::has_known_identity_v<s::maximum<T>, T>);
+  static_assert(s::has_known_identity_v<s::maximum<>, T>);
+
+  BOOST_TEST((s::known_identity_v<s::plus<T>, T>) == T{0});
+  BOOST_TEST((s::known_identity_v<s::plus<>, T>) == T{0});
+  BOOST_TEST((s::known_identity_v<s::multiplies<T>, T>) == T{1});
+  BOOST_TEST((s::known_identity_v<s::multiplies<>, T>) == T{1});
+
+  if constexpr (std::is_floating_point_v<T>) {
+    BOOST_TEST((s::known_identity_v<s::minimum<T>, T>) == std::numeric_limits<T>::infinity());
+    BOOST_TEST((s::known_identity_v<s::minimum<>, T>) == std::numeric_limits<T>::infinity());
+    BOOST_TEST((s::known_identity_v<s::maximum<T>, T>) == -std::numeric_limits<T>::infinity());
+    BOOST_TEST((s::known_identity_v<s::maximum<>, T>) == -std::numeric_limits<T>::infinity());
+  } else {
+    BOOST_TEST((s::known_identity_v<s::minimum<T>, T>) == std::numeric_limits<T>::max());
+    BOOST_TEST((s::known_identity_v<s::minimum<>, T>) == std::numeric_limits<T>::max());
+    BOOST_TEST((s::known_identity_v<s::maximum<T>, T>) == std::numeric_limits<T>::lowest());
+    BOOST_TEST((s::known_identity_v<s::maximum<>, T>) == std::numeric_limits<T>::lowest());
+  }
+
+  if constexpr (std::is_integral_v<T>) {
+    static_assert(s::has_known_identity_v<s::bit_or<T>, T>);
+    static_assert(s::has_known_identity_v<s::bit_or<>, T>);
+    static_assert(s::has_known_identity_v<s::bit_xor<T>, T>);
+    static_assert(s::has_known_identity_v<s::bit_xor<>, T>);
+
+    BOOST_TEST((s::known_identity_v<s::bit_or<T>, T>) == T{0});
+    BOOST_TEST((s::known_identity_v<s::bit_or<>, T>) == T{0});
+    BOOST_TEST((s::known_identity_v<s::bit_xor<T>, T>) == T{0});
+    BOOST_TEST((s::known_identity_v<s::bit_xor<>, T>) == T{0});
+  }
+
+  if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
+    static_assert(s::has_known_identity_v<s::bit_and<T>, T>);
+    static_assert(s::has_known_identity_v<s::bit_and<>, T>);
+
+    BOOST_TEST((s::known_identity_v<s::bit_and<T>, T>) == static_cast<T>(~T{0}));
+    BOOST_TEST((s::known_identity_v<s::bit_and<>, T>) == static_cast<T>(~T{0}));
+  }
+
+  if constexpr (std::is_same_v<T, bool>) {
+    static_assert(s::has_known_identity_v<s::bit_and<T>, T>);
+    static_assert(s::has_known_identity_v<s::bit_and<>, T>);
+    static_assert(s::has_known_identity_v<s::logical_or<T>, T>);
+    static_assert(s::has_known_identity_v<s::logical_or<>, T>);
+    static_assert(s::has_known_identity_v<s::logical_and<T>, T>);
+    static_assert(s::has_known_identity_v<s::logical_and<>, T>);
+
+    BOOST_TEST((s::known_identity_v<s::bit_and<T>, T>) == true);
+    BOOST_TEST((s::known_identity_v<s::bit_and<>, T>) == true);
+    BOOST_TEST((s::known_identity_v<s::logical_or<T>, T>) == false);
+    BOOST_TEST((s::known_identity_v<s::logical_or<>, T>) == false);
+    BOOST_TEST((s::known_identity_v<s::logical_and<T>, T>) == true);
+    BOOST_TEST((s::known_identity_v<s::logical_and<>, T>) == true);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // NOTE: Make sure not to add anything below this line

--- a/tests/sycl/reduction.cpp
+++ b/tests/sycl/reduction.cpp
@@ -437,10 +437,10 @@ BOOST_AUTO_TEST_CASE(buffer_reduction) {
     auto values_acc = values_buff.get_access<sycl::access_mode::read>(
         cgh);
 
-    auto sumReduction = sycl::reduction(sum_buff, cgh, sycl::plus<>(), initialize_to_identity);
-    auto maxReduction = sycl::reduction(max_buff, cgh, sycl::maximum<int>());
+    auto sum_reduction = sycl::reduction(sum_buff, cgh, sycl::plus<>(), initialize_to_identity);
+    auto max_reduction = sycl::reduction(max_buff, cgh, sycl::maximum<int>());
 
-    cgh.parallel_for(sycl::range<1>{1024}, sumReduction, maxReduction,
+    cgh.parallel_for(sycl::range<1>{1024}, sum_reduction, max_reduction,
                      [=](sycl::id<1> idx, auto &sum, auto &max) {
                        sum += values_acc[idx];
                        max.combine(values_acc[idx]);
@@ -459,10 +459,10 @@ BOOST_AUTO_TEST_CASE(combine_none_or_multiple) {
   max_buff.get_host_access()[0] = 0;
 
   q.submit([&](sycl::handler &cgh) {
-      auto sumReduction = sycl::reduction(sum_buff, cgh, sycl::plus<>());
-      auto maxReduction = sycl::reduction(max_buff, cgh, sycl::maximum<int>()); // no identity
+      auto sum_reduction = sycl::reduction(sum_buff, cgh, sycl::plus<>());
+      auto max_reduction = sycl::reduction(max_buff, cgh, sycl::maximum<int>()); // no identity
 
-      cgh.parallel_for(sycl::range<1>{1024}, sumReduction, maxReduction,
+      cgh.parallel_for(sycl::range<1>{1024}, sum_reduction, max_reduction,
           [=](sycl::id<1> idx, auto &sum, auto &max) {
               // Test both validity of 0 combines or > 1 combine per item
               for (int i = 0; i < static_cast<int>(idx.get(0)) % 3; ++i) {
@@ -474,6 +474,33 @@ BOOST_AUTO_TEST_CASE(combine_none_or_multiple) {
 
   BOOST_CHECK(max_buff.get_host_access()[0] == 1022);
   BOOST_CHECK(sum_buff.get_host_access()[0] == 523435);
+}
+
+BOOST_AUTO_TEST_CASE(deprecated_accessor_reduction) {
+    sycl::queue q;
+    sycl::buffer<int> sum_buff_a{1};
+    sycl::buffer<int> sum_buff_b{1};
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated"
+
+    q.submit([&](sycl::handler &cgh) {
+      auto sum_a_reduction = sycl::reduction(sycl::accessor{sum_buff_a, cgh, sycl::write_only, sycl::no_init},
+          sycl::plus<>());
+      auto sum_b_reduction = sycl::reduction(sycl::accessor{sum_buff_b, cgh, sycl::write_only, sycl::no_init},
+          0, sycl::plus<int>());
+
+      cgh.parallel_for(sycl::range<1>{1024}, sum_a_reduction, sum_b_reduction,
+          [=](sycl::item<1> idx, auto &sum_a, auto &sum_b) {
+              sum_a += idx.get_id(0);
+              sum_b += idx.get_id(0);
+          });
+    });
+
+#pragma GCC diagnostic pop
+
+    BOOST_CHECK(sum_buff_a.get_host_access()[0] == 523776);
+    BOOST_CHECK(sum_buff_b.get_host_access()[0] == 523776);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/sycl/reduction.cpp
+++ b/tests/sycl/reduction.cpp
@@ -355,8 +355,7 @@ BOOST_AUTO_TEST_CASE(accessor_reduction) {
         cgh);
 
     auto sumReduction = sycl::reduction(sum_buff, cgh, sycl::plus<int>(), initialize_to_identity);
-    // auto maxReduction = sycl::reduction(max_buff, cgh, sycl::maximum<int>()); // TODO currently not on GPU
-    auto maxReduction = sycl::reduction(max_buff, cgh, 0, sycl::maximum<int>());
+    auto maxReduction = sycl::reduction(max_buff, cgh, sycl::maximum<int>());
 
     cgh.parallel_for(sycl::range<1>{1024}, sumReduction, maxReduction,
                      [=](sycl::id<1> idx, auto &sum, auto &max) {
@@ -365,6 +364,7 @@ BOOST_AUTO_TEST_CASE(accessor_reduction) {
                      });
   });
 
+  auto x = max_buff.get_host_access()[0];
   BOOST_CHECK(max_buff.get_host_access()[0] == 1023);
   BOOST_CHECK(sum_buff.get_host_access()[0] == 523776);
 }

--- a/tests/sycl/reduction.cpp
+++ b/tests/sycl/reduction.cpp
@@ -443,7 +443,9 @@ BOOST_AUTO_TEST_CASE(buffer_reduction) {
     cgh.parallel_for(sycl::range<1>{1024}, sum_reduction, max_reduction,
                      [=](sycl::id<1> idx, auto &sum, auto &max) {
                        sum += values_acc[idx];
+                       sum += sum.identity();
                        max.combine(values_acc[idx]);
+                       max.combine(max.identity());
                      });
   });
 

--- a/tests/sycl/reduction.cpp
+++ b/tests/sycl/reduction.cpp
@@ -38,8 +38,7 @@ BOOST_FIXTURE_TEST_SUITE(reduction_tests, reset_device_fixture)
 auto tolerance = boost::test_tools::tolerance(0.001f);
 
 template <class T, class Generator, class Handler, class BinaryOp>
-void test_scalar_reduction(sycl::queue &q, const T& identity,
-                           std::size_t num_elements,
+void test_scalar_reduction(sycl::queue &q, std::size_t num_elements,
                            BinaryOp op, Generator gen, Handler h) {
   T* test_data = sycl::malloc_shared<T>(num_elements, q);
   T* output_data = sycl::malloc_shared<T>(1, q);
@@ -51,7 +50,7 @@ void test_scalar_reduction(sycl::queue &q, const T& identity,
   q.wait();
 
   T expected_result =
-      std::accumulate(test_data, test_data + num_elements, identity, op);
+      std::accumulate(test_data, test_data + num_elements, sycl::known_identity_v<BinaryOp, T>, op);
   
   if constexpr(std::is_floating_point_v<T>) {
     BOOST_TEST(expected_result == *output_data, tolerance);
@@ -90,21 +89,19 @@ template<class T, class BinaryOp, int Line>
 class reduction_kernel;
 
 template<class T, class BinaryOp>
-void test_single_reduction(std::size_t input_size, std::size_t local_size, 
-                          const T& identity, BinaryOp op){
+void test_single_reduction(std::size_t input_size, std::size_t local_size, BinaryOp op) {
   sycl::queue q;
 
   auto input_gen = [&](std::size_t i){
     return input_generator<T,BinaryOp>{}(i);
   };
 
-  test_scalar_reduction(q, identity, 
-    input_size, op, input_gen,
+  test_scalar_reduction<T>(q, input_size, op, input_gen,
     [&](T* input, T* output){
 
       q.parallel_for<reduction_kernel<T,BinaryOp,__LINE__>>(
                   sycl::range<1>(input_size), 
-                  sycl::reduction(output, identity, op), 
+                  sycl::reduction(output, op),
                   [=](sycl::id<1> idx, auto& reducer){
         reducer.combine(input[idx[0]]);
       });
@@ -112,14 +109,13 @@ void test_single_reduction(std::size_t input_size, std::size_t local_size,
     });
 
   if(input_size % local_size == 0) {
-    test_scalar_reduction(q, identity,
-      input_size, op, input_gen,
+    test_scalar_reduction<T>(q, input_size, op, input_gen,
       [&](T* input, T* output){
 
         q.parallel_for<reduction_kernel<T,BinaryOp,__LINE__>>(
                       sycl::nd_range(sycl::range{input_size}, 
                                      sycl::range{local_size}), 
-                      sycl::reduction(output, identity, op), 
+                      sycl::reduction(output, op),
                       [=](sycl::nd_item<1> idx, auto& reducer){
           reducer.combine(input[idx.get_global_linear_id()]);
         });
@@ -128,14 +124,13 @@ void test_single_reduction(std::size_t input_size, std::size_t local_size,
     
     std::size_t num_groups = input_size / local_size;
 
-    test_scalar_reduction(q, identity,
-      input_size, op, input_gen,
+    test_scalar_reduction<T>(q, input_size, op, input_gen,
       [&](T* input, T* output){
 
         q.submit([&](sycl::handler& cgh){
           cgh.parallel_for_work_group<reduction_kernel<T,BinaryOp,__LINE__>>(
                       sycl::range{num_groups}, sycl::range{local_size}, 
-                      sycl::reduction(output, identity, op), 
+                      sycl::reduction(output, op),
                       [=](sycl::group<1> grp, auto& reducer){
             grp.parallel_for_work_item([&](sycl::h_item<1> idx){
               reducer.combine(input[idx.get_global_id()[0]]);
@@ -144,13 +139,12 @@ void test_single_reduction(std::size_t input_size, std::size_t local_size,
         });
       });
    
-    test_scalar_reduction(q, identity,
-      input_size, op, input_gen,
+    test_scalar_reduction<T>(q, input_size, op, input_gen,
       [&](T* input, T* output){
 
         q.parallel<reduction_kernel<T,BinaryOp,__LINE__>>(
                       sycl::range{num_groups}, sycl::range{local_size}, 
-                      sycl::reduction(output, identity, op), 
+                      sycl::reduction(output, op),
                       [=](auto grp, auto& reducer){
           sycl::distribute_items(grp, [&](sycl::s_item<1> idx){
             reducer.combine(input[idx.get_global_linear_id()]);
@@ -210,8 +204,8 @@ void test_two_reductions(std::size_t input_size, std::size_t local_size){
 
   q.parallel_for<reduction_kernel<T,class MultiOp,__LINE__>>(
               sycl::range<1>(input_size), 
-              sycl::reduction(output0, T{0}, sycl::plus<T>{}),
-              sycl::reduction(output1, T{1}, sycl::multiplies<T>{}), 
+              sycl::reduction(output0, sycl::plus<T>{}),
+              sycl::reduction(output1, sycl::multiplies<T>{}),
               [=](sycl::id<1> idx, auto& add_reducer, auto& mul_reducer){
     add_reducer += input0[idx[0]];
     mul_reducer *= input1[idx[0]];
@@ -224,8 +218,8 @@ void test_two_reductions(std::size_t input_size, std::size_t local_size){
     q.parallel_for<reduction_kernel<T,class MultiOp,__LINE__>>(
                 sycl::nd_range(sycl::range{input_size}, 
                                sycl::range{local_size}), 
-                sycl::reduction(output0, T{0}, sycl::plus<T>{}),
-                sycl::reduction(output1, T{1}, sycl::multiplies<T>{}), 
+                sycl::reduction(output0, sycl::plus<T>{}),
+                sycl::reduction(output1, sycl::multiplies<T>{}),
                 [=](sycl::nd_item<1> idx, auto& add_reducer, auto& mul_reducer){
       add_reducer += input0[idx.get_global_linear_id()];
       mul_reducer *= input1[idx.get_global_linear_id()];
@@ -238,8 +232,8 @@ void test_two_reductions(std::size_t input_size, std::size_t local_size){
     q.submit([&](sycl::handler& cgh) {
       cgh.parallel_for_work_group<reduction_kernel<T,class MultiOp,__LINE__>>(
                   sycl::range{num_groups}, sycl::range{local_size},
-                  sycl::reduction(output0, T{0}, sycl::plus<T>{}),
-                  sycl::reduction(output1, T{1}, sycl::multiplies<T>{}), 
+                  sycl::reduction(output0, sycl::plus<T>{}),
+                  sycl::reduction(output1, sycl::multiplies<T>{}),
                   [=](sycl::group<1> grp, auto& add_reducer, auto& mul_reducer){
         // On omp backend, this is executed in a pragma omp simd loop.
         // It seems clang generates incorrect code when doing two
@@ -259,8 +253,8 @@ void test_two_reductions(std::size_t input_size, std::size_t local_size){
 
     q.parallel<reduction_kernel<T, class MultiOp, __LINE__>>(
         sycl::range{num_groups}, sycl::range{local_size},
-        sycl::reduction(output0, T{0}, sycl::plus<T>{}),
-        sycl::reduction(output1, T{1}, sycl::multiplies<T>{}),
+        sycl::reduction(output0, sycl::plus<T>{}),
+        sycl::reduction(output1, sycl::multiplies<T>{}),
         [=](auto grp, auto &add_reducer, auto &mul_reducer) {
           sycl::distribute_items(grp, [&](sycl::s_item<1> idx) {
             mul_reducer *= input1[idx.get_global_linear_id()];
@@ -296,28 +290,28 @@ using very_large_test_types = boost::mpl::list<unsigned int, long long, float,
   double>;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(single_kernel_single_scalar_reduction, T, all_test_types) {
-  test_single_reduction(128, 128, T{0}, sycl::plus<T>{});
-  test_single_reduction(128, 128, T{1}, sycl::multiplies<T>{});
+  test_single_reduction<T>(128, 128, sycl::plus<T>{});
+  test_single_reduction<T>(128, 128, sycl::multiplies<T>{});
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(two_kernels_single_scalar_reduction, T, large_test_types) {
-  test_single_reduction(128*128, 128, T{0}, sycl::plus<T>{});
-  test_single_reduction(128*128, 128, T{1}, sycl::multiplies<T>{});
+  test_single_reduction<T>(128*128, 128, sycl::plus<T>{});
+  test_single_reduction<T>(128*128, 128, sycl::multiplies<T>{});
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(three_kernels_single_scalar_reduction, T, very_large_test_types) {
-  test_single_reduction(64*64*64, 64, T{0}, sycl::plus<T>{});
-  test_single_reduction(64*64*64, 64, T{1}, sycl::multiplies<T>{});
+  test_single_reduction<T>(64*64*64, 64, sycl::plus<T>{});
+  test_single_reduction<T>(64*64*64, 64, sycl::multiplies<T>{});
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(mismatching_group_size, T, large_test_types) {
-  test_single_reduction(1000, 128, T{0}, sycl::plus<T>{});
-  test_single_reduction(1000, 128, T{1}, sycl::multiplies<T>{});
+  test_single_reduction<T>(1000, 128, sycl::plus<T>{});
+  test_single_reduction<T>(1000, 128, sycl::multiplies<T>{});
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(oversized_group_size, T, all_test_types) {
-  test_single_reduction(20, 128, T{0}, sycl::plus<T>{});
-  test_single_reduction(20, 128, T{1}, sycl::multiplies<T>{});
+  test_single_reduction<T>(20, 128, sycl::plus<T>{});
+  test_single_reduction<T>(20, 128, sycl::multiplies<T>{});
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(two_reductions, T, large_test_types) {
@@ -340,11 +334,8 @@ BOOST_AUTO_TEST_CASE(accessor_reduction) {
     auto values_acc = values_buff.get_access<sycl::access_mode::read>(
         cgh);
 
-    sycl::accessor sum_acc {sum_buff, cgh};
-    sycl::accessor max_acc {max_buff, cgh};
-    
-    auto sumReduction = sycl::reduction(sum_acc, sycl::plus<int>());
-    auto maxReduction = sycl::reduction(max_acc, sycl::maximum<int>());
+    auto sumReduction = sycl::reduction(sum_buff, cgh, sycl::plus<int>());
+    auto maxReduction = sycl::reduction(max_buff, cgh, 0, sycl::maximum<int>()); // TODO
     
     cgh.parallel_for(sycl::range<1>{1024}, sumReduction, maxReduction,
                      [=](sycl::id<1> idx, auto &sum, auto &max) {

--- a/tests/sycl/reduction.cpp
+++ b/tests/sycl/reduction.cpp
@@ -483,8 +483,10 @@ BOOST_AUTO_TEST_CASE(deprecated_accessor_reduction) {
     sycl::buffer<int> sum_buff_a{1};
     sycl::buffer<int> sum_buff_b{1};
 
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated"
+#endif
 
     q.submit([&](sycl::handler &cgh) {
       auto sum_a_reduction = sycl::reduction(sycl::accessor{sum_buff_a, cgh, sycl::write_only, sycl::no_init},
@@ -499,7 +501,9 @@ BOOST_AUTO_TEST_CASE(deprecated_accessor_reduction) {
           });
     });
 
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
 
     BOOST_CHECK(sum_buff_a.get_host_access()[0] == 523776);
     BOOST_CHECK(sum_buff_b.get_host_access()[0] == 523776);

--- a/tests/sycl/reduction.cpp
+++ b/tests/sycl/reduction.cpp
@@ -364,9 +364,33 @@ BOOST_AUTO_TEST_CASE(accessor_reduction) {
                      });
   });
 
-  auto x = max_buff.get_host_access()[0];
   BOOST_CHECK(max_buff.get_host_access()[0] == 1023);
   BOOST_CHECK(sum_buff.get_host_access()[0] == 523776);
+}
+
+BOOST_AUTO_TEST_CASE(combine_none_or_multiple) {
+  sycl::queue q;
+  sycl::buffer<int> sum_buff{1};
+  sycl::buffer<int> max_buff{1};
+  sum_buff.get_host_access()[0] = 0;
+  max_buff.get_host_access()[0] = 0;
+
+  q.submit([&](sycl::handler &cgh) {
+      auto sumReduction = sycl::reduction(sum_buff, cgh, sycl::plus<int>());
+      auto maxReduction = sycl::reduction(max_buff, cgh, sycl::maximum<int>()); // no identity
+
+      cgh.parallel_for(sycl::range<1>{1024}, sumReduction, maxReduction,
+          [=](sycl::id<1> idx, auto &sum, auto &max) {
+              // Test both validity of 0 combines or > 1 combine per item
+              for (int i = 0; i < static_cast<int>(idx.get(0)) % 3; ++i) {
+                sum += idx[0];
+                max.combine(idx[0]);
+              }
+          });
+  });
+
+  BOOST_CHECK(max_buff.get_host_access()[0] == 1022);
+  BOOST_CHECK(sum_buff.get_host_access()[0] == 523435);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/sycl/reduction.cpp
+++ b/tests/sycl/reduction.cpp
@@ -94,10 +94,67 @@ struct input_generator <T, sycl::multiplies<T>> {
 
     if(i % 100 == 0)
       return static_cast<T>(2);
-    
+
     return static_cast<T>(1);
   }
 };
+
+template<class T>
+struct input_generator <T, sycl::minimum<T>> {
+  T operator() (std::size_t i) const {
+    return 1234 - (i % 567);
+  }
+};
+
+template<class T>
+struct input_generator <T, sycl::maximum<T>> {
+  T operator() (std::size_t i) const {
+    return 1234 + (i % 567);
+  }
+};
+
+template<class T>
+struct input_generator <T, sycl::bit_and<T>> {
+  T operator() (std::size_t i) const {
+    return static_cast<T>((2ull * static_cast<unsigned long long>(i)) | (1ull << (8 * sizeof(T) - 1)) | 1ull);
+  }
+};
+
+template<class T>
+struct input_generator <T, sycl::bit_or<T>> {
+T operator() (std::size_t i) const {
+  return static_cast<T>(i ? 2ull * static_cast<unsigned long long>(i) : (1ull << (8 * sizeof(T) - 1)));
+}
+};
+
+template<class T>
+struct input_generator <T, sycl::bit_xor<T>> {
+  T operator() (std::size_t i) const {
+    return static_cast<T>(17 * i);
+  }
+};
+
+template<>
+struct input_generator <bool, sycl::logical_or<bool>> {
+  bool operator() (std::size_t i) const {
+    return i == 0;
+  }
+};
+
+template<>
+struct input_generator <bool, sycl::logical_and<bool>> {
+bool operator() (std::size_t i) const {
+  return i != 0;
+}
+};
+
+
+// Unknown to SYCL, so either an explicit identity must be provided or the slow non-identity reduction path is entered
+template<typename T>
+struct no_identity_maximum {
+    T operator()(T a, T b) const { return a < b ? b : a ;}
+};
+
 
 template<class T, class BinaryOp, int Line>
 class reduction_kernel;
@@ -307,9 +364,24 @@ using large_test_types = boost::mpl::list<unsigned int, int, long long, float,
 using very_large_test_types = boost::mpl::list<unsigned int, long long, float, 
   double>;
 
+using int_test_types = boost::mpl::list<char, unsigned int, int, long long>;
+
 BOOST_AUTO_TEST_CASE_TEMPLATE(single_kernel_single_scalar_reduction, T, all_test_types) {
   test_single_reduction<T>(128, 128, sycl::plus<T>{});
   test_single_reduction<T>(128, 128, sycl::multiplies<T>{});
+  test_single_reduction<T>(128, 128, sycl::minimum<T>{});
+  test_single_reduction<T>(128, 128, sycl::maximum<T>{});
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(single_kernel_single_scalar_int_reduction, T, int_test_types) {
+  test_single_reduction<T>(128, 128, sycl::bit_or<T>{});
+  test_single_reduction<T>(128, 128, sycl::bit_and<T>{});
+  test_single_reduction<T>(128, 128, sycl::bit_xor<T>{});
+}
+
+BOOST_AUTO_TEST_CASE(single_kernel_single_scalar_bool_reduction) {
+  test_single_reduction<bool>(128, 128, sycl::logical_and<bool>{});
+  test_single_reduction<bool>(128, 128, sycl::logical_or<bool>{});
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(two_kernels_single_scalar_reduction, T, large_test_types) {
@@ -332,11 +404,22 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(oversized_group_size, T, all_test_types) {
   test_single_reduction<T>(20, 128, sycl::multiplies<T>{});
 }
 
+BOOST_AUTO_TEST_CASE_TEMPLATE(oversized_group_size_int, T, int_test_types) {
+  test_single_reduction<T>(20, 128, sycl::bit_or<T>{});
+  test_single_reduction<T>(20, 128, sycl::bit_and<T>{});
+  test_single_reduction<T>(20, 128, sycl::bit_xor<T>{});
+}
+
+BOOST_AUTO_TEST_CASE(oversized_group_size_bool) {
+  test_single_reduction<bool>(20, 128, sycl::logical_or<bool>{});
+  test_single_reduction<bool>(20, 128, sycl::logical_and<bool>{});
+}
+
 BOOST_AUTO_TEST_CASE_TEMPLATE(two_reductions, T, large_test_types) {
   test_two_reductions<T>(128*128, 128);
 }
 
-BOOST_AUTO_TEST_CASE(accessor_reduction) {
+BOOST_AUTO_TEST_CASE(buffer_reduction) {
   sycl::queue q;
   const auto initialize_to_identity = sycl::property::reduction::initialize_to_identity{};
   sycl::buffer<int> values_buff{1024};

--- a/tests/sycl/reduction.cpp
+++ b/tests/sycl/reduction.cpp
@@ -38,20 +38,26 @@ BOOST_FIXTURE_TEST_SUITE(reduction_tests, reset_device_fixture)
 auto tolerance = boost::test_tools::tolerance(0.001f);
 
 template <class T, class Generator, class Handler, class BinaryOp>
-void test_scalar_reduction(sycl::queue &q, std::size_t num_elements,
-                           BinaryOp op, Generator gen, Handler h) {
+void test_scalar_reduction_with_properties(sycl::queue &q, std::size_t num_elements,
+    BinaryOp op, Generator gen, Handler h, const sycl::property_list &prop_list = {}) {
   T* test_data = sycl::malloc_shared<T>(num_elements, q);
   T* output_data = sycl::malloc_shared<T>(1, q);
+  const T initial_output_value = 42;
 
   for(std::size_t i = 0; i < num_elements;++i)
     test_data[i] = gen(i);
-  
-  h(test_data, output_data);
+  output_data[0] = initial_output_value;
+
+  h(test_data, output_data, prop_list);
   q.wait();
 
+  T accumulate_initial = sycl::known_identity_v<BinaryOp, T>;
+  if (!prop_list.has_property<sycl::property::reduction::initialize_to_identity>()) {
+    accumulate_initial = initial_output_value;
+  }
   T expected_result =
-      std::accumulate(test_data, test_data + num_elements, sycl::known_identity_v<BinaryOp, T>, op);
-  
+      std::accumulate(test_data, test_data + num_elements, accumulate_initial, op);
+
   if constexpr(std::is_floating_point_v<T>) {
     BOOST_TEST(expected_result == *output_data, tolerance);
   } else {
@@ -60,6 +66,14 @@ void test_scalar_reduction(sycl::queue &q, std::size_t num_elements,
 
   sycl::free(test_data, q);
   sycl::free(output_data, q);
+}
+
+template <class T, class Generator, class Handler, class BinaryOp>
+void test_scalar_reduction(sycl::queue &q, std::size_t num_elements,
+                           BinaryOp op, Generator gen, Handler h) {
+  // test_scalar_reduction_with_properties<T>(q, num_elements, op, gen, h);
+  test_scalar_reduction_with_properties<T>(q, num_elements, op, gen, h,
+      sycl::property::reduction::initialize_to_identity{});
 }
 
 template<class T, class BinaryOp>
@@ -92,16 +106,18 @@ template<class T, class BinaryOp>
 void test_single_reduction(std::size_t input_size, std::size_t local_size, BinaryOp op) {
   sycl::queue q;
 
+  const auto initialize_to_identity = sycl::property::reduction::initialize_to_identity{};
+
   auto input_gen = [&](std::size_t i){
     return input_generator<T,BinaryOp>{}(i);
   };
 
   test_scalar_reduction<T>(q, input_size, op, input_gen,
-    [&](T* input, T* output){
+    [&](T* input, T* output, const sycl::property_list &reduction_prop_list){
 
       q.parallel_for<reduction_kernel<T,BinaryOp,__LINE__>>(
                   sycl::range<1>(input_size), 
-                  sycl::reduction(output, op),
+                  sycl::reduction(output, op, reduction_prop_list),
                   [=](sycl::id<1> idx, auto& reducer){
         reducer.combine(input[idx[0]]);
       });
@@ -110,12 +126,12 @@ void test_single_reduction(std::size_t input_size, std::size_t local_size, Binar
 
   if(input_size % local_size == 0) {
     test_scalar_reduction<T>(q, input_size, op, input_gen,
-      [&](T* input, T* output){
+      [&](T* input, T* output, const sycl::property_list &reduction_prop_list){
 
         q.parallel_for<reduction_kernel<T,BinaryOp,__LINE__>>(
                       sycl::nd_range(sycl::range{input_size}, 
                                      sycl::range{local_size}), 
-                      sycl::reduction(output, op),
+                      sycl::reduction(output, op, reduction_prop_list),
                       [=](sycl::nd_item<1> idx, auto& reducer){
           reducer.combine(input[idx.get_global_linear_id()]);
         });
@@ -125,12 +141,12 @@ void test_single_reduction(std::size_t input_size, std::size_t local_size, Binar
     std::size_t num_groups = input_size / local_size;
 
     test_scalar_reduction<T>(q, input_size, op, input_gen,
-      [&](T* input, T* output){
+      [&](T* input, T* output, const sycl::property_list &reduction_prop_list){
 
         q.submit([&](sycl::handler& cgh){
           cgh.parallel_for_work_group<reduction_kernel<T,BinaryOp,__LINE__>>(
                       sycl::range{num_groups}, sycl::range{local_size}, 
-                      sycl::reduction(output, op),
+                      sycl::reduction(output, op, reduction_prop_list),
                       [=](sycl::group<1> grp, auto& reducer){
             grp.parallel_for_work_item([&](sycl::h_item<1> idx){
               reducer.combine(input[idx.get_global_id()[0]]);
@@ -140,11 +156,11 @@ void test_single_reduction(std::size_t input_size, std::size_t local_size, Binar
       });
    
     test_scalar_reduction<T>(q, input_size, op, input_gen,
-      [&](T* input, T* output){
+      [&](T* input, T* output, const sycl::property_list &reduction_prop_list){
 
         q.parallel<reduction_kernel<T,BinaryOp,__LINE__>>(
                       sycl::range{num_groups}, sycl::range{local_size}, 
-                      sycl::reduction(output, op),
+                      sycl::reduction(output, op, reduction_prop_list),
                       [=](auto grp, auto& reducer){
           sycl::distribute_items(grp, [&](sycl::s_item<1> idx){
             reducer.combine(input[idx.get_global_linear_id()]);
@@ -159,6 +175,8 @@ void test_single_reduction(std::size_t input_size, std::size_t local_size, Binar
 template<class T>
 void test_two_reductions(std::size_t input_size, std::size_t local_size){
   sycl::queue q;
+
+  const auto initialize_to_identity = sycl::property::reduction::initialize_to_identity{};
 
   std::size_t num_reductions = 2;
 
@@ -204,8 +222,8 @@ void test_two_reductions(std::size_t input_size, std::size_t local_size){
 
   q.parallel_for<reduction_kernel<T,class MultiOp,__LINE__>>(
               sycl::range<1>(input_size), 
-              sycl::reduction(output0, sycl::plus<T>{}),
-              sycl::reduction(output1, sycl::multiplies<T>{}),
+              sycl::reduction(output0, sycl::plus<T>{}, initialize_to_identity),
+              sycl::reduction(output1, sycl::multiplies<T>{}, initialize_to_identity),
               [=](sycl::id<1> idx, auto& add_reducer, auto& mul_reducer){
     add_reducer += input0[idx[0]];
     mul_reducer *= input1[idx[0]];
@@ -218,8 +236,8 @@ void test_two_reductions(std::size_t input_size, std::size_t local_size){
     q.parallel_for<reduction_kernel<T,class MultiOp,__LINE__>>(
                 sycl::nd_range(sycl::range{input_size}, 
                                sycl::range{local_size}), 
-                sycl::reduction(output0, sycl::plus<T>{}),
-                sycl::reduction(output1, sycl::multiplies<T>{}),
+                sycl::reduction(output0, sycl::plus<T>{}, initialize_to_identity),
+                sycl::reduction(output1, sycl::multiplies<T>{}, initialize_to_identity),
                 [=](sycl::nd_item<1> idx, auto& add_reducer, auto& mul_reducer){
       add_reducer += input0[idx.get_global_linear_id()];
       mul_reducer *= input1[idx.get_global_linear_id()];
@@ -232,8 +250,8 @@ void test_two_reductions(std::size_t input_size, std::size_t local_size){
     q.submit([&](sycl::handler& cgh) {
       cgh.parallel_for_work_group<reduction_kernel<T,class MultiOp,__LINE__>>(
                   sycl::range{num_groups}, sycl::range{local_size},
-                  sycl::reduction(output0, sycl::plus<T>{}),
-                  sycl::reduction(output1, sycl::multiplies<T>{}),
+                  sycl::reduction(output0, sycl::plus<T>{}, initialize_to_identity),
+                  sycl::reduction(output1, sycl::multiplies<T>{}, initialize_to_identity),
                   [=](sycl::group<1> grp, auto& add_reducer, auto& mul_reducer){
         // On omp backend, this is executed in a pragma omp simd loop.
         // It seems clang generates incorrect code when doing two
@@ -253,8 +271,8 @@ void test_two_reductions(std::size_t input_size, std::size_t local_size){
 
     q.parallel<reduction_kernel<T, class MultiOp, __LINE__>>(
         sycl::range{num_groups}, sycl::range{local_size},
-        sycl::reduction(output0, sycl::plus<T>{}),
-        sycl::reduction(output1, sycl::multiplies<T>{}),
+        sycl::reduction(output0, sycl::plus<T>{}, initialize_to_identity),
+        sycl::reduction(output1, sycl::multiplies<T>{}, initialize_to_identity),
         [=](auto grp, auto &add_reducer, auto &mul_reducer) {
           sycl::distribute_items(grp, [&](sycl::s_item<1> idx) {
             mul_reducer *= input1[idx.get_global_linear_id()];
@@ -320,6 +338,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(two_reductions, T, large_test_types) {
 
 BOOST_AUTO_TEST_CASE(accessor_reduction) {
   sycl::queue q;
+  const auto initialize_to_identity = sycl::property::reduction::initialize_to_identity{};
   sycl::buffer<int> values_buff{1024};
   { 
     sycl::host_accessor a{values_buff};
@@ -328,15 +347,17 @@ BOOST_AUTO_TEST_CASE(accessor_reduction) {
   
   sycl::buffer<int> sum_buff{1};
   sycl::buffer<int> max_buff{1};
-  
-  q.submit([&](sycl::handler
-                   &cgh) {
+
+  max_buff.get_host_access()[0] = 0;
+
+  q.submit([&](sycl::handler &cgh) {
     auto values_acc = values_buff.get_access<sycl::access_mode::read>(
         cgh);
 
-    auto sumReduction = sycl::reduction(sum_buff, cgh, sycl::plus<int>());
-    auto maxReduction = sycl::reduction(max_buff, cgh, 0, sycl::maximum<int>()); // TODO
-    
+    auto sumReduction = sycl::reduction(sum_buff, cgh, sycl::plus<int>(), initialize_to_identity);
+    // auto maxReduction = sycl::reduction(max_buff, cgh, sycl::maximum<int>()); // TODO currently not on GPU
+    auto maxReduction = sycl::reduction(max_buff, cgh, 0, sycl::maximum<int>());
+
     cgh.parallel_for(sycl::range<1>{1024}, sumReduction, maxReduction,
                      [=](sycl::id<1> idx, auto &sum, auto &max) {
                        sum += values_acc[idx];

--- a/tests/sycl/reduction.cpp
+++ b/tests/sycl/reduction.cpp
@@ -461,17 +461,17 @@ BOOST_AUTO_TEST_CASE(combine_none_or_multiple) {
   max_buff.get_host_access()[0] = 0;
 
   q.submit([&](sycl::handler &cgh) {
-      auto sum_reduction = sycl::reduction(sum_buff, cgh, sycl::plus<>());
-      auto max_reduction = sycl::reduction(max_buff, cgh, sycl::maximum<int>()); // no identity
+    auto sum_reduction = sycl::reduction(sum_buff, cgh, sycl::plus<>());
+    auto max_reduction = sycl::reduction(max_buff, cgh, sycl::maximum<int>()); // no identity
 
-      cgh.parallel_for(sycl::range<1>{1024}, sum_reduction, max_reduction,
-          [=](sycl::id<1> idx, auto &sum, auto &max) {
-              // Test both validity of 0 combines or > 1 combine per item
-              for (int i = 0; i < static_cast<int>(idx.get(0)) % 3; ++i) {
-                sum += idx[0];
-                max.combine(idx[0]);
-              }
-          });
+    cgh.parallel_for(sycl::range<1>{1024}, sum_reduction, max_reduction,
+        [=](sycl::id<1> idx, auto &sum, auto &max) {
+          // Test both validity of 0 combines or > 1 combine per item
+          for (int i = 0; i < static_cast<int>(idx.get(0)) % 3; ++i) {
+            sum += idx[0];
+            max.combine(idx[0]);
+          }
+        });
   });
 
   BOOST_CHECK(max_buff.get_host_access()[0] == 1022);
@@ -479,34 +479,34 @@ BOOST_AUTO_TEST_CASE(combine_none_or_multiple) {
 }
 
 BOOST_AUTO_TEST_CASE(deprecated_accessor_reduction) {
-    sycl::queue q;
-    sycl::buffer<int> sum_buff_a{1};
-    sycl::buffer<int> sum_buff_b{1};
+  sycl::queue q;
+  sycl::buffer<int> sum_buff_a{1};
+  sycl::buffer<int> sum_buff_b{1};
 
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated"
 #endif
 
-    q.submit([&](sycl::handler &cgh) {
-      auto sum_a_reduction = sycl::reduction(sycl::accessor{sum_buff_a, cgh, sycl::write_only, sycl::no_init},
-          sycl::plus<>());
-      auto sum_b_reduction = sycl::reduction(sycl::accessor{sum_buff_b, cgh, sycl::write_only, sycl::no_init},
-          0, sycl::plus<int>());
+  q.submit([&](sycl::handler &cgh) {
+    auto sum_a_reduction = sycl::reduction(sycl::accessor{sum_buff_a, cgh, sycl::write_only, sycl::no_init},
+        sycl::plus<>());
+    auto sum_b_reduction = sycl::reduction(sycl::accessor{sum_buff_b, cgh, sycl::write_only, sycl::no_init},
+        0, sycl::plus<int>());
 
-      cgh.parallel_for(sycl::range<1>{1024}, sum_a_reduction, sum_b_reduction,
-          [=](sycl::item<1> idx, auto &sum_a, auto &sum_b) {
-              sum_a += idx.get_id(0);
-              sum_b += idx.get_id(0);
-          });
-    });
+    cgh.parallel_for(sycl::range<1>{1024}, sum_a_reduction, sum_b_reduction,
+        [=](sycl::item<1> idx, auto &sum_a, auto &sum_b) {
+          sum_a += idx.get_id(0);
+          sum_b += idx.get_id(0);
+        });
+  });
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif
 
-    BOOST_CHECK(sum_buff_a.get_host_access()[0] == 523776);
-    BOOST_CHECK(sum_buff_b.get_host_access()[0] == 523776);
+  BOOST_CHECK(sum_buff_a.get_host_access()[0] == 523776);
+  BOOST_CHECK(sum_buff_b.get_host_access()[0] == 523776);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/sycl/reduction.cpp
+++ b/tests/sycl/reduction.cpp
@@ -79,15 +79,15 @@ void test_scalar_reduction(sycl::queue &q, std::size_t num_elements,
 template<class T, class BinaryOp>
 struct input_generator {};
 
-template<class T>
-struct input_generator <T, sycl::plus<T>> {
+template<class T, typename U>
+struct input_generator <T, sycl::plus<U>> {
   T operator() (std::size_t i) const {
     return static_cast<T>(i);
   }
 };
 
-template<class T>
-struct input_generator <T, sycl::multiplies<T>> {
+template<class T, typename U>
+struct input_generator <T, sycl::multiplies<U>> {
   T operator() (std::size_t i) const {
     if(i > 1500)
       return static_cast<T>(1);
@@ -99,50 +99,50 @@ struct input_generator <T, sycl::multiplies<T>> {
   }
 };
 
-template<class T>
-struct input_generator <T, sycl::minimum<T>> {
+template<class T, typename U>
+struct input_generator <T, sycl::minimum<U>> {
   T operator() (std::size_t i) const {
     return 1234 - (i % 567);
   }
 };
 
-template<class T>
-struct input_generator <T, sycl::maximum<T>> {
+template<class T, typename U>
+struct input_generator <T, sycl::maximum<U>> {
   T operator() (std::size_t i) const {
     return 1234 + (i % 567);
   }
 };
 
-template<class T>
-struct input_generator <T, sycl::bit_and<T>> {
+template<class T, typename U>
+struct input_generator <T, sycl::bit_and<U>> {
   T operator() (std::size_t i) const {
     return static_cast<T>((2ull * static_cast<unsigned long long>(i)) | (1ull << (8 * sizeof(T) - 1)) | 1ull);
   }
 };
 
-template<class T>
-struct input_generator <T, sycl::bit_or<T>> {
+template<class T, typename U>
+struct input_generator <T, sycl::bit_or<U>> {
 T operator() (std::size_t i) const {
   return static_cast<T>(i ? 2ull * static_cast<unsigned long long>(i) : (1ull << (8 * sizeof(T) - 1)));
 }
 };
 
-template<class T>
-struct input_generator <T, sycl::bit_xor<T>> {
+template<class T, typename U>
+struct input_generator <T, sycl::bit_xor<U>> {
   T operator() (std::size_t i) const {
     return static_cast<T>(17 * i);
   }
 };
 
-template<>
-struct input_generator <bool, sycl::logical_or<bool>> {
+template<typename U>
+struct input_generator <bool, sycl::logical_or<U>> {
   bool operator() (std::size_t i) const {
     return i == 0;
   }
 };
 
-template<>
-struct input_generator <bool, sycl::logical_and<bool>> {
+template<typename U>
+struct input_generator <bool, sycl::logical_and<U>> {
 bool operator() (std::size_t i) const {
   return i != 0;
 }
@@ -374,9 +374,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(single_kernel_single_scalar_reduction, T, all_test
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(single_kernel_single_scalar_int_reduction, T, int_test_types) {
-  test_single_reduction<T>(128, 128, sycl::bit_or<T>{});
-  test_single_reduction<T>(128, 128, sycl::bit_and<T>{});
-  test_single_reduction<T>(128, 128, sycl::bit_xor<T>{});
+  test_single_reduction<T>(128, 128, sycl::bit_or<>{});
+  test_single_reduction<T>(128, 128, sycl::bit_and<>{});
+  test_single_reduction<T>(128, 128, sycl::bit_xor<>{});
 }
 
 BOOST_AUTO_TEST_CASE(single_kernel_single_scalar_bool_reduction) {
@@ -385,8 +385,8 @@ BOOST_AUTO_TEST_CASE(single_kernel_single_scalar_bool_reduction) {
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(two_kernels_single_scalar_reduction, T, large_test_types) {
-  test_single_reduction<T>(128*128, 128, sycl::plus<T>{});
-  test_single_reduction<T>(128*128, 128, sycl::multiplies<T>{});
+  test_single_reduction<T>(128*128, 128, sycl::plus<>{});
+  test_single_reduction<T>(128*128, 128, sycl::multiplies<>{});
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(three_kernels_single_scalar_reduction, T, very_large_test_types) {
@@ -437,7 +437,7 @@ BOOST_AUTO_TEST_CASE(buffer_reduction) {
     auto values_acc = values_buff.get_access<sycl::access_mode::read>(
         cgh);
 
-    auto sumReduction = sycl::reduction(sum_buff, cgh, sycl::plus<int>(), initialize_to_identity);
+    auto sumReduction = sycl::reduction(sum_buff, cgh, sycl::plus<>(), initialize_to_identity);
     auto maxReduction = sycl::reduction(max_buff, cgh, sycl::maximum<int>());
 
     cgh.parallel_for(sycl::range<1>{1024}, sumReduction, maxReduction,
@@ -459,7 +459,7 @@ BOOST_AUTO_TEST_CASE(combine_none_or_multiple) {
   max_buff.get_host_access()[0] = 0;
 
   q.submit([&](sycl::handler &cgh) {
-      auto sumReduction = sycl::reduction(sum_buff, cgh, sycl::plus<int>());
+      auto sumReduction = sycl::reduction(sum_buff, cgh, sycl::plus<>());
       auto maxReduction = sycl::reduction(max_buff, cgh, sycl::maximum<int>()); // no identity
 
       cgh.parallel_for(sycl::range<1>{1024}, sumReduction, maxReduction,


### PR DESCRIPTION
Will fix #572 once complete.

## Resolved so far
- [x] Pass buffers instead of accessors into `sycl::reduction`
- [x] Provide implicit identities to `sycl::plus` and companions
- [x] Handle the `initialize_to_identity` property on reductions
- [x] Support reduction functions without an identity
- [x] Clarify whether `sycl::minimum` and `sycl::maximum` should have an identity -- the spec does not mention this, we should probably see what DPC++ is doing here and mirror the behavior. See also: KhronosGroup/SYCL-Docs#163
- [x] Properly handle implicit identities of `sycl::plus` and the like in the face of implicit argument type conversions
- [x] Come up with a less hacky implementation in `hiplike_kernel_launcher`
- [x] Document the implementation

## Open

None 

## Probably out of Scope
- Level Zero support (old API not implemented either)
- Evaluate whether the `initialized` predicate for the no-identity case can be handled more efficiently on the GPU (e.g. with bitmasks and subgroup reductions). Not investigated so far since the reduction of values themselves still has optimization potential by sharing code with (optimized) group reductions, e.g. using intrinsics like CUDA `__reduce_and_sync`.