### PR TITLE
Build with llvm 14

### DIFF
--- a/src/compiler/cbs/IRUtils.cpp
+++ b/src/compiler/cbs/IRUtils.cpp
@@ -33,8 +33,10 @@
 #include <llvm/Analysis/LoopInfo.h>
 #include <llvm/Analysis/RegionInfo.h>
 #include <llvm/IR/DIBuilder.h>
+#include <llvm/IR/DebugInfo.h>
 #include <llvm/IR/Dominators.h>
 #include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/IntrinsicInst.h>
 #include <llvm/Transforms/Utils/BasicBlockUtils.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <llvm/Transforms/Utils/Local.h>

--- a/src/compiler/cbs/SubCfgFormation.cpp
+++ b/src/compiler/cbs/SubCfgFormation.cpp
@@ -38,6 +38,7 @@
 #include <llvm/IR/Dominators.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Verifier.h>
+#include <llvm/Support/Regex.h>
 #include <llvm/Transforms/Utils/BasicBlockUtils.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <llvm/Transforms/Utils/Local.h>


### PR DESCRIPTION
Hi, after 2a6cc3db76de28183556b78b0b78e88fa83b16ea  to build hipSYCL with LLVM 14/15 these includes are now required