### PR TITLE
[SYCL 2020][host] Missing negation

### DIFF
--- a/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
@@ -238,7 +238,7 @@ inline bool __hipsycl_all_of_group(group<Dim> g, bool pred) {
 
 HIPSYCL_KERNEL_TARGET
 inline bool __hipsycl_all_of_group(sub_group g, bool pred) {
-  return pred;
+  return !pred;
 }
 
 // none_of

--- a/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
@@ -238,7 +238,7 @@ inline bool __hipsycl_all_of_group(group<Dim> g, bool pred) {
 
 HIPSYCL_KERNEL_TARGET
 inline bool __hipsycl_all_of_group(sub_group g, bool pred) {
-  return !pred;
+  return pred;
 }
 
 // none_of
@@ -293,7 +293,7 @@ inline bool __hipsycl_none_of_group(group<Dim> g, bool pred) {
 
 HIPSYCL_KERNEL_TARGET
 inline bool __hipsycl_none_of_group(sub_group g, bool pred) {
-  return pred;
+  return !pred;
 }
 
 // reduce


### PR DESCRIPTION
Fixes a bug in sycl::none_of_group that happens only on host/omp and sub_groups.
Reproducer: 

```C++
    sycl::queue q{sycl::cpu_selector{}};
    q.submit([](sycl::handler& cgh) {
        sycl::stream os(256, 1024, cgh);
        cgh.parallel_for(sycl::nd_range<1>(32, 32), [=](sycl::nd_item<1> item) {
            if (sycl::none_of_group(item.get_sub_group(), true)) {
                os << "None of group" << sycl::endl;
            } else {
                os << "At least one of group" << sycl::endl; // Expected result.
            }
        });
    }).wait();
```