### PR TITLE
Make buffer::reinterpret more standard conforming.

### DIFF
--- a/doc/runtime-spec.md
+++ b/doc/runtime-spec.md
@@ -53,7 +53,7 @@ Using an accessor that is not of a read-only access mode on a device *d*  shall 
 
 Data transfers generated from accessors (see below) shall cause transferred pages to be marked as up-to-date on the target allocation.
 
-If a `buffer` is reinterpreted to a data type of different size than the original buffer element size, the implementation may assume a page range for accessors to the reinterpreted buffer that is larger than the page range as defined above.
+If a `buffer` is reinterpreted to a data type of different size than the original buffer element size or reshaped into a different range, the implementation may assume a page range for accessors to the reinterpreted buffer that is larger than the page range as defined above.
 
 #### Data transfers
 

--- a/doc/runtime-spec.md
+++ b/doc/runtime-spec.md
@@ -53,7 +53,7 @@ Using an accessor that is not of a read-only access mode on a device *d*  shall 
 
 Data transfers generated from accessors (see below) shall cause transferred pages to be marked as up-to-date on the target allocation.
 
-After reinterpreting a `buffer` with a differing type, the implementation may require the transfer of all pages, despite a smaller range being specified by an accessor.
+If a `buffer` is reinterpreted to a data type of different size than the original buffer element size, the implementation may assume a page range for accessors to the reinterpreted buffer that is larger than the page range as defined above.
 
 #### Data transfers
 

--- a/doc/runtime-spec.md
+++ b/doc/runtime-spec.md
@@ -49,9 +49,11 @@ For each allocation managed on each device, the `buffer` implementation shall tr
 
 If a page is fully contained within or overlaps with the accessed range of an accessor (taking into account the accessor's access offset and range), we use the terminology that the page is part of the accessor's *page range*.
 
-Using an accessor that is not of a read-only access mode on a device *d*  shall cause all pages within its page range to be marked as outdated on all allocations except for those on device *d*. This is because the implementations has to assume that data was modified on `d`.
+Using an accessor that is not of a read-only access mode on a device *d*  shall cause all pages within its page range to be marked as outdated on all allocations except for those on device *d*. This is because the implementation has to assume that data was modified on `d`.
 
 Data transfers generated from accessors (see below) shall cause transferred pages to be marked as up-to-date on the target allocation.
+
+After reinterpreting a `buffer` with a differing type, the implementation may require the transfer of all pages, despite a smaller range being specified by an accessor.
 
 #### Data transfers
 

--- a/include/hipSYCL/sycl/buffer.hpp
+++ b/include/hipSYCL/sycl/buffer.hpp
@@ -711,8 +711,8 @@ public:
 
   template <typename ReinterpretT, int ReinterpretDim>
   buffer<ReinterpretT, ReinterpretDim,
-        typename std::allocator_traits<AllocatorT>::template rebind_alloc<
-             ReinterpretT>>
+        typename std::allocator_traits<AllocatorT>
+                 ::template rebind_alloc<ReinterpretT>>
   reinterpret(range<ReinterpretDim> reinterpretRange) const {
     if(_range.size() * sizeof(T) != reinterpretRange.size() * sizeof(ReinterpretT))
       throw invalid_parameter_error{"reinterpret must preserve the byte count of the buffer"};
@@ -732,7 +732,8 @@ public:
     std::enable_if_t<ReinterpretDim == 1 ||
       (ReinterpretDim == dimensions && sizeof(ReinterpretT) == sizeof(T)), int> = 0>
   buffer<ReinterpretT, ReinterpretDim,
-    typename std::allocator_traits<AllocatorT>::template rebind_alloc<ReinterpretT>>
+        typename std::allocator_traits<AllocatorT>
+                 ::template rebind_alloc<ReinterpretT>>
   reinterpret() const {
     if constexpr (ReinterpretDim == 1) {
       return reinterpret<ReinterpretT, 1>(range<1>{

--- a/include/hipSYCL/sycl/buffer.hpp
+++ b/include/hipSYCL/sycl/buffer.hpp
@@ -710,14 +710,36 @@ public:
   { return false; }
 
   template <typename ReinterpretT, int ReinterpretDim>
-  buffer<ReinterpretT, ReinterpretDim, AllocatorT>
+  buffer<ReinterpretT, ReinterpretDim,
+        typename std::allocator_traits<AllocatorT>::template rebind_alloc<
+             ReinterpretT>>
   reinterpret(range<ReinterpretDim> reinterpretRange) const {
+    if(_range.size() * sizeof(T) != reinterpretRange.size() * sizeof(ReinterpretT))
+      throw invalid_parameter_error{"reinterpret must preserve the byte count of the buffer"};
 
-    buffer<ReinterpretT, ReinterpretDim, AllocatorT> new_buffer;
-    new_buffer.init_from(*this);
+    buffer<ReinterpretT, ReinterpretDim,
+            typename std::allocator_traits<AllocatorT>::template rebind_alloc<
+            ReinterpretT>> new_buffer;
+    static_cast<detail::property_carrying_object&>(new_buffer) = *this;
+    new_buffer._alloc = _alloc;
+    new_buffer._impl = _impl;
     new_buffer._range = reinterpretRange;
     
     return new_buffer;
+  }
+
+  template <typename ReinterpretT, int ReinterpretDim = dimensions,
+    std::enable_if_t<ReinterpretDim == 1 ||
+      (ReinterpretDim == dimensions && sizeof(ReinterpretT) == sizeof(T)), int> = 0>
+  buffer<ReinterpretT, ReinterpretDim,
+    typename std::allocator_traits<AllocatorT>::template rebind_alloc<ReinterpretT>>
+  reinterpret() const {
+    if constexpr (ReinterpretDim == 1) {
+      return reinterpret<ReinterpretT, 1>(range<1>{
+        (_range.size() * sizeof(T)) / sizeof(ReinterpretT)});
+    } else {
+      return reinterpret<ReinterpretT, ReinterpretDim>(_range);
+    }
   }
 
   friend bool operator==(const buffer& lhs, const buffer& rhs)
@@ -989,14 +1011,6 @@ private:
   buffer()
   : detail::property_carrying_object {property_list {}}
   {}
-
-  template <class OtherT, int OtherDim, class OtherAllocatorT>
-  void init_from(const buffer<OtherT, OtherDim, OtherAllocatorT> &other) {
-    detail::property_carrying_object::operator=(other);
-    this->_alloc = other._alloc;
-    this->_range = other._range;
-    this->_impl = other._impl;
-  }
   
   void init_data_backend(const range<dimensions>& range)
   {

--- a/include/hipSYCL/sycl/handler.hpp
+++ b/include/hipSYCL/sycl/handler.hpp
@@ -29,6 +29,7 @@
 #ifndef HIPSYCL_HANDLER_HPP
 #define HIPSYCL_HANDLER_HPP
 
+#include <memory>
 #include <type_traits>
 #include <unordered_map>
 
@@ -105,20 +106,22 @@ class handler {
           "because it is not bound to a buffer."};
     }
 
-    size_t element_size = data.mem->get_element_size();
-
-    if (element_size != sizeof(typename AccessorType::value_type)) {
-      assert(false && "Reinterpreting data with elements of different size is "
-                      "not yet supported");
-    }
-
     // Translate no_init property and host_task modes
     access_mode mode =
         detail::get_effective_access_mode(AccessorType::mode, data.is_no_init);
+    
+    size_t element_size = data.mem->get_element_size();
 
-    auto req = std::make_unique<rt::buffer_memory_requirement>(
+    std::unique_ptr<rt::buffer_memory_requirement> req;
+    if (element_size != sizeof(typename AccessorType::value_type)) {
+      req.reset(new rt::buffer_memory_requirement(
+        data.mem, rt::id<3>{}, data.mem->get_num_elements(), mode,
+        AccessorType::access_target));
+    } else {
+      req.reset(new rt::buffer_memory_requirement(
         data.mem, rt::make_id(data.offset), rt::make_range(data.range), mode,
-        AccessorType::access_target);
+        AccessorType::access_target));
+    }
 
     // Bind the accessor's embedded pointer to the requirement, such that
     // the scheduler is able to initialize the accessor's data pointer
@@ -716,14 +719,16 @@ private:
 
     std::shared_ptr<rt::buffer_data_region> data = get_memory_region(acc);
 
-    if(sizeof(T) != data->get_element_size())
-      assert(false && "Accessors with different element size than original "
-                      "buffer are not yet supported");
-
     rt::dag_build_guard build{rt::application::dag()};
 
-    auto explicit_requirement = rt::make_operation<rt::buffer_memory_requirement>(
-        data, rt::make_id(get_offset(acc)), rt::make_range(get_range(acc)), mode, tgt);
+    std::unique_ptr<rt::buffer_memory_requirement> explicit_requirement;
+    if(sizeof(T) != data->get_element_size()) {
+      explicit_requirement.reset(new rt::buffer_memory_requirement(
+          data, rt::id<3>{}, data->get_num_elements(), mode, tgt));
+    } else {
+      explicit_requirement.reset(new rt::buffer_memory_requirement(
+          data, rt::make_id(get_offset(acc)), rt::make_range(get_range(acc)), mode, tgt));
+    }
 
     rt::execution_hints enforce_bind_to_dev;
     enforce_bind_to_dev.add_hint(

--- a/tests/sycl/buffer.cpp
+++ b/tests/sycl/buffer.cpp
@@ -120,10 +120,14 @@ BOOST_AUTO_TEST_CASE(buffer_api_2d) {
   BOOST_REQUIRE(buf_a == buf_c);
 
   // compile test, that reinterpreted buffer uses rebound allocator
-  s::buffer<std::uint16_t, 1, s::buffer_allocator<std::uint16_t>> buf_d = buf_a.reinterpret<std::uint16_t>(s::range<1>{32});
-  s::buffer<std::uint32_t, 1, s::buffer_allocator<std::uint32_t>> buf_e = buf_a.reinterpret<std::uint32_t, 1>();
-  s::buffer<std::uint16_t, 2, s::buffer_allocator<std::uint16_t>> buf_f = buf_a.reinterpret<std::uint16_t>(s::range<2>{4, 8});
-  s::buffer<std::uint32_t, 2, s::buffer_allocator<std::uint32_t>> buf_g = buf_a.reinterpret<std::uint32_t, 2>();
+  s::buffer<std::uint16_t, 1, s::buffer_allocator<std::uint16_t>> buf_d
+    = buf_a.reinterpret<std::uint16_t>(s::range<1>{32});
+  s::buffer<std::uint32_t, 1, s::buffer_allocator<std::uint32_t>> buf_e
+    = buf_a.reinterpret<std::uint32_t, 1>();
+  s::buffer<std::uint16_t, 2, s::buffer_allocator<std::uint16_t>> buf_f
+    = buf_a.reinterpret<std::uint16_t>(s::range<2>{4, 8});
+  s::buffer<std::uint32_t, 2, s::buffer_allocator<std::uint32_t>> buf_g
+    = buf_a.reinterpret<std::uint32_t, 2>();
 
   auto host_d = buf_d.get_host_access();
   auto host_e = buf_e.get_host_access();
@@ -132,8 +136,10 @@ BOOST_AUTO_TEST_CASE(buffer_api_2d) {
   auto host_a = buf_a.get_host_access();
   for(size_t i = 0; i < host_a.get_range()[0]; ++i) {
     for(size_t j = 0; j < host_a.get_range()[1]; ++j) {
-      BOOST_CHECK_EQUAL(host_a[i][j], static_cast<int>(host_d[i * host_a.get_range()[1] * 2 + j * 2]));
-      BOOST_CHECK_EQUAL(host_a[i][j], static_cast<int>(host_e[i * host_a.get_range()[1] + j]));
+      BOOST_CHECK_EQUAL(host_a[i][j], 
+        static_cast<int>(host_d[i * host_a.get_range()[1] * 2 + j * 2]));
+      BOOST_CHECK_EQUAL(host_a[i][j], 
+        static_cast<int>(host_e[i * host_a.get_range()[1] + j]));
       BOOST_CHECK_EQUAL(host_a[i][j], static_cast<int>(host_f[i][j * 2]));
       BOOST_CHECK_EQUAL(host_a[i][j], static_cast<int>(host_g[i][j]));
     }

--- a/tests/sycl/buffer.cpp
+++ b/tests/sycl/buffer.cpp
@@ -65,11 +65,11 @@ BOOST_AUTO_TEST_CASE(buffer_versioning) {
 BOOST_AUTO_TEST_CASE(buffer_api) {
   namespace s = cl::sycl;
 
-  s::buffer<int, 1> buf_a(32);
+  s::buffer<std::int32_t, 1> buf_a(32);
   s::buffer<int, 1> buf_b(32);
   {
     auto host_a = buf_a.get_host_access();
-    auto host_b = buf_a.get_host_access();
+    auto host_b = buf_b.get_host_access();
     for(size_t i = 0; i < host_a.size(); ++i) {
       host_a[i] = i;
       host_b[i] = -1;
@@ -77,16 +77,67 @@ BOOST_AUTO_TEST_CASE(buffer_api) {
   }
 
   auto buf_c = buf_a;
-  auto buf_f = buf_a.reinterpret<unsigned>(s::range<1>{32});
 
   BOOST_REQUIRE(buf_a == buf_a);
   BOOST_REQUIRE(buf_a != buf_b);
   BOOST_REQUIRE(buf_a == buf_c);
-  
+
+  // compile test, that reinterpreted buffer uses rebound allocator
+  s::buffer<std::uint16_t, 1, s::buffer_allocator<std::uint16_t>> buf_e = buf_a.reinterpret<std::uint16_t>(s::range<1>{64});
+  s::buffer<std::uint32_t, 1, s::buffer_allocator<std::uint32_t>> buf_f = buf_a.reinterpret<std::uint32_t>();
+
+  auto host_e = buf_e.get_host_access();
   auto host_f = buf_f.get_host_access();
   auto host_a = buf_a.get_host_access();
-  for(size_t i = 0; i < host_a.size(); ++i)
+  for(size_t i = 0; i < host_a.size(); ++i) {
+    BOOST_CHECK_EQUAL(host_a[i], static_cast<int>(host_e[i * 2]));
     BOOST_CHECK_EQUAL(host_a[i], static_cast<int>(host_f[i]));
+  }
+}
+
+
+// TODO: Extend this
+BOOST_AUTO_TEST_CASE(buffer_api_2d) {
+  namespace s = cl::sycl;
+
+  s::buffer<std::int32_t, 2> buf_a(s::range<2>{4, 4});
+  s::buffer<std::int32_t, 2> buf_b(s::range<2>{4, 4});
+  {
+    auto host_a = buf_a.get_host_access();
+    auto host_b = buf_b.get_host_access();
+    for(size_t i = 0; i < host_a.get_range()[0]; ++i) {
+      for(size_t j = 0; j < host_a.get_range()[1]; ++j) {
+        host_a[i][j] = i;
+        host_b[i][j] = -1;
+      }
+    }
+  }
+
+  auto buf_c = buf_a;
+
+  BOOST_REQUIRE(buf_a == buf_a);
+  BOOST_REQUIRE(buf_a != buf_b);
+  BOOST_REQUIRE(buf_a == buf_c);
+
+  // compile test, that reinterpreted buffer uses rebound allocator
+  s::buffer<std::uint16_t, 1, s::buffer_allocator<std::uint16_t>> buf_d = buf_a.reinterpret<std::uint16_t>(s::range<1>{32});
+  s::buffer<std::uint32_t, 1, s::buffer_allocator<std::uint32_t>> buf_e = buf_a.reinterpret<std::uint32_t, 1>();
+  s::buffer<std::uint16_t, 2, s::buffer_allocator<std::uint16_t>> buf_f = buf_a.reinterpret<std::uint16_t>(s::range<2>{4, 8});
+  s::buffer<std::uint32_t, 2, s::buffer_allocator<std::uint32_t>> buf_g = buf_a.reinterpret<std::uint32_t, 2>();
+
+  auto host_d = buf_d.get_host_access();
+  auto host_e = buf_e.get_host_access();
+  auto host_f = buf_f.get_host_access();
+  auto host_g = buf_g.get_host_access();
+  auto host_a = buf_a.get_host_access();
+  for(size_t i = 0; i < host_a.get_range()[0]; ++i) {
+    for(size_t j = 0; j < host_a.get_range()[1]; ++j) {
+      BOOST_CHECK_EQUAL(host_a[i][j], static_cast<int>(host_d[i * host_a.get_range()[1] * 2 + j * 2]));
+      BOOST_CHECK_EQUAL(host_a[i][j], static_cast<int>(host_e[i * host_a.get_range()[1] + j]));
+      BOOST_CHECK_EQUAL(host_a[i][j], static_cast<int>(host_f[i][j * 2]));
+      BOOST_CHECK_EQUAL(host_a[i][j], static_cast<int>(host_g[i][j]));
+    }
+  }
 }
 
 BOOST_AUTO_TEST_CASE(buffer_update_host) {


### PR DESCRIPTION
- return buffer with rebound allocator,
- add overload without range parameter,
- allow and handle differently sized target types,
- throw an exception if the byte size is not fully covered.

Handling differently sized types is a bit tricky as hipSYCL's page mechanism works on the original element's size. Thus, whenever the size of the element type of a ranged accessor is different than the size of the type, the buffer was originally created with, all pages of the buffer are migrated to prevent partial values.