### PR TITLE
Fix compile error about OptimizationLevel on LLVM 14

### DIFF
--- a/src/compiler/HipsyclClangPlugin.cpp
+++ b/src/compiler/HipsyclClangPlugin.cpp
@@ -68,7 +68,13 @@ extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo llvmGetPassPluginIn
             // Note: for Clang < 12, this EP is not called for O0, but the new PM isn't
             // really used there anyways..
             PB.registerOptimizerLastEPCallback(
-                [](llvm::ModulePassManager &MPM, llvm::PassBuilder::OptimizationLevel) {
+                [](llvm::ModulePassManager &MPM,
+#if LLVM_VERSION_MAJOR >= 14
+                   llvm::OptimizationLevel
+#else
+                   llvm::PassBuilder::OptimizationLevel
+#endif
+                  ) {
                   MPM.addPass(hipsycl::compiler::GlobalsPruningPass{});
                 });
           }};


### PR DESCRIPTION
Hi there.
A compile error was triggered when building against Intel's LLVM fork. After investigation I found that at LLVM's commit [`7a797b2`](https://github.com/llvm/llvm-project/commit/7a797b2), the `llvm::PassBuilder::OptimizationLevel` was moved to `llvm::OptimizationLevel` , so I added a `#if` to fix that error.