### PR TITLE
Fix: Make local_accessor default-constructible

### DIFF
--- a/include/hipSYCL/sycl/libkernel/accessor.hpp
+++ b/include/hipSYCL/sycl/libkernel/accessor.hpp
@@ -1744,7 +1744,7 @@ private:
     : _addr{addr}, _num_elements{r}
   {}
 
-  const address _addr;
+  const address _addr{};
   const range<dimensions> _num_elements;
 };
 

--- a/tests/sycl/accessor.cpp
+++ b/tests/sycl/accessor.cpp
@@ -387,4 +387,11 @@ BOOST_AUTO_TEST_CASE(accessor_simplifications) {
   q.wait();
 }
 
+BOOST_AUTO_TEST_CASE(local_accessor_default_constructible) {
+  namespace s = cl::sycl;
+  s::local_accessor<int, 1> a1;
+  s::local_accessor<int, 2> a2;
+  s::local_accessor<int, 3> a3;
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
`local_accessor` aka `accessor<.... target::local>` has an explicitly-defaulted default constructor that is implicitly deleted because it does not initialize the `const address _addr` field (where `address` is `size_t`).

This PR value-initializes `_addr` and adds a regression test to ensure the class is now default-constructible.