### PR TITLE
Fix access to non-friend vec instantiation in vec::convert

### DIFF
--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -323,7 +323,7 @@ public:
 
     for(int i = 0; i < N; ++i) {
       // TODO: Take rounding mode into account
-      result._data[i] = static_cast<ConvertT>(_data[i]);
+      result[i] = static_cast<ConvertT>(_data[i]);
     }
 
     return result;
@@ -341,7 +341,7 @@ public:
     
     AsT* in_ptr = reinterpret_cast<AsT*>(&_data[0]);
     for(int i = 0; i < OtherN; ++i)
-      result._data[i] = in_ptr[i];
+      result[i] = in_ptr[i];
 
     return result;
   }

--- a/tests/sycl/vec.cpp
+++ b/tests/sycl/vec.cpp
@@ -131,4 +131,16 @@ BOOST_AUTO_TEST_CASE(vec_api) {
 }
 
 
+// Regression test: convert<>() would not compile because of illegal private data member access
+BOOST_AUTO_TEST_CASE(vec_convert) {
+  auto floats_in = cl::sycl::float4{1.f, 2.f, 3.f, 4.f};
+  auto ints = floats_in.convert<int>();
+  auto floats_out = ints.convert<float>();
+  BOOST_TEST(floats_in.x() == floats_out.x());
+  BOOST_TEST(floats_in.y() == floats_out.y());
+  BOOST_TEST(floats_in.z() == floats_out.z());
+  BOOST_TEST(floats_in.w() == floats_out.w());
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
`vec::convert` would not compile because it accessed the `_data` member of the result type, which is a non-friend vec instantiation.