### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,18 +85,9 @@ In order to compile software with hipSYCL, use `syclcc` which automatically adds
 
 `syclcc` accepts both command line arguments and environment variables to configure its behavior (e.g., to select the target platform CUDA/ROCm/CPU to compile for). See `syclcc --help` for a comprehensive list of options.
 
-When compiling with hipSYCL, you will need to specify the targets you wish to compile for using the `--hipsycl-targets="backend1:target1,target2,...;backend2:..."` command line argument, `HIPSYCL_TARGETS` environment variable or cmake argument. 
+When compiling with hipSYCL, you will need to specify the targets you wish to compile for using the `--hipsycl-targets="backend1:target1,target2,...;backend2:..."` command line argument, `HIPSYCL_TARGETS` environment variable or cmake argument. See the documentation on [using hipSYCL](doc/using-hipsycl.md) for details.
 
-For GPUs, the expected targets are defined by clang CUDA/HIP. Examples:
-* `sm_52`: NVIDIA Maxwell GPUs
-* `sm_60`: NVIDIA Pascal GPUs
-* `sm_70`: NVIDIA Volta GPUs
-* `gfx900`: AMD Vega 10 GPUs
-* `gfx906`: AMD Vega 20 GPUs
-
-When using the `cuda-nvcxx` compiler driver, specifying targets is optional. If they are defined, the need to follow the format `ccXY` where `XY` stands for the compute capability of the device.
-
-The full documentation of syclcc and hints for the CMake integration can be found in [using hipSYCL](doc/using-hipsycl.md).
+Instructions for using hipSYCL in CMake projects can also be found in the documentation on [using hipSYCL](doc/using-hipsycl.md).
 
 ## Documentation
 * hipSYCL [design and architecture](doc/architecture.md)

--- a/doc/compilation.md
+++ b/doc/compilation.md
@@ -10,16 +10,17 @@ hipSYCL distinguishes two modes of compilation:
 * *integrated multipass*, where host and device compilation passes are handled by clang's CUDA and HIP drivers. This mode allows for the most interoperability with backends because backend-specific language extensions are also available in the host pass. For example, kernels can be launched using the `<<<>>>` syntax. However, limitations in clang's compilation drivers also affect hipSYCL in this mode. In particular, CUDA and HIP cannot be targeted simultaneously because host code cannot support language extensions from *both* at the same time.
 * *explicit multipass*, where host and device compilation passes are handled by hipSYCL's `syclcc` compiler driver. Here, `syclcc` invokes backend-specific device passes, which then result in a compiled kernel image for the target device. `syclcc` then embeds the compiled kernel image into the host binary. At runtime, the kernel is extracted from the image and invoked using runtime functions instead of language extensions. As a consequence, explicit multipass compilation for one backend can be combined with arbitrary other backends simultaneously, allowing hipSYCL to target multiple device backends at the same time. Note that in explicit multipass, different guarantees might be made regarding the availability of backend-specific language extensions in the host pass compared to integrated multipass. See the section on language extension guarantees below for more details.
 
-Not all backends support all modes:
+Not all backends support all modes. The following compilation flows are currently supported, and can be requested as backend targets in `syclcc`. Note that some are available in both explicit multipass and integrated multipass flavor:
 
-
-| Backend      | Integrated multipass? | Explicit multipass? | Comment                                  |
-|--------------|-----------------------|---------------------|------------------------------------------|
-| OpenMP       | N/A                   | N/A                 | Does not require multipass compilation   |
-| CUDA         | Yes                   | Yes                 |                                          |
-| CUDA (nvc++) | Yes                   | No                  | No support for CPU nd-range acceleration |
-| HIP          | Yes                   | No                  |                                          |
-| SPIR-V       | No                    | Yes                 |                                          |
+| Compilation flow | Target hardware | Integrated/explicit multipass? | Short description |
+|------------------|-------------------|-------------------|-------------------|
+| `omp.library-only` | Any CPU | (no multipass compilation) | CPU backend (OpenMP library) |
+| `omp.accelerated` | Any CPU supported by LLVM | (no multipass compilation) | CPU backend (OpenMP library with additional clang acceleration) |
+| `cuda.integrated-multipass` | NVIDIA GPUs | Integrated | CUDA backend|
+| `cuda.explicit-multipass` | NVIDIA GPUs | Explicit | CUDA backend |
+| `cuda-nvcxx` | NVIDIA GPUs | Integrated (single-pass host/device compiler) | CUDA backend using nvc++ |
+| `hip.integrated-multipass` | AMD GPUs (supported by ROCm) | Integrated | HIP backend |
+| `spirv` | Intel GPUs | Explicit | SPIR-V/Level Zero backend |
 
 **Note:** Explicit multipass requires building hipSYCL against a clang that supports `__builtin_unique_stable_name()` (available in clang 11), or clang 13 or newer as described in the [installation documentation](installing.md).
 
@@ -41,15 +42,16 @@ hipSYCL allows using backend-specific language extensions (e.g. CUDA/HIP C++). T
 
 
 
-## Compiler support to accelerate nd_range parallel_for on CPUs
-The nd_range parallel_for is not efficiently implementable without explicit compiler support.
-hipSYCL provides multiple options to circumvent this, though.
+## Compiler support to accelerate nd_range parallel_for on CPUs (omp.accelerated)
+
+The `nd_range parallel_for` paradigm is not efficiently implementable without explicit compiler support.
+hipSYCL however provides multiple options to circumvent this.
+
 1. The recommended and library-only solution is writing kernels using a performance portable
 paradigm as hipSYCL's [scoped parallelism](scoped-parallelism.md) extension.
-2. If that is not an option (e.g. due to preexisting code), hipSYCL provides a compiler extension that allows efficient 
-execution of the nd_range paradigm at the cost of forcing the host compiler to Clang.
-3. Without the Clang plugin, a Boost.Fiber implementation of the nd_range paradigm will be used.
-This will come with a significant performance hit, though, as soon as a barrier is used inside the kernel.
+2. If that is not an option (e.g. due to preexisting code), hipSYCL provides a compiler extension that allows efficient execution of the nd_range paradigm at the cost of forcing the host compiler to Clang.
+3. Without the Clang plugin, a fiber-based implementation of the `nd_range` paradigm will be used.
+However, the relative cost of a barrier in this paradigm is significantly higher compared to e.g. GPU backends. This means that kernels relying on barriers may experience substantial performance degradation, especially if the ratio between barriers and other instructions was tuned for GPUs. Additionally, utilizing barriers in this scenario may prevent vectorization across work items.
 
 For the compiler extension variant, the hipSYCL Clang plugin implements a set of passes to perform deep loop fission
 on nd_range parallel_for kernels that contain barriers. The continuation-based synchronization
@@ -57,11 +59,4 @@ approach is employed to achieve good performance and functional correctness (_Ka
 A deep dive into how the implementation works and why this approach was chosen
 can be found in Joachim Meyer's [master thesis](https://joameyer.de/hipsycl/Thesis_JoachimMeyer.pdf).
 
-As Clang plugins are only officially supported on Linux, this functionality is currently
-supported by hipSYCL on Linux only as well.
-By default, this compiler support is used on Linux.
-It can be explicitly disabled, by setting `-DWITH_ACCELERATED_CPU=OFF` at hipSYCL build time.
-If hipSYCL was built with the compiler support enabled, it can be explicitly en-/disabled
-by adding `--hipsycl-use-accelerated-cpu`/`--hipsycl-use-accelerated-cpu=false` to the 
-syclcc command line. When using CMake, set `-DHIPSYCL_USE_ACCELERATED_CPU=` to override
-the default behavior.
+For more details, see the [installation instructions](installing.md) and the documentation [using hipSYCL](using-hipsycl.md).

--- a/doc/install-llvm.md
+++ b/doc/install-llvm.md
@@ -48,4 +48,4 @@ If hipSYCL does not select the right clang++ or include directories, use the fol
 
 
 * `-DCLANG_EXECUTABLE_PATH=/path/to/clang++` must be pointed to the `clang++` executable from this LLVM installation.
-* `-DCLANG_INCLUDE_PATH=/path/to/clang-includes` must be pointed to the clang internal header directory. Typically, this is something like `$LLVM_INSTALL_PREFIX/include/clang/<llvm-version>/include`. Newer ROCm versions will require the parent directory instead, i.e. `$LLVM_INSTALL_PREFIX/include/clang/<llvm-version>`.
+* `-DCLANG_INCLUDE_PATH=/path/to/clang-includes` must be pointed to the clang internal header directory. Typically, this is something like `$LLVM_INSTALL_PREFIX/include/clang/<llvm-version>/include`. Newer ROCm versions will require the parent directory instead, i.e. `$LLVM_INSTALL_PREFIX/include/clang/<llvm-version>`. This is only important for the ROCm backend.

--- a/doc/install-spirv.md
+++ b/doc/install-spirv.md
@@ -4,6 +4,6 @@
 
 Please install the Level Zero loader and a Level Zero driver such as the Intel [compute runtime](https://github.com/intel/compute-runtime) for Intel GPUs.
 
-Please build hipSYCL against a clang/LLVM that has Intel's patches to generate SPIR-V. Once all required patches are upstreamed this will work with regular clang distributions; until then hipSYCL needs to be built against DPC++/Intel's LLVM [fork](https://github.com/intel/llvm).
+Please build hipSYCL against a clang/LLVM that has Intel's patches to generate SPIR-V, following the [LLVM installation instructions](install-llvm.md). Once all required patches are upstreamed this will work with regular clang distributions; until then hipSYCL needs to be built against DPC++/Intel's LLVM [fork](https://github.com/intel/llvm).
 Unfortunately, the binary distribution of DPC++ do not contain development headers, so the clang plugin required by the CUDA and ROCm backends cannot be compiled, but the open source fork should be able to also target CUDA and ROCm.
 

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -15,7 +15,7 @@ In addition, the various supported compilation flows have additional requirement
 
 | Compilation flow | Target hardware | Short description | Requirements |
 |------------------|-------------------|-------------------|-------------------|
-| `omp` | Any CPU | OpenMP CPU backend | Any OpenMP compiler |
+| `omp.library-only` | Any CPU | OpenMP CPU backend | Any OpenMP compiler |
 | `omp.accelerated` | Any CPU supported by LLVM | OpenMP CPU backend (compiler-accelerated)| LLVM >= 11 |
 | `cuda.integrated-multipass` | NVIDIA GPUs | CUDA backend (clang)| CUDA >= 10, LLVM >= 10 |
 | `cuda.explicit-multipass` | NVIDIA GPUs | CUDA backend (clang, can be targeted simultaneously with other backends) | CUDA >= 10, LLVM 11 or 13+ |
@@ -47,16 +47,45 @@ Once the software requirements mentioned above are met, clone the repository:
 ```
 $ git clone https://github.com/illuhad/hipSYCL
 ```
-Then, create a build directory and compile hipSYCL:
+Then, create a build directory and compile hipSYCL. As described below, some backends and compilation flows must be configured with specific cmake arguments which should be passed during the cmake step.
+
 ```
 $ cd <build directory>
 $ cmake -DCMAKE_INSTALL_PREFIX=<installation prefix> <more optional options, e.g. to configure the LLVM dependency> <hipSYCL source directory>
 $ make install
 ```
+
 The default installation prefix is `/usr/local`. Change this to your liking.
 **Note: hipSYCL needs to be installed to function correctly; don't replace "make install" with just "make"!**
 
-A `cmake` variable that maybe useful to set is `CMAKE_CXX_COMPILER` which should be pointed to the C++ compiler to compile hipSYCL with. Note that this also sets the default C++ compiler for the CPU backend when using syclcc once hipSYCL is installed. This can however also be modified later using `HIPSYCL_CPU_CXX`.
+##### CMake options to configure the hipSYCL build
+
+###### General
+*  `-DCMAKE_CXX_COMPILER` should be pointed to the C++ compiler to compile hipSYCL with. Note that this also sets the default C++ compiler for the CPU backend when using syclcc once hipSYCL is installed. This can however also be modified later using `HIPSYCL_CPU_CXX`.
+
+###### omp.library-only
+
+* `-DCMAKE_CXX_COMPILER` can be used to set the default OpenMP compiler.
+
+###### omp.accelerated
+
+* `-DWITH_ACCELERATED_CPU=OFF/ON` can be used to explicitly disable/enable CPU acceleration. Support for CPU acceleration is enabled by default when enabling the LLVM dependency, and LLVM is sufficiently new.
+
+###### cuda.*
+
+* See the CUDA [installation instructions](install-cuda.md) instructions (section on clang).
+
+###### cuda-nvcxx
+
+* See the CUDA [installation instructions](install-cuda.md) instructions (section on nvc++).
+
+###### hip.*
+
+* See the ROCm [installation instructions](install-rocm.md) instructions.
+
+###### spirv
+
+* No specific cmake flags are currently available.
 
 ## Manual installation (Mac)
 
@@ -65,6 +94,7 @@ On Mac, only the CPU backends are supported. The required steps are analogous to
 ## Manual installation (Windows)
 
 For experimental building on Windows (CPU and CUDA backends) see the corresponding [wiki](https://github.com/illuhad/hipSYCL/wiki/Using-hipSYCL-on-Windows).
+The `omp.accelerated` CPU compilation flow is unsupported on Windows.
 
 ## Repositories (Linux)
 


### PR DESCRIPTION
Restructure docmentation a bit and better explain syclcc behavior, and collect cmake flags at unified places.

@fodinabor I've shuffled around your documentation from compilation.md a little. Please have a look.