### PR TITLE
Add __SYCL_DEVICE_ONLY__

### DIFF
--- a/include/hipSYCL/sycl/libkernel/backend.hpp
+++ b/include/hipSYCL/sycl/libkernel/backend.hpp
@@ -62,6 +62,9 @@
 
 #ifdef HIPSYCL_LIBKERNEL_DEVICE_PASS
  #define SYCL_DEVICE_ONLY
+ #ifndef __SYCL_DEVICE_ONLY__
+  #define __SYCL_DEVICE_ONLY__
+ #endif
 #endif
 
 #ifdef __clang__


### PR DESCRIPTION
Previously only `SYCL_DEVICE_ONLY` was defined. However, the standard requires that `__SYCL_DEVICE_ONLY__`  is defined, which is added In this PR. 