### PR TITLE
Add support for multiversioning scoped parallelism kernels

### DIFF
--- a/include/hipSYCL/glue/kernel_launcher_factory.hpp
+++ b/include/hipSYCL/glue/kernel_launcher_factory.hpp
@@ -65,15 +65,14 @@ make_kernel_launchers(sycl::id<Dim> offset, sycl::range<Dim> local_range,
                       std::size_t dynamic_local_memory, Kernel k,
                       Reductions... reductions) {
 
-  using complete_name = complete_kernel_name_t<KernelNameTag, Kernel>;
-  using effective_name = effective_kernel_name_t<KernelNameTag, Kernel>;
+  using name_traits = kernel_name_traits<KernelNameTag, Kernel>;
   
   std::vector<std::unique_ptr<rt::backend_kernel_launcher>> launchers;
 #ifdef __HIPSYCL_ENABLE_HIP_TARGET__
   {
     auto launcher = std::make_unique<hip_kernel_launcher>();
-    launcher->bind<complete_name, Type>(offset, global_range, local_range,
-                                        dynamic_local_memory, k, reductions...);
+    launcher->bind<name_traits, Type>(offset, global_range, local_range,
+                                      dynamic_local_memory, k, reductions...);
     launchers.emplace_back(std::move(launcher));
   }
 #endif
@@ -81,19 +80,17 @@ make_kernel_launchers(sycl::id<Dim> offset, sycl::range<Dim> local_range,
 #ifdef __HIPSYCL_ENABLE_CUDA_TARGET__
   {
     auto launcher = std::make_unique<cuda_kernel_launcher>();
-    launcher->bind<complete_name, Type>(offset, global_range, local_range,
-                                        dynamic_local_memory, k, reductions...);
+    launcher->bind<name_traits, Type>(offset, global_range, local_range,
+                                      dynamic_local_memory, k, reductions...);
     launchers.emplace_back(std::move(launcher));
   }
 #endif
 
 #ifdef __HIPSYCL_ENABLE_SPIRV_TARGET__
   {
-    using effective_name = effective_kernel_name_t<KernelNameTag, Kernel>;
-
     auto launcher = std::make_unique<ze_kernel_launcher>();
-    launcher->bind<effective_name, Type>(offset, global_range, local_range,
-                                        dynamic_local_memory, k, reductions...);
+    launcher->bind<name_traits, Type>(offset, global_range, local_range,
+                                      dynamic_local_memory, k, reductions...);
     launchers.emplace_back(std::move(launcher));
   }
 #endif
@@ -103,8 +100,8 @@ make_kernel_launchers(sycl::id<Dim> offset, sycl::range<Dim> local_range,
    !defined(HIPSYCL_LIBKERNEL_DEVICE_PASS)
   {
     auto launcher = std::make_unique<omp_kernel_launcher>();
-    launcher->bind<complete_name, Type>(offset, global_range, local_range,
-                                        dynamic_local_memory, k, reductions...);
+    launcher->bind<name_traits, Type>(offset, global_range, local_range,
+                                      dynamic_local_memory, k, reductions...);
     launchers.emplace_back(std::move(launcher));
   }
 #endif

--- a/include/hipSYCL/glue/kernel_names.hpp
+++ b/include/hipSYCL/glue/kernel_names.hpp
@@ -33,28 +33,50 @@ struct __hipsycl_unnamed_kernel {};
 namespace hipsycl {
 namespace glue {
 
-template<class KernelName> struct complete_kernel_name {};
-
 // This can be used to turn incomplete types of kernel names into complete
 // types for backends which e.g. use typeid() to access the mangled name.
-template <class Name, class KernelBody> struct kernel_name {
-  using complete_type = complete_kernel_name<Name>;
-  using effective_type = Name;
+template<class KernelName> struct complete_kernel_name {};
+
+template<class KernelName, typename... MultiversionParamaters>
+struct multiversioned_kernel_name {};
+
+template<class KernelNameTag, class KernelBodyT>
+struct kernel_name_traits {
+  using tag = KernelNameTag;
+  // The name that the kernel should have. __hipsycl_unnamed_kernel if
+  // unnamed, a type based on the name tag if named.
+  using name = complete_kernel_name<tag>;
+  // The name that is suggested to be used for name mangling. If unnamed,
+  // the kernel body type. Otherwise a type based on the tag.
+  using suggested_mangling_name = name;
+
+  template <typename... MultiversionParameters>
+  using multiversioned_name =
+      multiversioned_kernel_name<name, MultiversionParameters...>;
+
+  template <typename... MultiversionParameters>
+  using multiversioned_suggested_mangling_name =
+      multiversioned_kernel_name<suggested_mangling_name, MultiversionParameters...>;
+
+  static constexpr bool is_unnamed = false;
 };
-template <class KernelBody>
-struct kernel_name<__hipsycl_unnamed_kernel, KernelBody> {
-  using complete_type = __hipsycl_unnamed_kernel;
-  using effective_type = KernelBody;
+
+template<class KernelBodyT>
+struct kernel_name_traits<__hipsycl_unnamed_kernel, KernelBodyT> {
+  using tag = __hipsycl_unnamed_kernel;
+  using name = __hipsycl_unnamed_kernel;
+  using suggested_mangling_name = KernelBodyT;
+
+  template <typename... MultiversionParameters>
+  using multiversioned_name = __hipsycl_unnamed_kernel;
+
+  template <typename... MultiversionParameters>
+  using multiversioned_suggested_mangling_name =
+      multiversioned_kernel_name<suggested_mangling_name, MultiversionParameters...>;
+
+  static constexpr bool is_unnamed = true;
 };
 
-template <class Name, class KernelBody>
-using complete_kernel_name_t = 
-  typename kernel_name<Name, KernelBody>::complete_type;
-
-
-template <class Name, class KernelBody>
-using effective_kernel_name_t = 
-  typename kernel_name<Name, KernelBody>::effective_type;
 }
 } // namespace hipsycl
 


### PR DESCRIPTION
This adds support for multiversioned scoped parallelism kernels. This is necessary to handle cases where the group size is not divisible by the subgroup size.