### PR TITLE
Workaround CUDA / MS ABI mismatch on Windows.

### DIFF
--- a/include/hipSYCL/sycl/libkernel/accessor.hpp
+++ b/include/hipSYCL/sycl/libkernel/accessor.hpp
@@ -458,11 +458,20 @@ struct no_init : public detail::property {};
 
 inline constexpr property::no_init no_init;
 
+// manually align layout with Itanium ABI, until MS ABI default changes
+// in a "future major version"
+// https://devblogs.microsoft.com/cppblog/optimizing-the-layout-of-empty-base-classes-in-vs2015-update-2-3/
+#if !defined(HIPSYCL_EMPTY_BASES) && defined(_WIN32)
+#define HIPSYCL_EMPTY_BASES __declspec(empty_bases)
+#else
+#define HIPSYCL_EMPTY_BASES
+#endif // HIPSYCL_EMPTY_BASES
+
 template <typename dataT, int dimensions = 1,
           access_mode accessmode = detail::default_access_mode<dataT>(),
           target accessTarget = target::device,
           accessor_variant AccessorVariant = accessor_variant::false_t>
-class accessor
+class HIPSYCL_EMPTY_BASES accessor
     : public detail::accessor_base<std::remove_const_t<dataT>>,
       public detail::accessor::conditional_buffer_pointer_storage<
           detail::accessor::stores_buffer_pointer(AccessorVariant)>,


### PR DESCRIPTION
On Windows the MS ABI is used for host code, that also influences the outline of structs.
For some obscure reason multiple empty base classes lead to 8 byte padding in MS ABI.
CUDA device code on the otherhand uses Itanium ABI.
Itanium ABI doesn't randomly add padding for empty base classes.
As the size of the accessor variants thus differs on host and device, invalid accesses occur, as the device loads the pointer from the kernel lambda from the wrong position -> bumms.
The standard SYCL accessors are fine as they don't have any empty base classes.

To mitigate this, we add __declspec(empty_bases) as presented in https://devblogs.microsoft.com/cppblog/optimizing-the-layout-of-empty-base-classes-in-vs2015-update-2-3/ to get the Itanium compatible layout.