### PR TITLE
Fix group_barrier(sub_group) on host

### DIFF
--- a/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
@@ -122,7 +122,7 @@ inline void group_barrier(group<Dim> g, memory_scope fence_scope = group<Dim>::f
 }
 
 HIPSYCL_KERNEL_TARGET
-inline void group_barrier(sub_group g, memory_scope fence_scope) {
+inline void group_barrier(sub_group g, memory_scope fence_scope = sub_group::fence_scope) {
   // doesn't need sync
 }
 


### PR DESCRIPTION
The second parameter, fence_scope, should be optional.