### PR TITLE
[SYCL 2020] Add atomic_ref, refactor atomics, implement atomic builtins for all types and operations

### DIFF
--- a/include/hipSYCL/sycl/detail/util.hpp
+++ b/include/hipSYCL/sycl/detail/util.hpp
@@ -101,7 +101,7 @@ Tout bit_cast(Tin x) {
   static_assert(sizeof(Tout)==sizeof(Tin), "Types must match sizes");
 
   Tout out;
-#if defined(__clang_major__) && __clang_major__ >= 11
+#if !defined(__APPLE__) && defined(__clang_major__) && __clang_major__ >= 11
   __builtin_memcpy_inline(&out, &x, sizeof(Tin));
 #elif HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_HOST
   memcpy(&out, &x, sizeof(Tin));

--- a/include/hipSYCL/sycl/detail/util.hpp
+++ b/include/hipSYCL/sycl/detail/util.hpp
@@ -32,6 +32,8 @@
 #include <atomic>
 #include <tuple>
 #include <utility>
+#include <cstring>
+#include "hipSYCL/sycl/libkernel/backend.hpp"
 
 namespace hipsycl {
 namespace sycl {
@@ -92,6 +94,25 @@ void separate_last_argument_and_apply(F&& f, Args&& ... args) {
 
   std::apply(f,
              std::tuple_cat(std::make_tuple(last_element), preceding_elements));
+}
+
+template <class Tout, class Tin>
+Tout bit_cast(Tin x) {
+  static_assert(sizeof(Tout)==sizeof(Tin), "Types must match sizes");
+
+  Tout out;
+#if defined(__clang_major__) && __clang_major__ >= 11
+  __builtin_memcpy_inline(&out, &x, sizeof(Tin));
+#elif HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_HOST
+  memcpy(&out, &x, sizeof(Tin));
+#else
+  char* cout = &out;
+  char* cin = &x;
+  for(int i = 0; i < sizeof(Tin); ++i)
+    cout[i] = cin[i];
+#endif
+  
+  return out;
 }
 
 }

--- a/include/hipSYCL/sycl/libkernel/atomic.hpp
+++ b/include/hipSYCL/sycl/libkernel/atomic.hpp
@@ -77,21 +77,21 @@ public:
   HIPSYCL_KERNEL_TARGET
   void store(T operand, memory_order memoryOrder =
       memory_order::relaxed) volatile {
-    detail::__hipsycl_atomic_store<T, addressSpace>(
+    detail::__hipsycl_atomic_store<addressSpace>(
         _ptr, operand, memoryOrder, default_scope());
   }
 
   HIPSYCL_KERNEL_TARGET
   T load(memory_order memoryOrder = memory_order::relaxed) const volatile {
-    return detail::__hipsycl_atomic_load<T, addressSpace>(_ptr, memoryOrder,
-                                                          default_scope());
+    return detail::__hipsycl_atomic_load<addressSpace>(_ptr, memoryOrder,
+                                                       default_scope());
   }
 
   HIPSYCL_KERNEL_TARGET
   T exchange(T operand, memory_order memoryOrder =
       memory_order::relaxed) volatile
   {
-    return detail::__hipsycl_atomic_exchange<T, addressSpace>(
+    return detail::__hipsycl_atomic_exchange<addressSpace>(
         _ptr, operand, memoryOrder, default_scope());
   }
 
@@ -101,7 +101,7 @@ public:
                                memory_order successMemoryOrder = memory_order::relaxed,
                                memory_order failMemoryOrder = memory_order::relaxed) volatile
   {
-    return detail::__hipsycl_atomic_compare_exchange_strong<T, addressSpace>(
+    return detail::__hipsycl_atomic_compare_exchange_strong<addressSpace>(
         _ptr, expected, desired, successMemoryOrder, failMemoryOrder,
         default_scope());
   }
@@ -113,7 +113,7 @@ public:
   T fetch_add(T operand, memory_order memoryOrder =
       memory_order::relaxed) volatile
   {
-    return detail::__hipsycl_atomic_fetch_add<T, addressSpace>(
+    return detail::__hipsycl_atomic_fetch_add<addressSpace>(
         _ptr, operand, memoryOrder, default_scope());
   }
 
@@ -124,7 +124,7 @@ public:
   T fetch_sub(T operand, memory_order memoryOrder =
       memory_order::relaxed) volatile
   {
-    return detail::__hipsycl_atomic_fetch_sub<T, addressSpace>(
+    return detail::__hipsycl_atomic_fetch_sub<addressSpace>(
         _ptr, operand, memoryOrder, default_scope());
   }
 
@@ -135,7 +135,7 @@ public:
   T fetch_and(T operand, memory_order memoryOrder =
       memory_order::relaxed) volatile
   {
-    return detail::__hipsycl_atomic_fetch_and<T, addressSpace>(
+    return detail::__hipsycl_atomic_fetch_and<addressSpace>(
         _ptr, operand, memoryOrder, default_scope());
   }
 
@@ -146,7 +146,7 @@ public:
   T fetch_or(T operand, memory_order memoryOrder =
       memory_order::relaxed) volatile
   {
-    return detail::__hipsycl_atomic_fetch_or<T, addressSpace>(
+    return detail::__hipsycl_atomic_fetch_or<addressSpace>(
         _ptr, operand, memoryOrder, default_scope());
   }
 
@@ -157,7 +157,7 @@ public:
   T fetch_xor(T operand, memory_order memoryOrder =
       memory_order::relaxed) volatile
   {
-    return detail::__hipsycl_atomic_fetch_xor<T, addressSpace>(
+    return detail::__hipsycl_atomic_fetch_xor<addressSpace>(
         _ptr, operand, memoryOrder, default_scope());
   }
 
@@ -168,7 +168,7 @@ public:
   T fetch_min(T operand, memory_order memoryOrder =
       memory_order::relaxed) volatile
   {
-    return detail::__hipsycl_atomic_fetch_min<T, addressSpace>(
+    return detail::__hipsycl_atomic_fetch_min<addressSpace>(
         _ptr, operand, memoryOrder, default_scope());
   }
 
@@ -179,7 +179,7 @@ public:
   T fetch_max(T operand, memory_order memoryOrder =
       memory_order::relaxed) volatile
   {
-    return detail::__hipsycl_atomic_fetch_max<T, addressSpace>(
+    return detail::__hipsycl_atomic_fetch_max<addressSpace>(
         _ptr, operand, memoryOrder, default_scope());
   }
 

--- a/include/hipSYCL/sycl/libkernel/atomic.hpp
+++ b/include/hipSYCL/sycl/libkernel/atomic.hpp
@@ -32,17 +32,16 @@
 
 #include "hipSYCL/sycl/access.hpp"
 #include "hipSYCL/sycl/libkernel/backend.hpp"
+#include "hipSYCL/sycl/libkernel/host/atomic_builtins.hpp"
+#include "hipSYCL/sycl/libkernel/memory.hpp"
 #include "multi_ptr.hpp"
 
+
+#include "atomic_builtins.hpp"
 
 namespace hipsycl {
 namespace sycl {
 
-
-enum class memory_order : int
-{
-  relaxed
-};
 
 #ifdef HIPSYCL_EXT_FP_ATOMICS
   #define HIPSYCL_CONDITIONALLY_ENABLE_ATOMICS(template_param) \
@@ -52,11 +51,19 @@ enum class memory_order : int
     std::enable_if_t<std::is_integral<template_param>::value>* = nullptr
 #endif
 
-/// \todo Atomics are only partially implemented.
-/// In particular, load / store are unimplemented on GPU.
+
 template <typename T, access::address_space addressSpace =
           access::address_space::global_space>
 class atomic {
+  static constexpr memory_scope default_scope() {
+    if(addressSpace == access::address_space::global_space)
+      return memory_scope::device;
+    else if(addressSpace == access::address_space::local_space)
+      return memory_scope::work_group;
+    else if(addressSpace == access::address_space::private_space)
+      return memory_scope::work_item;
+    return memory_scope::device;
+  }
 public:
   template <typename pointerT>
   HIPSYCL_UNIVERSAL_TARGET
@@ -67,25 +74,25 @@ public:
                   "Invalid pointer type for atomic<>");
   }
 
-  /// \todo unimplemented on GPU
   HIPSYCL_KERNEL_TARGET
   void store(T operand, memory_order memoryOrder =
-      memory_order::relaxed) volatile;
+      memory_order::relaxed) volatile {
+    detail::__hipsycl_atomic_store<T, addressSpace>(
+        _ptr, operand, memoryOrder, default_scope());
+  }
 
-  /// \todo unimplemented on GPU
   HIPSYCL_KERNEL_TARGET
-  T load(memory_order memoryOrder = memory_order::relaxed) const volatile;
+  T load(memory_order memoryOrder = memory_order::relaxed) const volatile {
+    return detail::__hipsycl_atomic_load<T, addressSpace>(_ptr, memoryOrder,
+                                                          default_scope());
+  }
 
   HIPSYCL_KERNEL_TARGET
   T exchange(T operand, memory_order memoryOrder =
       memory_order::relaxed) volatile
   {
-#ifdef SYCL_DEVICE_ONLY
-    return atomicExch(_ptr, operand);
-#else
-    assert(memoryOrder == memory_order::relaxed);
-    return __atomic_exchange_n(_ptr, operand, __ATOMIC_RELAXED);
-#endif
+    return detail::__hipsycl_atomic_exchange<T, addressSpace>(
+        _ptr, operand, memoryOrder, default_scope());
   }
 
   /* Available only when: T != float */
@@ -94,15 +101,9 @@ public:
                                memory_order successMemoryOrder = memory_order::relaxed,
                                memory_order failMemoryOrder = memory_order::relaxed) volatile
   {
-#ifdef SYCL_DEVICE_ONLY
-    T old = expected;
-    expected = atomicCAS(_ptr, expected, desired);
-    return old == expected;
-#else
-    assert(successMemoryOrder == memory_order::relaxed);
-    assert(failMemoryOrder == memory_order::relaxed);
-    return __atomic_compare_exchange_n(_ptr, &expected, desired, false, __ATOMIC_RELAXED, __ATOMIC_RELAXED);
-#endif
+    return detail::__hipsycl_atomic_compare_exchange_strong<T, addressSpace>(
+        _ptr, expected, desired, successMemoryOrder, failMemoryOrder,
+        default_scope());
   }
 
   /* Available only when: T != float */
@@ -112,12 +113,8 @@ public:
   T fetch_add(T operand, memory_order memoryOrder =
       memory_order::relaxed) volatile
   {
-#ifdef SYCL_DEVICE_ONLY
-    return atomicAdd(_ptr, operand);
-#else
-    assert(memoryOrder == memory_order::relaxed);
-    return __atomic_fetch_add(_ptr, operand, __ATOMIC_RELAXED);
-#endif
+    return detail::__hipsycl_atomic_fetch_add<T, addressSpace>(
+        _ptr, operand, memoryOrder, default_scope());
   }
 
   /* Available only when: T != float */
@@ -127,12 +124,8 @@ public:
   T fetch_sub(T operand, memory_order memoryOrder =
       memory_order::relaxed) volatile
   {
-#ifdef SYCL_DEVICE_ONLY
-    return atomicSub(_ptr, operand);
-#else
-    assert(memoryOrder == memory_order::relaxed);
-    return __atomic_fetch_sub(_ptr, operand, __ATOMIC_RELAXED);
-#endif
+    return detail::__hipsycl_atomic_fetch_sub<T, addressSpace>(
+        _ptr, operand, memoryOrder, default_scope());
   }
 
   /* Available only when: T != float */
@@ -142,12 +135,8 @@ public:
   T fetch_and(T operand, memory_order memoryOrder =
       memory_order::relaxed) volatile
   {
-#ifdef SYCL_DEVICE_ONLY
-    return atomicAnd(_ptr, operand);
-#else
-    assert(memoryOrder == memory_order::relaxed);
-    return __atomic_fetch_and(_ptr, operand, __ATOMIC_RELAXED);
-#endif
+    return detail::__hipsycl_atomic_fetch_and<T, addressSpace>(
+        _ptr, operand, memoryOrder, default_scope());
   }
 
   /* Available only when: T != float */
@@ -157,12 +146,8 @@ public:
   T fetch_or(T operand, memory_order memoryOrder =
       memory_order::relaxed) volatile
   {
-#ifdef SYCL_DEVICE_ONLY
-    return atomicOr(_ptr, operand);
-#else
-    assert(memoryOrder == memory_order::relaxed);
-    return __atomic_fetch_or(_ptr, operand, __ATOMIC_RELAXED);
-#endif
+    return detail::__hipsycl_atomic_fetch_or<T, addressSpace>(
+        _ptr, operand, memoryOrder, default_scope());
   }
 
   /* Available only when: T != float */
@@ -172,12 +157,8 @@ public:
   T fetch_xor(T operand, memory_order memoryOrder =
       memory_order::relaxed) volatile
   {
-#ifdef SYCL_DEVICE_ONLY
-    return atomicXor(_ptr, operand);
-#else
-    assert(memoryOrder == memory_order::relaxed);
-    return __atomic_fetch_xor(_ptr, operand, __ATOMIC_RELAXED);
-#endif
+    return detail::__hipsycl_atomic_fetch_xor<T, addressSpace>(
+        _ptr, operand, memoryOrder, default_scope());
   }
 
   /* Available only when: T != float */
@@ -187,16 +168,8 @@ public:
   T fetch_min(T operand, memory_order memoryOrder =
       memory_order::relaxed) volatile
   {
-#ifdef SYCL_DEVICE_ONLY
-    return atomicMin(_ptr, operand);
-#else
-    t old = load();
-    do
-    {
-        if (old < operand) return old;
-    } while(!compare_exchange_strong(old, operand));
-    return operand;
-#endif
+    return detail::__hipsycl_atomic_fetch_min<T, addressSpace>(
+        _ptr, operand, memoryOrder, default_scope());
   }
 
   /* Available only when: T != float */
@@ -206,40 +179,13 @@ public:
   T fetch_max(T operand, memory_order memoryOrder =
       memory_order::relaxed) volatile
   {
-#ifdef SYCL_DEVICE_ONLY
-    return atomicMax(_ptr, operand);
-#else
-    t old = load();
-    do
-    {
-        if (old > operand) return old;
-    } while(!compare_exchange_strong(old, operand));
-    return operand;
-#endif
+    return detail::__hipsycl_atomic_fetch_max<T, addressSpace>(
+        _ptr, operand, memoryOrder, default_scope());
   }
 
 private:
   T* _ptr;
 };
-
-#ifdef HIPSYCL_PLATFORM_CPU
-  template <typename T, access::address_space addressSpace>
-  HIPSYCL_KERNEL_TARGET
-  void atomic<T,addressSpace>::store(T operand, memory_order memoryOrder) volatile
-  {
-    assert(memoryOrder == memory_order::relaxed);
-    return __atomic_store_n(_ptr, operand, __ATOMIC_RELAXED);
-  }
-
-  template <typename T, access::address_space addressSpace>
-  HIPSYCL_KERNEL_TARGET
-  T atomic<T,addressSpace>::load(memory_order memoryOrder) const volatile
-  {
-    assert(memoryOrder == memory_order::relaxed);
-    return __atomic_load_n(_ptr, __ATOMIC_RELAXED);
-  }
-#endif
-
 
 
 template <typename T, access::address_space addressSpace>

--- a/include/hipSYCL/sycl/libkernel/atomic_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/atomic_builtins.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2020 Aksel Alpay
+ * Copyright (c) 2021 Aksel Alpay
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,55 +25,18 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef HIPSYCL_MEMORY_HPP
-#define HIPSYCL_MEMORY_HPP
+#ifndef HIPSYCL_ATOMIC_BUILTINS_HPP
+#define HIPSYCL_ATOMIC_BUILTINS_HPP
 
-namespace hipsycl {
-namespace sycl {
+#include "hipSYCL/sycl/libkernel/backend.hpp"
 
-enum class memory_scope {
-  work_item,
-  sub_group,
-  work_group,
-  device,
-  system
-};
-
-inline constexpr auto memory_scope_work_item = memory_scope::work_item;
-inline constexpr auto memory_scope_sub_group = memory_scope::sub_group;
-inline constexpr auto memory_scope_work_group = memory_scope::work_group;
-inline constexpr auto memory_scope_device = memory_scope::device;
-inline constexpr auto memory_scope_system = memory_scope::system;
-
-enum class memory_order : int
-{
-  relaxed,
-  acquire,
-  release,
-  acq_rel,
-  seq_cst
-};
-
-inline constexpr auto memory_order_relaxed = memory_order::relaxed;
-inline constexpr auto memory_order_acquire = memory_order::acquire;
-inline constexpr auto memory_order_release = memory_order::release;
-inline constexpr auto memory_order_acq_rel = memory_order::acq_rel;
-inline constexpr auto memory_order_seq_cst = memory_order::seq_cst;
-
-namespace access {
-
-enum class address_space : int
-{
-  global_space,
-  local_space,
-  constant_space,
-  private_space,
-  generic_space
-};
-
-} // namespace access
-
-}
-} // namespace hipsycl
+#if HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_HOST
+#include "host/atomic_builtins.hpp"
+#elif HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_CUDA ||                                 \
+    HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_HIP
+#include "generic/hiplike/atomic_builtins.hpp"
+#elif HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_SPIRV
+#include "spirv/atomic_builtins.hpp"
+#endif
 
 #endif

--- a/include/hipSYCL/sycl/libkernel/atomic_ref.hpp
+++ b/include/hipSYCL/sycl/libkernel/atomic_ref.hpp
@@ -105,7 +105,7 @@ public:
   void store(T operand,
     memory_order order = default_write_order,
     memory_scope scope = default_scope) const noexcept {
-    detail::__hipsycl_atomic_store<T, Space>(_ptr, operand, order, scope);
+    detail::__hipsycl_atomic_store<Space>(_ptr, operand, order, scope);
   }
 
   T operator=(T desired) const noexcept {
@@ -115,7 +115,7 @@ public:
 
   T load(memory_order order = default_read_order,
     memory_scope scope = default_scope) const noexcept {
-    return detail::__hipsycl_atomic_load<T, Space>(_ptr, order, scope);
+    return detail::__hipsycl_atomic_load<Space>(_ptr, order, scope);
   }
 
   operator T() const noexcept {
@@ -125,7 +125,7 @@ public:
   T exchange(T operand,
     memory_order order = default_read_modify_write_order,
     memory_scope scope = default_scope) const noexcept {
-    return detail::__hipsycl_atomic_exchange<T, Space>(_ptr, operand, order,
+    return detail::__hipsycl_atomic_exchange<Space>(_ptr, operand, order,
                                                        scope);
   }
 
@@ -133,7 +133,7 @@ public:
     memory_order success,
     memory_order failure,
     memory_scope scope = default_scope) const noexcept {
-    return detail::__hipsycl_atomic_compare_exchange_weak<T, Space>(
+    return detail::__hipsycl_atomic_compare_exchange_weak<Space>(
         _ptr, expected, desired, success, failure, scope);
   }
 
@@ -148,7 +148,7 @@ public:
     memory_order success,
     memory_order failure,
     memory_scope scope = default_scope) const noexcept {
-    return detail::__hipsycl_atomic_compare_exchange_strong<T, Space>(
+    return detail::__hipsycl_atomic_compare_exchange_strong<Space>(
         _ptr, expected, desired, success, failure, scope);
   }
 
@@ -163,8 +163,8 @@ public:
   Integral fetch_add(Integral operand,
                      memory_order order = default_read_modify_write_order,
                      memory_scope scope = default_scope) const noexcept {
-    return detail::__hipsycl_atomic_fetch_add<Integral, Space>(_ptr, operand,
-                                                               order, scope);
+    return detail::__hipsycl_atomic_fetch_add<Space>(_ptr, operand, order,
+                                                     scope);
   }
 
   template <class Integral = T,
@@ -172,8 +172,8 @@ public:
   Integral fetch_sub(Integral operand,
                      memory_order order = default_read_modify_write_order,
                      memory_scope scope = default_scope) const noexcept {
-    return detail::__hipsycl_atomic_fetch_sub<Integral, Space>(_ptr, operand,
-                                                               order, scope);
+    return detail::__hipsycl_atomic_fetch_sub<Space>(_ptr, operand, order,
+                                                     scope);
   }
 
   template <class Integral = T,
@@ -181,8 +181,8 @@ public:
   Integral fetch_and(Integral operand,
                      memory_order order = default_read_modify_write_order,
                      memory_scope scope = default_scope) const noexcept {
-    return detail::__hipsycl_atomic_fetch_and<Integral, Space>(_ptr, operand,
-                                                               order, scope);
+    return detail::__hipsycl_atomic_fetch_and<Space>(_ptr, operand, order,
+                                                     scope);
   }
 
   template <class Integral = T,
@@ -190,8 +190,8 @@ public:
   Integral fetch_or(Integral operand,
                     memory_order order = default_read_modify_write_order,
                     memory_scope scope = default_scope) const noexcept {
-    return detail::__hipsycl_atomic_fetch_or<Integral, Space>(_ptr, operand,
-                                                              order, scope);
+    return detail::__hipsycl_atomic_fetch_or<Space>(_ptr, operand, order,
+                                                    scope);
   }
 
   template <class Integral = T,
@@ -199,8 +199,8 @@ public:
   Integral fetch_xor(Integral operand,
                      memory_order order = default_read_modify_write_order,
                      memory_scope scope = default_scope) const noexcept {
-    return detail::__hipsycl_atomic_fetch_xor<Integral, Space>(_ptr, operand,
-                                                               order, scope);
+    return detail::__hipsycl_atomic_fetch_xor<Space>(_ptr, operand, order,
+                                                     scope);
   }
 
   template <class Integral = T,
@@ -208,8 +208,8 @@ public:
   Integral fetch_min(Integral operand,
                      memory_order order = default_read_modify_write_order,
                      memory_scope scope = default_scope) const noexcept {
-    return detail::__hipsycl_atomic_fetch_min<Integral, Space>(_ptr, operand,
-                                                               order, scope);
+    return detail::__hipsycl_atomic_fetch_min<Space>(_ptr, operand, order,
+                                                     scope);
   }
 
   template <class Integral = T,
@@ -217,8 +217,8 @@ public:
   Integral fetch_max(Integral operand,
                      memory_order order = default_read_modify_write_order,
                      memory_scope scope = default_scope) const noexcept {
-    return detail::__hipsycl_atomic_fetch_max<Integral, Space>(_ptr, operand,
-                                                               order, scope);
+    return detail::__hipsycl_atomic_fetch_max<Space>(_ptr, operand, order,
+                                                     scope);
   }
 
   template <class Integral = T,
@@ -280,8 +280,8 @@ public:
   Floating fetch_add(Floating operand,
                      memory_order order = default_read_modify_write_order,
                      memory_scope scope = default_scope) const noexcept {
-    return detail::__hipsycl_atomic_fetch_add<Floating, Space>(_ptr, operand,
-                                                               order, scope);
+    return detail::__hipsycl_atomic_fetch_add<Space>(_ptr, operand, order,
+                                                     scope);
   }
 
   template <class Floating = T,
@@ -289,8 +289,8 @@ public:
   Floating fetch_sub(Floating operand,
                      memory_order order = default_read_modify_write_order,
                      memory_scope scope = default_scope) const noexcept {
-    return detail::__hipsycl_atomic_fetch_sub<Floating, Space>(_ptr, operand,
-                                                               order, scope);
+    return detail::__hipsycl_atomic_fetch_sub<Space>(_ptr, operand, order,
+                                                     scope);
   }
 
   template <class Floating = T,
@@ -298,8 +298,8 @@ public:
   Floating fetch_min(Floating operand,
                      memory_order order = default_read_modify_write_order,
                      memory_scope scope = default_scope) const noexcept {
-    return detail::__hipsycl_atomic_fetch_min<Floating, Space>(_ptr, operand,
-                                                               order, scope);
+    return detail::__hipsycl_atomic_fetch_min<Space>(_ptr, operand, order,
+                                                     scope);
   }
 
   template <class Floating = T,
@@ -307,8 +307,8 @@ public:
   Floating fetch_max(Floating operand,
                      memory_order order = default_read_modify_write_order,
                      memory_scope scope = default_scope) const noexcept {
-    return detail::__hipsycl_atomic_fetch_max<Floating, Space>(_ptr, operand,
-                                                               order, scope);
+    return detail::__hipsycl_atomic_fetch_max<Space>(_ptr, operand, order,
+                                                     scope);
   }
 
   template <class Floating = T,
@@ -373,7 +373,7 @@ public:
   void store(T* operand,
     memory_order order = default_write_order,
     memory_scope scope = default_scope) const noexcept {
-    detail::__hipsycl_atomic_store<std::intptr_t, Space>(
+    detail::__hipsycl_atomic_store<Space>(
         _ptr, ptr_to_int(operand), order, scope);
   }
 
@@ -385,7 +385,7 @@ public:
   T* load(memory_order order = default_read_order,
     memory_scope scope = default_scope) const noexcept {
     std::intptr_t v =
-        detail::__hipsycl_atomic_load<std::intptr_t, Space>(_ptr, order, scope);
+        detail::__hipsycl_atomic_load<Space>(_ptr, order, scope);
     return int_to_ptr(v);
   }
 
@@ -396,7 +396,7 @@ public:
   T* exchange(T* operand,
     memory_order order = default_read_modify_write_order,
     memory_scope scope = default_scope) const noexcept {
-    std::intptr_t v = detail::__hipsycl_atomic_exchange<std::intptr_t, Space>(
+    std::intptr_t v = detail::__hipsycl_atomic_exchange<Space>(
         _ptr, ptr_to_int(operand), order, scope);
     return int_to_ptr(v);
   }
@@ -409,7 +409,7 @@ public:
     std::intptr_t desired_v = ptr_to_int(desired);
     std::intptr_t& expected_v = ptr_ref_to_int_ref(expected);
 
-    return detail::__hipsycl_atomic_compare_exchange_weak<std::intptr_t, Space>(
+    return detail::__hipsycl_atomic_compare_exchange_weak<Space>(
         _ptr, expected_v, desired_v, success, failure, scope);
   }
 
@@ -428,7 +428,7 @@ public:
     std::intptr_t desired_v = ptr_to_int(desired);
     std::intptr_t& expected_v = ptr_ref_to_int_ref(expected);
 
-    return detail::__hipsycl_atomic_compare_exchange_strong<std::intptr_t, Space>(
+    return detail::__hipsycl_atomic_compare_exchange_strong<Space>(
         _ptr, expected_v, desired_v, success, failure, scope);
   }
 
@@ -443,16 +443,16 @@ public:
                memory_order order = default_read_modify_write_order,
                memory_scope scope = default_scope) const noexcept {
 
-    return int_to_ptr(detail::__hipsycl_atomic_fetch_add<std::intptr_t, Space>(
-        _ptr, static_cast<std::intptr_t>(x) * sizeof(T), order, scope));
+    return int_to_ptr(detail::__hipsycl_atomic_fetch_add<Space>(
+        _ptr, static_cast<std::intptr_t>(x * sizeof(T)), order, scope));
   }
 
   T *fetch_sub(difference_type x,
                memory_order order = default_read_modify_write_order,
                memory_scope scope = default_scope) const noexcept {
 
-    return int_to_ptr(detail::__hipsycl_atomic_fetch_sub<std::intptr_t, Space>(
-        _ptr, static_cast<std::intptr_t>(x) * sizeof(T), order, scope));
+    return int_to_ptr(detail::__hipsycl_atomic_fetch_sub<Space>(
+        _ptr, static_cast<std::intptr_t>(x * sizeof(T)), order, scope));
   }
 
   T* operator++(int) const noexcept {

--- a/include/hipSYCL/sycl/libkernel/atomic_ref.hpp
+++ b/include/hipSYCL/sycl/libkernel/atomic_ref.hpp
@@ -1,0 +1,479 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2021 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HIPSYCL_ATOMIC_REF_HPP
+#define HIPSYCL_ATOMIC_REF_HPP
+
+#include <cstdint>
+#include <type_traits>
+
+#include "memory.hpp"
+#include "atomic_builtins.hpp"
+
+namespace hipsycl {
+namespace sycl {
+
+template <memory_order ReadModifyWriteOrder>
+struct memory_order_traits;
+
+template <>
+struct memory_order_traits<memory_order::relaxed> {
+  static constexpr memory_order read_order = memory_order::relaxed;
+  static constexpr memory_order write_order = memory_order::relaxed;
+};
+
+template <>
+struct memory_order_traits<memory_order::acq_rel> {
+  static constexpr memory_order read_order = memory_order::acquire;
+  static constexpr memory_order write_order = memory_order::release;
+};
+
+template <>
+struct memory_order_traits<memory_order::seq_cst> {
+  static constexpr memory_order read_order = memory_order::seq_cst;
+  static constexpr memory_order write_order = memory_order::seq_cst;
+};
+
+
+template <typename T, memory_order DefaultOrder, memory_scope DefaultScope,
+          access::address_space Space = access::address_space::generic_space>
+class atomic_ref {
+public:
+  static_assert(std::is_same_v<T, int> || std::is_same_v<T, unsigned int> ||
+                    std::is_same_v<T, long> ||
+                    std::is_same_v<T, unsigned long> ||
+                    std::is_same_v<T, long long> ||
+                    std::is_same_v<T, unsigned long long> ||
+                    std::is_same_v<T, float> || std::is_same_v<T, double> ||
+                    std::is_pointer_v<T>,
+                "Invalid data type for atomic_ref");
+
+  static_assert(Space == access::address_space::generic_space ||
+                    Space == access::address_space::global_space ||
+                    Space == access::address_space::local_space,
+                "Invalid address space for atomic_ref");
+
+  using value_type = T;
+  using difference_type = value_type;
+
+  static constexpr std::size_t required_alignment = alignof(T);
+  // TODO
+  static constexpr bool is_always_lock_free = true;
+
+  static constexpr memory_order default_read_order =
+      memory_order_traits<DefaultOrder>::read_order;
+  static constexpr memory_order default_write_order =
+      memory_order_traits<DefaultOrder>::write_order;
+  static constexpr memory_order default_read_modify_write_order = DefaultOrder;
+  static constexpr memory_scope default_scope = DefaultScope;
+
+  bool is_lock_free() const noexcept {
+    // TODO
+    return true;
+  }
+
+  explicit atomic_ref(T& x)
+  : _ptr{&x} {}
+
+  atomic_ref(const atomic_ref&) noexcept = default;
+  atomic_ref& operator=(const atomic_ref&) = delete;
+
+  void store(T operand,
+    memory_order order = default_write_order,
+    memory_scope scope = default_scope) const noexcept {
+    detail::__hipsycl_atomic_store<T, Space>(_ptr, operand, order, scope);
+  }
+
+  T operator=(T desired) const noexcept {
+    store(desired);
+    return desired;
+  }
+
+  T load(memory_order order = default_read_order,
+    memory_scope scope = default_scope) const noexcept {
+    return detail::__hipsycl_atomic_load<T, Space>(_ptr, order, scope);
+  }
+
+  operator T() const noexcept {
+    return load();
+  }
+
+  T exchange(T operand,
+    memory_order order = default_read_modify_write_order,
+    memory_scope scope = default_scope) const noexcept {
+    return detail::__hipsycl_atomic_exchange<T, Space>(_ptr, operand, order,
+                                                       scope);
+  }
+
+  bool compare_exchange_weak(T &expected, T desired,
+    memory_order success,
+    memory_order failure,
+    memory_scope scope = default_scope) const noexcept {
+    return detail::__hipsycl_atomic_compare_exchange_weak<T, Space>(
+        _ptr, expected, desired, success, failure, scope);
+  }
+
+  bool
+  compare_exchange_weak(T &expected, T desired,
+                        memory_order order = default_read_modify_write_order,
+                        memory_scope scope = default_scope) const noexcept {
+    return compare_exchange_weak(expected, desired, order, order, scope);
+  }
+
+  bool compare_exchange_strong(T &expected, T desired,
+    memory_order success,
+    memory_order failure,
+    memory_scope scope = default_scope) const noexcept {
+    return detail::__hipsycl_atomic_compare_exchange_strong<T, Space>(
+        _ptr, expected, desired, success, failure, scope);
+  }
+
+  bool compare_exchange_strong(T &expected, T desired,
+    memory_order order = default_read_modify_write_order,
+    memory_scope scope = default_scope) const noexcept {
+    return compare_exchange_strong(expected, desired, order, order, scope);
+  }
+
+  template <class Integral = T,
+            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
+  Integral fetch_add(Integral operand,
+                     memory_order order = default_read_modify_write_order,
+                     memory_scope scope = default_scope) const noexcept {
+    return detail::__hipsycl_atomic_fetch_add<Integral, Space>(_ptr, operand,
+                                                               order, scope);
+  }
+
+  template <class Integral = T,
+            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
+  Integral fetch_sub(Integral operand,
+                     memory_order order = default_read_modify_write_order,
+                     memory_scope scope = default_scope) const noexcept {
+    return detail::__hipsycl_atomic_fetch_sub<Integral, Space>(_ptr, operand,
+                                                               order, scope);
+  }
+
+  template <class Integral = T,
+            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
+  Integral fetch_and(Integral operand,
+                     memory_order order = default_read_modify_write_order,
+                     memory_scope scope = default_scope) const noexcept {
+    return detail::__hipsycl_atomic_fetch_and<Integral, Space>(_ptr, operand,
+                                                               order, scope);
+  }
+
+  template <class Integral = T,
+            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
+  Integral fetch_or(Integral operand,
+                    memory_order order = default_read_modify_write_order,
+                    memory_scope scope = default_scope) const noexcept {
+    return detail::__hipsycl_atomic_fetch_or<Integral, Space>(_ptr, operand,
+                                                              order, scope);
+  }
+
+  template <class Integral = T,
+            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
+  Integral fetch_xor(Integral operand,
+                     memory_order order = default_read_modify_write_order,
+                     memory_scope scope = default_scope) const noexcept {
+    return detail::__hipsycl_atomic_fetch_xor<Integral, Space>(_ptr, operand,
+                                                               order, scope);
+  }
+
+  template <class Integral = T,
+            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
+  Integral fetch_min(Integral operand,
+                     memory_order order = default_read_modify_write_order,
+                     memory_scope scope = default_scope) const noexcept {
+    return detail::__hipsycl_atomic_fetch_min<Integral, Space>(_ptr, operand,
+                                                               order, scope);
+  }
+
+  template <class Integral = T,
+            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
+  Integral fetch_max(Integral operand,
+                     memory_order order = default_read_modify_write_order,
+                     memory_scope scope = default_scope) const noexcept {
+    return detail::__hipsycl_atomic_fetch_max<Integral, Space>(_ptr, operand,
+                                                               order, scope);
+  }
+
+  template <class Integral = T,
+            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
+  Integral operator++(int) const noexcept {
+    return fetch_add(Integral{1});
+  }
+
+  template <class Integral = T,
+            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
+  Integral operator--(int) const noexcept {
+    return fetch_sub(Integral{1});
+  }
+
+  template <class Integral = T,
+            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
+  Integral operator++() const noexcept {
+    return fetch_add(Integral{1}) + 1;
+  }
+
+  template <class Integral = T,
+            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
+  Integral operator--() const noexcept {
+    return fetch_sub(Integral{1}) - 1;
+  }
+
+  template <class Integral = T,
+            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
+  Integral operator+=(Integral op) const noexcept {
+    return fetch_add(op);
+  }
+
+  template <class Integral = T,
+            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
+  Integral operator-=(Integral op) const noexcept {
+    return fetch_sub(op);
+  }
+
+  template <class Integral = T,
+            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
+  Integral operator&=(Integral op) const noexcept {
+    return fetch_and(op);
+  }
+
+  template <class Integral = T,
+            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
+  Integral operator|=(Integral op) const noexcept {
+    return fetch_or(op);
+  }
+
+  template <class Integral = T,
+            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
+  Integral operator^=(Integral op) const noexcept {
+    return fetch_xor(op);
+  }
+
+  template <class Floating = T,
+            std::enable_if_t<std::is_floating_point_v<Floating>, int> = 0>
+  Floating fetch_add(Floating operand,
+                     memory_order order = default_read_modify_write_order,
+                     memory_scope scope = default_scope) const noexcept {
+    return detail::__hipsycl_atomic_fetch_add<Floating, Space>(_ptr, operand,
+                                                               order, scope);
+  }
+
+  template <class Floating = T,
+            std::enable_if_t<std::is_floating_point_v<Floating>, int> = 0>
+  Floating fetch_sub(Floating operand,
+                     memory_order order = default_read_modify_write_order,
+                     memory_scope scope = default_scope) const noexcept {
+    return detail::__hipsycl_atomic_fetch_sub<Floating, Space>(_ptr, operand,
+                                                               order, scope);
+  }
+
+  template <class Floating = T,
+            std::enable_if_t<std::is_floating_point_v<Floating>, int> = 0>
+  Floating fetch_min(Floating operand,
+                     memory_order order = default_read_modify_write_order,
+                     memory_scope scope = default_scope) const noexcept {
+    return detail::__hipsycl_atomic_fetch_min<Floating, Space>(_ptr, operand,
+                                                               order, scope);
+  }
+
+  template <class Floating = T,
+            std::enable_if_t<std::is_floating_point_v<Floating>, int> = 0>
+  Floating fetch_max(Floating operand,
+                     memory_order order = default_read_modify_write_order,
+                     memory_scope scope = default_scope) const noexcept {
+    return detail::__hipsycl_atomic_fetch_max<Floating, Space>(_ptr, operand,
+                                                               order, scope);
+  }
+
+  template <class Floating = T,
+            std::enable_if_t<std::is_floating_point_v<Floating>, int> = 0>
+  Floating operator+=(Floating op) const noexcept {
+    return fetch_add(op);
+  }
+
+  template <class Floating = T,
+            std::enable_if_t<std::is_floating_point_v<Floating>, int> = 0>
+  Floating operator-=(Floating op) const noexcept {
+    return fetch_sub(op);
+  }
+
+private:
+  T* _ptr;
+};
+
+template <typename T, memory_order DefaultOrder, memory_scope DefaultScope,
+          access::address_space Space>
+class atomic_ref<T *, DefaultOrder, DefaultScope, Space> {
+
+  std::intptr_t ptr_to_int(T* p) { return reinterpret_cast<std::intptr_t>(p); }
+  T* int_to_ptr(std::intptr_t i) { return reinterpret_cast<T*>(i); }
+  std::intptr_t &ptr_ref_to_int_ref(T *&p) {
+    T **pp = &p;
+    return *reinterpret_cast<std::intptr_t *>(pp);
+  }
+
+public:
+  using value_type = T*;
+  using difference_type = std::ptrdiff_t;
+  static constexpr std::size_t required_alignment = alignof(T*);
+  // TODO
+  static constexpr bool is_always_lock_free = true;
+
+  static constexpr memory_order default_read_order = memory_order_traits<DefaultOrder>::read_order;
+  static constexpr memory_order default_write_order = memory_order_traits<DefaultOrder>::write_order;
+  static constexpr memory_order default_read_modify_write_order = DefaultOrder;
+  static constexpr memory_scope default_scope = DefaultScope;
+
+  bool is_lock_free() const noexcept {
+    // TODO
+    return true;
+  }
+
+  explicit atomic_ref(T*& val) {
+    _ptr = reinterpret_cast<std::intptr_t>(&val);
+  }
+
+  atomic_ref(const atomic_ref&) noexcept = default;
+  atomic_ref& operator=(const atomic_ref&) = delete;
+
+  void store(T* operand,
+    memory_order order = default_write_order,
+    memory_scope scope = default_scope) const noexcept {
+    detail::__hipsycl_atomic_store<std::intptr_t, Space>(
+        _ptr, ptr_to_int(operand), order, scope);
+  }
+
+  T* operator=(T* desired) const noexcept {
+    store(desired);
+    return desired;
+  }
+
+  T* load(memory_order order = default_read_order,
+    memory_scope scope = default_scope) const noexcept {
+    std::intptr_t v =
+        detail::__hipsycl_atomic_load<std::intptr_t, Space>(_ptr, order, scope);
+    return int_to_ptr(v);
+  }
+
+  operator T*() const noexcept {
+    return load();
+  }
+
+  T* exchange(T* operand,
+    memory_order order = default_read_modify_write_order,
+    memory_scope scope = default_scope) const noexcept {
+    std::intptr_t v = detail::__hipsycl_atomic_exchange<std::intptr_t, Space>(
+        _ptr, ptr_to_int(operand), order, scope);
+    return int_to_ptr(v);
+  }
+
+  bool compare_exchange_weak(T* &expected, T* desired,
+    memory_order success,
+    memory_order failure,
+    memory_scope scope = default_scope) const noexcept {
+
+    std::intptr_t desired_v = ptr_to_int(desired);
+    std::intptr_t& expected_v = ptr_ref_to_int_ref(expected);
+
+    return detail::__hipsycl_atomic_compare_exchange_weak<std::intptr_t, Space>(
+        _ptr, expected_v, desired_v, success, failure, scope);
+  }
+
+  bool compare_exchange_weak(T* &expected, T* desired,
+    memory_order order = default_read_modify_write_order,
+    memory_scope scope = default_scope) const noexcept {
+
+    return compare_exchange_weak(expected, desired, order, order, scope);
+  }
+
+  bool compare_exchange_strong(T* &expected, T* desired,
+    memory_order success,
+    memory_order failure,
+    memory_scope scope = default_scope) const noexcept {
+    
+    std::intptr_t desired_v = ptr_to_int(desired);
+    std::intptr_t& expected_v = ptr_ref_to_int_ref(expected);
+
+    return detail::__hipsycl_atomic_compare_exchange_strong<std::intptr_t, Space>(
+        _ptr, expected_v, desired_v, success, failure, scope);
+  }
+
+  bool compare_exchange_strong(T* &expected, T* desired,
+    memory_order order = default_read_modify_write_order,
+    memory_scope scope = default_scope) const noexcept {
+    
+    return compare_exchange_strong(expected, desired, order, order, scope);
+  }
+
+  T* fetch_add(difference_type x,
+    memory_order order = default_read_modify_write_order,
+    memory_scope scope = default_scope) const noexcept {
+
+    return int_to_ptr(detail::__hipsycl_atomic_fetch_add<std::intptr_t, Space>(
+        _ptr, x, order, scope));
+  }
+
+  T* fetch_sub(difference_type x,
+    memory_order order = default_read_modify_write_order,
+    memory_scope scope = default_scope) const noexcept {
+
+    return int_to_ptr(detail::__hipsycl_atomic_fetch_sub<std::intptr_t, Space>(
+        _ptr, x, order, scope));
+  }
+
+  T* operator++(int) const noexcept {
+    return fetch_add(1);
+  }
+
+  T* operator--(int) const noexcept {
+    return fetch_sub(1);
+  }
+
+  T* operator++() const noexcept {
+    return fetch_add(1) + 1;
+  }
+
+  T* operator--() const noexcept {
+    return fetch_sub(1) - 1;
+  }
+
+  T* operator+=(difference_type x) const noexcept {
+    return fetch_add(x);
+  }
+
+  T* operator-=(difference_type x) const noexcept {
+    return fetch_sub(x);
+  }
+private:
+  std::intptr_t* _ptr;
+};
+}
+}
+
+#endif

--- a/include/hipSYCL/sycl/libkernel/atomic_ref.hpp
+++ b/include/hipSYCL/sycl/libkernel/atomic_ref.hpp
@@ -331,9 +331,15 @@ template <typename T, memory_order DefaultOrder, memory_scope DefaultScope,
           access::address_space Space>
 class atomic_ref<T *, DefaultOrder, DefaultScope, Space> {
 
-  std::intptr_t ptr_to_int(T* p) { return reinterpret_cast<std::intptr_t>(p); }
-  T* int_to_ptr(std::intptr_t i) { return reinterpret_cast<T*>(i); }
-  std::intptr_t &ptr_ref_to_int_ref(T *&p) {
+  static std::intptr_t ptr_to_int(T *p) {
+    return reinterpret_cast<std::intptr_t>(p);
+  }
+
+  static T *int_to_ptr(std::intptr_t i) {
+    return reinterpret_cast<T *>(i);
+  }
+  
+  static std::intptr_t &ptr_ref_to_int_ref(T *&p) {
     T **pp = &p;
     return *reinterpret_cast<std::intptr_t *>(pp);
   }
@@ -356,7 +362,7 @@ public:
   }
 
   explicit atomic_ref(T*& val) {
-    _ptr = reinterpret_cast<std::intptr_t>(&val);
+    _ptr = reinterpret_cast<std::intptr_t*>(&val);
   }
 
   atomic_ref(const atomic_ref&) noexcept = default;

--- a/include/hipSYCL/sycl/libkernel/atomic_ref.hpp
+++ b/include/hipSYCL/sycl/libkernel/atomic_ref.hpp
@@ -338,7 +338,7 @@ class atomic_ref<T *, DefaultOrder, DefaultScope, Space> {
   static T *int_to_ptr(std::intptr_t i) {
     return reinterpret_cast<T *>(i);
   }
-  
+
   static std::intptr_t &ptr_ref_to_int_ref(T *&p) {
     T **pp = &p;
     return *reinterpret_cast<std::intptr_t *>(pp);
@@ -351,8 +351,10 @@ public:
   // TODO
   static constexpr bool is_always_lock_free = true;
 
-  static constexpr memory_order default_read_order = memory_order_traits<DefaultOrder>::read_order;
-  static constexpr memory_order default_write_order = memory_order_traits<DefaultOrder>::write_order;
+  static constexpr memory_order default_read_order =
+      memory_order_traits<DefaultOrder>::read_order;
+  static constexpr memory_order default_write_order =
+      memory_order_traits<DefaultOrder>::write_order;
   static constexpr memory_order default_read_modify_write_order = DefaultOrder;
   static constexpr memory_scope default_scope = DefaultScope;
 
@@ -437,20 +439,20 @@ public:
     return compare_exchange_strong(expected, desired, order, order, scope);
   }
 
-  T* fetch_add(difference_type x,
-    memory_order order = default_read_modify_write_order,
-    memory_scope scope = default_scope) const noexcept {
+  T *fetch_add(difference_type x,
+               memory_order order = default_read_modify_write_order,
+               memory_scope scope = default_scope) const noexcept {
 
     return int_to_ptr(detail::__hipsycl_atomic_fetch_add<std::intptr_t, Space>(
-        _ptr, x, order, scope));
+        _ptr, static_cast<std::intptr_t>(x) * sizeof(T), order, scope));
   }
 
-  T* fetch_sub(difference_type x,
-    memory_order order = default_read_modify_write_order,
-    memory_scope scope = default_scope) const noexcept {
+  T *fetch_sub(difference_type x,
+               memory_order order = default_read_modify_write_order,
+               memory_scope scope = default_scope) const noexcept {
 
     return int_to_ptr(detail::__hipsycl_atomic_fetch_sub<std::intptr_t, Space>(
-        _ptr, x, order, scope));
+        _ptr, static_cast<std::intptr_t>(x) * sizeof(T), order, scope));
   }
 
   T* operator++(int) const noexcept {

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/atomic_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/atomic_builtins.hpp
@@ -64,11 +64,39 @@ HIPSYCL_BUILTIN void __hipsycl_atomic_store(T *addr, T x, memory_order order,
 }
 
 template <class T, access::address_space S>
+HIPSYCL_BUILTIN float __hipsycl_atomic_store(float *addr, float x, memory_order order,
+                                            memory_scope scope) noexcept {
+  __atomic_store_n(reinterpret_cast<unsigned int *>(addr),
+                   bit_cast<unsigned int>(x), builtin_memory_order(order));
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN double __hipsycl_atomic_store(double *addr, double x, memory_order order,
+                                            memory_scope scope) noexcept {
+  __atomic_store_n(reinterpret_cast<unsigned long long *>(addr),
+                   bit_cast<unsigned long long>(x), builtin_memory_order(order));
+}
+
+template <class T, access::address_space S>
 HIPSYCL_BUILTIN T __hipsycl_atomic_load(T *addr, memory_order order,
                                         memory_scope scope) noexcept {
   return __atomic_load_n(addr, builtin_memory_order(order));
 }
 
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN float __hipsycl_atomic_load(float *addr, memory_order order,
+                                            memory_scope scope) noexcept {
+  return bit_cast<float>(__atomic_load_n(reinterpret_cast<unsigned int *>(addr),
+                                         builtin_memory_order(order)));
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN double __hipsycl_atomic_load(double *addr, memory_order order,
+                                             memory_scope scope) noexcept {
+  return bit_cast<double>(
+      __atomic_load_n(reinterpret_cast<unsigned long long *>(addr),
+                      builtin_memory_order(order)));
+}
 
 //********************* atomic exchange ***********************
 
@@ -159,7 +187,7 @@ HIPSYCL_BUILTIN bool __hipsycl_bitcast_compare_exchange_strong(
 
   InvokedT cast_expected = bit_cast<InvokedT>(expected);
   
-  bool r = __hipsycl_atomic_exchange<InvokedT, S>(
+  bool r = __hipsycl_atomic_compare_exchange_strong<InvokedT, S>(
       reinterpret_cast<InvokedT *>(addr), cast_expected,
       bit_cast<InvokedT>(desired), success, failure, scope);
 
@@ -174,7 +202,7 @@ HIPSYCL_BUILTIN bool __hipsycl_staticcast_compare_exchange_strong(
 
   InvokedT cast_expected = static_cast<InvokedT>(expected);
   
-  bool r = __hipsycl_atomic_exchange<InvokedT, S>(
+  bool r = __hipsycl_atomic_compare_exchange_strong<InvokedT, S>(
       reinterpret_cast<InvokedT *>(addr), cast_expected,
       static_cast<InvokedT>(desired), success, failure, scope);
 
@@ -191,7 +219,7 @@ HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
 
   return __hipsycl_bitcast_compare_exchange_strong<long long, S,
                                                    unsigned long long>(
-      addr, expected, desired, success, failure, order);
+      addr, expected, desired, success, failure, scope);
 }
 
 template <class T, access::address_space S>
@@ -201,11 +229,11 @@ HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
 
   if constexpr(sizeof(long) == 4) {
     return __hipsycl_staticcast_compare_exchange_strong<long, S, int>(
-        addr, expected, desired, success, failure, order);
+        addr, expected, desired, success, failure, scope);
   } else {
     return __hipsycl_bitcast_compare_exchange_strong<long, S,
                                                      unsigned long long>(
-        addr, expected, desired, success, failure, order);
+        addr, expected, desired, success, failure, scope);
   }
 }
 
@@ -216,11 +244,11 @@ HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
 
   if constexpr(sizeof(unsigned long) == 4) {
     return __hipsycl_staticcast_compare_exchange_strong<unsigned long, S, unsigned int>(
-        addr, expected, desired, success, failure, order);
+        addr, expected, desired, success, failure, scope);
   } else {
     return __hipsycl_staticcast_compare_exchange_strong<unsigned long, S,
                                                         unsigned long long>(
-        addr, expected, desired, success, failure, order);
+        addr, expected, desired, success, failure, scope);
   }
 }
 
@@ -231,7 +259,7 @@ HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
 
   return __hipsycl_bitcast_compare_exchange_strong<float, S,
                                                    int>(
-      addr, expected, desired, success, failure, order);
+      addr, expected, desired, success, failure, scope);
 }
 
 template <class T, access::address_space S>
@@ -241,7 +269,7 @@ HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
 
   return __hipsycl_bitcast_compare_exchange_strong<double, S,
                                                    unsigned long long>(
-      addr, expected, desired, success, failure, order);
+      addr, expected, desired, success, failure, scope);
 }
 
 // ******************* atomic compare exchange weak ********************

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/atomic_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/atomic_builtins.hpp
@@ -41,6 +41,22 @@ namespace hipsycl {
 namespace sycl {
 namespace detail {
 
+inline constexpr int builtin_memory_order(memory_order o) noexcept {
+  switch(o){
+    case memory_order::relaxed:
+      return __ATOMIC_RELAXED;
+    case memory_order::acquire:
+      return __ATOMIC_ACQUIRE;
+    case memory_order::release:
+      return __ATOMIC_RELEASE;
+    case memory_order::acq_rel:
+      return __ATOMIC_ACQ_REL;
+    case memory_order::seq_cst:
+      return __ATOMIC_SEQ_CST;
+  }
+  return __ATOMIC_RELAXED;
+}
+
 template <class T, access::address_space S>
 HIPSYCL_BUILTIN void __hipsycl_atomic_store(T *addr, T x, memory_order order,
                                             memory_scope scope) noexcept {

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/atomic_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/atomic_builtins.hpp
@@ -70,25 +70,29 @@ HIPSYCL_BUILTIN T __hipsycl_atomic_load(T *addr, memory_order order,
 template <class T, access::address_space S>
 HIPSYCL_BUILTIN T __hipsycl_atomic_exchange(T *addr, T x, memory_order order,
                                             memory_scope scope) noexcept {
-  return __atomic_exchange_n(addr, x, builtin_memory_order(order));
+  return atomicExch(addr, x);
 }
 
 template <class T, access::address_space S>
 HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_weak(
     T *addr, T &expected, T desired, memory_order success, memory_order failure,
     memory_scope scope) noexcept {
-  return __atomic_compare_exchange_n(addr, &expected, desired, true,
-                                     builtin_memory_order(success),
-                                     builtin_memory_order(failure));
+
+  T old = expected;
+  expected = atomicCAS(addr, expected, desired);
+  return old == expected;
+
 }
 
 template <class T, access::address_space S>
 HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
     T *addr, T &expected, T desired, memory_order success, memory_order failure,
     memory_scope scope) noexcept {
-  return __atomic_compare_exchange_n(addr, &expected, desired, false,
-                                     builtin_memory_order(success),
-                                     builtin_memory_order(failure));
+
+  T old = expected;
+  expected = atomicCAS(addr, expected, desired);
+  return old == expected;
+
 }
 
 // Integral values only
@@ -96,19 +100,19 @@ HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
 template <class T, access::address_space S>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_and(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
-  return __atomic_fetch_and(addr, x, builtin_memory_order(order));
+  return atomicAnd(addr, x);
 }
 
 template <class T, access::address_space S>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_or(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
-   return __atomic_fetch_or(addr, x, builtin_memory_order(order));
+   return atomicOr(addr, x);
 }
 
 template <class T, access::address_space S>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_xor(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
-   return __atomic_fetch_xor(addr, x, builtin_memory_order(order));
+   return atomicXor(addr, x);
 }
 
 // Floating point and integral values
@@ -116,13 +120,13 @@ HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_xor(T *addr, T x, memory_order order,
 template <class T, access::address_space S>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_add(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
-   return __atomic_fetch_add(addr, x, builtin_memory_order(order));
+   return atomicAdd(addr, x);
 }
 
 template <class T, access::address_space S>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_sub(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
-   return __atomic_fetch_sub(addr, x, builtin_memory_order(order));
+   return atomicSub(addr, x);
 }
 
 template <class T, access::address_space S>

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/atomic_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/atomic_builtins.hpp
@@ -30,6 +30,9 @@
 
 #include "hipSYCL/sycl/libkernel/backend.hpp"
 #include "hipSYCL/sycl/libkernel/memory.hpp"
+#include "hipSYCL/sycl/detail/util.hpp"
+
+#include <type_traits>
 
 #if HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_CUDA ||                                   \
     HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_HIP
@@ -37,23 +40,6 @@
 namespace hipsycl {
 namespace sycl {
 namespace detail {
-
-inline constexpr int builtin_memory_order(memory_order o) noexcept {
-  switch(o){
-    case memory_order::relaxed:
-      return __ATOMIC_RELAXED;
-    case memory_order::acquire:
-      return __ATOMIC_ACQUIRE;
-    case memory_order::release:
-      return __ATOMIC_RELEASE;
-    case memory_order::acq_rel:
-      return __ATOMIC_ACQ_REL;
-    case memory_order::seq_cst:
-      return __ATOMIC_SEQ_CST;
-  }
-  return __ATOMIC_RELAXED;
-}
-
 
 template <class T, access::address_space S>
 HIPSYCL_BUILTIN void __hipsycl_atomic_store(T *addr, T x, memory_order order,
@@ -67,22 +53,77 @@ HIPSYCL_BUILTIN T __hipsycl_atomic_load(T *addr, memory_order order,
   return __atomic_load_n(addr, builtin_memory_order(order));
 }
 
+
+//********************* atomic exchange ***********************
+
 template <class T, access::address_space S>
 HIPSYCL_BUILTIN T __hipsycl_atomic_exchange(T *addr, T x, memory_order order,
                                             memory_scope scope) noexcept {
   return atomicExch(addr, x);
 }
 
-template <class T, access::address_space S>
-HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_weak(
-    T *addr, T &expected, T desired, memory_order success, memory_order failure,
-    memory_scope scope) noexcept {
+template <class T, access::address_space S, class InvokedT>
+HIPSYCL_BUILTIN T __hipsycl_bitcast_atomic_exchange(
+    T *addr, T x, memory_order order, memory_scope scope) noexcept {
 
-  T old = expected;
-  expected = atomicCAS(addr, expected, desired);
-  return old == expected;
-
+  return bit_cast<T>(__hipsycl_atomic_exchange<InvokedT, S>(
+      reinterpret_cast<InvokedT*>(addr), bit_cast<InvokedT>(x), order, scope));
 }
+
+template <class T, access::address_space S, class InvokedT>
+HIPSYCL_BUILTIN T __hipsycl_staticcast_atomic_exchange(
+    T *addr, T x, memory_order order, memory_scope scope) noexcept {
+
+  return static_cast<T>(__hipsycl_atomic_exchange<InvokedT, S>(
+      reinterpret_cast<InvokedT*>(addr), static_cast<InvokedT>(x), order, scope));
+}
+
+
+// No direct support for long long, long and unsigned long, and double
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_exchange(long long *addr, long long x,
+                                            memory_order order,
+                                            memory_scope scope) noexcept {
+
+  return __hipsycl_bitcast_atomic_exchange<long long, S, unsigned long long>(
+      addr, x, order, scope);
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_exchange(long *addr, long x,
+                                            memory_order order,
+                                            memory_scope scope) noexcept {
+  if constexpr(sizeof(long) == 4) {
+    return __hipsycl_staticcast_atomic_exchange<long, S, int>(addr, x, order, scope);
+  } else {
+    return __hipsycl_bitcast_atomic_exchange<long, S, unsigned long long>(addr, x, order,
+                                                                    scope);
+  }
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_exchange(unsigned long *addr, unsigned long x,
+                                            memory_order order,
+                                            memory_scope scope) noexcept {
+  if constexpr (sizeof(long) == 4) {
+    return __hipsycl_staticcast_atomic_exchange<unsigned long, S, unsigned int>(
+        addr, x, order, scope);
+  } else {
+    return __hipsycl_staticcast_atomic_exchange<unsigned long, S,
+                                                unsigned long long>(
+        addr, x, order, scope);
+  }
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_exchange(double *addr, double x,
+                                            memory_order order,
+                                            memory_scope scope) noexcept {
+  return __hipsycl_bitcast_atomic_exchange<double, S, unsigned long long>(
+      addr, x, order, scope);
+}
+
+// ******************* atomic compare exchange strong ********************
 
 template <class T, access::address_space S>
 HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
@@ -92,10 +133,155 @@ HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
   T old = expected;
   expected = atomicCAS(addr, expected, desired);
   return old == expected;
-
 }
 
-// Integral values only
+
+template <class T, access::address_space S, class InvokedT>
+HIPSYCL_BUILTIN bool __hipsycl_bitcast_compare_exchange_strong(
+    T *addr, T &expected, T desired, memory_order success, memory_order failure,
+    memory_scope scope) noexcept {
+
+  InvokedT cast_expected = bit_cast<InvokedT>(expected);
+  
+  bool r = __hipsycl_atomic_exchange<InvokedT, S>(
+      reinterpret_cast<InvokedT *>(addr), cast_expected,
+      bit_cast<InvokedT>(desired), success, failure, scope);
+
+  expected = bit_cast<T>(cast_expected);
+  return r;
+}
+
+template <class T, access::address_space S, class InvokedT>
+HIPSYCL_BUILTIN bool __hipsycl_staticcast_compare_exchange_strong(
+    T *addr, T &expected, T desired, memory_order success, memory_order failure,
+    memory_scope scope) noexcept {
+
+  InvokedT cast_expected = static_cast<InvokedT>(expected);
+  
+  bool r = __hipsycl_atomic_exchange<InvokedT, S>(
+      reinterpret_cast<InvokedT *>(addr), cast_expected,
+      static_cast<InvokedT>(desired), success, failure, scope);
+
+  expected = static_cast<T>(cast_expected);
+  return r;
+}
+
+// No direct support for long long, long and unsigned long, float, double
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
+    long long *addr, long long &expected, long long desired,
+    memory_order success, memory_order failure, memory_scope scope) noexcept {
+
+  return __hipsycl_bitcast_compare_exchange_strong<long long, S,
+                                                   unsigned long long>(
+      addr, expected, desired, success, failure, order);
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
+    long *addr, long &expected, long desired,
+    memory_order success, memory_order failure, memory_scope scope) noexcept {
+
+  if constexpr(sizeof(long) == 4) {
+    return __hipsycl_staticcast_compare_exchange_strong<long, S, int>(
+        addr, expected, desired, success, failure, order);
+  } else {
+    return __hipsycl_bitcast_compare_exchange_strong<long, S,
+                                                     unsigned long long>(
+        addr, expected, desired, success, failure, order);
+  }
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
+    unsigned long *addr, unsigned long &expected, unsigned long desired,
+    memory_order success, memory_order failure, memory_scope scope) noexcept {
+
+  if constexpr(sizeof(unsigned long) == 4) {
+    return __hipsycl_staticcast_compare_exchange_strong<unsigned long, S, unsigned int>(
+        addr, expected, desired, success, failure, order);
+  } else {
+    return __hipsycl_staticcast_compare_exchange_strong<unsigned long, S,
+                                                        unsigned long long>(
+        addr, expected, desired, success, failure, order);
+  }
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
+    float *addr, float &expected, float desired,
+    memory_order success, memory_order failure, memory_scope scope) noexcept {
+
+  return __hipsycl_bitcast_compare_exchange_strong<float, S,
+                                                   int>(
+      addr, expected, desired, success, failure, order);
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
+    double *addr, double &expected, double desired,
+    memory_order success, memory_order failure, memory_scope scope) noexcept {
+
+  return __hipsycl_bitcast_compare_exchange_strong<double, S,
+                                                   unsigned long long>(
+      addr, expected, desired, success, failure, order);
+}
+
+// ******************* atomic compare exchange weak ********************
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_weak(
+    T *addr, T &expected, T desired, memory_order success, memory_order failure,
+    memory_scope scope) noexcept {
+
+  return __hipsycl_atomic_compare_exchange_strong<T, S>(
+      addr, expected, desired, success, failure, scope);
+}
+
+// *********************** Integral values only *****************************
+
+// Defines overloads for integral atomics for types that are not natively supported
+// using bitcasts: long long, long and unsigned long
+#define HIPSYCL_DEFINE_HIPLIKE_ATOMIC_INTEGRAL_NONNATIVE_OVERLOADS(            \
+    name, bitcast_name)                                                        \
+  template <class T, access::address_space S, class InvokedT>                  \
+  HIPSYCL_BUILTIN T bitcast_name(T *addr, T x, memory_order order,             \
+                                 memory_scope scope) noexcept {                \
+    return bit_cast<T>(name<InvokedT, S>(reinterpret_cast<InvokedT *>(addr),   \
+                                         bit_cast<InvokedT>(x), order,         \
+                                         scope));                              \
+  }                                                                            \
+  template <class T, access::address_space S>                                  \
+  HIPSYCL_BUILTIN long long name(long long *addr, long long x,                 \
+                                 memory_order order,                           \
+                                 memory_scope scope) noexcept {                \
+    return bitcast_name<long long, S, unsigned long long>(addr, x, order,      \
+                                                          scope);              \
+  }                                                                            \
+  template <class T, access::address_space S>                                  \
+  HIPSYCL_BUILTIN long name(long *addr, long x, memory_order order,            \
+                            memory_scope scope) noexcept {                     \
+    if constexpr (sizeof(long) == 4) {                                         \
+      return bitcast_name<long, S, int>(addr, x, order, scope);                \
+    } else {                                                                   \
+      return bitcast_name<long, S, unsigned long long>(addr, x, order, scope); \
+    }                                                                          \
+  }                                                                            \
+  template <class T, access::address_space S>                                  \
+  HIPSYCL_BUILTIN unsigned long name(unsigned long *addr, unsigned long x,     \
+                                     memory_order order,                       \
+                                     memory_scope scope) noexcept {            \
+    if constexpr (sizeof(long) == 4) {                                         \
+      return bitcast_name<unsigned long, S, unsigned int>(addr, x, order,      \
+                                                          scope);              \
+    } else {                                                                   \
+      return bitcast_name<unsigned long, S, unsigned long long>(addr, x,       \
+                                                                order, scope); \
+    }                                                                          \
+  }
+
+// ******************** atomic fetch and ************************
 
 template <class T, access::address_space S>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_and(T *addr, T x, memory_order order,
@@ -103,11 +289,22 @@ HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_and(T *addr, T x, memory_order order,
   return atomicAnd(addr, x);
 }
 
+HIPSYCL_DEFINE_HIPLIKE_ATOMIC_INTEGRAL_NONNATIVE_OVERLOADS(
+    __hipsycl_atomic_fetch_and, __hipsycl_bitcast_atomic_fetch_and);
+
+// ************************ atomic fetch or **********************
+
+
 template <class T, access::address_space S>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_or(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
    return atomicOr(addr, x);
 }
+
+HIPSYCL_DEFINE_HIPLIKE_ATOMIC_INTEGRAL_NONNATIVE_OVERLOADS(
+    __hipsycl_atomic_fetch_or, __hipsycl_bitcast_atomic_fetch_or);
+
+// ************************ atomic fetch xor **********************
 
 template <class T, access::address_space S>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_xor(T *addr, T x, memory_order order,
@@ -115,7 +312,13 @@ HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_xor(T *addr, T x, memory_order order,
    return atomicXor(addr, x);
 }
 
-// Floating point and integral values
+HIPSYCL_DEFINE_HIPLIKE_ATOMIC_INTEGRAL_NONNATIVE_OVERLOADS(
+    __hipsycl_atomic_fetch_xor, __hipsycl_bitcast_atomic_fetch_xor);
+
+// ***************** Floating point and integral values *************
+
+
+// *********************** atomic add ****************************
 
 template <class T, access::address_space S>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_add(T *addr, T x, memory_order order,
@@ -123,11 +326,72 @@ HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_add(T *addr, T x, memory_order order,
    return atomicAdd(addr, x);
 }
 
+// atomicAdd supports float and double, so we only need to complete the integral
+// overload set
+HIPSYCL_DEFINE_HIPLIKE_ATOMIC_INTEGRAL_NONNATIVE_OVERLOADS(
+    __hipsycl_atomic_fetch_add, __hipsycl_bitcast_atomic_fetch_add);
+
+// *********************** atomic sub ****************************
+
+// Only supports int and unsigned
 template <class T, access::address_space S>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_sub(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
    return atomicSub(addr, x);
 }
+
+// Need CAS loop for 64bit types - the definition of this
+// is required in order to be able to use the 
+// HIPSYCL_DEFINE_HIPLIKE_ATOMIC_INTEGRAL_NONNATIVE_OVERLOADS macro
+
+#define HIPSYCL_DEFINE_HIPLIKE_ATOMICSUB_CAS_EMULATION(Type)                   \
+  template <class T, access::address_space S>                                  \
+  HIPSYCL_BUILTIN Type __hipsycl_atomic_fetch_sub(                             \
+      Type *addr, Type x, memory_order order, memory_scope scope) noexcept {   \
+    Type old = __hipsycl_atomic_load<Type, S>(addr, order, scope);             \
+    while (!__hipsycl_atomic_compare_exchange_strong<Type, S>(                 \
+        addr, old, old - x, order, order, scope))                              \
+      ;                                                                        \
+    return old;                                                                \
+  }
+
+
+HIPSYCL_DEFINE_HIPLIKE_ATOMICSUB_CAS_EMULATION(long long)
+HIPSYCL_DEFINE_HIPLIKE_ATOMICSUB_CAS_EMULATION(unsigned long long)
+HIPSYCL_DEFINE_HIPLIKE_ATOMICSUB_CAS_EMULATION(float)
+HIPSYCL_DEFINE_HIPLIKE_ATOMICSUB_CAS_EMULATION(double)
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN long __hipsycl_atomic_fetch_sub(long *addr, long x,
+                                                memory_order order,
+                                                memory_scope scope) noexcept {
+  if constexpr (sizeof(long) == 4) {
+    return static_cast<long>(__hipsycl_atomic_fetch_sub<int, S>(
+        reinterpret_cast<int *>(addr), static_cast<int>(x), order, scope));
+  } else {
+    return static_cast<long>(__hipsycl_atomic_fetch_sub<long long, S>(
+        reinterpret_cast<long long *>(addr), static_cast<long long>(x), order,
+        scope));
+  }
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN unsigned long
+__hipsycl_atomic_fetch_sub(unsigned long *addr, unsigned long x,
+                           memory_order order, memory_scope scope) noexcept {
+  if constexpr (sizeof(unsigned long) == 4) {
+    return static_cast<unsigned long>(__hipsycl_atomic_fetch_sub<unsigned, S>(
+        reinterpret_cast<unsigned *>(addr), static_cast<unsigned>(x), order,
+        scope));
+  } else {
+    return static_cast<unsigned long>(
+        __hipsycl_atomic_fetch_sub<unsigned long long, S>(
+            reinterpret_cast<unsigned long long *>(addr),
+            static_cast<unsigned long long>(x), order, scope));
+  }
+}
+
+// *********************** atomic min ****************************
 
 template <class T, access::address_space S>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_min(T *addr, T x, memory_order order,
@@ -135,10 +399,74 @@ HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_min(T *addr, T x, memory_order order,
   return atomicMin(addr, x);
 }
 
+// Need completion of integral overload set
+HIPSYCL_DEFINE_HIPLIKE_ATOMIC_INTEGRAL_NONNATIVE_OVERLOADS(
+    __hipsycl_atomic_fetch_min, __hipsycl_bitcast_atomic_fetch_min);
+
+// Need CAS loop for emulation of floating point overloads
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN float __hipsycl_atomic_fetch_min(float *addr, float x,
+                                                 memory_order order,
+                                                 memory_scope scope) noexcept {
+  float old = __hipsycl_atomic_load<float, S>(addr, order, scope);
+  do {
+    if (old < x)
+      return old;
+  } while (!__hipsycl_atomic_compare_exchange_strong<float, S>(
+      addr, old, x, order, order, scope));
+  return x;
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN double __hipsycl_atomic_fetch_min(double *addr, double x,
+                                                  memory_order order,
+                                                  memory_scope scope) noexcept {
+  double old = __hipsycl_atomic_load<double, S>(addr, order, scope);
+  do {
+    if (old < x)
+      return old;
+  } while (!__hipsycl_atomic_compare_exchange_strong<double, S>(
+      addr, old, x, order, order, scope));
+  return x;
+}
+
+// *********************** atomic max ****************************
+
 template <class T, access::address_space S>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_max(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
   return atomicMax(addr, x);
+}
+
+// Need completion of integral overload set
+HIPSYCL_DEFINE_HIPLIKE_ATOMIC_INTEGRAL_NONNATIVE_OVERLOADS(
+    __hipsycl_atomic_fetch_max, __hipsycl_bitcast_atomic_fetch_max);
+
+// Need CAS loop for emulation of floating point overloads
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN float __hipsycl_atomic_fetch_max(float *addr, float x,
+                                                 memory_order order,
+                                                 memory_scope scope) noexcept {
+  float old = __hipsycl_atomic_load<float, S>(addr, order, scope);
+  do {
+    if (old > x)
+      return old;
+  } while (!__hipsycl_atomic_compare_exchange_strong<float, S>(
+      addr, old, x, order, order, scope));
+  return x;
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN double __hipsycl_atomic_fetch_max(double *addr, double x,
+                                                  memory_order order,
+                                                  memory_scope scope) noexcept {
+  double old = __hipsycl_atomic_load<double, S>(addr, order, scope);
+  do {
+    if (old > x)
+      return old;
+  } while (!__hipsycl_atomic_compare_exchange_strong<double, S>(
+      addr, old, x, order, order, scope));
+  return x;
 }
 
 }

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/atomic_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/atomic_builtins.hpp
@@ -1,0 +1,146 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2021 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HIPSYCL_ATOMIC_HIPLIKE_BUILTINS_HPP
+#define HIPSYCL_ATOMIC_HIPLIKE_BUILTINS_HPP
+
+#include "hipSYCL/sycl/libkernel/backend.hpp"
+#include "hipSYCL/sycl/libkernel/memory.hpp"
+
+#if HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_CUDA ||                                   \
+    HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_HIP
+
+namespace hipsycl {
+namespace sycl {
+namespace detail {
+
+inline constexpr int builtin_memory_order(memory_order o) noexcept {
+  switch(o){
+    case memory_order::relaxed:
+      return __ATOMIC_RELAXED;
+    case memory_order::acquire:
+      return __ATOMIC_ACQUIRE;
+    case memory_order::release:
+      return __ATOMIC_RELEASE;
+    case memory_order::acq_rel:
+      return __ATOMIC_ACQ_REL;
+    case memory_order::seq_cst:
+      return __ATOMIC_SEQ_CST;
+  }
+  return __ATOMIC_RELAXED;
+}
+
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN void __hipsycl_atomic_store(T *addr, T x, memory_order order,
+                                            memory_scope scope) noexcept {
+  __atomic_store_n(addr, x, builtin_memory_order(order));
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_load(T *addr, memory_order order,
+                                        memory_scope scope) noexcept {
+  return __atomic_load_n(addr, builtin_memory_order(order));
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_exchange(T *addr, T x, memory_order order,
+                                            memory_scope scope) noexcept {
+  return __atomic_exchange_n(addr, x, builtin_memory_order(order));
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_weak(
+    T *addr, T &expected, T desired, memory_order success, memory_order failure,
+    memory_scope scope) noexcept {
+  return __atomic_compare_exchange_n(addr, &expected, desired, true,
+                                     builtin_memory_order(success),
+                                     builtin_memory_order(failure));
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
+    T *addr, T &expected, T desired, memory_order success, memory_order failure,
+    memory_scope scope) noexcept {
+  return __atomic_compare_exchange_n(addr, &expected, desired, false,
+                                     builtin_memory_order(success),
+                                     builtin_memory_order(failure));
+}
+
+// Integral values only
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_and(T *addr, T x, memory_order order,
+                                             memory_scope scope) noexcept {
+  return __atomic_fetch_and(addr, x, builtin_memory_order(order));
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_or(T *addr, T x, memory_order order,
+                                             memory_scope scope) noexcept {
+   return __atomic_fetch_or(addr, x, builtin_memory_order(order));
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_xor(T *addr, T x, memory_order order,
+                                             memory_scope scope) noexcept {
+   return __atomic_fetch_xor(addr, x, builtin_memory_order(order));
+}
+
+// Floating point and integral values
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_add(T *addr, T x, memory_order order,
+                                             memory_scope scope) noexcept {
+   return __atomic_fetch_add(addr, x, builtin_memory_order(order));
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_sub(T *addr, T x, memory_order order,
+                                             memory_scope scope) noexcept {
+   return __atomic_fetch_or(addr, x, builtin_memory_order(order));
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_min(T *addr, T x, memory_order order,
+                                             memory_scope scope) noexcept {
+  return atomicMin(addr, x);
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_max(T *addr, T x, memory_order order,
+                                             memory_scope scope) noexcept {
+  return atomicMax(addr, x);
+}
+
+}
+}
+}
+
+#endif
+
+#endif

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/atomic_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/atomic_builtins.hpp
@@ -122,7 +122,7 @@ HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_add(T *addr, T x, memory_order order,
 template <class T, access::address_space S>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_sub(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
-   return __atomic_fetch_or(addr, x, builtin_memory_order(order));
+   return __atomic_fetch_sub(addr, x, builtin_memory_order(order));
 }
 
 template <class T, access::address_space S>

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/atomic_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/atomic_builtins.hpp
@@ -57,40 +57,40 @@ inline constexpr int builtin_memory_order(memory_order o) noexcept {
   return __ATOMIC_RELAXED;
 }
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN void __hipsycl_atomic_store(T *addr, T x, memory_order order,
                                             memory_scope scope) noexcept {
   __atomic_store_n(addr, x, builtin_memory_order(order));
 }
 
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN float __hipsycl_atomic_store(float *addr, float x, memory_order order,
                                             memory_scope scope) noexcept {
   __atomic_store_n(reinterpret_cast<unsigned int *>(addr),
                    bit_cast<unsigned int>(x), builtin_memory_order(order));
 }
 
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN double __hipsycl_atomic_store(double *addr, double x, memory_order order,
                                             memory_scope scope) noexcept {
   __atomic_store_n(reinterpret_cast<unsigned long long *>(addr),
                    bit_cast<unsigned long long>(x), builtin_memory_order(order));
 }
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_load(T *addr, memory_order order,
                                         memory_scope scope) noexcept {
   return __atomic_load_n(addr, builtin_memory_order(order));
 }
 
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN float __hipsycl_atomic_load(float *addr, memory_order order,
                                             memory_scope scope) noexcept {
   return bit_cast<float>(__atomic_load_n(reinterpret_cast<unsigned int *>(addr),
                                          builtin_memory_order(order)));
 }
 
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN double __hipsycl_atomic_load(double *addr, memory_order order,
                                              memory_scope scope) noexcept {
   return bit_cast<double>(
@@ -100,76 +100,75 @@ HIPSYCL_BUILTIN double __hipsycl_atomic_load(double *addr, memory_order order,
 
 //********************* atomic exchange ***********************
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_exchange(T *addr, T x, memory_order order,
                                             memory_scope scope) noexcept {
   return atomicExch(addr, x);
 }
 
-template <class T, access::address_space S, class InvokedT>
+template <access::address_space S, class InvokedT, class T>
 HIPSYCL_BUILTIN T __hipsycl_bitcast_atomic_exchange(
     T *addr, T x, memory_order order, memory_scope scope) noexcept {
 
-  return bit_cast<T>(__hipsycl_atomic_exchange<InvokedT, S>(
+  return bit_cast<T>(__hipsycl_atomic_exchange<S>(
       reinterpret_cast<InvokedT*>(addr), bit_cast<InvokedT>(x), order, scope));
 }
 
-template <class T, access::address_space S, class InvokedT>
+template <access::address_space S, class InvokedT, class T>
 HIPSYCL_BUILTIN T __hipsycl_staticcast_atomic_exchange(
     T *addr, T x, memory_order order, memory_scope scope) noexcept {
 
-  return static_cast<T>(__hipsycl_atomic_exchange<InvokedT, S>(
+  return static_cast<T>(__hipsycl_atomic_exchange<S>(
       reinterpret_cast<InvokedT*>(addr), static_cast<InvokedT>(x), order, scope));
 }
 
 
 // No direct support for long long, long and unsigned long, and double
-template <class T, access::address_space S>
-HIPSYCL_BUILTIN T __hipsycl_atomic_exchange(long long *addr, long long x,
+template <access::address_space S>
+HIPSYCL_BUILTIN long long __hipsycl_atomic_exchange(long long *addr, long long x,
                                             memory_order order,
                                             memory_scope scope) noexcept {
 
-  return __hipsycl_bitcast_atomic_exchange<long long, S, unsigned long long>(
+  return __hipsycl_bitcast_atomic_exchange<S, unsigned long long>(
       addr, x, order, scope);
 }
 
-template <class T, access::address_space S>
-HIPSYCL_BUILTIN T __hipsycl_atomic_exchange(long *addr, long x,
+template <access::address_space S>
+HIPSYCL_BUILTIN long __hipsycl_atomic_exchange(long *addr, long x,
                                             memory_order order,
                                             memory_scope scope) noexcept {
   if constexpr(sizeof(long) == 4) {
-    return __hipsycl_staticcast_atomic_exchange<long, S, int>(addr, x, order, scope);
+    return __hipsycl_staticcast_atomic_exchange<S, int>(addr, x, order, scope);
   } else {
-    return __hipsycl_bitcast_atomic_exchange<long, S, unsigned long long>(addr, x, order,
+    return __hipsycl_bitcast_atomic_exchange<S, unsigned long long>(addr, x, order,
                                                                     scope);
   }
 }
 
-template <class T, access::address_space S>
-HIPSYCL_BUILTIN T __hipsycl_atomic_exchange(unsigned long *addr, unsigned long x,
-                                            memory_order order,
-                                            memory_scope scope) noexcept {
+template <access::address_space S>
+HIPSYCL_BUILTIN unsigned long
+__hipsycl_atomic_exchange(unsigned long *addr, unsigned long x,
+                          memory_order order, memory_scope scope) noexcept {
   if constexpr (sizeof(long) == 4) {
-    return __hipsycl_staticcast_atomic_exchange<unsigned long, S, unsigned int>(
+    return __hipsycl_staticcast_atomic_exchange<S, unsigned int>(
         addr, x, order, scope);
   } else {
-    return __hipsycl_staticcast_atomic_exchange<unsigned long, S,
-                                                unsigned long long>(
+    return __hipsycl_staticcast_atomic_exchange<S, unsigned long long>(
         addr, x, order, scope);
   }
 }
 
-template <class T, access::address_space S>
-HIPSYCL_BUILTIN T __hipsycl_atomic_exchange(double *addr, double x,
+template <access::address_space S>
+HIPSYCL_BUILTIN double __hipsycl_atomic_exchange(double *addr, double x,
                                             memory_order order,
                                             memory_scope scope) noexcept {
-  return __hipsycl_bitcast_atomic_exchange<double, S, unsigned long long>(
+  return __hipsycl_bitcast_atomic_exchange<S, unsigned long long>(
       addr, x, order, scope);
 }
 
 // ******************* atomic compare exchange strong ********************
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
     T *addr, T &expected, T desired, memory_order success, memory_order failure,
     memory_scope scope) noexcept {
@@ -180,14 +179,14 @@ HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
 }
 
 
-template <class T, access::address_space S, class InvokedT>
+template <access::address_space S, class InvokedT, class T>
 HIPSYCL_BUILTIN bool __hipsycl_bitcast_compare_exchange_strong(
     T *addr, T &expected, T desired, memory_order success, memory_order failure,
     memory_scope scope) noexcept {
 
   InvokedT cast_expected = bit_cast<InvokedT>(expected);
   
-  bool r = __hipsycl_atomic_compare_exchange_strong<InvokedT, S>(
+  bool r = __hipsycl_atomic_compare_exchange_strong<S>(
       reinterpret_cast<InvokedT *>(addr), cast_expected,
       bit_cast<InvokedT>(desired), success, failure, scope);
 
@@ -195,14 +194,14 @@ HIPSYCL_BUILTIN bool __hipsycl_bitcast_compare_exchange_strong(
   return r;
 }
 
-template <class T, access::address_space S, class InvokedT>
+template <access::address_space S, class InvokedT, class T>
 HIPSYCL_BUILTIN bool __hipsycl_staticcast_compare_exchange_strong(
     T *addr, T &expected, T desired, memory_order success, memory_order failure,
     memory_scope scope) noexcept {
 
   InvokedT cast_expected = static_cast<InvokedT>(expected);
   
-  bool r = __hipsycl_atomic_compare_exchange_strong<InvokedT, S>(
+  bool r = __hipsycl_atomic_compare_exchange_strong<S>(
       reinterpret_cast<InvokedT *>(addr), cast_expected,
       static_cast<InvokedT>(desired), success, failure, scope);
 
@@ -212,122 +211,113 @@ HIPSYCL_BUILTIN bool __hipsycl_staticcast_compare_exchange_strong(
 
 // No direct support for long long, long and unsigned long, float, double
 
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
     long long *addr, long long &expected, long long desired,
     memory_order success, memory_order failure, memory_scope scope) noexcept {
 
-  return __hipsycl_bitcast_compare_exchange_strong<long long, S,
-                                                   unsigned long long>(
+  return __hipsycl_bitcast_compare_exchange_strong<S, unsigned long long>(
       addr, expected, desired, success, failure, scope);
 }
 
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
     long *addr, long &expected, long desired,
     memory_order success, memory_order failure, memory_scope scope) noexcept {
 
-  if constexpr(sizeof(long) == 4) {
-    return __hipsycl_staticcast_compare_exchange_strong<long, S, int>(
+  if constexpr (sizeof(long) == 4) {
+    return __hipsycl_staticcast_compare_exchange_strong<S, int>(
         addr, expected, desired, success, failure, scope);
   } else {
-    return __hipsycl_bitcast_compare_exchange_strong<long, S,
-                                                     unsigned long long>(
+    return __hipsycl_bitcast_compare_exchange_strong<S, unsigned long long>(
         addr, expected, desired, success, failure, scope);
   }
 }
 
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
     unsigned long *addr, unsigned long &expected, unsigned long desired,
     memory_order success, memory_order failure, memory_scope scope) noexcept {
 
   if constexpr(sizeof(unsigned long) == 4) {
-    return __hipsycl_staticcast_compare_exchange_strong<unsigned long, S, unsigned int>(
+    return __hipsycl_staticcast_compare_exchange_strong<S, unsigned int>(
         addr, expected, desired, success, failure, scope);
   } else {
-    return __hipsycl_staticcast_compare_exchange_strong<unsigned long, S,
-                                                        unsigned long long>(
+    return __hipsycl_staticcast_compare_exchange_strong<S, unsigned long long>(
         addr, expected, desired, success, failure, scope);
   }
 }
 
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
     float *addr, float &expected, float desired,
     memory_order success, memory_order failure, memory_scope scope) noexcept {
 
-  return __hipsycl_bitcast_compare_exchange_strong<float, S,
-                                                   int>(
+  return __hipsycl_bitcast_compare_exchange_strong<S, int>(
       addr, expected, desired, success, failure, scope);
 }
 
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
     double *addr, double &expected, double desired,
     memory_order success, memory_order failure, memory_scope scope) noexcept {
 
-  return __hipsycl_bitcast_compare_exchange_strong<double, S,
-                                                   unsigned long long>(
+  return __hipsycl_bitcast_compare_exchange_strong<S, unsigned long long>(
       addr, expected, desired, success, failure, scope);
 }
 
 // ******************* atomic compare exchange weak ********************
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_weak(
     T *addr, T &expected, T desired, memory_order success, memory_order failure,
     memory_scope scope) noexcept {
 
-  return __hipsycl_atomic_compare_exchange_strong<T, S>(
+  return __hipsycl_atomic_compare_exchange_strong<S>(
       addr, expected, desired, success, failure, scope);
 }
 
 // *********************** Integral values only *****************************
 
-// Defines overloads for integral atomics for types that are not natively supported
-// using bitcasts: long long, long and unsigned long
+// Defines overloads for integral atomics for types that are not natively
+// supported using bitcasts: long long, long and unsigned long
 #define HIPSYCL_DEFINE_HIPLIKE_ATOMIC_INTEGRAL_NONNATIVE_OVERLOADS(            \
     name, bitcast_name)                                                        \
-  template <class T, access::address_space S, class InvokedT>                  \
+  template <access::address_space S, class InvokedT, class T>                  \
   HIPSYCL_BUILTIN T bitcast_name(T *addr, T x, memory_order order,             \
                                  memory_scope scope) noexcept {                \
-    return bit_cast<T>(name<InvokedT, S>(reinterpret_cast<InvokedT *>(addr),   \
-                                         bit_cast<InvokedT>(x), order,         \
-                                         scope));                              \
+    return bit_cast<T>(name<S>(reinterpret_cast<InvokedT *>(addr),             \
+                               bit_cast<InvokedT>(x), order, scope));          \
   }                                                                            \
-  template <class T, access::address_space S>                                  \
+  template <access::address_space S>                                           \
   HIPSYCL_BUILTIN long long name(long long *addr, long long x,                 \
                                  memory_order order,                           \
                                  memory_scope scope) noexcept {                \
-    return bitcast_name<long long, S, unsigned long long>(addr, x, order,      \
-                                                          scope);              \
+    return bitcast_name<S, unsigned long long>(addr, x, order, scope);         \
   }                                                                            \
-  template <class T, access::address_space S>                                  \
+  template <access::address_space S>                                           \
   HIPSYCL_BUILTIN long name(long *addr, long x, memory_order order,            \
                             memory_scope scope) noexcept {                     \
     if constexpr (sizeof(long) == 4) {                                         \
-      return bitcast_name<long, S, int>(addr, x, order, scope);                \
+      return bitcast_name<S, int>(addr, x, order, scope);                      \
     } else {                                                                   \
-      return bitcast_name<long, S, unsigned long long>(addr, x, order, scope); \
+      return bitcast_name<S, unsigned long long>(addr, x, order, scope);       \
     }                                                                          \
   }                                                                            \
-  template <class T, access::address_space S>                                  \
+  template <access::address_space S>                                           \
   HIPSYCL_BUILTIN unsigned long name(unsigned long *addr, unsigned long x,     \
                                      memory_order order,                       \
                                      memory_scope scope) noexcept {            \
     if constexpr (sizeof(long) == 4) {                                         \
-      return bitcast_name<unsigned long, S, unsigned int>(addr, x, order,      \
-                                                          scope);              \
+      return bitcast_name<S, unsigned int>(addr, x, order, scope);             \
     } else {                                                                   \
-      return bitcast_name<unsigned long, S, unsigned long long>(addr, x,       \
-                                                                order, scope); \
+      return bitcast_name<S, unsigned long long>(addr, x, order, scope);       \
     }                                                                          \
   }
 
 // ******************** atomic fetch and ************************
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_and(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
   return atomicAnd(addr, x);
@@ -339,7 +329,7 @@ HIPSYCL_DEFINE_HIPLIKE_ATOMIC_INTEGRAL_NONNATIVE_OVERLOADS(
 // ************************ atomic fetch or **********************
 
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_or(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
    return atomicOr(addr, x);
@@ -350,7 +340,7 @@ HIPSYCL_DEFINE_HIPLIKE_ATOMIC_INTEGRAL_NONNATIVE_OVERLOADS(
 
 // ************************ atomic fetch xor **********************
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_xor(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
    return atomicXor(addr, x);
@@ -364,7 +354,7 @@ HIPSYCL_DEFINE_HIPLIKE_ATOMIC_INTEGRAL_NONNATIVE_OVERLOADS(
 
 // *********************** atomic add ****************************
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_add(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
    return atomicAdd(addr, x);
@@ -378,7 +368,7 @@ HIPSYCL_DEFINE_HIPLIKE_ATOMIC_INTEGRAL_NONNATIVE_OVERLOADS(
 // *********************** atomic sub ****************************
 
 // Only supports int and unsigned
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_sub(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
    return atomicSub(addr, x);
@@ -389,47 +379,46 @@ HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_sub(T *addr, T x, memory_order order,
 // HIPSYCL_DEFINE_HIPLIKE_ATOMIC_INTEGRAL_NONNATIVE_OVERLOADS macro
 
 #define HIPSYCL_DEFINE_HIPLIKE_ATOMICSUB_CAS_EMULATION(Type)                   \
-  template <class T, access::address_space S>                                  \
+  template <access::address_space S>                                           \
   HIPSYCL_BUILTIN Type __hipsycl_atomic_fetch_sub(                             \
       Type *addr, Type x, memory_order order, memory_scope scope) noexcept {   \
-    Type old = __hipsycl_atomic_load<Type, S>(addr, order, scope);             \
-    while (!__hipsycl_atomic_compare_exchange_strong<Type, S>(                 \
-        addr, old, old - x, order, order, scope))                              \
+    Type old = __hipsycl_atomic_load<S>(addr, order, scope);                   \
+    while (!__hipsycl_atomic_compare_exchange_strong<S>(addr, old, old - x,    \
+                                                        order, order, scope))  \
       ;                                                                        \
     return old;                                                                \
   }
-
 
 HIPSYCL_DEFINE_HIPLIKE_ATOMICSUB_CAS_EMULATION(long long)
 HIPSYCL_DEFINE_HIPLIKE_ATOMICSUB_CAS_EMULATION(unsigned long long)
 HIPSYCL_DEFINE_HIPLIKE_ATOMICSUB_CAS_EMULATION(float)
 HIPSYCL_DEFINE_HIPLIKE_ATOMICSUB_CAS_EMULATION(double)
 
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN long __hipsycl_atomic_fetch_sub(long *addr, long x,
                                                 memory_order order,
                                                 memory_scope scope) noexcept {
   if constexpr (sizeof(long) == 4) {
-    return static_cast<long>(__hipsycl_atomic_fetch_sub<int, S>(
+    return static_cast<long>(__hipsycl_atomic_fetch_sub<S>(
         reinterpret_cast<int *>(addr), static_cast<int>(x), order, scope));
   } else {
-    return static_cast<long>(__hipsycl_atomic_fetch_sub<long long, S>(
+    return static_cast<long>(__hipsycl_atomic_fetch_sub<S>(
         reinterpret_cast<long long *>(addr), static_cast<long long>(x), order,
         scope));
   }
 }
 
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN unsigned long
 __hipsycl_atomic_fetch_sub(unsigned long *addr, unsigned long x,
                            memory_order order, memory_scope scope) noexcept {
   if constexpr (sizeof(unsigned long) == 4) {
-    return static_cast<unsigned long>(__hipsycl_atomic_fetch_sub<unsigned, S>(
+    return static_cast<unsigned long>(__hipsycl_atomic_fetch_sub<S>(
         reinterpret_cast<unsigned *>(addr), static_cast<unsigned>(x), order,
         scope));
   } else {
     return static_cast<unsigned long>(
-        __hipsycl_atomic_fetch_sub<unsigned long long, S>(
+        __hipsycl_atomic_fetch_sub<S>(
             reinterpret_cast<unsigned long long *>(addr),
             static_cast<unsigned long long>(x), order, scope));
   }
@@ -437,7 +426,7 @@ __hipsycl_atomic_fetch_sub(unsigned long *addr, unsigned long x,
 
 // *********************** atomic min ****************************
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_min(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
   return atomicMin(addr, x);
@@ -448,35 +437,35 @@ HIPSYCL_DEFINE_HIPLIKE_ATOMIC_INTEGRAL_NONNATIVE_OVERLOADS(
     __hipsycl_atomic_fetch_min, __hipsycl_bitcast_atomic_fetch_min);
 
 // Need CAS loop for emulation of floating point overloads
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN float __hipsycl_atomic_fetch_min(float *addr, float x,
                                                  memory_order order,
                                                  memory_scope scope) noexcept {
-  float old = __hipsycl_atomic_load<float, S>(addr, order, scope);
+  float old = __hipsycl_atomic_load<S>(addr, order, scope);
   do {
     if (old < x)
       return old;
-  } while (!__hipsycl_atomic_compare_exchange_strong<float, S>(
+  } while (!__hipsycl_atomic_compare_exchange_strong<S>(
       addr, old, x, order, order, scope));
   return x;
 }
 
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN double __hipsycl_atomic_fetch_min(double *addr, double x,
                                                   memory_order order,
                                                   memory_scope scope) noexcept {
-  double old = __hipsycl_atomic_load<double, S>(addr, order, scope);
+  double old = __hipsycl_atomic_load<S>(addr, order, scope);
   do {
     if (old < x)
       return old;
-  } while (!__hipsycl_atomic_compare_exchange_strong<double, S>(
+  } while (!__hipsycl_atomic_compare_exchange_strong<S>(
       addr, old, x, order, order, scope));
   return x;
 }
 
 // *********************** atomic max ****************************
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_max(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
   return atomicMax(addr, x);
@@ -487,28 +476,28 @@ HIPSYCL_DEFINE_HIPLIKE_ATOMIC_INTEGRAL_NONNATIVE_OVERLOADS(
     __hipsycl_atomic_fetch_max, __hipsycl_bitcast_atomic_fetch_max);
 
 // Need CAS loop for emulation of floating point overloads
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN float __hipsycl_atomic_fetch_max(float *addr, float x,
                                                  memory_order order,
                                                  memory_scope scope) noexcept {
-  float old = __hipsycl_atomic_load<float, S>(addr, order, scope);
+  float old = __hipsycl_atomic_load<S>(addr, order, scope);
   do {
     if (old > x)
       return old;
-  } while (!__hipsycl_atomic_compare_exchange_strong<float, S>(
+  } while (!__hipsycl_atomic_compare_exchange_strong<S>(
       addr, old, x, order, order, scope));
   return x;
 }
 
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN double __hipsycl_atomic_fetch_max(double *addr, double x,
                                                   memory_order order,
                                                   memory_scope scope) noexcept {
-  double old = __hipsycl_atomic_load<double, S>(addr, order, scope);
+  double old = __hipsycl_atomic_load<S>(addr, order, scope);
   do {
     if (old > x)
       return old;
-  } while (!__hipsycl_atomic_compare_exchange_strong<double, S>(
+  } while (!__hipsycl_atomic_compare_exchange_strong<S>(
       addr, old, x, order, order, scope));
   return x;
 }

--- a/include/hipSYCL/sycl/libkernel/host/atomic_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/host/atomic_builtins.hpp
@@ -1,0 +1,154 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2021 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HIPSYCL_ATOMIC_HOST_BUILTINS_HPP
+#define HIPSYCL_ATOMIC_HOST_BUILTINS_HPP
+
+#include "hipSYCL/sycl/libkernel/backend.hpp"
+#include "hipSYCL/sycl/libkernel/memory.hpp"
+
+#if HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_HOST
+
+namespace hipsycl {
+namespace sycl {
+namespace detail {
+
+inline constexpr int builtin_memory_order(memory_order o) noexcept {
+  switch(o){
+    case memory_order::relaxed:
+      return __ATOMIC_RELAXED;
+    case memory_order::acquire:
+      return __ATOMIC_ACQUIRE;
+    case memory_order::release:
+      return __ATOMIC_RELEASE;
+    case memory_order::acq_rel:
+      return __ATOMIC_ACQ_REL;
+    case memory_order::seq_cst:
+      return __ATOMIC_SEQ_CST;
+  }
+  return __ATOMIC_RELAXED;
+}
+
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN void __hipsycl_atomic_store(T *addr, T x, memory_order order,
+                                            memory_scope scope) noexcept {
+  __atomic_store_n(addr, x, builtin_memory_order(order));
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_load(T *addr, memory_order order,
+                                        memory_scope scope) noexcept {
+  return __atomic_load_n(addr, builtin_memory_order(order));
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_exchange(T *addr, T x, memory_order order,
+                                            memory_scope scope) noexcept {
+  return __atomic_exchange_n(addr, x, builtin_memory_order(order));
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_weak(
+    T *addr, T &expected, T desired, memory_order success, memory_order failure,
+    memory_scope scope) noexcept {
+  return __atomic_compare_exchange_n(addr, &expected, desired, true,
+                                     builtin_memory_order(success),
+                                     builtin_memory_order(failure));
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
+    T *addr, T &expected, T desired, memory_order success, memory_order failure,
+    memory_scope scope) noexcept {
+  return __atomic_compare_exchange_n(addr, &expected, desired, false,
+                                     builtin_memory_order(success),
+                                     builtin_memory_order(failure));
+}
+
+// Integral values only
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_and(T *addr, T x, memory_order order,
+                                             memory_scope scope) noexcept {
+  return __atomic_fetch_and(addr, x, builtin_memory_order(order));
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_or(T *addr, T x, memory_order order,
+                                             memory_scope scope) noexcept {
+   return __atomic_fetch_or(addr, x, builtin_memory_order(order));
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_xor(T *addr, T x, memory_order order,
+                                             memory_scope scope) noexcept {
+   return __atomic_fetch_xor(addr, x, builtin_memory_order(order));
+}
+
+// Floating point and integral values
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_add(T *addr, T x, memory_order order,
+                                             memory_scope scope) noexcept {
+   return __atomic_fetch_add(addr, x, builtin_memory_order(order));
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_sub(T *addr, T x, memory_order order,
+                                             memory_scope scope) noexcept {
+   return __atomic_fetch_or(addr, x, builtin_memory_order(order));
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_min(T *addr, T x, memory_order order,
+                                             memory_scope scope) noexcept {
+  T old = __hipsycl_atomic_load<T,S>(addr, order, scope);
+  do{
+    if (old < x) return old;
+  } while (!__hipsycl_atomic_compare_exchange_strong<T, S>(addr, old, x, order,
+                                                           order, scope));
+  return x;
+}
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_max(T *addr, T x, memory_order order,
+                                             memory_scope scope) noexcept {
+  T old = __hipsycl_atomic_load<T,S>(addr, order, scope);
+  do{
+    if (old > x) return old;
+  } while (!__hipsycl_atomic_compare_exchange_strong<T, S>(addr, old, x, order,
+                                                           order, scope));
+  return x;
+}
+
+}
+}
+}
+#endif
+
+#endif

--- a/include/hipSYCL/sycl/libkernel/host/atomic_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/host/atomic_builtins.hpp
@@ -32,6 +32,7 @@
 
 #include "hipSYCL/sycl/libkernel/backend.hpp"
 #include "hipSYCL/sycl/libkernel/memory.hpp"
+#include "hipSYCL/sycl/detail/util.hpp"
 
 #if HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_HOST
 
@@ -56,62 +57,62 @@ inline constexpr int builtin_memory_order(memory_order o) noexcept {
 }
 
 HIPSYCL_BUILTIN int32_t float_as_int(float f) noexcept {
-  return *reinterpret_cast<int32_t*>(&f);
+  return bit_cast<int32_t>(f);
 }
 
 HIPSYCL_BUILTIN int64_t float_as_int(double f) noexcept {
-  return *reinterpret_cast<int64_t*>(&f);
+  return bit_cast<int64_t>(f);
 }
 
 HIPSYCL_BUILTIN float int_as_float(int32_t i) noexcept {
-  return *reinterpret_cast<float*>(&i);
+  return bit_cast<float>(i);
 }
 
 HIPSYCL_BUILTIN double int_as_float(int64_t i) noexcept {
-  return *reinterpret_cast<double*>(&i);
+  return bit_cast<double>(i);
 }
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN void __hipsycl_atomic_store(T *addr, T x, memory_order order,
                                             memory_scope scope) noexcept {
   __atomic_store_n(addr, x, builtin_memory_order(order));
 }
 
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN void __hipsycl_atomic_store(float* addr, float x, memory_order order,
                                             memory_scope scope) noexcept {
-  __hipsycl_atomic_store<int32_t, S>(reinterpret_cast<int32_t *>(addr),
-                                     float_as_int(x), order, scope);
+  __hipsycl_atomic_store<S>(reinterpret_cast<int32_t *>(addr), float_as_int(x),
+                            order, scope);
 }
 
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN void __hipsycl_atomic_store(double* addr, double x, memory_order order,
                                             memory_scope scope) noexcept {
-  __hipsycl_atomic_store<int64_t, S>(reinterpret_cast<int64_t *>(addr),
-                                     float_as_int(x), order, scope);
+  __hipsycl_atomic_store<S>(reinterpret_cast<int64_t *>(addr), float_as_int(x),
+                            order, scope);
 }
 
 
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_load(T *addr, memory_order order,
                                         memory_scope scope) noexcept {
   return __atomic_load_n(addr, builtin_memory_order(order));
 }
 
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN float __hipsycl_atomic_load(float* addr, memory_order order,
                                             memory_scope scope) noexcept {
-  int32_t v = __hipsycl_atomic_load<int32_t, S>(
-      reinterpret_cast<int32_t *>(addr), order, scope);
-  
+  int32_t v =
+      __hipsycl_atomic_load<S>(reinterpret_cast<int32_t *>(addr), order, scope);
+
   return int_as_float(v);
 }
 
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN double __hipsycl_atomic_load(double* addr, memory_order order,
                                             memory_scope scope) noexcept {
-  int64_t v = __hipsycl_atomic_load<int64_t, S>(
+  int64_t v = __hipsycl_atomic_load<S>(
       reinterpret_cast<int64_t *>(addr), order, scope);
   
   return int_as_float(v);
@@ -119,30 +120,31 @@ HIPSYCL_BUILTIN double __hipsycl_atomic_load(double* addr, memory_order order,
 
 
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_exchange(T *addr, T x, memory_order order,
                                             memory_scope scope) noexcept {
   return __atomic_exchange_n(addr, x, builtin_memory_order(order));
 }
 
-template <class T, access::address_space S>
-HIPSYCL_BUILTIN float __hipsycl_atomic_exchange(float *addr, float x, memory_order order,
-                                            memory_scope scope) noexcept {
-  int32_t v = __hipsycl_atomic_exchange<int32_t, S>(
-      reinterpret_cast<int32_t *>(addr), float_as_int(x), order, scope);
+template <access::address_space S>
+HIPSYCL_BUILTIN float __hipsycl_atomic_exchange(
+    float *addr, float x, memory_order order, memory_scope scope) noexcept {
+  
+  int32_t v = __hipsycl_atomic_exchange<S>(reinterpret_cast<int32_t *>(addr),
+                                           float_as_int(x), order, scope);
   return int_as_float(v);
 }
 
-template <class T, access::address_space S>
-HIPSYCL_BUILTIN double __hipsycl_atomic_exchange(double *addr, double x, memory_order order,
-                                            memory_scope scope) noexcept {
-  int64_t v = __hipsycl_atomic_exchange<int64_t, S>(
-      reinterpret_cast<int64_t *>(addr), float_as_int(x), order, scope);
+template <access::address_space S>
+HIPSYCL_BUILTIN double __hipsycl_atomic_exchange(
+    double *addr, double x, memory_order order, memory_scope scope) noexcept {
+  
+  int64_t v = __hipsycl_atomic_exchange<S>(reinterpret_cast<int64_t *>(addr),
+                                           float_as_int(x), order, scope);
   return int_as_float(v);
 }
 
-
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_weak(
     T *addr, T &expected, T desired, memory_order success, memory_order failure,
     memory_scope scope) noexcept {
@@ -151,7 +153,7 @@ HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_weak(
                                      builtin_memory_order(failure));
 }
 
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_weak(
     float *addr, float &expected, float desired, memory_order success,
     memory_order failure, memory_scope scope) noexcept {
@@ -159,7 +161,7 @@ HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_weak(
   int32_t expected_int = float_as_int(expected);
   int32_t desired_int = float_as_int(desired);
   
-  bool res = __hipsycl_atomic_compare_exchange_weak<int32_t, S>(
+  bool res = __hipsycl_atomic_compare_exchange_weak<S>(
       reinterpret_cast<int32_t *>(addr), expected_int, desired_int, success,
       failure, scope);
   
@@ -167,7 +169,7 @@ HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_weak(
   return res;
 }
 
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_weak(
     double *addr, double &expected, double desired, memory_order success,
     memory_order failure, memory_scope scope) noexcept {
@@ -175,7 +177,7 @@ HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_weak(
   int64_t expected_int = float_as_int(expected);
   int64_t desired_int = float_as_int(desired);
   
-  bool res = __hipsycl_atomic_compare_exchange_weak<int64_t, S>(
+  bool res = __hipsycl_atomic_compare_exchange_weak<S>(
       reinterpret_cast<int64_t *>(addr), expected_int, desired_int, success,
       failure, scope);
   
@@ -183,7 +185,7 @@ HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_weak(
   return res;
 }
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
     T *addr, T &expected, T desired, memory_order success, memory_order failure,
     memory_scope scope) noexcept {
@@ -193,7 +195,7 @@ HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
 }
 
 
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
     float *addr, float &expected, float desired, memory_order success,
     memory_order failure, memory_scope scope) noexcept {
@@ -201,7 +203,7 @@ HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
   int32_t expected_int = float_as_int(expected);
   int32_t desired_int = float_as_int(desired);
   
-  bool res = __hipsycl_atomic_compare_exchange_strong<int32_t, S>(
+  bool res = __hipsycl_atomic_compare_exchange_strong<S>(
       reinterpret_cast<int32_t *>(addr), expected_int, desired_int, success,
       failure, scope);
   
@@ -209,7 +211,7 @@ HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
   return res;
 }
 
-template <class T, access::address_space S>
+template <access::address_space S>
 HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
     double *addr, double &expected, double desired, memory_order success,
     memory_order failure, memory_scope scope) noexcept {
@@ -217,7 +219,7 @@ HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
   int64_t expected_int = float_as_int(expected);
   int64_t desired_int = float_as_int(desired);
   
-  bool res = __hipsycl_atomic_compare_exchange_strong<int64_t, S>(
+  bool res = __hipsycl_atomic_compare_exchange_strong<S>(
       reinterpret_cast<int64_t *>(addr), expected_int, desired_int, success,
       failure, scope);
   
@@ -227,19 +229,19 @@ HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
 
 // Integral values only
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_and(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
   return __atomic_fetch_and(addr, x, builtin_memory_order(order));
 }
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_or(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
    return __atomic_fetch_or(addr, x, builtin_memory_order(order));
 }
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_xor(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
    return __atomic_fetch_xor(addr, x, builtin_memory_order(order));
@@ -247,78 +249,82 @@ HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_xor(T *addr, T x, memory_order order,
 
 // Floating point and integral values
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_add(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
    return __atomic_fetch_add(addr, x, builtin_memory_order(order));
 }
 
-template <class T, access::address_space S>
-HIPSYCL_BUILTIN float __hipsycl_atomic_fetch_add(float *addr, float x, memory_order order,
-                                             memory_scope scope) noexcept {
-  float old = __hipsycl_atomic_load<float,S>(addr, order, scope);
-  while (!__hipsycl_atomic_compare_exchange_strong<float, S>(
-      addr, old, old + x, order, order, scope));
+template <access::address_space S>
+HIPSYCL_BUILTIN float __hipsycl_atomic_fetch_add(
+    float *addr, float x, memory_order order, memory_scope scope) noexcept {
+  
+  float old = __hipsycl_atomic_load<S>(addr, order, scope);
+  while (!__hipsycl_atomic_compare_exchange_strong<S>(addr, old, old + x, order,
+                                                      order, scope))
+    ;
   return old;
 }
 
-template <class T, access::address_space S>
-HIPSYCL_BUILTIN double __hipsycl_atomic_fetch_add(double *addr, double x, memory_order order,
-                                             memory_scope scope) noexcept {
-  double old = __hipsycl_atomic_load<double,S>(addr, order, scope);
-  while (!__hipsycl_atomic_compare_exchange_strong<double, S>(
-      addr, old, old + x, order, order, scope));
+template <access::address_space S>
+HIPSYCL_BUILTIN double __hipsycl_atomic_fetch_add(
+    double *addr, double x, memory_order order, memory_scope scope) noexcept {
+  
+  double old = __hipsycl_atomic_load<S>(addr, order, scope);
+  while (!__hipsycl_atomic_compare_exchange_strong<S>(addr, old, old + x, order,
+                                                      order, scope))
+    ;
   return old;
 }
 
-
-
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_sub(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
    return __atomic_fetch_sub(addr, x, builtin_memory_order(order));
 }
 
-template <class T, access::address_space S>
-HIPSYCL_BUILTIN float __hipsycl_atomic_fetch_sub(float *addr, float x, memory_order order,
-                                             memory_scope scope) noexcept {
-  float old = __hipsycl_atomic_load<float,S>(addr, order, scope);
-  while (!__hipsycl_atomic_compare_exchange_strong<float, S>(
-      addr, old, old - x, order, order, scope));
+template <access::address_space S>
+HIPSYCL_BUILTIN float __hipsycl_atomic_fetch_sub(
+    float *addr, float x, memory_order order, memory_scope scope) noexcept {
+  
+  float old = __hipsycl_atomic_load<S>(addr, order, scope);
+  while (!__hipsycl_atomic_compare_exchange_strong<S>(addr, old, old - x, order,
+                                                      order, scope))
+    ;
   return old;
 }
 
-template <class T, access::address_space S>
-HIPSYCL_BUILTIN double __hipsycl_atomic_fetch_sub(double *addr, double x, memory_order order,
-                                             memory_scope scope) noexcept {
-  double old = __hipsycl_atomic_load<double,S>(addr, order, scope);
-  while (!__hipsycl_atomic_compare_exchange_strong<double, S>(
-      addr, old, old - x, order, order, scope));
+template <access::address_space S>
+HIPSYCL_BUILTIN double __hipsycl_atomic_fetch_sub(
+    double *addr, double x, memory_order order, memory_scope scope) noexcept {
+  
+  double old = __hipsycl_atomic_load<S>(addr, order, scope);
+  while (!__hipsycl_atomic_compare_exchange_strong<S>(addr, old, old - x, order,
+                                                      order, scope))
+    ;
   return old;
 }
 
-
-
-
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_min(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
-  T old = __hipsycl_atomic_load<T,S>(addr, order, scope);
+  T old = __hipsycl_atomic_load<S>(addr, order, scope);
   do{
     if (old < x) return old;
-  } while (!__hipsycl_atomic_compare_exchange_strong<T, S>(addr, old, x, order,
+  } while (!__hipsycl_atomic_compare_exchange_strong<S>(addr, old, x, order,
                                                            order, scope));
   return x;
 }
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_max(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
-  T old = __hipsycl_atomic_load<T,S>(addr, order, scope);
+  T old = __hipsycl_atomic_load<S>(addr, order, scope);
   do{
-    if (old > x) return old;
-  } while (!__hipsycl_atomic_compare_exchange_strong<T, S>(addr, old, x, order,
-                                                           order, scope));
+    if (old > x)
+      return old;
+  } while (!__hipsycl_atomic_compare_exchange_strong<S>(addr, old, x, order,
+                                                        order, scope));
   return x;
 }
 

--- a/include/hipSYCL/sycl/libkernel/host/atomic_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/host/atomic_builtins.hpp
@@ -28,7 +28,6 @@
 #ifndef HIPSYCL_ATOMIC_HOST_BUILTINS_HPP
 #define HIPSYCL_ATOMIC_HOST_BUILTINS_HPP
 
-#include <bits/stdint-intn.h>
 #include <cstdint>
 
 #include "hipSYCL/sycl/libkernel/backend.hpp"

--- a/include/hipSYCL/sycl/libkernel/multi_ptr.hpp
+++ b/include/hipSYCL/sycl/libkernel/multi_ptr.hpp
@@ -30,22 +30,12 @@
 
 #include "hipSYCL/sycl/libkernel/backend.hpp"
 #include "hipSYCL/sycl/access.hpp"
+#include "hipSYCL/sycl/libkernel/memory.hpp"
 
 #include <type_traits>
 
 namespace hipsycl {
 namespace sycl {
-namespace access {
-
-enum class address_space : int
-{
-  global_space,
-  local_space,
-  constant_space,
-  private_space
-};
-
-} // namespace access
 
 template<typename dataT, int dimensions,
          access::mode accessmode,

--- a/include/hipSYCL/sycl/libkernel/spirv/atomic_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/spirv/atomic_builtins.hpp
@@ -44,57 +44,57 @@ namespace detail {
 // 1.) How we can extract this information/how does DPC++ do it?
 // 2.) How to attach the attribute?
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN void __hipsycl_atomic_store(T *addr, T x, memory_order order,
                                             memory_scope scope) noexcept;
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_load(T *addr, memory_order order,
                                         memory_scope scope) noexcept;
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_exchange(T *addr, T x, memory_order order,
                                             memory_scope scope) noexcept;
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_weak(
     T *addr, T &expected, T desired, memory_order success, memory_order failure,
     memory_scope scope) noexcept;
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
     T *addr, T &expected, T desired, memory_order success, memory_order failure,
     memory_scope scope) noexcept;
 
 // Integral values only
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_and(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept;
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_or(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept;
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_xor(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept;
 
 // Floating point and integral values
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_add(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept;
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_sub(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept;
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_min(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept;
 
-template <class T, access::address_space S>
+template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_max(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept;
 

--- a/include/hipSYCL/sycl/libkernel/spirv/atomic_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/spirv/atomic_builtins.hpp
@@ -1,0 +1,107 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2021 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HIPSYCL_ATOMIC_SPIRV_BUILTINS_HPP
+#define HIPSYCL_ATOMIC_SPIRV_BUILTINS_HPP
+
+#include "hipSYCL/sycl/libkernel/backend.hpp"
+#include "hipSYCL/sycl/libkernel/memory.hpp"
+#include "spirv_ops.hpp"
+
+#if HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_SPIRV
+
+namespace hipsycl {
+namespace sycl {
+namespace detail {
+
+// TODO - Map the hipSYCL atomic interface to SPIR-V atomics.
+// This seems to require mapping generic pointers to ones with
+// opencl_global or opencl_local attribute. We need to investigate:
+// 1.) How we can extract this information/how does DPC++ do it?
+// 2.) How to attach the attribute?
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN void __hipsycl_atomic_store(T *addr, T x, memory_order order,
+                                            memory_scope scope) noexcept;
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_load(T *addr, memory_order order,
+                                        memory_scope scope) noexcept;
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_exchange(T *addr, T x, memory_order order,
+                                            memory_scope scope) noexcept;
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_weak(
+    T *addr, T &expected, T desired, memory_order success, memory_order failure,
+    memory_scope scope) noexcept;
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN bool __hipsycl_atomic_compare_exchange_strong(
+    T *addr, T &expected, T desired, memory_order success, memory_order failure,
+    memory_scope scope) noexcept;
+
+// Integral values only
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_and(T *addr, T x, memory_order order,
+                                             memory_scope scope) noexcept;
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_or(T *addr, T x, memory_order order,
+                                             memory_scope scope) noexcept;
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_xor(T *addr, T x, memory_order order,
+                                             memory_scope scope) noexcept;
+
+// Floating point and integral values
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_add(T *addr, T x, memory_order order,
+                                             memory_scope scope) noexcept;
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_sub(T *addr, T x, memory_order order,
+                                             memory_scope scope) noexcept;
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_min(T *addr, T x, memory_order order,
+                                             memory_scope scope) noexcept;
+
+template <class T, access::address_space S>
+HIPSYCL_BUILTIN T __hipsycl_atomic_fetch_max(T *addr, T x, memory_order order,
+                                             memory_scope scope) noexcept;
+
+}
+}
+}
+
+#endif
+
+#endif

--- a/include/hipSYCL/sycl/sycl.hpp
+++ b/include/hipSYCL/sycl/sycl.hpp
@@ -63,6 +63,7 @@
 #include "libkernel/vec.hpp"
 #include "libkernel/builtins.hpp"
 #include "libkernel/atomic.hpp"
+#include "libkernel/atomic_ref.hpp"
 #include "libkernel/stream.hpp"
 #include "libkernel/sub_group.hpp"
 #include "libkernel/memory.hpp"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ add_sycl_to_target(TARGET device_compilation_tests)
 add_executable(sycl_tests
   sycl/smoke/task_graph.cpp
   sycl/accessor.cpp
+  sycl/atomic.cpp
   sycl/buffer.cpp
   sycl/explicit_copy.cpp
   sycl/extensions.cpp

--- a/tests/sycl/atomic.cpp
+++ b/tests/sycl/atomic.cpp
@@ -1,0 +1,202 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2021 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "sycl_test_suite.hpp"
+#include <cstddef>
+#include <type_traits>
+
+using namespace cl;
+
+BOOST_FIXTURE_TEST_SUITE(atomic_tests, reset_device_fixture)
+
+
+// mainly compile test
+BOOST_AUTO_TEST_CASE(load_store) {
+  sycl::queue q;
+
+  sycl::buffer<int> b{sycl::range{1}};
+
+  q.submit([&](sycl::handler& cgh){
+    sycl::accessor acc{b, cgh, sycl::read_write};
+    cgh.single_task([=]() {
+      sycl::atomic_ref<int, sycl::memory_order::relaxed,
+                       sycl::memory_scope::device>
+          r{acc[0]};
+      r.store(1);
+      int x = r.load();
+      r.store(x+1);
+    });
+  });
+  sycl::host_accessor hacc{b};
+  BOOST_CHECK(hacc[0] == 2);
+}
+
+template<class T>
+T int_to_t(int i) {
+  if constexpr(std::is_pointer_v<T>) {
+    return reinterpret_cast<T>(i);
+  } else {
+    return static_cast<T>(i);
+  }
+}
+
+template <class T, class AtomicTester,
+          class Verifier>
+void atomic_device_reduction_test(AtomicTester t, Verifier v) {
+  
+  sycl::queue q;
+
+  const std::size_t size = 2048;
+  sycl::buffer<T> b{sycl::range{size}};
+  {
+    sycl::host_accessor hacc{b};
+    for(std::size_t i = 0; i < size; ++i) {
+      hacc[i] = int_to_t<T>(i);
+    }
+  }
+  q.submit([&](sycl::handler& cgh){
+    sycl::accessor acc{b, cgh, sycl::read_write};
+    cgh.parallel_for(sycl::range{size}, [=](sycl::id<1> idx){
+
+      sycl::atomic_ref<T, sycl::memory_order::relaxed,
+                       sycl::memory_scope::device> r{acc[0]};
+      if constexpr(std::is_pointer_v<T>) {
+        t(r, reinterpret_cast<std::ptrdiff_t>(acc[idx]));
+      } else {
+        t(r, acc[idx]);
+      }
+    });
+  });
+  {
+    sycl::host_accessor hacc{b};
+    T expected = int_to_t<T>(0);
+    for(std::size_t i = 0; i < size; ++i) {
+      if constexpr(std::is_pointer_v<T>) {
+        v(expected, static_cast<std::ptrdiff_t>(i));
+      } else {
+        v(expected, int_to_t<T>(i));
+      }
+    }
+    assert(expected == hacc[0]);
+    BOOST_CHECK(expected == hacc[0]);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(fetch_op) {
+
+  auto fetch_add = [](auto& atomic, auto x) {
+    return atomic.fetch_add(x);
+  };
+
+  auto fetch_sub = [](auto& atomic, auto x) {
+    return atomic.fetch_sub(x);
+  };
+
+  auto fetch_and = [](auto& atomic, auto x) {
+    return atomic.fetch_and(x);
+  };
+
+  auto fetch_or = [](auto& atomic, auto x) {
+    return atomic.fetch_or(x);
+  };
+
+  auto fetch_xor = [](auto& atomic, auto x) {
+    return atomic.fetch_or(x);
+  };
+
+  auto fetch_min = [](auto& atomic, auto x) {
+    return atomic.fetch_min(x);
+  };
+
+  auto fetch_max = [](auto& atomic, auto x) {
+    return atomic.fetch_max(x);
+  };
+
+
+  auto fetch_add_verifier = [](auto& v, auto x) {
+    v += x;
+  };
+
+  auto fetch_sub_verifier = [](auto& v, auto x) {
+    v -= x;
+  };
+
+  auto fetch_and_verifier = [](auto& v, auto x) {
+    v &= x;
+  };
+
+  auto fetch_or_verifier = [](auto& v, auto x) {
+    v |= x;
+  };
+
+  auto fetch_xor_verifier = [](auto& v, auto x) {
+    v ^= x;
+  };
+
+  auto fetch_min_verifier = [](auto& v, auto x) {
+    v = std::min(v,x);
+  };
+
+  auto fetch_max_verifier = [](auto& v, auto x) {
+    v = std::max(v,x);
+  };
+
+#define HIPSYCL_ATOMIC_REF_INTEGER_TEST(Tester, Verifier)                      \
+  atomic_device_reduction_test<int>(Tester, Verifier);                         \
+  atomic_device_reduction_test<unsigned int>(Tester, Verifier);                \
+  atomic_device_reduction_test<long>(Tester, Verifier);                        \
+  atomic_device_reduction_test<unsigned long>(Tester, Verifier);               \
+  atomic_device_reduction_test<long long>(Tester, Verifier);                   \
+  atomic_device_reduction_test<unsigned long long>(Tester, Verifier);
+
+#define HIPSYCL_ATOMIC_REF_FP_TEST(Tester, Verifier)                           \
+  atomic_device_reduction_test<float>(Tester, Verifier);                       \
+  atomic_device_reduction_test<double>(Tester, Verifier);
+
+#define HIPSYCL_ATOMIC_REF_PTR_TEST(Tester, Verifier)                          \
+  atomic_device_reduction_test<int *>(Tester, Verifier);
+
+  HIPSYCL_ATOMIC_REF_INTEGER_TEST(fetch_add, fetch_add_verifier);
+  HIPSYCL_ATOMIC_REF_INTEGER_TEST(fetch_sub, fetch_sub_verifier);
+  HIPSYCL_ATOMIC_REF_INTEGER_TEST(fetch_or, fetch_or_verifier);
+  HIPSYCL_ATOMIC_REF_INTEGER_TEST(fetch_xor, fetch_xor_verifier);
+  HIPSYCL_ATOMIC_REF_INTEGER_TEST(fetch_and, fetch_and_verifier);
+  HIPSYCL_ATOMIC_REF_INTEGER_TEST(fetch_min, fetch_min_verifier);
+  HIPSYCL_ATOMIC_REF_INTEGER_TEST(fetch_max, fetch_max_verifier);
+
+  HIPSYCL_ATOMIC_REF_FP_TEST(fetch_add, fetch_add_verifier);
+  HIPSYCL_ATOMIC_REF_FP_TEST(fetch_sub, fetch_sub_verifier);
+  HIPSYCL_ATOMIC_REF_FP_TEST(fetch_min, fetch_min_verifier);
+  HIPSYCL_ATOMIC_REF_FP_TEST(fetch_max, fetch_max_verifier);
+
+  HIPSYCL_ATOMIC_REF_PTR_TEST(fetch_add, fetch_add_verifier);
+  HIPSYCL_ATOMIC_REF_PTR_TEST(fetch_sub, fetch_sub_verifier);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
* Add SYCL 2020 `atomic_ref`
* Refactor atomics in a fashion similar to how math builtins work: A common `atomic_builtins.hpp` header includes backend-specific headers which provide `__hipsycl_atomic_*` backend builtins. These can then be used by both `atomic` and `atomic_ref` classes.
* Add support for previously unsupported atomic operations, such as load/store on GPU, or floating point atomics on CPU by adding appropriate CAS emulations. With this PR, all atomic operations are supported for all types on all backends (except SPIR-V, which requires more work in a separate PR)
* Add test coverage