### PR TITLE
Implement `known_identity`

### DIFF
--- a/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
@@ -485,8 +485,8 @@ private:
         ceil_division(allocated_local_mem_size, alignment) *
         alignment;
 
-    // Dynamic local memory layout, reduction known:   [values...]
-    // Dynamic local memory layout, reduction unknown: [values...][initialized_flags...]
+    // Dynamic local memory layout, identity known:   [values...]
+    // Dynamic local memory layout, identity unknown: [values...][initialized_flags...]
     allocated_local_mem_size = _local_memory_offset +
         work_group_size * (sizeof(value_type) + sizeof_initialized_flag);
   }

--- a/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
@@ -487,7 +487,7 @@ public:
     return hiplike::local_reducer<ReductionDescriptor>{
         _descriptor, my_local_id,
         static_cast<value_type *>(get_local_scratch_mem()), group_output_ptr,
-        global_input_ptr};
+        global_input_ptr, _is_final};
   }
 #endif
   

--- a/include/hipSYCL/glue/generic/hiplike/hiplike_reducer.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/hiplike_reducer.hpp
@@ -218,6 +218,11 @@ public:
     _private_accumulator.combine_with(_desc, _local_accumulator.get_global_input(my_global_id));
 #endif
   }
+
+  __host__ __device__ value_type identity() const {
+    return _desc.identity;
+  }
+
 private:
   const ReductionDescriptor &_desc;
   const int _my_lid;

--- a/include/hipSYCL/glue/generic/hiplike/hiplike_reducer.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/hiplike_reducer.hpp
@@ -28,39 +28,140 @@
 #ifndef HIPSYCL_GLUE_HIPLIKE_REDUCER_HPP
 #define HIPSYCL_GLUE_HIPLIKE_REDUCER_HPP
 
+#include "hipSYCL/glue/generic/reduction_accumulator.hpp"
 #include "hipSYCL/sycl/libkernel/backend.hpp"
 
 namespace hipsycl {
 namespace glue {
 namespace hiplike {
 
+using local_memory_flag = bool;
+
 template<class ReductionDescriptor, class Enable = void>
-class local_reducer;
+class local_reduction_accumulator;
 
 template<class ReductionDescriptor>
-class local_reducer<ReductionDescriptor, std::enable_if_t<ReductionDescriptor::has_identity>> {
+class local_reduction_accumulator<ReductionDescriptor,
+    std::enable_if_t<ReductionDescriptor::has_identity>> {
+public:
+  using value_type = typename ReductionDescriptor::value_type;
+  using private_accumulator_type = sequential_reduction_accumulator<ReductionDescriptor>;
+
+  __host__ __device__ local_reduction_accumulator(value_type *local_memory,
+      value_type *local_output, value_type *global_input)
+      : _local_memory{local_memory}, _local_output{local_output}, _global_input{global_input} {}
+
+  __host__ __device__ void init_value(int my_lid,
+      const private_accumulator_type &private_accumulator) {
+    _local_memory[my_lid] = private_accumulator.value;
+  }
+
+  __host__ __device__ void combine_with(const ReductionDescriptor &desc,
+      int my_lid, int other_lid) {
+    _local_memory[my_lid] = desc.combiner(_local_memory[my_lid], _local_memory[other_lid]);
+  }
+
+  __host__ __device__ void store_intermediate_output() {
+    *_local_output = _local_memory[0];
+  }
+
+  __host__ __device__ void combine_final_output(const ReductionDescriptor &desc) {
+     if (!desc.initialize_to_identity) {
+       *_local_output = desc.combiner(*_local_output, _local_memory[0]);
+     } else {
+       *_local_output = _local_memory[0];
+     }
+  }
+
+  __host__ __device__ private_accumulator_type get_global_input(int my_global_id) {
+    return private_accumulator_type{_global_input[my_global_id]};
+  }
+
+private:
+  value_type *_local_memory;
+  value_type *_local_output;
+  value_type *_global_input;
+};
+
+template<class ReductionDescriptor>
+class local_reduction_accumulator<ReductionDescriptor,
+    std::enable_if_t<!ReductionDescriptor::has_identity>> {
+public:
+  using value_type = typename ReductionDescriptor::value_type;
+  using private_accumulator_type = sequential_reduction_accumulator<ReductionDescriptor>;
+
+  __host__ __device__ local_reduction_accumulator(
+      value_type *local_memory, local_memory_flag *memory_initialized,
+      value_type *local_output, local_memory_flag *output_initialized,
+      value_type *global_input, local_memory_flag *input_initialized)
+    : _local_memory{local_memory}, _memory_initialized{memory_initialized}
+    , _local_output{local_output}, _output_initialized{output_initialized}
+    , _global_input{global_input}, _input_initialized{input_initialized} {}
+
+  __host__ __device__ void init_value(int my_lid,
+      const private_accumulator_type &private_accumulator) {
+    _local_memory[my_lid] = private_accumulator.value;
+    _memory_initialized[my_lid] = private_accumulator.initialized;
+  }
+
+  __host__ __device__ void combine_with(const ReductionDescriptor &desc,
+      int my_lid, int other_lid) {
+    if (!_memory_initialized[other_lid]) return;
+    _local_memory[my_lid] = _memory_initialized[my_lid]
+        ? desc.combiner(_local_memory[my_lid], _local_memory[other_lid])
+        : _local_memory[other_lid];
+    _memory_initialized[my_lid] = true;
+  }
+
+  __host__ __device__ void store_intermediate_output() {
+    *_local_output = _local_memory[0];
+    *_output_initialized = _memory_initialized[0];
+  }
+
+  __host__ __device__ void combine_final_output(const ReductionDescriptor &desc) {
+    if (_memory_initialized[0]) {
+      *_local_output = desc.combiner(*_local_output, _local_memory[0]);
+    }
+  }
+
+  __host__ __device__ private_accumulator_type get_global_input(int my_global_id) {
+    return private_accumulator_type{_global_input[my_global_id], _input_initialized[my_global_id]};
+  }
+
+private:
+  value_type *_local_memory;
+  local_memory_flag *_memory_initialized;
+  value_type *_local_output;
+  local_memory_flag *_output_initialized;
+  value_type *_global_input;
+  local_memory_flag *_input_initialized;
+};
+
+template<class ReductionDescriptor>
+class local_reducer {
 public:
   using value_type = typename ReductionDescriptor::value_type;
   using combiner_type = typename ReductionDescriptor::combiner_type;
+  using private_accumulator_type = sequential_reduction_accumulator<ReductionDescriptor>;
+  using local_accumulator_type = local_reduction_accumulator<ReductionDescriptor>;
 
   __host__ __device__ local_reducer(const ReductionDescriptor &desc, int my_lid,
-                                    value_type *local_memory,
-                                    value_type *local_output,
-                                    value_type *global_input, bool is_final_stage)
-      : _desc{desc}, _my_lid{my_lid}, _my_value{desc.identity},
-        _local_memory{local_memory}, _local_output{local_output},
-        _global_input{global_input}, _is_final_stage{is_final_stage} {}
+                                    const private_accumulator_type &private_accumulator,
+                                    const local_accumulator_type &local_accumulator,
+                                    bool is_final_stage)
+      : _desc{desc}, _my_lid{my_lid},
+        _private_accumulator{private_accumulator}, _local_accumulator{local_accumulator},
+        _is_final_stage{is_final_stage} {}
 
   __host__ __device__
   void combine(const value_type& v) {
-    _my_value = _desc.combiner(_my_value, v);
+    _private_accumulator.combine_with(_desc, v);
   }
 
   __host__ __device__
   void finalize_result() {
-    _local_memory[_my_lid] = _my_value;
-    // TODO Optimize this - may be able to share
-    // code with group algorithms
+    _local_accumulator.init_value(_my_lid, _private_accumulator);
+    // TODO Optimize this - may be able to share code with group algorithms
     // TODO What if local size is not power of two?
 #ifdef SYCL_DEVICE_ONLY
     __syncthreads();
@@ -68,15 +169,14 @@ public:
         __hipsycl_lsize_x * __hipsycl_lsize_y * __hipsycl_lsize_z;
     for (int i = local_size / 2; i > 0; i /= 2) {
       if(_my_lid < i)
-        _local_memory[_my_lid] =
-            _desc.combiner(_local_memory[_my_lid], _local_memory[_my_lid + i]);
+        _local_accumulator.combine_with(_desc, _my_lid, _my_lid + i);
       __syncthreads();
     }
     if (_my_lid == 0) {
-      if (_is_final_stage && !_desc.initialize_to_identity) {
-        *_local_output = _desc.combiner(*_local_output, _local_memory[0]);
+      if (_is_final_stage) {
+        _local_accumulator.combine_final_output(_desc);
       } else {
-        *_local_output = _local_memory[0];
+        _local_accumulator.store_intermediate_output();
       }
     }
 #endif
@@ -84,16 +184,14 @@ public:
 
   __host__ __device__ void combine_global_input(int my_global_id) {
 #ifdef SYCL_DEVICE_ONLY
-    combine(_global_input[my_global_id]);
+    _private_accumulator.combine_with(_desc, _local_accumulator.get_global_input(my_global_id));
 #endif
   }
 private:
   const ReductionDescriptor &_desc;
   const int _my_lid;
-  value_type _my_value;
-  value_type* _local_memory;
-  value_type* _local_output;
-  value_type* _global_input;
+  private_accumulator_type _private_accumulator;
+  local_accumulator_type _local_accumulator;
   bool _is_final_stage;
 };
 

--- a/include/hipSYCL/glue/generic/hiplike/hiplike_reducer.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/hiplike_reducer.hpp
@@ -146,11 +146,10 @@ public:
   using local_accumulator_type = local_reduction_accumulator<ReductionDescriptor>;
 
   __host__ __device__ local_reducer(const ReductionDescriptor &desc, int my_lid,
-                                    const private_accumulator_type &private_accumulator,
                                     const local_accumulator_type &local_accumulator,
                                     bool is_final_stage)
       : _desc{desc}, _my_lid{my_lid},
-        _private_accumulator{private_accumulator}, _local_accumulator{local_accumulator},
+        _private_accumulator{desc}, _local_accumulator{local_accumulator},
         _is_final_stage{is_final_stage} {}
 
   __host__ __device__

--- a/include/hipSYCL/glue/generic/host/sequential_reducer.hpp
+++ b/include/hipSYCL/glue/generic/host/sequential_reducer.hpp
@@ -87,6 +87,10 @@ public:
     *(_desc.get_pointer()) = accumulator.value;
   }
 
+  value_type identity() const {
+    return _desc.identity;
+  }
+
 private:
   ReductionDescriptor &_desc;
   // TODO: new does not necessarily respect over-aligned alignas requirements.

--- a/include/hipSYCL/glue/generic/host/sequential_reducer.hpp
+++ b/include/hipSYCL/glue/generic/host/sequential_reducer.hpp
@@ -54,6 +54,49 @@ template <class T> struct cache_line_aligned {
   alignas(cache_line_size) T value;
 };
 
+template<class ReductionDescriptor, class Enable = void>
+struct reduction_accumulator;
+
+template<class ReductionDescriptor>
+struct alignas(cache_line_size) reduction_accumulator<ReductionDescriptor,
+    std::enable_if_t<ReductionDescriptor::has_identity>> {
+  using value_type = typename ReductionDescriptor::value_type;
+
+  value_type value;
+
+  explicit reduction_accumulator(ReductionDescriptor &desc): value(desc.identity) {}
+
+  void combine_with(ReductionDescriptor &desc, const value_type &v) {
+    value = desc.combiner(value, v);
+  }
+
+  void combine_with(ReductionDescriptor &desc, const reduction_accumulator &v) {
+    value = desc.combiner(value, v.value);
+  }
+};
+
+template<class ReductionDescriptor>
+struct alignas(cache_line_size) reduction_accumulator<ReductionDescriptor,
+    std::enable_if_t<!ReductionDescriptor::has_identity>> {
+  using value_type = typename ReductionDescriptor::value_type;
+
+  value_type value;
+  bool initialized = false;
+
+  explicit reduction_accumulator(ReductionDescriptor &) {}
+
+  void combine_with(ReductionDescriptor &desc, const value_type &v) {
+    value = initialized ? desc.combiner(value, v) : v;
+    initialized = true;
+  }
+
+  void combine_with(ReductionDescriptor &desc, const reduction_accumulator &v) {
+    if (!v.initialized) return;
+    value = initialized ? desc.combiner(value, v.value) : v.value;
+    initialized = true;
+  }
+};
+
 template<class ReductionDescriptor>
 class sequential_reducer {
 public:
@@ -61,35 +104,36 @@ public:
   using combiner_type = typename ReductionDescriptor::combiner_type;
 
   sequential_reducer(int num_threads, ReductionDescriptor &desc)
-      : _desc{desc},
-        _per_thread_results(num_threads,
-                            cache_line_aligned<value_type>{identity()}) {}
-
-  value_type identity() const { return _desc.identity; }
+      : _desc{desc}, _per_thread_results(num_threads, reduction_accumulator<ReductionDescriptor>{desc}) {}
 
   void combine(int my_thread_id, const value_type& v) {
     assert(my_thread_id < _per_thread_results.size());
-    _per_thread_results[my_thread_id].value =
-        _desc.combiner(_per_thread_results[my_thread_id].value, v);
+    _per_thread_results[my_thread_id].combine_with(_desc, v);
   }
 
   // This should be executed in a single threaded scope.
   // Sums up all the partial results and stores in the result data buffer
   void finalize_result() {
-    for (std::size_t i = 1; i < _per_thread_results.size(); ++i) {
-      _per_thread_results[0].value = _desc.combiner(
-          _per_thread_results[0].value, _per_thread_results[i].value);
+    bool initialize_from_dest = true;
+    if constexpr (ReductionDescriptor::has_identity) {
+      initialize_from_dest = !_desc.initialize_to_identity;
     }
-    
-    *(_desc.get_pointer()) = _per_thread_results[0].value;
+    reduction_accumulator<ReductionDescriptor> accumulator(_desc);
+    if (initialize_from_dest) {
+      accumulator.combine_with(_desc, *_desc.get_pointer());
+    }
+    for (std::size_t i = 0; i < _per_thread_results.size(); ++i) {
+      accumulator.combine_with(_desc, _per_thread_results[i]);
+    }
+    *(_desc.get_pointer()) = accumulator.value;
   }
+
 private:
   ReductionDescriptor &_desc;
   // TODO: new does not necessarily respect over-aligned alignas requirements.
   // Depending on the value of std::max_align_t and cache_line_size,
   // alignment may be off and not match cache lines.
-  std::vector<cache_line_aligned<value_type>> _per_thread_results;
-
+  std::vector<reduction_accumulator<ReductionDescriptor>> _per_thread_results;
 };
 
 }

--- a/include/hipSYCL/glue/generic/reduction_accumulator.hpp
+++ b/include/hipSYCL/glue/generic/reduction_accumulator.hpp
@@ -1,0 +1,93 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2021 Aksel Alpay and Contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HIPSYCL_GLUE_REDUCTION_ACCUMULATOR_H
+#define HIPSYCL_GLUE_REDUCTION_ACCUMULATOR_H
+
+#include "hipSYCL/sycl/libkernel/backend.hpp"
+
+namespace hipsycl {
+namespace glue {
+
+template<class ReductionDescriptor, class Enable = void>
+struct sequential_reduction_accumulator;
+
+template<class ReductionDescriptor>
+struct sequential_reduction_accumulator<ReductionDescriptor,
+    std::enable_if_t<ReductionDescriptor::has_identity>> {
+  using value_type = typename ReductionDescriptor::value_type;
+
+  value_type value;
+
+  explicit HIPSYCL_UNIVERSAL_TARGET sequential_reduction_accumulator(
+      const ReductionDescriptor &desc)
+    : value(desc.identity) {}
+
+  explicit HIPSYCL_UNIVERSAL_TARGET sequential_reduction_accumulator(value_type value)
+    : value{value} {}
+
+  HIPSYCL_UNIVERSAL_TARGET void combine_with(const ReductionDescriptor &desc, const value_type &v) {
+    value = desc.combiner(value, v);
+  }
+
+  HIPSYCL_UNIVERSAL_TARGET void combine_with(const ReductionDescriptor &desc,
+      const sequential_reduction_accumulator &v) {
+    value = desc.combiner(value, v.value);
+  }
+};
+
+template<class ReductionDescriptor>
+struct sequential_reduction_accumulator<ReductionDescriptor,
+    std::enable_if_t<!ReductionDescriptor::has_identity>> {
+  using value_type = typename ReductionDescriptor::value_type;
+
+  value_type value;
+  bool initialized = false;
+
+  explicit HIPSYCL_UNIVERSAL_TARGET sequential_reduction_accumulator(const ReductionDescriptor &) {}
+
+  explicit HIPSYCL_UNIVERSAL_TARGET sequential_reduction_accumulator(value_type value,
+      bool initialized)
+    : value{value}, initialized{initialized} {}
+
+  HIPSYCL_UNIVERSAL_TARGET void combine_with(const ReductionDescriptor &desc, const value_type &v) {
+    value = initialized ? desc.combiner(value, v) : v;
+    initialized = true;
+  }
+
+  HIPSYCL_UNIVERSAL_TARGET void combine_with(const ReductionDescriptor &desc,
+      const sequential_reduction_accumulator &v) {
+    if (!v.initialized) return;
+    value = initialized ? desc.combiner(value, v.value) : v.value;
+    initialized = true;
+  }
+};
+
+}
+}
+
+#endif

--- a/include/hipSYCL/glue/generic/reduction_accumulator.hpp
+++ b/include/hipSYCL/glue/generic/reduction_accumulator.hpp
@@ -33,9 +33,12 @@
 namespace hipsycl {
 namespace glue {
 
+// Common interface for accumulating values in a reduction variable, for both the known-identity and the
+// unknown-identity cases.
 template<class ReductionDescriptor, class Enable = void>
 struct sequential_reduction_accumulator;
 
+// In the common case, the accumulator is initialized to the known identity.
 template<class ReductionDescriptor>
 struct sequential_reduction_accumulator<ReductionDescriptor,
     std::enable_if_t<ReductionDescriptor::has_identity>> {
@@ -60,6 +63,8 @@ struct sequential_reduction_accumulator<ReductionDescriptor,
   }
 };
 
+// When the identity is unknown, the accumulator is effectively a std::optional, remembering whether at least one
+// value has been combine()d.
 template<class ReductionDescriptor>
 struct sequential_reduction_accumulator<ReductionDescriptor,
     std::enable_if_t<!ReductionDescriptor::has_identity>> {

--- a/include/hipSYCL/sycl/libkernel/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/builtins.hpp
@@ -387,28 +387,28 @@ using ulonglong16 = vec<unsigned long long, 16>;
   HIPSYCL_BUILTIN_OVERLOAD_SET_INTN(handler, name, builtin_impl_name) \
   HIPSYCL_BUILTIN_OVERLOAD_SET_UINTN(handler, name, builtin_impl_name) 
 
-#define HIPSYCL_BUILTIN_GENERATOR_TRINARY_T_T_T(T, name, impl_name)            \
-  HIPSYCL_BUILTIN T name(T a, T b, T c) noexcept {                             \
-    if constexpr (std::is_arithmetic_v<T>) {                                   \
-      return impl_name(detail::data_element(a, 0), detail::data_element(b, 0), \
-                       detail::data_element(c, 0));                            \
-    } else {                                                                   \
-      T result;                                                                \
-      for (int i = 0; i < detail::builtin_type_traits<T>::num_elements; ++i) { \
-        auto a_i = detail::data_element(a, i);                                 \
-        auto b_i = detail::data_element(b, i);                                 \
-        auto c_i = detail::data_element(c, i);                                 \
-        detail::data_element(result, i) = impl_name(a_i, b_i, c_i);            \
-      }                                                                        \
-      return result;                                                           \
-    }                                                                          \
+#define HIPSYCL_BUILTIN_GENERATOR_TRINARY_T_T_T(T, name, impl_name)                           \
+  HIPSYCL_BUILTIN T name(T a, T b, T c) noexcept {                                            \
+    if constexpr (std::is_arithmetic_v<T>) {                                                  \
+      return static_cast<T>(impl_name(detail::data_element(a, 0), detail::data_element(b, 0), \
+                            detail::data_element(c, 0)));                                     \
+    } else {                                                                                  \
+      T result;                                                                               \
+      for (int i = 0; i < detail::builtin_type_traits<T>::num_elements; ++i) {                \
+        auto a_i = detail::data_element(a, i);                                                \
+        auto b_i = detail::data_element(b, i);                                                \
+        auto c_i = detail::data_element(c, i);                                                \
+        detail::data_element(result, i) = impl_name(a_i, b_i, c_i);                           \
+      }                                                                                       \
+      return result;                                                                          \
+    }                                                                                         \
   }
 
 #define HIPSYCL_BUILTIN_GENERATOR_BINARY_T_T(T, name, impl_name)               \
   HIPSYCL_BUILTIN T name(T a, T b) noexcept {                                  \
     if constexpr (std::is_arithmetic_v<T>) {                                   \
-      return impl_name(detail::data_element(a, 0),                             \
-                       detail::data_element(b, 0));                            \
+      return static_cast<T>(impl_name(detail::data_element(a, 0),              \
+                       detail::data_element(b, 0)));                           \
     } else {                                                                   \
       T result;                                                                \
       for (int i = 0; i < detail::builtin_type_traits<T>::num_elements; ++i) { \
@@ -424,7 +424,7 @@ using ulonglong16 = vec<unsigned long long, 16>;
   template <access::address_space A>                                           \
   HIPSYCL_BUILTIN T name(T a, const multi_ptr<T, A> &b) noexcept {             \
     if constexpr (std::is_arithmetic_v<T>) {                                   \
-      return impl_name(detail::data_element(a, 0), b.get());                   \
+      return static_cast<T>(impl_name(detail::data_element(a, 0), b.get()));   \
     } else {                                                                   \
       T result;                                                                \
       for (int i = 0; i < detail::builtin_type_traits<T>::num_elements; ++i) { \
@@ -442,8 +442,8 @@ using ulonglong16 = vec<unsigned long long, 16>;
                              int> = 0>                                         \
   HIPSYCL_BUILTIN T name(T a, IntType b) noexcept {                            \
     if constexpr (std::is_arithmetic_v<T>) {                                   \
-      return impl_name(detail::data_element(a, 0),                             \
-                       detail::data_element(b, 0));                            \
+      return static_cast<T>(impl_name(detail::data_element(a, 0),              \
+                       detail::data_element(b, 0)));                           \
     } else {                                                                   \
       T result;                                                                \
       for (int i = 0; i < detail::builtin_type_traits<T>::num_elements; ++i) { \
@@ -461,7 +461,7 @@ using ulonglong16 = vec<unsigned long long, 16>;
                              int> = 0>                                         \
   HIPSYCL_BUILTIN T name(T a, const multi_ptr<IntType, A> &b) noexcept {       \
     if constexpr (std::is_arithmetic_v<T>) {                                   \
-      return impl_name(detail::data_element(a, 0), b.get());                   \
+      return static_cast<T>(impl_name(detail::data_element(a, 0), b.get()));   \
     } else {                                                                   \
       T result;                                                                \
       for (int i = 0; i < detail::builtin_type_traits<T>::num_elements; ++i) { \
@@ -476,7 +476,7 @@ using ulonglong16 = vec<unsigned long long, 16>;
 #define HIPSYCL_BUILTIN_GENERATOR_UNARY_T(T, name, impl_name)                  \
   HIPSYCL_BUILTIN T name(T a) noexcept {                                       \
     if constexpr (std::is_arithmetic_v<T>) {                                   \
-      return impl_name(detail::data_element(a, 0));                            \
+      return static_cast<T>(impl_name(detail::data_element(a, 0)));            \
     } else {                                                                   \
       T result;                                                                \
       for (int i = 0; i < detail::builtin_type_traits<T>::num_elements; ++i) { \
@@ -487,21 +487,22 @@ using ulonglong16 = vec<unsigned long long, 16>;
     }                                                                          \
   }
 
-#define HIPSYCL_BUILTIN_GENERATOR_UNARY_T_RET_INT(T, name, impl_name)          \
-  HIPSYCL_BUILTIN                                                              \
-  typename detail::builtin_type_traits<T>::alternative_data_type<int> name(    \
-      T a) noexcept {                                                          \
-    if constexpr (std::is_arithmetic_v<T>) {                                   \
-      return impl_name(detail::data_element(a, 0));                            \
-    } else {                                                                   \
-      typename detail::builtin_type_traits<T>::alternative_data_type<int>      \
-          result;                                                              \
-      for (int i = 0; i < detail::builtin_type_traits<T>::num_elements; ++i) { \
-        auto a_i = detail::data_element(a, i);                                 \
-        detail::data_element(result, i) = impl_name(a_i);                      \
-      }                                                                        \
-      return result;                                                           \
-    }                                                                          \
+#define HIPSYCL_BUILTIN_GENERATOR_UNARY_T_RET_INT(T, name, impl_name)                 \
+  HIPSYCL_BUILTIN                                                                     \
+  typename detail::builtin_type_traits<T>::alternative_data_type<int> name(           \
+      T a) noexcept {                                                                 \
+    if constexpr (std::is_arithmetic_v<T>) {                                          \
+      return static_cast<detail::builtin_type_traits<T>::alternative_data_type<int>>( \
+                      static_cast<int>(impl_name(detail::data_element(a, 0))));       \
+    } else {                                                                          \
+      typename detail::builtin_type_traits<T>::alternative_data_type<int>             \
+          result;                                                                     \
+      for (int i = 0; i < detail::builtin_type_traits<T>::num_elements; ++i) {        \
+        auto a_i = detail::data_element(a, i);                                        \
+        detail::data_element(result, i) = static_cast<int>(impl_name(a_i));           \
+      }                                                                               \
+      return result;                                                                  \
+    }                                                                                 \
   }
 
 #define HIPSYCL_DEFINE_BUILTIN(builtin_name, OVERLOAD_SET_GENERATOR,           \

--- a/include/hipSYCL/sycl/libkernel/detail/local_memory_allocator.hpp
+++ b/include/hipSYCL/sycl/libkernel/detail/local_memory_allocator.hpp
@@ -168,9 +168,8 @@ private:
 #pragma omp threadprivate(_origin)
 };
 
-HIPSYCL_KERNEL_TARGET
-inline void* hiplike_dynamic_local_memory() {
-#ifdef SYCL_DEVICE_ONLY
+#if defined(HIPSYCL_PLATFORM_HIP) || defined(HIPSYCL_PLATFORM_CUDA)
+__device__ inline void* hiplike_dynamic_local_memory() {
   #ifdef HIPSYCL_PLATFORM_CUDA
     extern __shared__ int local_mem [];
     return static_cast<void*>(local_mem);
@@ -178,11 +177,8 @@ inline void* hiplike_dynamic_local_memory() {
   #ifdef HIPSYCL_PLATFORM_ROCM
     return __amdgcn_get_dynamicgroupbaseptr();
   #endif
-#else
-  assert(false && "this function should only be called on device");
-  return nullptr;
-#endif
 }
+#endif
 
 class local_memory
 {

--- a/include/hipSYCL/sycl/libkernel/functional.hpp
+++ b/include/hipSYCL/sycl/libkernel/functional.hpp
@@ -79,6 +79,39 @@ template <typename T> struct maximum {
   T operator()(const T &x, const T &y) const { return (x > y) ? x : y; }
 };
 
+
+template<typename BinaryOperation, typename AccumulatorT>
+struct known_identity;
+
+template <typename BinaryOperation, typename AccumulatorT>
+inline constexpr AccumulatorT known_identity_v = known_identity<BinaryOperation, AccumulatorT>::value;
+
+template<typename BinaryOperation, typename AccumulatorT>
+struct has_known_identity {
+    static constexpr bool value = false;
+};
+
+template <typename BinaryOperation, typename AccumulatorT>
+inline constexpr bool has_known_identity_v = has_known_identity<BinaryOperation, AccumulatorT>::value;
+
+#define HIPSYCL_DEFINE_IDENTITY(op, identity) \
+    template<typename T> \
+    struct known_identity<op<T>, T> { \
+        inline static constexpr T value = (identity); \
+    }; \
+    template<typename T> \
+    struct has_known_identity<op<T>, T> { \
+        static constexpr bool value = true; \
+    };
+
+HIPSYCL_DEFINE_IDENTITY(plus, 0);
+HIPSYCL_DEFINE_IDENTITY(multiplies, 1);
+HIPSYCL_DEFINE_IDENTITY(bit_or, T{});
+HIPSYCL_DEFINE_IDENTITY(bit_and, ~T{});
+HIPSYCL_DEFINE_IDENTITY(bit_xor, T{});
+HIPSYCL_DEFINE_IDENTITY(logical_or, T{0});
+HIPSYCL_DEFINE_IDENTITY(logical_and, ~T{});
+
 } // namespace sycl
 }
 

--- a/include/hipSYCL/sycl/libkernel/functional.hpp
+++ b/include/hipSYCL/sycl/libkernel/functional.hpp
@@ -99,6 +99,19 @@ struct known_identity_trait {
         inline static constexpr acc known_identity = (identity); \
     };
 
+template<typename T, typename Enable=void>
+struct minmax_identity {
+    inline static constexpr T max_id = std::numeric_limits<T>::lowest();
+    inline static constexpr T min_id = std::numeric_limits<T>::max();
+};
+
+template<typename T>
+struct minmax_identity<T, std::enable_if_t<std::numeric_limits<T>::has_infinity>> {
+    inline static constexpr T max_id = -std::numeric_limits<T>::infinity();
+    inline static constexpr T min_id = std::numeric_limits<T>::infinity();
+};
+
+// TODO is_arithmetic implicitly covers the current pseudo half = ushort type, resolve once half is implemented
 HIPSYCL_DEFINE_IDENTITY(plus, typename T, T, T{0}, std::enable_if_t<std::is_arithmetic_v<T>>)
 HIPSYCL_DEFINE_IDENTITY(multiplies, typename T, T, T{1}, std::enable_if_t<std::is_arithmetic_v<T>>)
 HIPSYCL_DEFINE_IDENTITY(bit_or, typename T, T, T{}, std::enable_if_t<std::is_integral_v<T>>)
@@ -106,6 +119,8 @@ HIPSYCL_DEFINE_IDENTITY(bit_and, typename T, T, ~T{}, std::enable_if_t<std::is_i
 HIPSYCL_DEFINE_IDENTITY(bit_xor, typename T, T, T{}, std::enable_if_t<std::is_integral_v<T>>)
 HIPSYCL_DEFINE_IDENTITY(logical_or, , bool, false, void)
 HIPSYCL_DEFINE_IDENTITY(logical_and, , bool, true, void)
+HIPSYCL_DEFINE_IDENTITY(minimum, typename T, T, minmax_identity<T>::min_id, std::enable_if_t<std::is_arithmetic_v<T>>);
+HIPSYCL_DEFINE_IDENTITY(maximum, typename T, T, minmax_identity<T>::max_id, std::enable_if_t<std::is_arithmetic_v<T>>);
 
 #undef HIPSYCL_DEFINE_IDENTITY
 

--- a/include/hipSYCL/sycl/libkernel/functional.hpp
+++ b/include/hipSYCL/sycl/libkernel/functional.hpp
@@ -73,14 +73,14 @@ template <typename T = void> struct bit_or {
 };
 
 template <> struct bit_or<void> {
-    template<typename T>
-    HIPSYCL_KERNEL_TARGET
-    T operator()(const T &x, const T &y) const { return x | y; }
+  template<typename T>
+  HIPSYCL_KERNEL_TARGET
+  T operator()(const T &x, const T &y) const { return x | y; }
 };
 
 template <typename T = void> struct bit_xor {
-    HIPSYCL_KERNEL_TARGET
-    T operator()(const T &x, const T &y) const { return x ^ y; }
+  HIPSYCL_KERNEL_TARGET
+  T operator()(const T &x, const T &y) const { return x ^ y; }
 };
 
 template <> struct bit_xor<void> {
@@ -117,14 +117,14 @@ template <typename T = void> struct minimum {
 };
 
 template <> struct minimum<void> {
-    template<typename T>
-    HIPSYCL_KERNEL_TARGET
-    T operator()(const T &x, const T &y) const { return (x < y) ? x : y; }
+  template<typename T>
+  HIPSYCL_KERNEL_TARGET
+  T operator()(const T &x, const T &y) const { return (x < y) ? x : y; }
 };
 
 template <typename T = void> struct maximum {
-    HIPSYCL_KERNEL_TARGET
-    T operator()(const T &x, const T &y) const { return (x > y) ? x : y; }
+  HIPSYCL_KERNEL_TARGET
+  T operator()(const T &x, const T &y) const { return (x > y) ? x : y; }
 };
 
 template <> struct maximum<void> {
@@ -138,32 +138,37 @@ namespace detail {
 
 template<typename BinaryOperation, typename AccumulatorT, typename Enable = void>
 struct known_identity_trait {
-    static constexpr bool has_known_identity = false; \
+  static constexpr bool has_known_identity = false; \
+};
+
+template<typename T, typename Enable=void>
+struct minmax_identity {
+  inline static constexpr T max_id = std::numeric_limits<T>::lowest();
+  inline static constexpr T min_id = std::numeric_limits<T>::max();
+};
+
+template<typename T>
+struct minmax_identity<T, std::enable_if_t<std::numeric_limits<T>::has_infinity>> {
+  inline static constexpr T max_id = -std::numeric_limits<T>::infinity();
+  inline static constexpr T min_id = std::numeric_limits<T>::infinity();
 };
 
 #define HIPSYCL_DEFINE_IDENTITY(op, cond, identity) \
     template<typename T, typename U> \
     struct known_identity_trait<op<T>, U, std::enable_if_t<cond>> { \
-        static constexpr bool has_known_identity = true; \
-        inline static constexpr T known_identity = (identity); \
+        inline static constexpr bool has_known_identity = true; \
+        inline static constexpr std::remove_cv_t<T> known_identity = (identity); \
     }; \
     template<typename T> \
     struct known_identity_trait<op<void>, T, std::enable_if_t<cond>> { \
         inline static constexpr bool has_known_identity = true; \
-        inline static constexpr T known_identity = (identity); \
+        inline static constexpr std::remove_cv_t<T> known_identity = (identity); \
     }
 
-template<typename T, typename Enable=void>
-struct minmax_identity {
-    inline static constexpr T max_id = std::numeric_limits<T>::lowest();
-    inline static constexpr T min_id = std::numeric_limits<T>::max();
-};
-
-template<typename T>
-struct minmax_identity<T, std::enable_if_t<std::numeric_limits<T>::has_infinity>> {
-    inline static constexpr T max_id = -std::numeric_limits<T>::infinity();
-    inline static constexpr T min_id = std::numeric_limits<T>::infinity();
-};
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wbool-operation"  // allow ~bool, bool & bool
+#endif
 
 // TODO is_arithmetic implicitly covers the current pseudo half = ushort type, resolve once half is implemented
 HIPSYCL_DEFINE_IDENTITY(plus, std::is_arithmetic_v<T>, T{});
@@ -171,10 +176,14 @@ HIPSYCL_DEFINE_IDENTITY(multiplies, std::is_arithmetic_v<T>, T{1});
 HIPSYCL_DEFINE_IDENTITY(bit_or, std::is_integral_v<T>, T{});
 HIPSYCL_DEFINE_IDENTITY(bit_and, std::is_integral_v<T>, ~T{});
 HIPSYCL_DEFINE_IDENTITY(bit_xor, std::is_integral_v<T>, T{});
-HIPSYCL_DEFINE_IDENTITY(logical_or, (std::is_same_v<T, bool>), false);
-HIPSYCL_DEFINE_IDENTITY(logical_and, (std::is_same_v<T, bool>), true);
-HIPSYCL_DEFINE_IDENTITY(minimum, std::is_arithmetic_v<T>, minmax_identity<T>::min_id);
-HIPSYCL_DEFINE_IDENTITY(maximum, std::is_arithmetic_v<T>, minmax_identity<T>::max_id);
+HIPSYCL_DEFINE_IDENTITY(logical_or, (std::is_same_v<std::remove_cv_t<T>, bool>), false);
+HIPSYCL_DEFINE_IDENTITY(logical_and, (std::is_same_v<std::remove_cv_t<T>, bool>), true);
+HIPSYCL_DEFINE_IDENTITY(minimum, std::is_arithmetic_v<T>, minmax_identity<std::remove_cv_t<T>>::min_id);
+HIPSYCL_DEFINE_IDENTITY(maximum, std::is_arithmetic_v<T>, minmax_identity<std::remove_cv_t<T>>::max_id);
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 #undef HIPSYCL_DEFINE_IDENTITY
 
@@ -182,8 +191,8 @@ HIPSYCL_DEFINE_IDENTITY(maximum, std::is_arithmetic_v<T>, minmax_identity<T>::ma
 
 template<typename BinaryOperation, typename AccumulatorT>
 struct known_identity {
-    static constexpr AccumulatorT value = detail::known_identity_trait<
-        BinaryOperation, AccumulatorT>::known_identity;
+  static constexpr AccumulatorT value = detail::known_identity_trait<
+      BinaryOperation, AccumulatorT>::known_identity;
 };
 
 template <typename BinaryOperation, typename AccumulatorT>
@@ -191,8 +200,8 @@ inline constexpr AccumulatorT known_identity_v = known_identity<BinaryOperation,
 
 template<typename BinaryOperation, typename AccumulatorT>
 struct has_known_identity {
-    static constexpr bool value = detail::known_identity_trait<
-        BinaryOperation, AccumulatorT>::has_known_identity;
+  static constexpr bool value = detail::known_identity_trait<
+      BinaryOperation, AccumulatorT>::has_known_identity;
 };
 
 template <typename BinaryOperation, typename AccumulatorT>

--- a/include/hipSYCL/sycl/libkernel/functional.hpp
+++ b/include/hipSYCL/sycl/libkernel/functional.hpp
@@ -156,13 +156,13 @@ struct minmax_identity<T, std::enable_if_t<std::numeric_limits<T>::has_infinity>
 #define HIPSYCL_DEFINE_IDENTITY(op, cond, identity) \
     template<typename T, typename U> \
     struct known_identity_trait<op<T>, U, std::enable_if_t<cond>> { \
-        inline static constexpr bool has_known_identity = true; \
-        inline static constexpr std::remove_cv_t<T> known_identity = (identity); \
+      inline static constexpr bool has_known_identity = true; \
+      inline static constexpr std::remove_cv_t<T> known_identity = (identity); \
     }; \
     template<typename T> \
     struct known_identity_trait<op<void>, T, std::enable_if_t<cond>> { \
-        inline static constexpr bool has_known_identity = true; \
-        inline static constexpr std::remove_cv_t<T> known_identity = (identity); \
+      inline static constexpr bool has_known_identity = true; \
+      inline static constexpr std::remove_cv_t<T> known_identity = (identity); \
     }
 
 #ifdef __GNUC__

--- a/include/hipSYCL/sycl/libkernel/functional.hpp
+++ b/include/hipSYCL/sycl/libkernel/functional.hpp
@@ -30,6 +30,7 @@
 #define HIPSYCL_SYCL_FUNCTIONAL_HPP
 
 #include "backend.hpp"
+#include "vec.hpp"
 
 namespace hipsycl {
 namespace sycl {
@@ -135,6 +136,20 @@ template <> struct maximum<void> {
 
 
 namespace detail {
+// simple construct to get type of elements in vector
+// detail::builtin_type_traits does not work for void and can not directly be used here.
+template<class T>
+struct element_type {
+  using type = T;
+};
+
+template<class T, int Dim>
+struct element_type<vec<T, Dim>> {
+  using type = T;
+};
+
+template<typename T>
+using element_type_t = typename element_type<T>::type;
 
 template<typename BinaryOperation, typename AccumulatorT, typename Enable = void>
 struct known_identity_trait {
@@ -143,14 +158,14 @@ struct known_identity_trait {
 
 template<typename T, typename Enable=void>
 struct minmax_identity {
-  inline static constexpr T max_id = std::numeric_limits<T>::lowest();
-  inline static constexpr T min_id = std::numeric_limits<T>::max();
+  inline static constexpr T max_id = static_cast<T>(std::numeric_limits<T>::lowest());
+  inline static constexpr T min_id = static_cast<T>(std::numeric_limits<T>::max());
 };
 
 template<typename T>
 struct minmax_identity<T, std::enable_if_t<std::numeric_limits<T>::has_infinity>> {
-  inline static constexpr T max_id = -std::numeric_limits<T>::infinity();
-  inline static constexpr T min_id = std::numeric_limits<T>::infinity();
+  inline static constexpr T max_id = static_cast<T>(-std::numeric_limits<T>::infinity());
+  inline static constexpr T min_id = static_cast<T>(std::numeric_limits<T>::infinity());
 };
 
 #define HIPSYCL_DEFINE_IDENTITY(op, cond, identity) \
@@ -171,15 +186,15 @@ struct minmax_identity<T, std::enable_if_t<std::numeric_limits<T>::has_infinity>
 #endif
 
 // TODO is_arithmetic implicitly covers the current pseudo half = ushort type, resolve once half is implemented
-HIPSYCL_DEFINE_IDENTITY(plus, std::is_arithmetic_v<T>, T{});
-HIPSYCL_DEFINE_IDENTITY(multiplies, std::is_arithmetic_v<T>, T{1});
-HIPSYCL_DEFINE_IDENTITY(bit_or, std::is_integral_v<T>, T{});
-HIPSYCL_DEFINE_IDENTITY(bit_and, std::is_integral_v<T>, ~T{});
-HIPSYCL_DEFINE_IDENTITY(bit_xor, std::is_integral_v<T>, T{});
-HIPSYCL_DEFINE_IDENTITY(logical_or, (std::is_same_v<std::remove_cv_t<T>, bool>), false);
-HIPSYCL_DEFINE_IDENTITY(logical_and, (std::is_same_v<std::remove_cv_t<T>, bool>), true);
-HIPSYCL_DEFINE_IDENTITY(minimum, std::is_arithmetic_v<T>, minmax_identity<std::remove_cv_t<T>>::min_id);
-HIPSYCL_DEFINE_IDENTITY(maximum, std::is_arithmetic_v<T>, minmax_identity<std::remove_cv_t<T>>::max_id);
+HIPSYCL_DEFINE_IDENTITY(plus, std::is_arithmetic_v<element_type_t<T>>, T{});
+HIPSYCL_DEFINE_IDENTITY(multiplies, std::is_arithmetic_v<element_type_t<T>>, T{static_cast<element_type_t<T>>(1)});
+HIPSYCL_DEFINE_IDENTITY(bit_or, std::is_integral_v<element_type_t<T>>, T{});
+HIPSYCL_DEFINE_IDENTITY(bit_and, std::is_integral_v<element_type_t<T>>, T{static_cast<element_type_t<T>>(~element_type_t<T>{})});
+HIPSYCL_DEFINE_IDENTITY(bit_xor, std::is_integral_v<element_type_t<T>>, T{});
+HIPSYCL_DEFINE_IDENTITY(logical_or, (std::is_same_v<element_type_t<std::remove_cv_t<T>>, bool>), T{false});
+HIPSYCL_DEFINE_IDENTITY(logical_and, (std::is_same_v<element_type_t<std::remove_cv_t<T>>, bool>), T{true});
+HIPSYCL_DEFINE_IDENTITY(minimum, std::is_arithmetic_v<element_type_t<T>>, T{minmax_identity<element_type_t<std::remove_cv_t<T>>>::min_id});
+HIPSYCL_DEFINE_IDENTITY(maximum, std::is_arithmetic_v<element_type_t<T>>, T{minmax_identity<element_type_t<std::remove_cv_t<T>>>::max_id});
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop

--- a/include/hipSYCL/sycl/libkernel/reduction.hpp
+++ b/include/hipSYCL/sycl/libkernel/reduction.hpp
@@ -264,6 +264,19 @@ auto reduction(BufferT vars, handler &cgh, const typename BufferT::value_type &i
       initialize_to_identity};
 }
 
+template <typename AccessorT, typename BinaryOperation>
+[[deprecated("Use the sycl::reduction() overload taking a buffer instead")]]
+auto reduction(AccessorT vars, BinaryOperation combiner) {
+  auto identity = typename AccessorT::value_type{};
+  return detail::accessor_reduction_descriptor{vars, identity, combiner, true /* initialize_to_identity */};
+}
+
+template <typename AccessorT, typename BinaryOperation>
+[[deprecated("Use the sycl::reduction() overload taking a buffer instead")]]
+auto reduction(AccessorT vars, const typename AccessorT::value_type &identity, BinaryOperation combiner) {
+  return detail::accessor_reduction_descriptor{vars, identity, combiner, true /* initialize_to_identity */};
+}
+
 template <typename T, typename BinaryOperation>
 auto reduction(T *var, BinaryOperation combiner, property_list prop_list = {}) {
   bool initialize_to_identity = prop_list.has_property<property::reduction::initialize_to_identity>();

--- a/include/hipSYCL/sycl/libkernel/reduction.hpp
+++ b/include/hipSYCL/sycl/libkernel/reduction.hpp
@@ -185,7 +185,7 @@ private:
 
 #define HIPSYCL_ENABLE_REDUCER_OP_IF_TYPE(T)                                   \
   class Op = typename reducer<BackendReducerImpl>::combiner_type,              \
-  std::enable_if_t<std::is_same_v<                                             \
+  std::enable_if_t<std::is_same_v<Op, T<void>> || std::is_same_v<              \
             Op, T<typename reducer<BackendReducerImpl>::value_type>>> * =      \
             nullptr
 

--- a/include/hipSYCL/sycl/libkernel/reduction.hpp
+++ b/include/hipSYCL/sycl/libkernel/reduction.hpp
@@ -43,30 +43,30 @@ struct reduction_descriptor_base;
 
 template<typename T, typename BinaryOperation>
 struct reduction_descriptor_base<T, BinaryOperation, false> {
-    using value_type = T;
-    using combiner_type = BinaryOperation;
+  using value_type = T;
+  using combiner_type = BinaryOperation;
 
-    constexpr static bool has_identity = false;
+  constexpr static bool has_identity = false;
 
-    BinaryOperation combiner;
+  BinaryOperation combiner;
 
-    explicit reduction_descriptor_base(BinaryOperation combiner)
-        : combiner(combiner) {}
+  explicit reduction_descriptor_base(BinaryOperation combiner)
+      : combiner(combiner) {}
 };
 
 template<typename T, typename BinaryOperation>
 struct reduction_descriptor_base<T, BinaryOperation, true> {
-    using value_type = T;
-    using combiner_type = BinaryOperation;
+  using value_type = T;
+  using combiner_type = BinaryOperation;
 
-    constexpr static bool has_identity = true;
+  constexpr static bool has_identity = true;
 
-    BinaryOperation combiner;
-    T identity;
-    bool initialize_to_identity;
+  BinaryOperation combiner;
+  T identity;
+  bool initialize_to_identity;
 
-    explicit reduction_descriptor_base(BinaryOperation combiner, T identity, bool initialize_to_identity)
-        : combiner(combiner), identity(identity), initialize_to_identity(initialize_to_identity) {}
+  explicit reduction_descriptor_base(BinaryOperation combiner, T identity, bool initialize_to_identity)
+      : combiner(combiner), identity(identity), initialize_to_identity(initialize_to_identity) {}
 };
 
 template <class T, typename BinaryOperation, bool KnownIdentity>

--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -49,10 +49,10 @@ public:
   using value_type = T;
 
   HIPSYCL_UNIVERSAL_TARGET
-  T& operator[](int i) { return _storage[i]; }
+  constexpr T& operator[](int i) { return _storage[i]; }
 
   HIPSYCL_UNIVERSAL_TARGET
-  const T& operator[](int i) const { return _storage[i]; }
+  constexpr const T& operator[](int i) const { return _storage[i]; }
 
   template<int Index>
   HIPSYCL_UNIVERSAL_TARGET
@@ -86,7 +86,7 @@ public:
   }
 
 private:
-  alignas(alignment) T _storage [effective_size];
+  alignas(alignment) T _storage [effective_size] = {0};
 };
 
 // An alternative implementation of the vec_storage concept
@@ -182,6 +182,17 @@ template <class Vector_type, class Function>
 HIPSYCL_UNIVERSAL_TARGET
 void for_each_vector_element(const Vector_type& v, Function&& f);
 
+template <typename Arg, typename T>
+HIPSYCL_UNIVERSAL_TARGET
+constexpr int external_count_num_elements() {
+  if constexpr(std::is_scalar_v<Arg>)
+    return 1;
+  else if(std::is_same_v<typename Arg::element_type, T>)
+    return Arg::get_count();
+  // ToDo: Trigger error
+  return 0;
+}
+
 }
 
 enum class rounding_mode {
@@ -260,7 +271,7 @@ public:
             std::enable_if_t<std::is_same_v<S, detail::vec_storage<T, N>>,
                              bool> = true>
   HIPSYCL_UNIVERSAL_TARGET
-  vec() {
+  constexpr vec() {
     for(int i = 0; i < N; ++i)
       _data[i] = T{};
   }
@@ -268,7 +279,7 @@ public:
   template <class S = VectorStorage,
             std::enable_if_t<std::is_same_v<S, detail::vec_storage<T, N>>,
                              bool> = true>
-  HIPSYCL_UNIVERSAL_TARGET explicit vec(const T &value) {
+  HIPSYCL_UNIVERSAL_TARGET explicit constexpr vec(const T &value) {
     for(int i = 0; i < N; ++i)
       _data[i] = value;
   }
@@ -276,8 +287,8 @@ public:
   template <typename... Args, class S = VectorStorage,
             std::enable_if_t<std::is_same_v<S, detail::vec_storage<T, N>>,
                              bool> = true>
-  HIPSYCL_UNIVERSAL_TARGET vec(const Args &...args) {
-    static_assert((count_num_elements<Args>() + ...) == N,
+  HIPSYCL_UNIVERSAL_TARGET constexpr vec(const Args &...args) {
+    static_assert((detail::external_count_num_elements<Args, T>() + ...) == N,
                   "Argument mismatch with vector size");
 
     int current_init_index = 0;
@@ -287,7 +298,7 @@ public:
   template <class OtherStorage, class S = VectorStorage,
             std::enable_if_t<std::is_same_v<S, detail::vec_storage<T, N>>,
                              bool> = true>
-  HIPSYCL_UNIVERSAL_TARGET vec(const vec<T, N, OtherStorage> &other)
+  HIPSYCL_UNIVERSAL_TARGET constexpr vec(const vec<T, N, OtherStorage> &other)
   {
     for(int i = 0; i < N; ++i)
       _data[i] = other[i];
@@ -858,13 +869,13 @@ private:
 
   template<typename Arg>
   HIPSYCL_UNIVERSAL_TARGET
-  void partial_initialization(int& current_init_index, const Arg& x) {
+  constexpr void partial_initialization(int& current_init_index, const Arg& x) {
     if constexpr(std::is_scalar_v<Arg>) {
       _data[current_init_index] = x;
       ++current_init_index;
     } else {
       // Assume we are dealing with another vector
-      constexpr int count = count_num_elements<Arg>();
+      constexpr int count = detail::external_count_num_elements<Arg, T>();
       
       for(int i = 0; i < count; ++i) {
         _data[i + current_init_index] = x[i];

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ add_executable(sycl_tests
   sycl/explicit_copy.cpp
   sycl/extensions.cpp
   sycl/fill.cpp
+  sycl/functional.cpp
   sycl/group_functions/group_functions_misc.cpp
   sycl/group_functions/group_functions_binary_reduce.cpp
   sycl/group_functions/group_functions_reduce.cpp

--- a/tests/sycl/functional.cpp
+++ b/tests/sycl/functional.cpp
@@ -1,0 +1,98 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018, 2019 Aksel Alpay and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sycl_test_suite.hpp"
+
+namespace s = cl::sycl;
+
+BOOST_FIXTURE_TEST_SUITE(functional_tests, reset_device_fixture)
+
+// list of types classified as "genfloat" in the SYCL standard
+using known_identity_types = boost::mpl::list<float, double, char, signed char, unsigned char,
+    int, long, unsigned int, unsigned long, bool>;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(known_identities, T, known_identity_types::type) {
+  static_assert(s::has_known_identity_v<s::minimum<T>, T>);
+  static_assert(s::has_known_identity_v<s::minimum<>, T>);
+  static_assert(s::has_known_identity_v<s::maximum<T>, T>);
+  static_assert(s::has_known_identity_v<s::maximum<>, T>);
+
+  BOOST_TEST((s::known_identity_v<s::plus<T>, T>) == T{0});
+  BOOST_TEST((s::known_identity_v<s::plus<>, T>) == T{0});
+  BOOST_TEST((s::known_identity_v<s::multiplies<T>, T>) == T{1});
+  BOOST_TEST((s::known_identity_v<s::multiplies<>, T>) == T{1});
+
+  if constexpr (std::is_floating_point_v<T>) {
+    BOOST_TEST((s::known_identity_v<s::minimum<T>, T>) == std::numeric_limits<T>::infinity());
+    BOOST_TEST((s::known_identity_v<s::minimum<>, T>) == std::numeric_limits<T>::infinity());
+    BOOST_TEST((s::known_identity_v<s::maximum<T>, T>) == -std::numeric_limits<T>::infinity());
+    BOOST_TEST((s::known_identity_v<s::maximum<>, T>) == -std::numeric_limits<T>::infinity());
+  } else {
+    BOOST_TEST((s::known_identity_v<s::minimum<T>, T>) == std::numeric_limits<T>::max());
+    BOOST_TEST((s::known_identity_v<s::minimum<>, T>) == std::numeric_limits<T>::max());
+    BOOST_TEST((s::known_identity_v<s::maximum<T>, T>) == std::numeric_limits<T>::lowest());
+    BOOST_TEST((s::known_identity_v<s::maximum<>, T>) == std::numeric_limits<T>::lowest());
+  }
+
+  if constexpr (std::is_integral_v<T>) {
+    static_assert(s::has_known_identity_v<s::bit_or<T>, T>);
+    static_assert(s::has_known_identity_v<s::bit_or<>, T>);
+    static_assert(s::has_known_identity_v<s::bit_xor<T>, T>);
+    static_assert(s::has_known_identity_v<s::bit_xor<>, T>);
+
+    BOOST_TEST((s::known_identity_v<s::bit_or<T>, T>) == T{0});
+    BOOST_TEST((s::known_identity_v<s::bit_or<>, T>) == T{0});
+    BOOST_TEST((s::known_identity_v<s::bit_xor<T>, T>) == T{0});
+    BOOST_TEST((s::known_identity_v<s::bit_xor<>, T>) == T{0});
+  }
+
+  if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
+    static_assert(s::has_known_identity_v<s::bit_and<T>, T>);
+    static_assert(s::has_known_identity_v<s::bit_and<>, T>);
+
+    BOOST_TEST((s::known_identity_v<s::bit_and<T>, T>) == static_cast<T>(~T{0}));
+    BOOST_TEST((s::known_identity_v<s::bit_and<>, T>) == static_cast<T>(~T{0}));
+  }
+
+  if constexpr (std::is_same_v<T, bool>) {
+    static_assert(s::has_known_identity_v<s::bit_and<T>, T>);
+    static_assert(s::has_known_identity_v<s::bit_and<>, T>);
+    static_assert(s::has_known_identity_v<s::logical_or<T>, T>);
+    static_assert(s::has_known_identity_v<s::logical_or<>, T>);
+    static_assert(s::has_known_identity_v<s::logical_and<T>, T>);
+    static_assert(s::has_known_identity_v<s::logical_and<>, T>);
+
+    BOOST_TEST((s::known_identity_v<s::bit_and<T>, T>) == true);
+    BOOST_TEST((s::known_identity_v<s::bit_and<>, T>) == true);
+    BOOST_TEST((s::known_identity_v<s::logical_or<T>, T>) == false);
+    BOOST_TEST((s::known_identity_v<s::logical_or<>, T>) == false);
+    BOOST_TEST((s::known_identity_v<s::logical_and<T>, T>) == true);
+    BOOST_TEST((s::known_identity_v<s::logical_and<>, T>) == true);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // NOTE: Make sure not to add anything below this line

--- a/tests/sycl/reduction.cpp
+++ b/tests/sycl/reduction.cpp
@@ -79,15 +79,15 @@ void test_scalar_reduction(sycl::queue &q, std::size_t num_elements,
 template<class T, class BinaryOp>
 struct input_generator {};
 
-template<class T>
-struct input_generator <T, sycl::plus<T>> {
+template<class T, typename U>
+struct input_generator <T, sycl::plus<U>> {
   T operator() (std::size_t i) const {
     return static_cast<T>(i);
   }
 };
 
-template<class T>
-struct input_generator <T, sycl::multiplies<T>> {
+template<class T, typename U>
+struct input_generator <T, sycl::multiplies<U>> {
   T operator() (std::size_t i) const {
     if(i > 1500)
       return static_cast<T>(1);
@@ -99,50 +99,50 @@ struct input_generator <T, sycl::multiplies<T>> {
   }
 };
 
-template<class T>
-struct input_generator <T, sycl::minimum<T>> {
+template<class T, typename U>
+struct input_generator <T, sycl::minimum<U>> {
   T operator() (std::size_t i) const {
     return 1234 - (i % 567);
   }
 };
 
-template<class T>
-struct input_generator <T, sycl::maximum<T>> {
+template<class T, typename U>
+struct input_generator <T, sycl::maximum<U>> {
   T operator() (std::size_t i) const {
     return 1234 + (i % 567);
   }
 };
 
-template<class T>
-struct input_generator <T, sycl::bit_and<T>> {
+template<class T, typename U>
+struct input_generator <T, sycl::bit_and<U>> {
   T operator() (std::size_t i) const {
     return static_cast<T>((2ull * static_cast<unsigned long long>(i)) | (1ull << (8 * sizeof(T) - 1)) | 1ull);
   }
 };
 
-template<class T>
-struct input_generator <T, sycl::bit_or<T>> {
+template<class T, typename U>
+struct input_generator <T, sycl::bit_or<U>> {
 T operator() (std::size_t i) const {
   return static_cast<T>(i ? 2ull * static_cast<unsigned long long>(i) : (1ull << (8 * sizeof(T) - 1)));
 }
 };
 
-template<class T>
-struct input_generator <T, sycl::bit_xor<T>> {
+template<class T, typename U>
+struct input_generator <T, sycl::bit_xor<U>> {
   T operator() (std::size_t i) const {
     return static_cast<T>(17 * i);
   }
 };
 
-template<>
-struct input_generator <bool, sycl::logical_or<bool>> {
+template<typename U>
+struct input_generator <bool, sycl::logical_or<U>> {
   bool operator() (std::size_t i) const {
     return i == 0;
   }
 };
 
-template<>
-struct input_generator <bool, sycl::logical_and<bool>> {
+template<typename U>
+struct input_generator <bool, sycl::logical_and<U>> {
 bool operator() (std::size_t i) const {
   return i != 0;
 }
@@ -376,9 +376,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(single_kernel_single_scalar_reduction, T, all_test
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(single_kernel_single_scalar_int_reduction, T, int_test_types) {
-  test_single_reduction<T>(128, 128, sycl::bit_or<T>{});
-  test_single_reduction<T>(128, 128, sycl::bit_and<T>{});
-  test_single_reduction<T>(128, 128, sycl::bit_xor<T>{});
+  test_single_reduction<T>(128, 128, sycl::bit_or<>{});
+  test_single_reduction<T>(128, 128, sycl::bit_and<>{});
+  test_single_reduction<T>(128, 128, sycl::bit_xor<>{});
 }
 
 BOOST_AUTO_TEST_CASE(single_kernel_single_scalar_bool_reduction) {
@@ -387,8 +387,8 @@ BOOST_AUTO_TEST_CASE(single_kernel_single_scalar_bool_reduction) {
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(two_kernels_single_scalar_reduction, T, large_test_types) {
-  test_single_reduction<T>(128*128, 128, sycl::plus<T>{});
-  test_single_reduction<T>(128*128, 128, sycl::multiplies<T>{});
+  test_single_reduction<T>(128*128, 128, sycl::plus<>{});
+  test_single_reduction<T>(128*128, 128, sycl::multiplies<>{});
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(three_kernels_single_scalar_reduction, T, very_large_test_types) {
@@ -439,7 +439,7 @@ BOOST_AUTO_TEST_CASE(buffer_reduction) {
     auto values_acc = values_buff.get_access<sycl::access_mode::read>(
         cgh);
 
-    auto sumReduction = sycl::reduction(sum_buff, cgh, sycl::plus<int>(), initialize_to_identity);
+    auto sumReduction = sycl::reduction(sum_buff, cgh, sycl::plus<>(), initialize_to_identity);
     auto maxReduction = sycl::reduction(max_buff, cgh, sycl::maximum<int>());
 
     cgh.parallel_for(sycl::range<1>{1024}, sumReduction, maxReduction,
@@ -461,7 +461,7 @@ BOOST_AUTO_TEST_CASE(combine_none_or_multiple) {
   max_buff.get_host_access()[0] = 0;
 
   q.submit([&](sycl::handler &cgh) {
-      auto sumReduction = sycl::reduction(sum_buff, cgh, sycl::plus<int>());
+      auto sumReduction = sycl::reduction(sum_buff, cgh, sycl::plus<>());
       auto maxReduction = sycl::reduction(max_buff, cgh, sycl::maximum<int>()); // no identity
 
       cgh.parallel_for(sycl::range<1>{1024}, sumReduction, maxReduction,

--- a/tests/sycl/reduction.cpp
+++ b/tests/sycl/reduction.cpp
@@ -445,7 +445,9 @@ BOOST_AUTO_TEST_CASE(buffer_reduction) {
     cgh.parallel_for(sycl::range<1>{1024}, sum_reduction, max_reduction,
                      [=](sycl::id<1> idx, auto &sum, auto &max) {
                        sum += values_acc[idx];
+                       sum += sum.identity();
                        max.combine(values_acc[idx]);
+                       max.combine(max.identity());
                      });
   });
 

--- a/tests/sycl/reduction.cpp
+++ b/tests/sycl/reduction.cpp
@@ -357,8 +357,7 @@ BOOST_AUTO_TEST_CASE(accessor_reduction) {
         cgh);
 
     auto sumReduction = sycl::reduction(sum_buff, cgh, sycl::plus<int>(), initialize_to_identity);
-    // auto maxReduction = sycl::reduction(max_buff, cgh, sycl::maximum<int>()); // TODO currently not on GPU
-    auto maxReduction = sycl::reduction(max_buff, cgh, 0, sycl::maximum<int>());
+    auto maxReduction = sycl::reduction(max_buff, cgh, sycl::maximum<int>());
 
     cgh.parallel_for(sycl::range<1>{1024}, sumReduction, maxReduction,
                      [=](sycl::id<1> idx, auto &sum, auto &max) {
@@ -367,6 +366,7 @@ BOOST_AUTO_TEST_CASE(accessor_reduction) {
                      });
   });
 
+  auto x = max_buff.get_host_access()[0];
   BOOST_CHECK(max_buff.get_host_access()[0] == 1023);
   BOOST_CHECK(sum_buff.get_host_access()[0] == 523776);
 }

--- a/tests/sycl/reduction.cpp
+++ b/tests/sycl/reduction.cpp
@@ -463,17 +463,17 @@ BOOST_AUTO_TEST_CASE(combine_none_or_multiple) {
   max_buff.get_host_access()[0] = 0;
 
   q.submit([&](sycl::handler &cgh) {
-      auto sum_reduction = sycl::reduction(sum_buff, cgh, sycl::plus<>());
-      auto max_reduction = sycl::reduction(max_buff, cgh, sycl::maximum<int>()); // no identity
+    auto sum_reduction = sycl::reduction(sum_buff, cgh, sycl::plus<>());
+    auto max_reduction = sycl::reduction(max_buff, cgh, sycl::maximum<int>()); // no identity
 
-      cgh.parallel_for(sycl::range<1>{1024}, sum_reduction, max_reduction,
-          [=](sycl::id<1> idx, auto &sum, auto &max) {
-              // Test both validity of 0 combines or > 1 combine per item
-              for (int i = 0; i < static_cast<int>(idx.get(0)) % 3; ++i) {
-                sum += idx[0];
-                max.combine(idx[0]);
-              }
-          });
+    cgh.parallel_for(sycl::range<1>{1024}, sum_reduction, max_reduction,
+        [=](sycl::id<1> idx, auto &sum, auto &max) {
+          // Test both validity of 0 combines or > 1 combine per item
+          for (int i = 0; i < static_cast<int>(idx.get(0)) % 3; ++i) {
+            sum += idx[0];
+            max.combine(idx[0]);
+          }
+        });
   });
 
   BOOST_CHECK(max_buff.get_host_access()[0] == 1022);
@@ -481,34 +481,34 @@ BOOST_AUTO_TEST_CASE(combine_none_or_multiple) {
 }
 
 BOOST_AUTO_TEST_CASE(deprecated_accessor_reduction) {
-    sycl::queue q;
-    sycl::buffer<int> sum_buff_a{1};
-    sycl::buffer<int> sum_buff_b{1};
+  sycl::queue q;
+  sycl::buffer<int> sum_buff_a{1};
+  sycl::buffer<int> sum_buff_b{1};
 
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated"
 #endif
 
-    q.submit([&](sycl::handler &cgh) {
-      auto sum_a_reduction = sycl::reduction(sycl::accessor{sum_buff_a, cgh, sycl::write_only, sycl::no_init},
-          sycl::plus<>());
-      auto sum_b_reduction = sycl::reduction(sycl::accessor{sum_buff_b, cgh, sycl::write_only, sycl::no_init},
-          0, sycl::plus<int>());
+  q.submit([&](sycl::handler &cgh) {
+    auto sum_a_reduction = sycl::reduction(sycl::accessor{sum_buff_a, cgh, sycl::write_only, sycl::no_init},
+        sycl::plus<>());
+    auto sum_b_reduction = sycl::reduction(sycl::accessor{sum_buff_b, cgh, sycl::write_only, sycl::no_init},
+        0, sycl::plus<int>());
 
-      cgh.parallel_for(sycl::range<1>{1024}, sum_a_reduction, sum_b_reduction,
-          [=](sycl::item<1> idx, auto &sum_a, auto &sum_b) {
-              sum_a += idx.get_id(0);
-              sum_b += idx.get_id(0);
-          });
-    });
+    cgh.parallel_for(sycl::range<1>{1024}, sum_a_reduction, sum_b_reduction,
+        [=](sycl::item<1> idx, auto &sum_a, auto &sum_b) {
+          sum_a += idx.get_id(0);
+          sum_b += idx.get_id(0);
+        });
+  });
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif
 
-    BOOST_CHECK(sum_buff_a.get_host_access()[0] == 523776);
-    BOOST_CHECK(sum_buff_b.get_host_access()[0] == 523776);
+  BOOST_CHECK(sum_buff_a.get_host_access()[0] == 523776);
+  BOOST_CHECK(sum_buff_b.get_host_access()[0] == 523776);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/sycl/reduction.cpp
+++ b/tests/sycl/reduction.cpp
@@ -485,8 +485,10 @@ BOOST_AUTO_TEST_CASE(deprecated_accessor_reduction) {
     sycl::buffer<int> sum_buff_a{1};
     sycl::buffer<int> sum_buff_b{1};
 
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated"
+#endif
 
     q.submit([&](sycl::handler &cgh) {
       auto sum_a_reduction = sycl::reduction(sycl::accessor{sum_buff_a, cgh, sycl::write_only, sycl::no_init},
@@ -501,7 +503,9 @@ BOOST_AUTO_TEST_CASE(deprecated_accessor_reduction) {
           });
     });
 
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
 
     BOOST_CHECK(sum_buff_a.get_host_access()[0] == 523776);
     BOOST_CHECK(sum_buff_b.get_host_access()[0] == 523776);


### PR DESCRIPTION
This implements `known_identity`, `has_known_identity` as well as corresponding tests.

Changes `buildins.hpp` consist of adding `static_cast<T>` to the scalar branch (and slight reformatting, since some lines are now longer). This doesn't change anything for scalar values, as T is returned anyways. For vectors the `static_cast` makes the branch valid, and doesn't change the return type, since vectors don't use the scalar branch.
In `HIPSYCL_BUILTIN_GENERATOR_UNARY_T_RET_INT` the return value needs to be casted to `int` first, to tell the compiler how the casting should work.

The vector class needed to be adjusted slightly to make it a literal type. For this the constructors are now labeled `constexpr` and `count_num_elements` was moved into the detail namespace (was a private vector-member before).
The `_storage` needs a default initialization, because writing to uninitialized elements is only allowed starting with C++20.

The actual identity implementation is done using a macro, which creates specializations for the default template for both `known_identity` and `has_known_identity`. If no identity is known, a compile time error is triggered.

This PR only includes the `known_identity` struct, but doesn't add code to use it for example when computing reductions.