### PR TITLE
Add implicit conversion from multi_ptr<T> to multi_ptr<const T>

### DIFF
--- a/include/hipSYCL/sycl/libkernel/multi_ptr.hpp
+++ b/include/hipSYCL/sycl/libkernel/multi_ptr.hpp
@@ -173,6 +173,13 @@ public:
     return multi_ptr<void, Space>{reinterpret_cast<void*>(_ptr)};
   }
 
+  // Implicit conversion to multi_ptr<const value_type, Space>.
+  HIPSYCL_UNIVERSAL_TARGET
+  operator multi_ptr<const ElementType, Space>() const
+  {
+    return multi_ptr<const ElementType, Space>{_ptr};
+  }
+
   // Arithmetic operators
   HIPSYCL_UNIVERSAL_TARGET
   friend multi_ptr& operator++(multi_ptr<ElementType, Space>& mp)


### PR DESCRIPTION
Per SYCL 2020 (rev 4), the following conversion operator must be defined for `multi_ptr`:

```cpp
  // Implicit conversion to multi_ptr<const value_type, Space>.
  template<access::decorated DecorateAddress2>
  operator multi_ptr<const value_type, Space, DecorateAddress2>() const;
```

Without this change, the following code fails to compile:

```cpp
#include <SYCL/sycl.hpp>

int main()
{
    sycl::multi_ptr<float, sycl::access::address_space::local_space> ptr;
    sycl::multi_ptr<const float, sycl::access::address_space::local_space> const_ptr = ptr;
}
```