### PR TITLE
Resolve CUDA explicit multipass performance with more aggressive CUDA module caching

### DIFF
--- a/include/hipSYCL/runtime/cuda/cuda_module.hpp
+++ b/include/hipSYCL/runtime/cuda/cuda_module.hpp
@@ -80,15 +80,6 @@ public:
 
   result load(rt::device_id dev, const cuda_module &module, CUmod_st*& out);
 
-private:
-  std::size_t _num_devices;
-
-  // Cache constructed modules
-  std::vector<cuda_module> _modules;
-
-  // Store active CUDA module per device
-  std::vector<CUmod_st *> _cuda_modules;
-  std::vector<cuda_module_id_t> _active_modules;
 };
 
 }


### PR DESCRIPTION
Previously, CUDA module caching when using explicit multipass was somewhat limited in the number of modules it could cache. Additionally, since the cache was part of the `cuda_module_manager`, it would be purged with every restart of the SYCL runtime - which happens after every test for our unit tests. This makes running the tests excessively slow in explicit multipass mode.

This PR resolves this by moving the cache outside of the SYCL runtime classes, and by removing restrictions on the number of cached modules. This should help performance for production code using many compilation units.

Depends on #683, and targets this branch.