### PR TITLE
[L0][SPIR-V] Make SPIR-V backend work with recent DPC++ / fix performance bug

### DIFF
--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -815,7 +815,6 @@ class spirv_multipass_invocation:
     flags = self._config.cuda_cxx_flags
     
     flags += [
-        "-fsycl",
         "-fsycl-device-only",
         "-fsycl-unnamed-lambda",
         "-fno-sycl-use-bitcode",
@@ -829,6 +828,7 @@ class spirv_multipass_invocation:
   # CXX flags for main pass
   def get_cxx_flags(self):
     return [
+      "-Xclang", "-fsycl-is-host",
       "-D__HIPSYCL_MULTIPASS_SPIRV_HEADER__=\"{}\"".format(
             self._integration_header),
       "-D__HIPSYCL_ENABLE_SPIRV_TARGET__"

--- a/src/runtime/ze/ze_hardware_manager.cpp
+++ b/src/runtime/ze/ze_hardware_manager.cpp
@@ -30,6 +30,7 @@
 #include <string>
 #include <limits>
 
+#include "hipSYCL/common/debug.hpp"
 #include "hipSYCL/runtime/ze/ze_hardware_manager.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
 #include "hipSYCL/runtime/error.hpp"
@@ -505,7 +506,10 @@ result ze_hardware_context::obtain_module(module_id_t id,
                                           ze_module* &out) {
   for(auto mod : _modules) {
     if(mod->get_id() == id && mod->get_variant() == variant) {
+      HIPSYCL_DEBUG_INFO << "ze_hardware_context: Found module " << id
+                         << " in cache" << std::endl;
       out = mod.get();
+      return make_success();
     }
   }
 


### PR DESCRIPTION
* Make SPIR-V driver and kernel launcher work with recent versions of DPC++ / LLVM SYCL driver
  * Use `__builtin_sycl_unique_stable_name()`
  * Use `[[clang::sycl_kernel]]`
  * Use `-Xclang -fsycl-is-host` in host pass in order to be able to use `__builtin_sycl_unique_stable_name()`
  * Account for different kernel parameter passing in recent DPC++ where our `packed_kernel` object is passed as a single argument
* Fix massive performance bug in module management of Level Zero backend: Due to a missing early exit modules would be recompiled for every kernel launch even if they were found in the compiled module cache.

Depends on #683 and targets this branch.