### PR TITLE
[SYCL 2020] Add support for implicit conversion from id<1> to size_t

### DIFF
--- a/include/hipSYCL/sycl/libkernel/id.hpp
+++ b/include/hipSYCL/sycl/libkernel/id.hpp
@@ -30,6 +30,7 @@
 #define HIPSYCL_ID_HPP
 
 #include <cassert>
+#include <cstddef>
 #include <type_traits>
 
 #include "hipSYCL/runtime/util.hpp"
@@ -49,6 +50,19 @@ struct item;
 
 template <int dimensions = 1>
 struct id {
+private:
+  struct not_convertible_to_scalar {};
+
+  static constexpr auto get_scalar_conversion_type() {
+    if constexpr(dimensions == 1)
+      return std::size_t{};
+    else
+      return not_convertible_to_scalar {};
+  }
+
+  using scalar_conversion_type = decltype(get_scalar_conversion_type());
+
+public:
 
   HIPSYCL_UNIVERSAL_TARGET
   id()
@@ -121,14 +135,15 @@ struct id {
   size_t operator[](int dimension) const {
     return this->_data[dimension];
   }
-/*
-  template <int D = dimensions, typename = std::enable_if_t<D == 1>>
+
+  // We cannot use enable_if since the involved templates would
+  // prevent implicit type conversion to other integer types.
   HIPSYCL_UNIVERSAL_TARGET
-  operator size_t() const {
+  operator scalar_conversion_type () const {
     return this->_data[0];
   }
-  */
-  // Implementation of id<dimensions> operatorOP(const size_t &rhs) const;
+  
+  // Implementation of id<dimensions> operatorOP(const id &rhs) const;
   // OP is: +, -, *, /, %, <<, >>, &, |, ˆ, &&, ||, <, >, <=, >=
 #define HIPSYCL_ID_BINARY_OP_OUT_OF_PLACE(op) \
   HIPSYCL_UNIVERSAL_TARGET  \
@@ -156,14 +171,22 @@ struct id {
   HIPSYCL_ID_BINARY_OP_OUT_OF_PLACE(<=)
   HIPSYCL_ID_BINARY_OP_OUT_OF_PLACE(>=)
 
-#define HIPSYCL_ID_BINARY_OP_OUT_OF_PLACE_SIZE_T(op) \
-  HIPSYCL_UNIVERSAL_TARGET \
-  friend id<dimensions> operator op(const id<dimensions> &lhs, \
-                             const std::size_t &rhs){ \
-    id<dimensions> result; \
-    for(std::size_t i = 0; i < dimensions; ++i) \
-      result._data[i] = static_cast<std::size_t>(lhs._data[i] op rhs); \
-    return result; \
+#define HIPSYCL_ID_BINARY_OP_OUT_OF_PLACE_SIZE_T(op)                           \
+  template<class T, std::enable_if_t<std::is_integral_v<T>, int> = 0>          \
+  HIPSYCL_UNIVERSAL_TARGET                                                     \
+  friend id<dimensions> operator op(const id<dimensions> &lhs,                 \
+                                    const T &rhs) {                            \
+    id<dimensions> result;                                                     \
+    for (std::size_t i = 0; i < dimensions; ++i)                               \
+      result._data[i] = static_cast<T>(lhs._data[i] op rhs);                   \
+    return result;                                                             \
+  }                                                                            \
+  /* Dedicated overload for range to avoid operator ambiguity due to */        \
+  /* implicit conversion to size_t                                   */        \
+  template <int D = dimensions, std::enable_if_t<D == 1, int> = 0>             \
+  HIPSYCL_UNIVERSAL_TARGET friend id<dimensions> operator op(                  \
+      const id<dimensions> &lhs, const range<dimensions> &rhs) {               \
+    return lhs op rhs[0];                                                      \
   }
 
   HIPSYCL_ID_BINARY_OP_OUT_OF_PLACE_SIZE_T(+)
@@ -205,12 +228,13 @@ struct id {
   HIPSYCL_ID_BINARY_OP_IN_PLACE(|=)
   HIPSYCL_ID_BINARY_OP_IN_PLACE(^=)
 
-#define HIPSYCL_ID_BINARY_OP_IN_PLACE_SIZE_T(op) \
-  HIPSYCL_UNIVERSAL_TARGET \
-  friend id<dimensions>& operator op(id<dimensions> &lhs, const std::size_t &rhs) { \
-    for(std::size_t i = 0; i < dimensions; ++i) \
-      lhs._data[i] op rhs; \
-    return lhs; \
+#define HIPSYCL_ID_BINARY_OP_IN_PLACE_SIZE_T(op)                          \
+  template<class T, std::enable_if_t<std::is_integral_v<T>, int> = 0>     \
+  HIPSYCL_UNIVERSAL_TARGET                                                \
+  friend id<dimensions>& operator op(id<dimensions> &lhs, const T &rhs) { \
+    for(std::size_t i = 0; i < dimensions; ++i)                           \
+      lhs._data[i] op rhs;                                                \
+    return lhs;                                                           \
   }
 
   HIPSYCL_ID_BINARY_OP_IN_PLACE_SIZE_T(+=)
@@ -224,13 +248,14 @@ struct id {
   HIPSYCL_ID_BINARY_OP_IN_PLACE_SIZE_T(|=)
   HIPSYCL_ID_BINARY_OP_IN_PLACE_SIZE_T(^=)
 
-#define HIPSYCL_ID_BINARY_OP_SIZE_T(op) \
-  HIPSYCL_UNIVERSAL_TARGET \
-  friend id<dimensions> operator op(const size_t &lhs, const id<dimensions> &rhs) { \
-    id<dimensions> result; \
-    for(std::size_t i = 0; i < dimensions; ++i) \
-      result[i] = lhs op rhs[i]; \
-    return result; \
+#define HIPSYCL_ID_BINARY_OP_SIZE_T(op)                                        \
+  template<class T, std::enable_if_t<std::is_integral_v<T>, int> = 0>          \
+  HIPSYCL_UNIVERSAL_TARGET                                                     \
+  friend id<dimensions> operator op(const T &lhs, const id<dimensions> &rhs) { \
+    id<dimensions> result;                                                     \
+    for(std::size_t i = 0; i < dimensions; ++i)                                \
+      result[i] = lhs op rhs[i];                                               \
+    return result;                                                             \
   }
 
   // OP is: +, -, *, /, %, <<, >>, &, |, ˆ

--- a/tests/sycl/usm.cpp
+++ b/tests/sycl/usm.cpp
@@ -200,10 +200,13 @@ BOOST_AUTO_TEST_CASE(allocations_in_kernels) {
   });
 
   q.parallel_for<class usm_alloc_pf>(sycl::range<1>{test_size},
-                                     [=](sycl::id<1> idx) {
-                                       shared_allocation[idx.get(0)] += 1;
-                                       explicit_allocation[idx.get(0)] += 1;
-                                       mapped_host_allocation[idx.get(0)] += 1;
+                                     [=] (sycl::id<1> idx) {
+                                       // Use idx directly to also make sure
+                                       // that implicit conversion to size_t
+                                       // works
+                                       shared_allocation[idx] += 1;
+                                       explicit_allocation[idx] += 1;
+                                       mapped_host_allocation[idx] += 1;
                                      });
 
   q.parallel_for<class usm_alloc_ndrange_pf>(


### PR DESCRIPTION
This PR adds support for implicit conversion from `id<1>` to `size_t`.

This is particularly useful in conjunction with USM, where it allows indexing USM pointers using `id<1>` objects.

The SYCL 2020 spec has added an implicit conversion operator to `id<1>`, however to make it work a couple of tricks were required to get implicit conversions to trigger when desired while also avoiding overload ambiguities.
* Explicit overload for `operatorOP(id<1>, range<1>)`
* Don't use `std::enable_if` with the scalar conversion operator because the template prevents the returned index from being implicitly converted further to other int types such as `long` which is required for array indexing
* Replace `operatorOP(id, size_t)` and `operatorOP(size_t, id)` with a template for the scalar type to make sure that an exact match can always be found when using integer literals. Otherwise, overload ambiguities appear.
