### PR TITLE
Add flush_sync() before querying node group in queue::get_wait_list()

### DIFF
--- a/include/hipSYCL/sycl/queue.hpp
+++ b/include/hipSYCL/sycl/queue.hpp
@@ -390,6 +390,7 @@ public:
     } else {
       // for non-in-order queues we need to ask the runtime for
       // all nodes of this node group
+      rt::application::dag().flush_sync();
       auto nodes = rt::application::dag().get_group(_node_group_id);
       std::vector<event> evts;
       for(auto node : nodes){


### PR DESCRIPTION
For non-in-order queues, it is likely that we need to `flush_sync()` the dag before querying the node list so that we actually retrieve an up-to-date node list. This PR adds a call `flush_sync()` prior to querying the node group.