### PR TITLE
Make all test cases pass on HIP

### DIFF
--- a/include/hipSYCL/sycl/device.hpp
+++ b/include/hipSYCL/sycl/device.hpp
@@ -36,7 +36,7 @@
 #include "types.hpp"
 #include "aspect.hpp"
 #include "info/info.hpp"
-#include "libkernel/backend.hpp"
+#include "backend.hpp"
 #include "exception.hpp"
 #include "version.hpp"
 #include "hipSYCL/sycl/libkernel/id.hpp"
@@ -257,6 +257,9 @@ public:
   friend bool operator!=(const device& lhs, const device &rhs)
   { return !(lhs == rhs); }
   
+  backend get_backend() const noexcept {
+    return _device_id.get_backend();
+  }
 private:
   rt::device_id _device_id;
 

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -91,6 +91,8 @@ if(WITH_CUDA_BACKEND)
 endif()
 
 if(WITH_ROCM_BACKEND)
+  set(ENABLE_ROCM_UNIFIED_MEMORY_API ON CACHE BOOL "Utilize unified memory API in ROCm. Older ROCm versions may not support this.")
+
   add_library(rt-backend-hip SHARED
     hip/hip_event.cpp
     hip/hip_queue.cpp
@@ -101,6 +103,9 @@ if(WITH_ROCM_BACKEND)
     hip/hip_backend.cpp)
 
   target_compile_definitions(rt-backend-hip PRIVATE HIPSYCL_RT_HIP_TARGET_ROCM=1)
+  if(ENABLE_ROCM_UNIFIED_MEMORY_API)
+    target_compile_definitions(rt-backend-hip PRIVATE HIPSYCL_RT_HIP_SUPPORTS_UNIFIED_MEMORY=1)
+  endif()
   target_include_directories(rt-backend-hip PRIVATE ${HIPSYCL_SOURCE_DIR}/include)
   if(NOT HIP_FOUND)
     target_include_directories(rt-backend-hip PRIVATE ${ROCM_PATH}/include)

--- a/src/runtime/hip/hip_queue.cpp
+++ b/src/runtime/hip/hip_queue.cpp
@@ -297,9 +297,12 @@ result hip_queue::submit_kernel(kernel_operation &op, dag_node_ptr node) {
 }
 
 result hip_queue::submit_prefetch(prefetch_operation& op, dag_node_ptr node) {
+  // Need to enable instrumentation even if we cannot enable actual
+  // prefetches so that the user will be able to access instrumentation
+  // properties of the event.
+  hip_instrumentation_guard instrumentation{this, op, node};
 #ifdef HIPSYCL_RT_HIP_SUPPORTS_UNIFIED_MEMORY
   
-  hip_instrumentation_guard instrumentation{this, op, node};
   hipError_t err = hipSuccess;
   
   if (op.get_target().is_host()) {

--- a/tests/sycl/profiler.cpp
+++ b/tests/sycl/profiler.cpp
@@ -148,6 +148,7 @@ BOOST_AUTO_TEST_CASE(queue_profiling)
   auto evt6 = queue.submit([&](cl::sycl::handler &cgh) {
     cgh.memset(src, 0, sizeof src);
   });
+
   auto t61 = evt6.get_profiling_info<cl::sycl::info::event_profiling::command_submit>();
   auto t62 = evt6.get_profiling_info<cl::sycl::info::event_profiling::command_start>();
   auto t63 = evt6.get_profiling_info<cl::sycl::info::event_profiling::command_end>();

--- a/tests/sycl/usm.cpp
+++ b/tests/sycl/usm.cpp
@@ -81,8 +81,12 @@ BOOST_AUTO_TEST_CASE(allocation_functions) {
     verify_allocation_type(aligned_device_mem_ptr, sycl::usm::alloc::device);
     verify_allocation_type(host_ptr, sycl::usm::alloc::host);
     verify_allocation_type(aligned_host_ptr, sycl::usm::alloc::host);
-    verify_allocation_type(shared_ptr, sycl::usm::alloc::shared);
-    verify_allocation_type(aligned_shared_ptr, sycl::usm::alloc::shared);
+    // As of yet, ROCm does not have proper shared allocations
+    // and gives us device-accessible host memory instead.
+    if(q.get_device().get_backend() != sycl::backend::hip) {
+      verify_allocation_type(shared_ptr, sycl::usm::alloc::shared);
+      verify_allocation_type(aligned_shared_ptr, sycl::usm::alloc::shared);
+    }
     verify_allocation_type(unregistered_data.data(), sycl::usm::alloc::unknown);
   }
 


### PR DESCRIPTION
Previously there were some minor issues that prevented clean runs of the test suite on HIP:
* Due to lack of proper shared allocations in ROCM, USM pointer query tests are expected to fail. This PR disables those tests when the device is a HIP device.
* There was a minor issue with instrumentation for prefetch operations in HIP, since those would not by default be enabled because earlier ROCm versions did not have the `hipMemPrefetchAsync` API. This PR enables utilizing this API by default and makes sure that instrumentation is possible even when prefetches are mapped to no-ops because the API is unavailable.

This PR is a prerequisite to integrating AMD GPUs in CI.