### PR TITLE
Add option to disable the usage of deviceMangler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,7 @@ endif()
 #Use add_definitions for now for older cmake versions
 cmake_policy(SET CMP0005 NEW)
 add_definitions(-DHIPSYCL_DEBUG_LEVEL=${HIPSYCL_DEBUG_LEVEL})
+option(HIPSYCL_NO_DEVICE_MANGLER "Disable the use of DeviceMangler. necessary for LLVM 13 distributed with the rocm packages." OFF)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/include/hipSYCL/compiler/Frontend.hpp
+++ b/include/hipSYCL/compiler/Frontend.hpp
@@ -171,7 +171,7 @@ inline std::string buildKernelName(clang::RecordDecl* D, clang::MangleContext *M
 }
 
 // Partially taken from CGCUDANV.cpp
-#if LLVM_VERSION_MAJOR >= 13
+#if LLVM_VERSION_MAJOR >= 13 && !defined(HIPSYCL_NO_DEVICE_MANGLER)
 inline std::string
 getDeviceSideName(clang::NamedDecl *ND, clang::ASTContext &Ctx,
                   clang::MangleContext *RegularMangleContext,
@@ -224,7 +224,7 @@ public:
     // Construct unique name mangler if supported
     NameMangler = clang::ItaniumMangleContext::create(
       instance.getASTContext(), instance.getASTContext().getDiagnostics(), true);
-#elif  LLVM_VERSION_MAJOR < 13
+#elif  LLVM_VERSION_MAJOR < 13 || defined(HIPSYCL_NO_DEVICE_MANGLER)
     NameMangler = clang::ItaniumMangleContext::create(
       instance.getASTContext(), instance.getASTContext().getDiagnostics());
 #else
@@ -687,7 +687,7 @@ private:
     nameKernelUsingTypes(F, true);
   }
 
-#if LLVM_VERSION_MAJOR >= 13
+#if LLVM_VERSION_MAJOR >= 13 && !defined(HIPSYCL_NO_DEVICE_MANGLER)
   void nameKernelUsingKernelManglingStub(clang::FunctionDecl* F) {
     const clang::RecordType* NamingComponent = getRelevantKernelNamingComponent(F);
     auto SuggestionIt = KernelManglingNameTemplates.find(NamingComponent);
@@ -737,7 +737,7 @@ private:
     nameKernelUsingTypes(F, false);
 #elif LLVM_VERSION_MAJOR == 11
     nameKernelUsingUniqueMangler(F);
-#elif LLVM_VERSION_MAJOR == 12
+#elif LLVM_VERSION_MAJOR == 12 || defined(HIPSYCL_NO_DEVICE_MANGLER)
     // Starting with clang 12, we rename all kernels
     nameKernelUsingTypes(F, true);
 #else

--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -52,6 +52,10 @@ target_include_directories(hipSYCL_clang PRIVATE
 
 target_compile_definitions(hipSYCL_clang PRIVATE
   ${LLVM_DEFINITIONS} -DHIPSYCL_COMPILER_COMPONENT)
+  
+if(HIPSYCL_NO_DEVICE_MANGLER)
+  target_compile_definitions(hipSYCL_clang PRIVATE -DHIPSYCL_NO_DEVICE_MANGLER)
+endif()
 
 if(NOT ${LLVM_ENABLE_EH})
   target_compile_options(hipSYCL_clang PRIVATE -fno-exceptions)


### PR DESCRIPTION
The clang 13 distributed with the ROCm packages does not contain the `createDeviceMangleContext` function. This PR adds the option to disable the usage manually. 