### PR TITLE
Fix SPIR-V isnan() builtin

### DIFF
--- a/include/hipSYCL/sycl/libkernel/spirv/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/spirv/builtins.hpp
@@ -470,12 +470,12 @@ HIPSYCL_BUILTIN T __hipsycl_fast_normalize(T a) noexcept {
 }
 
 // ****************** relational functions ******************
-#define HIPSYCL_DEFINE_SPIRV_CORE_BUILTIN(name)                            \
-  template <class T> HIPSYCL_BUILTIN T __hipsycl_##name(T x) noexcept {    \
-    return __spirv_##name(x);                                              \
+#define HIPSYCL_DEFINE_SPIRV_CORE_BUILTIN(builtin_name, dispatched_name)   \
+  template <class T> HIPSYCL_BUILTIN T __hipsycl_##builtin_name(T x) noexcept {    \
+    return __spirv_##dispatched_name(x);                                              \
   }
 
-HIPSYCL_DEFINE_SPIRV_CORE_BUILTIN(IsNan)
+HIPSYCL_DEFINE_SPIRV_CORE_BUILTIN(isnan, IsNan)
 
 }
 }


### PR DESCRIPTION
The `isnan` builtin generation macro did not take into account the different capitalization between `__spirv_IsNan` and our interface `__hipsycl_isnan`, causing compilation error. This PR fixes this.