### PR TITLE
Don't submit work to async worker if DAG is empty

### DIFF
--- a/src/runtime/dag_manager.cpp
+++ b/src/runtime/dag_manager.cpp
@@ -72,11 +72,11 @@ void dag_manager::flush_async()
   HIPSYCL_DEBUG_INFO << "dag_manager: Submitting asynchronous flush..."
                      << std::endl;
   if(_builder->get_current_dag_size() > 0){
-    _worker([this](){
+    dag new_dag = _builder->finish_and_reset();
+
+    _worker([this, new_dag](){
       // Construct new DAG
       HIPSYCL_DEBUG_INFO << "dag_manager [async]: Flushing!" << std::endl;
-
-      dag new_dag = _builder->finish_and_reset();
       
       // Release any old users of memory buffers used in this dag
       for(dag_node_ptr req : new_dag.get_memory_requirements()){

--- a/src/runtime/dag_manager.cpp
+++ b/src/runtime/dag_manager.cpp
@@ -71,9 +71,8 @@ void dag_manager::flush_async()
 {
   HIPSYCL_DEBUG_INFO << "dag_manager: Submitting asynchronous flush..."
                      << std::endl;
-
-  _worker([this](){
-    if(_builder->get_current_dag_size() > 0){
+  if(_builder->get_current_dag_size() > 0){
+    _worker([this](){
       // Construct new DAG
       HIPSYCL_DEBUG_INFO << "dag_manager [async]: Flushing!" << std::endl;
 
@@ -121,10 +120,11 @@ void dag_manager::flush_async()
       }
       HIPSYCL_DEBUG_INFO << "dag_manager [async]: DAG flush complete."
                          << std::endl;
-    } else {
-      HIPSYCL_DEBUG_INFO << "dag_manager [async]: Nothing to do" << std::endl;
-    }
-  });
+    
+    });
+  } else {
+    HIPSYCL_DEBUG_INFO << "dag_manager: Nothing to do" << std::endl;
+  }
 }
 
 void dag_manager::flush_sync()


### PR DESCRIPTION
Previously, when flushing the DAG, it was only checked inside the async worker whether the DAG size is actually zero. This can lead to a substantial amount of no-op tasks being queued in the worker, which can slow things down.

This PR changes this so that work is only enqueued if we are sure that there is work.