### PR TITLE
Use R-Value references in buffer::get_access

### DIFF
--- a/include/hipSYCL/sycl/buffer.hpp
+++ b/include/hipSYCL/sycl/buffer.hpp
@@ -674,12 +674,12 @@ public:
   }
 
   template<typename... Args>
-  auto get_access(Args... args) {
+  auto get_access(Args&&... args) {
     return accessor{*this, args...};
   }
 
   template<typename... Args>
-  auto get_host_access(Args... args) {
+  auto get_host_access(Args&&... args) {
     return host_accessor{*this, args...};
   }
 

--- a/include/hipSYCL/sycl/buffer.hpp
+++ b/include/hipSYCL/sycl/buffer.hpp
@@ -37,6 +37,7 @@
 #include <mutex>
 #include <type_traits>
 #include <algorithm>
+#include <utility>
 
 #include "hipSYCL/common/debug.hpp"
 #include "hipSYCL/runtime/allocator.hpp"
@@ -675,12 +676,12 @@ public:
 
   template<typename... Args>
   auto get_access(Args&&... args) {
-    return accessor{*this, args...};
+    return accessor{*this, std::forward<Args>(args)...};
   }
 
   template<typename... Args>
   auto get_host_access(Args&&... args) {
-    return host_accessor{*this, args...};
+    return host_accessor{*this, std::forward<Args>(args)...};
   }
 
   void set_final_data(std::shared_ptr<T> finalData)


### PR DESCRIPTION
Potential fix for variadic `buffer::get_access` issue reported in #609 