### PR TITLE
Don't build NewPM passes for LLVM < 11.

### DIFF
--- a/include/hipSYCL/compiler/GlobalsPruningPass.hpp
+++ b/include/hipSYCL/compiler/GlobalsPruningPass.hpp
@@ -58,7 +58,7 @@ struct GlobalsPruningPassLegacy : public llvm::ModulePass {
   bool runOnModule(llvm::Module &M) override;
 };
 
-#ifndef _WIN32
+#if !defined(_WIN32) && LLVM_VERSION_MAJOR >= 11
 class GlobalsPruningPass : public llvm::PassInfoMixin<GlobalsPruningPass> {
 public:
   explicit GlobalsPruningPass() {}
@@ -66,7 +66,7 @@ public:
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
   static bool isRequired() { return true; }
 };
-#endif // !_WIN32
+#endif // !_WIN32 && LLVM_VERSION_MAJOR >= 11
 
 } // namespace compiler
 } // namespace hipsycl

--- a/src/compiler/GlobalsPruningPass.cpp
+++ b/src/compiler/GlobalsPruningPass.cpp
@@ -43,7 +43,7 @@ bool hipsycl::compiler::GlobalsPruningPassLegacy::runOnModule(llvm::Module &M) {
   return true;
 }
 
-#ifndef _WIN32
+#if !defined(_WIN32) && LLVM_VERSION_MAJOR >= 11
 llvm::PreservedAnalyses
 hipsycl::compiler::GlobalsPruningPass::run(llvm::Module &M,
                                            llvm::ModuleAnalysisManager &AM) {
@@ -55,6 +55,6 @@ hipsycl::compiler::GlobalsPruningPass::run(llvm::Module &M,
   // todo: be a bit more granular
   return llvm::PreservedAnalyses::none();
 }
-#endif // !_WIN32
+#endif // !_WIN32 && LLVM_VERSION_MAJOR >= 11
 
 char hipsycl::compiler::GlobalsPruningPassLegacy::ID = 0;

--- a/src/compiler/HipsyclClangPlugin.cpp
+++ b/src/compiler/HipsyclClangPlugin.cpp
@@ -56,7 +56,7 @@ static llvm::RegisterStandardPasses
     RegisterGlobalsPruningPassOptimizerLast(llvm::PassManagerBuilder::EP_OptimizerLast,
                                             registerGlobalsPruningPass);
 
-#ifndef _WIN32
+#if !defined(_WIN32) && LLVM_VERSION_MAJOR >= 11
 #define HIPSYCL_STRINGIFY(V) #V
 #define HIPSYCL_PLUGIN_VERSION_STRING                                                    \
   "v" HIPSYCL_STRINGIFY(HIPSYCL_VERSION_MAJOR) "." HIPSYCL_STRINGIFY(                    \
@@ -73,7 +73,7 @@ extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo llvmGetPassPluginIn
                 });
           }};
 }
-#endif // !_WIN32
+#endif // !_WIN32 && LLVM_VERSION_MAJOR >= 11
 
 } // namespace compiler
 } // namespace hipsycl


### PR DESCRIPTION
As mentioned in #577 a quick fix, if compatibility with previous LLVM versions is broken, is to extend the preprocessor check, which is hereby done. I don't really expect the new PM to be used with LLVM < 11, so no one will miss the IR pass there and it saves me from installing yet another LLVM version.... 💀 

@psalz could you pull this change in and verify it indeed fixes the LLVM 10 build?