### PR TITLE
Bump version to 0.9.2 and add syclcc --hipsycl-version support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ endif()
 
 set(HIPSYCL_VERSION_MAJOR 0)
 set(HIPSYCL_VERSION_MINOR 9)
-set(HIPSYCL_VERSION_PATCH 1)
+set(HIPSYCL_VERSION_PATCH 2)
 
 project(hipSYCL VERSION ${HIPSYCL_VERSION_MAJOR}.${HIPSYCL_VERSION_MINOR}.${HIPSYCL_VERSION_PATCH})
 
@@ -292,6 +292,9 @@ if(NOT SEQUENTIAL_CXX_FLAGS)
 endif()
 
 set(SYCLCC_CONFIG_FILE "{
+  \"version-major\" : \"${HIPSYCL_VERSION_MAJOR}\",
+  \"version-minor\" : \"${HIPSYCL_VERSION_MINOR}\",
+  \"version-patch\" : \"${HIPSYCL_VERSION_PATCH}\",
   \"default-clang\"     : \"${CLANG_EXECUTABLE_PATH}\",
   \"default-nvcxx\"     : \"${NVCXX_COMPILER}\",
   \"default-platform\"  : \"${DEFAULT_PLATFORM}\",

--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -63,6 +63,10 @@ class config_file:
   def location(self):
     return self._location
 
+  @property
+  def keys(self):
+    return self._data.keys()
+
   def contains_key(self, key):
     if not key in self._data:
       return False
@@ -434,6 +438,26 @@ class syclcc_config:
     return result
   
   @property
+  def version(self):
+  
+    if not self._config_file.contains_key("version-major"):
+      raise OptionNotSet("Could not retrieve major version from config file")
+    if not self._config_file.contains_key("version-minor"):
+      raise OptionNotSet("Could not retrieve major version from config file")
+    if not self._config_file.contains_key("version-patch"):
+      raise OptionNotSet("Could not retrieve major version from config file")
+
+    return (
+      self._config_file.get("version-major"), 
+      self._config_file.get("version-minor"),
+      self._config_file.get("version-patch"))
+
+  @property
+  def runtime_backends(self):
+    backend_path = os.path.join(self.hipsycl_installation_path, "lib", "hipSYCL")
+    return os.listdir(backend_path)
+
+  @property
   def targets(self):
     
     if self._targets == None:
@@ -601,6 +625,10 @@ class syclcc_config:
           if arg.lower().endswith(ending):
             source_files.append(arg)
     return source_files
+
+  @property
+  def configfile(self):
+    return self._config_file
 
   def is_pure_linking_stage(self):
     return len(self.source_file_arguments) == 0
@@ -1388,13 +1416,36 @@ class compiler:
       print("syclcc: Using temporary directory:",temp_dir)
       return self._run(temp_dir)
 
+def print_config(config):
+  config_file = config.configfile
+  print("\n\nFull configuration [can be overriden using environment variables or command line arguments]:")
+  for k in config_file.keys:
+    v = "(unconfigured)"
+    try:
+      v = config_file.get(k)
+    except Exception as e:
+      pass
+    print("    {}: {}".format(k, v))
+
+
+def print_version(config):
+  version = config.version
+  print("syclcc [hipSYCL compilation driver], Copyright (C) 2018-2022 Aksel Alpay and the hipSYCL project")
+  print("  hipSYCL version: {}.{}.{}".format(version[0],version[1],version[2]))
+  print("  Installation root:",os.path.abspath(config.hipsycl_installation_path))
+  print("  Available runtime backends:")
+  for b in config.runtime_backends:
+    print("    ",b)
+
 
 def print_usage(config):
-  print("syclcc [hipSYCL compilation driver], Copyright (C) 2018-2020 Aksel Alpay")
+  print_version(config)
   print("Usage: syclcc <options>\n")
   print("Options are:")
   config.print_options()
   config.print_flags()
+  print("--hipsycl-version\n  Print hipSYCL version and configuration\n")
+  print("--help\n  Print this help message\n")
   print("\nAny other options will be forwarded to the compiler.")
   print("\nNote: Command line arguments take precedence over environment variables.")
 
@@ -1415,6 +1466,10 @@ if __name__ == '__main__':
     for arg in args:
       if arg == "--help":
         print_usage(config)
+        sys.exit(0)
+      elif arg == "--hipsycl-version":
+        print_version(config)
+        print_config(config)
         sys.exit(0)
 
     if not config.is_pure_linking_stage():


### PR DESCRIPTION
* Bump version to 0.9.2
* Add support to syclcc to print version and configuration information using `--hipsycl-version`. Example output:

```
syclcc [hipSYCL compilation driver], Copyright (C) 2018-2022 Aksel Alpay and the hipSYCL project
  hipSYCL version: 0.9.2
  Installation root: /home/aksel/src/hipSYCL/hipSYCL/build/install
  Available runtime backends:
     librt-backend-omp.so
     librt-backend-hip.so
     librt-backend-cuda.so
     librt-backend-ze.so


Full configuration [can be overriden using environment variables or command line arguments]:
    version-major: 0
    version-minor: 9
    version-patch: 2
    default-clang: /usr/bin/clang++-13
    default-nvcxx: (unconfigured)
    default-platform: cuda
    default-cuda-path: /usr/local/cuda
    default-gpu-arch: (unconfigured)
    default-cpu-cxx: /usr/bin/c++
    default-rocm-path: /opt/rocm-4.5.2
    default-use-bootstrap-mode: false
    default-is-dryrun: false
    default-clang-include-path: /usr/include/clang/13.0.1/include/..
    default-sequential-link-line: -L/usr/lib/x86_64-linux-gnu -lboost_context -lboost_fiber -lomp -Wl,-rpath=/usr/lib/x86_64-linux-gnu
    default-sequential-cxx-flags: -I/usr/include
    default-omp-link-line: -L/usr/lib/x86_64-linux-gnu -lboost_context -lboost_fiber -Wl,-rpath=/usr/lib/x86_64-linux-gnu -fopenmp
    default-omp-cxx-flags: -I/usr/include -fopenmp
    default-rocm-link-line: -Wl,-rpath=$HIPSYCL_ROCM_PATH/lib -Wl,-rpath=$HIPSYCL_ROCM_PATH/hip/lib -L/opt/rocm-4.5.2/lib -L/opt/rocm-4.5.2/hip/lib -lamdhip64
    default-rocm-cxx-flags: -isystem $HIPSYCL_PATH/include/hipSYCL/std/hiplike -isystem /usr/include/clang/13.0.1/include/.. -U__FLOAT128__ -U__SIZEOF_FLOAT128__ -I$HIPSYCL_ROCM_PATH/include -I$HIPSYCL_ROCM_PATH/include --rocm-device-lib-path=$HIPSYCL_ROCM_PATH/amdgcn/bitcode --rocm-path=$HIPSYCL_ROCM_PATH -fhip-new-launch-api -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -D__HIP_ROCclr__
    default-cuda-link-line: -Wl,-rpath=$HIPSYCL_CUDA_LIB_PATH -L$HIPSYCL_CUDA_LIB_PATH -lcudart
    default-cuda-cxx-flags: -U__FLOAT128__ -U__SIZEOF_FLOAT128__ -isystem $HIPSYCL_PATH/include/hipSYCL/std/hiplike
    default-is-explicit-multipass: false
    default-save-temps: false
```