### PR TITLE
[Win32] `__device__ signbit(long double)` is available in clang >= 12.

### DIFF
--- a/include/hipSYCL/std/hiplike/complex
+++ b/include/hipSYCL/std/hiplike/complex
@@ -28,7 +28,7 @@
 
 #if defined(__clang__) && (defined(__CUDACC__) || defined(__HIP__))
 
-#ifdef _WIN32
+#if defined(_WIN32) && __clang_major__ < 12
 #include <cmath>
 
 namespace std {


### PR DESCRIPTION
The workaround to add `__device__ signbit(long double)` ourselves is only necessary for Clang < 12 and breaks with Clang 12+ due to redeclaration. Thus extending the macro guard.