### PR TITLE
Minor improvements around sycl::backend

### DIFF
--- a/include/hipSYCL/sycl/backend.hpp
+++ b/include/hipSYCL/sycl/backend.hpp
@@ -37,6 +37,12 @@ namespace sycl {
 
 using backend = hipsycl::rt::backend_id;
 
+// Per SYCL 2020, 4.1.1 Backend macros
+#define SYCL_BACKEND_CUDA
+#define SYCL_BACKEND_HIP
+#define SYCL_BACKEND_LEVEL_ZERO
+#define SYCL_BACKEND_OMP
+
 #if defined(HIPSYCL_PLATFORM_CPU) && defined(__HIPSYCL_ENABLE_OMPHOST_TARGET__)
  #define SYCL_EXT_HIPSYCL_BACKEND_OMPHOST
 #endif

--- a/src/runtime/serialization/serialization.cpp
+++ b/src/runtime/serialization/serialization.cpp
@@ -48,6 +48,9 @@ std::ostream &operator<<(std::ostream &out, const hardware_platform value) {
   case rt::hardware_platform::rocm:
     out << "ROCm";
     break;
+  case rt::hardware_platform::level_zero:
+    out << "Level Zero";
+    break;
   default:
     out << "<unknown>";
     break;
@@ -57,8 +60,14 @@ std::ostream &operator<<(std::ostream &out, const hardware_platform value) {
 
 std::ostream &operator<<(std::ostream &out, const api_platform value) {
   switch (value) {
+  case rt::api_platform::cuda:
+    out << "CUDA";
+    break;
   case rt::api_platform::hip:
     out << "HIP";
+    break;
+  case rt::api_platform::level_zero:
+    out << "Level Zero";
     break;
   case rt::api_platform::omp:
     out << "OpenMP";
@@ -77,6 +86,9 @@ std::ostream &operator<<(std::ostream &out, const backend_id value) {
     break;
   case rt::backend_id::cuda:
     out << "CUDA";
+    break;
+  case rt::backend_id::level_zero:
+    out << "Level Zero";
     break;
   case rt::backend_id::omp:
     out << "OpenMP";

--- a/src/runtime/settings.cpp
+++ b/src/runtime/settings.cpp
@@ -62,7 +62,7 @@ std::istream &operator>>(std::istream &istr, std::vector<rt::backend_id> &out) {
       out.push_back(rt::backend_id::hip);
     } else if (name == "ze") {
       out.push_back(rt::backend_id::level_zero);
-    } else if("omp") {
+    } else if (name == "omp") {
       // looking for this, even though we have to allow it always.
       out.push_back(rt::backend_id::omp);
     } else {


### PR DESCRIPTION
1. Added backend macros, defining the available enum values. Per [SYCL 2020 spec, paragraph 4.1.1](https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:backend-macros).
2. Fixes a conditional in backend name parsing.
3. Updated serializer for platform/API/backend to include all possible enum values.