### PR TITLE
Optimize data user tracking by replacing weaker dependencies

### DIFF
--- a/src/runtime/data.cpp
+++ b/src/runtime/data.cpp
@@ -92,21 +92,6 @@ void data_user_tracker::release_dead_users()
                _users.end());
 }
 
-void data_user_tracker::add_user(
-  dag_node_ptr user, 
-  sycl::access::mode mode, 
-  sycl::access::target target, 
-  id<3> offset, 
-  range<3> range)
-{
-  std::lock_guard<std::mutex> lock{_lock};
-
-  _users.push_back(
-      data_user{std::weak_ptr<dag_node>(user), mode, target, offset, range});
-}
-
-
-
 range_store::range_store(range<3> size)
 : _size{size}, _contained_data(size.size())
 {}


### PR DESCRIPTION
The data user tracker is responsible for storing a list of all operations currently using a buffer. This list is used to calculate dependencies for new operations that come in. It is purged when operations finish. However, when many operations are submitted before they can finish, this list can grow considerably in size. This causes the `dag_builder` to potentially add a lot of dependencies to an operation during access conflict detection. This in turn considerably slows down the DAG optimization algorithms which try to find edges that can be elided, as the analysis problem becomes potentially very large.

This PR optimizes this scenario by removing nodes from the data user tracker when a new node is added that we know will already synchronize with the existing ones.


Fixes #630 