### PR TITLE
Add dummy code() member function to the exception class

### DIFF
--- a/include/hipSYCL/sycl/exception.hpp
+++ b/include/hipSYCL/sycl/exception.hpp
@@ -32,6 +32,7 @@
 #include <exception>
 #include <functional>
 #include <string>
+#include <system_error>
 
 #include "hipSYCL/runtime/error.hpp"
 #include "types.hpp"
@@ -60,6 +61,11 @@ public:
   bool has_context() const
   {
     return false;
+  }
+
+  const std::error_code& code() const noexcept
+  {
+    return std::error_code(_error_details.info().error_code().get_code(), std::system_category());
   }
 
   // Implementation in context.hpp


### PR DESCRIPTION
This PR adds the code() member function to the exception class in order to be able to return the error code. This is necessary in order to support https://github.com/oneapi-src/oneMKL/pull/104