### PR TITLE
Feature: add missing copy functions to sycl::queue and sycl::handler

### DIFF
--- a/include/hipSYCL/sycl/handler.hpp
+++ b/include/hipSYCL/sycl/handler.hpp
@@ -558,8 +558,8 @@ public:
   
   template <typename T>
   void copy(const T* src, T* dest, std::size_t count) {
-    this->memcpy(reinterpret_cast<void*>(dest), 
-      reinterpret_cast<const void*>(src), count * sizeof(T));
+    this->memcpy(static_cast<void*>(dest),
+      static_cast<const void*>(src), count * sizeof(T));
   }
 
 

--- a/include/hipSYCL/sycl/handler.hpp
+++ b/include/hipSYCL/sycl/handler.hpp
@@ -558,7 +558,8 @@ public:
   
   template <typename T>
   void copy(const T* src, T* dest, std::size_t count) {
-    this->memcpy(reinterpret_cast<void*>(dest), reinterpret_cast<const void*>(src), count * sizeof(T));
+    this->memcpy(reinterpret_cast<void*>(dest), 
+      reinterpret_cast<const void*>(src), count * sizeof(T));
   }
 
 

--- a/include/hipSYCL/sycl/handler.hpp
+++ b/include/hipSYCL/sycl/handler.hpp
@@ -555,6 +555,11 @@ public:
 
     _command_group_nodes.push_back(node);
   }
+  
+  template <typename T>
+  void copy(const T* src, T* dest, std::size_t count) {
+    this->memcpy(reinterpret_cast<void*>(dest), reinterpret_cast<const void*>(src), count * sizeof(T));
+  }
 
 
   template <class T> void fill(void *ptr, const T &pattern, std::size_t count) {

--- a/include/hipSYCL/sycl/queue.hpp
+++ b/include/hipSYCL/sycl/queue.hpp
@@ -606,6 +606,26 @@ public:
       cgh.memcpy(dest, src, num_bytes);
     });
   }
+  
+  template <typename T>
+  event copy(const T* src, T* dest, std::size_t count) {
+    return this->memcpy(reinterpret_cast<void*>(dest), 
+      reinterpret_cast<const void*>(src), count * sizeof(T));
+  }
+  
+  template <typename T>
+  event copy(const T* src, T* dest, std::size_t count, 
+             event dependency) {
+    return this->memcpy(reinterpret_cast<void*>(dest), 
+      reinterpret_cast<const void*>(src), count * sizeof(T), dependency);
+  }
+  
+  template <typename T>
+  event copy(const T* src, T* dest, std::size_t count, 
+             const std::vector<event>& dependencies) {
+    return this->memcpy(reinterpret_cast<void*>(dest), 
+      reinterpret_cast<const void*>(src), count * sizeof(T), dependencies);
+  }
 
   event memset(void *ptr, int value, std::size_t num_bytes) {
     return this->submit([&](sycl::handler &cgh) {

--- a/include/hipSYCL/sycl/queue.hpp
+++ b/include/hipSYCL/sycl/queue.hpp
@@ -825,6 +825,15 @@ public:
       cgh.update_host(acc);
     });  
   }
+  
+  template <typename T, int dim, access::mode mode, access::target tgt,
+            access::placeholder isPlaceholder>
+  event update(accessor<T, dim, mode, tgt, isPlaceholder> acc) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.require(acc);
+      cgh.update(acc);
+    });  
+  }
 
   template <typename T, int dim, access::mode mode, access::target tgt,
             access::placeholder isPlaceholder>

--- a/include/hipSYCL/sycl/queue.hpp
+++ b/include/hipSYCL/sycl/queue.hpp
@@ -609,22 +609,22 @@ public:
   
   template <typename T>
   event copy(const T* src, T* dest, std::size_t count) {
-    return this->memcpy(reinterpret_cast<void*>(dest), 
-      reinterpret_cast<const void*>(src), count * sizeof(T));
+    return this->memcpy(static_cast<void*>(dest), 
+      static_cast<const void*>(src), count * sizeof(T));
   }
   
   template <typename T>
   event copy(const T* src, T* dest, std::size_t count, 
              event dependency) {
-    return this->memcpy(reinterpret_cast<void*>(dest), 
-      reinterpret_cast<const void*>(src), count * sizeof(T), dependency);
+    return this->memcpy(static_cast<void*>(dest), 
+      static_cast<const void*>(src), count * sizeof(T), dependency);
   }
   
   template <typename T>
   event copy(const T* src, T* dest, std::size_t count, 
              const std::vector<event>& dependencies) {
-    return this->memcpy(reinterpret_cast<void*>(dest), 
-      reinterpret_cast<const void*>(src), count * sizeof(T), dependencies);
+    return this->memcpy(static_cast<void*>(dest), 
+      static_cast<const void*>(src), count * sizeof(T), dependencies);
   }
 
   event memset(void *ptr, int value, std::size_t num_bytes) {

--- a/include/hipSYCL/sycl/queue.hpp
+++ b/include/hipSYCL/sycl/queue.hpp
@@ -766,7 +766,7 @@ public:
   // Explicit copy functions
   
   template <typename T, int dim, access_mode mode, target tgt,
-            access::placeholder isPlaceholder>
+            accessor_variant isPlaceholder>
   event copy(accessor<T, dim, mode, tgt, isPlaceholder> src,
              shared_ptr_class<T> dest) {
     return this->submit([&](sycl::handler &cgh) {
@@ -776,7 +776,7 @@ public:
   }
   
   template <typename T, int dim, access_mode mode, target tgt,
-            access::placeholder isPlaceholder>
+            accessor_variant isPlaceholder>
   event copy(shared_ptr_class<T> src,
              accessor<T, dim, mode, tgt, isPlaceholder> dest) {
     return this->submit([&](sycl::handler &cgh) {
@@ -786,7 +786,7 @@ public:
   }
 
   template <typename T, int dim, access_mode mode, target tgt,
-            access::placeholder isPlaceholder>
+            accessor_variant isPlaceholder>
   event copy(accessor<T, dim, mode, tgt, isPlaceholder> src,
              T *dest) {
     return this->submit([&](sycl::handler &cgh) {
@@ -796,7 +796,7 @@ public:
   }
 
   template <typename T, int dim, access_mode mode, target tgt,
-            access::placeholder isPlaceholder>
+            accessor_variant isPlaceholder>
   event copy(const T *src,
              accessor<T, dim, mode, tgt, isPlaceholder> dest) {
     return this->submit([&](sycl::handler &cgh) {
@@ -807,7 +807,7 @@ public:
 
   template <typename T, int dim, access_mode srcMode, access_mode dstMode,
             target srcTgt, target destTgt,
-            access::placeholder isPlaceholderSrc, access::placeholder isPlaceholderDst>
+            accessor_variant isPlaceholderSrc, accessor_variant isPlaceholderDst>
   event copy(accessor<T, dim, srcMode, srcTgt, isPlaceholderSrc> src,
              accessor<T, dim, dstMode, destTgt, isPlaceholderDst> dest) {
     return this->submit([&](sycl::handler &cgh) {
@@ -818,7 +818,7 @@ public:
   }
 
   template <typename T, int dim, access_mode mode, target tgt,
-            access::placeholder isPlaceholder>
+            accessor_variant isPlaceholder>
   event update_host(accessor<T, dim, mode, tgt, isPlaceholder> acc) {
     return this->submit([&](sycl::handler &cgh) {
       cgh.require(acc);
@@ -827,7 +827,7 @@ public:
   }
   
   template <typename T, int dim, access_mode mode, target tgt,
-            access::placeholder isPlaceholder>
+            accessor_variant isPlaceholder>
   event update(accessor<T, dim, mode, tgt, isPlaceholder> acc) {
     return this->submit([&](sycl::handler &cgh) {
       cgh.require(acc);
@@ -836,7 +836,7 @@ public:
   }
 
   template <typename T, int dim, access_mode mode, target tgt,
-            access::placeholder isPlaceholder>
+            accessor_variant isPlaceholder>
   event fill(accessor<T, dim, mode, tgt, isPlaceholder> dest, const T &src) {
     return this->submit([&](sycl::handler &cgh) {
       cgh.require(dest);

--- a/include/hipSYCL/sycl/queue.hpp
+++ b/include/hipSYCL/sycl/queue.hpp
@@ -765,7 +765,7 @@ public:
   
   // Explicit copy functions
   
-  template <typename T, int dim, access::mode mode, access::target tgt,
+  template <typename T, int dim, access_mode mode, target tgt,
             access::placeholder isPlaceholder>
   event copy(accessor<T, dim, mode, tgt, isPlaceholder> src,
              shared_ptr_class<T> dest) {
@@ -775,7 +775,7 @@ public:
     });           
   }
   
-  template <typename T, int dim, access::mode mode, access::target tgt,
+  template <typename T, int dim, access_mode mode, target tgt,
             access::placeholder isPlaceholder>
   event copy(shared_ptr_class<T> src,
              accessor<T, dim, mode, tgt, isPlaceholder> dest) {
@@ -785,7 +785,7 @@ public:
     });           
   }
 
-  template <typename T, int dim, access::mode mode, access::target tgt,
+  template <typename T, int dim, access_mode mode, target tgt,
             access::placeholder isPlaceholder>
   event copy(accessor<T, dim, mode, tgt, isPlaceholder> src,
              T *dest) {
@@ -795,7 +795,7 @@ public:
     });     
   }
 
-  template <typename T, int dim, access::mode mode, access::target tgt,
+  template <typename T, int dim, access_mode mode, target tgt,
             access::placeholder isPlaceholder>
   event copy(const T *src,
              accessor<T, dim, mode, tgt, isPlaceholder> dest) {
@@ -805,8 +805,8 @@ public:
     });             
   }
 
-  template <typename T, int dim, access::mode srcMode, access::mode dstMode,
-            access::target srcTgt, access::target destTgt,
+  template <typename T, int dim, access_mode srcMode, access_mode dstMode,
+            target srcTgt, target destTgt,
             access::placeholder isPlaceholderSrc, access::placeholder isPlaceholderDst>
   event copy(accessor<T, dim, srcMode, srcTgt, isPlaceholderSrc> src,
              accessor<T, dim, dstMode, destTgt, isPlaceholderDst> dest) {
@@ -817,7 +817,7 @@ public:
     });  
   }
 
-  template <typename T, int dim, access::mode mode, access::target tgt,
+  template <typename T, int dim, access_mode mode, target tgt,
             access::placeholder isPlaceholder>
   event update_host(accessor<T, dim, mode, tgt, isPlaceholder> acc) {
     return this->submit([&](sycl::handler &cgh) {
@@ -826,7 +826,7 @@ public:
     });  
   }
   
-  template <typename T, int dim, access::mode mode, access::target tgt,
+  template <typename T, int dim, access_mode mode, target tgt,
             access::placeholder isPlaceholder>
   event update(accessor<T, dim, mode, tgt, isPlaceholder> acc) {
     return this->submit([&](sycl::handler &cgh) {
@@ -835,7 +835,7 @@ public:
     });  
   }
 
-  template <typename T, int dim, access::mode mode, access::target tgt,
+  template <typename T, int dim, access_mode mode, target tgt,
             access::placeholder isPlaceholder>
   event fill(accessor<T, dim, mode, tgt, isPlaceholder> dest, const T &src) {
     return this->submit([&](sycl::handler &cgh) {

--- a/include/hipSYCL/sycl/queue.hpp
+++ b/include/hipSYCL/sycl/queue.hpp
@@ -761,6 +761,71 @@ public:
     });
   }
 
+  
+  // Explicit copy functions
+  template <typename T, int dim, access::mode mode, access::target tgt,
+            accessor_variant variant>
+  event copy(accessor<T, dim, mode, tgt, variant> src,
+             shared_ptr_class<T> dest) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.copy(src, dest);
+    });           
+  }
+  
+  template <typename T, int dim, access::mode mode, access::target tgt,
+            accessor_variant variant>
+  event copy(shared_ptr_class<T> src,
+             accessor<T, dim, mode, tgt, variant> dest) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.copy(src, dest);
+    });           
+  }
+
+  template <typename T, int dim, access::mode mode, access::target tgt,
+            accessor_variant variant>
+  event copy(accessor<T, dim, mode, tgt, variant> src,
+             T *dest) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.copy(src, dest);
+    });     
+  }
+
+  template <typename T, int dim, access::mode mode, access::target tgt,
+            accessor_variant variant>
+  event copy(const T *src,
+             accessor<T, dim, mode, tgt, variant> dest) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.copy(src, dest);
+    });             
+  }
+
+  template <typename T, int dim, access::mode srcMode, access::mode dstMode,
+            access::target srcTgt, access::target destTgt,
+            accessor_variant VariantSrc, accessor_variant VariantDest>
+  event copy(accessor<T, dim, srcMode, srcTgt, VariantSrc> src,
+             accessor<T, dim, dstMode, destTgt, VariantDest> dest) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.copy(src, dest);
+    });  
+  }
+
+  template <typename T, int dim, access::mode mode, access::target tgt,
+            accessor_variant variant>
+  event update_host(accessor<T, dim, mode, tgt, variant> acc) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.update_host(acc);
+    });  
+  }
+
+  template <typename T, int dim, access::mode mode, access::target tgt,
+            accessor_variant variant>
+  event fill(accessor<T, dim, mode, tgt, variant> dest, const T &src) {
+    return this->submit([&](sycl::handler &cgh) {
+      cgh.fill(dest, src);
+    });  
+  }
+
+
 
 private:
   template<int Dim>

--- a/include/hipSYCL/sycl/queue.hpp
+++ b/include/hipSYCL/sycl/queue.hpp
@@ -761,70 +761,79 @@ public:
     });
   }
 
+  /// Placeholder accessor shortcuts
   
   // Explicit copy functions
+  
   template <typename T, int dim, access::mode mode, access::target tgt,
-            accessor_variant variant>
-  event copy(accessor<T, dim, mode, tgt, variant> src,
+            access::placeholder isPlaceholder>
+  event copy(accessor<T, dim, mode, tgt, isPlaceholder> src,
              shared_ptr_class<T> dest) {
     return this->submit([&](sycl::handler &cgh) {
+      cgh.require(src);
       cgh.copy(src, dest);
     });           
   }
   
   template <typename T, int dim, access::mode mode, access::target tgt,
-            accessor_variant variant>
+            access::placeholder isPlaceholder>
   event copy(shared_ptr_class<T> src,
-             accessor<T, dim, mode, tgt, variant> dest) {
+             accessor<T, dim, mode, tgt, isPlaceholder> dest) {
     return this->submit([&](sycl::handler &cgh) {
+      cgh.require(dest);
       cgh.copy(src, dest);
     });           
   }
 
   template <typename T, int dim, access::mode mode, access::target tgt,
-            accessor_variant variant>
-  event copy(accessor<T, dim, mode, tgt, variant> src,
+            access::placeholder isPlaceholder>
+  event copy(accessor<T, dim, mode, tgt, isPlaceholder> src,
              T *dest) {
     return this->submit([&](sycl::handler &cgh) {
+      cgh.require(src);
       cgh.copy(src, dest);
     });     
   }
 
   template <typename T, int dim, access::mode mode, access::target tgt,
-            accessor_variant variant>
+            access::placeholder isPlaceholder>
   event copy(const T *src,
-             accessor<T, dim, mode, tgt, variant> dest) {
+             accessor<T, dim, mode, tgt, isPlaceholder> dest) {
     return this->submit([&](sycl::handler &cgh) {
+      cgh.require(dest);
       cgh.copy(src, dest);
     });             
   }
 
   template <typename T, int dim, access::mode srcMode, access::mode dstMode,
             access::target srcTgt, access::target destTgt,
-            accessor_variant VariantSrc, accessor_variant VariantDest>
-  event copy(accessor<T, dim, srcMode, srcTgt, VariantSrc> src,
-             accessor<T, dim, dstMode, destTgt, VariantDest> dest) {
+            access::placeholder isPlaceholderSrc, access::placeholder isPlaceholderDst>
+  event copy(accessor<T, dim, srcMode, srcTgt, isPlaceholderSrc> src,
+             accessor<T, dim, dstMode, destTgt, isPlaceholderDst> dest) {
     return this->submit([&](sycl::handler &cgh) {
+      cgh.require(src);
+      cgh.require(dest);
       cgh.copy(src, dest);
     });  
   }
 
   template <typename T, int dim, access::mode mode, access::target tgt,
-            accessor_variant variant>
-  event update_host(accessor<T, dim, mode, tgt, variant> acc) {
+            access::placeholder isPlaceholder>
+  event update_host(accessor<T, dim, mode, tgt, isPlaceholder> acc) {
     return this->submit([&](sycl::handler &cgh) {
+      cgh.require(acc);
       cgh.update_host(acc);
     });  
   }
 
   template <typename T, int dim, access::mode mode, access::target tgt,
-            accessor_variant variant>
-  event fill(accessor<T, dim, mode, tgt, variant> dest, const T &src) {
+            access::placeholder isPlaceholder>
+  event fill(accessor<T, dim, mode, tgt, isPlaceholder> dest, const T &src) {
     return this->submit([&](sycl::handler &cgh) {
+      cgh.require(dest);
       cgh.fill(dest, src);
     });  
   }
-
 
 
 private:


### PR DESCRIPTION
This pull request adds to following functions:
- `void handler::copy(const T *src, T *dest, size_t count)`: 
  the `src` and `dest` parameters are ordered with respect to [commandGroupHandler.h](https://github.com/KhronosGroup/SYCL-Docs/blob/SYCL-2020/master/adoc/headers/commandGroupHandler.h) (line 79)

- copy shortcuts for the `sycl::queue` class:
  - `event queue::copy(const T* src, T *dest, size_t count)`
  - `event queue::copy(const T* src, T *dest, size_t count, event depEvent)`
  - `event queue::copy(const T* src, T *dest, size_t count, const std::vector<event> &depEvents)`
  
  again the `src` and `dest` parameter order is the same as [queue.h](https://github.com/KhronosGroup/SYCL-Docs/blob/07775c05b7ef08b8d6c8dac52ca69639b8cce74c/adoc/headers/queue.h) (line 126 ff.)

- the "Explicit copy functions" in the `sycl::queue` class:
  - `event copy(accessor<T, dim, mode, tgt, variant> src, shared_ptr_class<T> dest)`
  - `event copy(shared_ptr_class<T> src, accessor<T, dim, mode, tgt, variant> dest)`
  - `event copy(accessor<T, dim, mode, tgt, variant> src, T *dest)`
  - `event copy(const T *src, accessor<T, dim, mode, tgt, variant> dest)`
  - `event copy(accessor<T, dim, srcMode, srcTgt, VariantSrc> src, accessor<T, dim, dstMode, destTgt, VariantDest> dest)`
  - `event update_host(accessor<T, dim, mode, tgt, variant> acc)`
  - `event fill(accessor<T, dim, mode, tgt, variant> dest, const T &src)`
  
  same as [queue.h](https://github.com/KhronosGroup/SYCL-Docs/blob/07775c05b7ef08b8d6c8dac52ca69639b8cce74c/adoc/headers/queue.h) (line 164 ff.) but with the template parameters changed to align with the same functions implemented in the `sycl::handler` class 

No functionality is newly implemented:
the new `copy` functions call the already implemented `memcpy` functions and the "Explicit copy functions" use the implementation provided in the `sycl::handler` class.