### PR TITLE
Fix outlining of lambda kernels with auto arguments

### DIFF
--- a/tests/device_compilation_tests.cpp
+++ b/tests/device_compilation_tests.cpp
@@ -351,21 +351,37 @@ template <auto ...>
 struct VariadicKernelNTTP {};
 
 BOOST_AUTO_TEST_CASE(variadic_kernel_name) {
-    cl::sycl::queue queue;
-    cl::sycl::buffer<size_t, 1> buf(1);
-    {
-      queue.submit([&](cl::sycl::handler& cgh) {
-          auto acc = buf.get_access<cl::sycl::access::mode::discard_write>(cgh);
-          cgh.parallel_for<VariadicKernelTP<int, bool, char>>(cl::sycl::range<1>(1), [=](cl::sycl::item<1>) {});
-      });
-    }
-    {
-      queue.submit([&](cl::sycl::handler& cgh) {
-          auto acc = buf.get_access<cl::sycl::access::mode::discard_write>(cgh);
-          cgh.parallel_for<VariadicKernelNTTP<1, true, 'a'>>(cl::sycl::range<1>(1), [=](cl::sycl::item<1>) {});
-      });
-    }
+  cl::sycl::queue queue;
+  cl::sycl::buffer<size_t, 1> buf(1);
+  {
+    queue.submit([&](cl::sycl::handler& cgh) {
+        auto acc = buf.get_access<cl::sycl::access::mode::discard_write>(cgh);
+        cgh.parallel_for<VariadicKernelTP<int, bool, char>>(cl::sycl::range<1>(1), [=](cl::sycl::item<1>) {});
+    });
+  }
+  {
+    queue.submit([&](cl::sycl::handler& cgh) {
+        auto acc = buf.get_access<cl::sycl::access::mode::discard_write>(cgh);
+        cgh.parallel_for<VariadicKernelNTTP<1, true, 'a'>>(cl::sycl::range<1>(1), [=](cl::sycl::item<1>) {});
+    });
+  }
 }
 
+void h(){}
+void f(){ h(); }
+void g(){}
+
+BOOST_AUTO_TEST_CASE(generic_lambda_outlining) {
+  cl::sycl::queue q;
+  q.parallel_for(cl::sycl::range{1024}, [=](auto item){
+    f();
+
+    int x = 3;
+    auto invoke = [&](auto value){
+      g();
+    };
+    invoke(x);
+  });
+}
 BOOST_AUTO_TEST_SUITE_END() // NOTE: Make sure not to add anything below this line
 


### PR DESCRIPTION
Previously, lambda kernels with `auto` arguments were not outlined correctly. The reason is that during parsing, we first collect all user kernel invocations and outline them later when parsing is finished and the call tree can be expected to be complete. For this, we store the declarations of the `operator()` of the kernel functor arguments. When the kernel functor is a generic lambda however, this `operator()` may not exist yet since it hasn't yet been instantiated. (At this point, we have just started parsing the kernel invocation). If that happens, the kernel will not be registered for outlining later, and kernel code may not be emitted to device when it should be.

This PR resolves this by instead of storing the `operator()` of the user kernel, storing the invocation kernel of the kernel launcher (e.g. `hipsycl::glue::hiplike_dispatch::parallel_for`) that has been instantiated with the user lambda. This function already exists and can therefore be stored for outlining.

I was briefly concerned whether this would affect the implementation of hierarchical parallelism, since hierarchical tries to allocate declarations in the outer scope in local memory. Since the outer scope has now moved up in the call tree to the `parallel_for_work_group` kernel launcher, in principle it might happen that variables from there end up in local memory. In practice however this cannot happen, since as a simple heuristic, we only store variables of functions in local memory that have a `group` as argument.

Fixes #640 