### PR TITLE
Fix sycl::memory_environment() invalid memory access for private memory requests

### DIFF
--- a/include/hipSYCL/sycl/libkernel/sp_private_memory.hpp
+++ b/include/hipSYCL/sycl/libkernel/sp_private_memory.hpp
@@ -62,7 +62,12 @@ private:
   HIPSYCL_KERNEL_TARGET
   T &get(const sycl::id<dimensions> &id,
          const sycl::range<dimensions> &local_range) const noexcept {
-    return _data[detail::linear_id<dimensions>::get(id, local_range)];
+    __hipsycl_if_target_host(
+      return _data[detail::linear_id<dimensions>::get(id, local_range)];
+    );
+    __hipsycl_if_target_device(
+      return *_data;
+    );
   }
 };
 


### PR DESCRIPTION
Previously the `private_memory_access` class would always attempt to index its pointer based on the logical local id. While this is the correct approach on CPU where private memory allocations are widened to an array due to the CPU execution model in scoped parallelism, this causes an invalid memory access on device where private memory allocations are simple scalar variable declarations.
This PR fixes this.