### PR TITLE
Align name mangling in clang 13 host pass with upstream clang and restrict uses of createDeviceMangleContext()

### DIFF
--- a/include/hipSYCL/compiler/Frontend.hpp
+++ b/include/hipSYCL/compiler/Frontend.hpp
@@ -241,10 +241,15 @@ public:
       NameMangler = clang::ItaniumMangleContext::create(
         instance.getASTContext(), instance.getASTContext().getDiagnostics());
 
-    // Only used during the host pass
-    if(instance.getAuxTarget())
-      DeviceNameMangler = instance.getASTContext().createDeviceMangleContext(
-          *instance.getAuxTarget());
+    // DeviceNameMangler is only used during the host pass
+    if (instance.getAuxTarget() && instance.getTarget().getCXXABI().isMicrosoft() &&
+        instance.getAuxTarget()->getCXXABI().isItaniumFamily()) {
+      DeviceNameMangler =
+          instance.getASTContext().createDeviceMangleContext(*instance.getAuxTarget());
+    } else {
+      DeviceNameMangler =
+          instance.getASTContext().createMangleContext(instance.getASTContext().getAuxTargetInfo());
+    }
 #endif
 
     KernelNameMangler.reset(NameMangler);


### PR DESCRIPTION
In the hipSYCL 0.9.2+ name mangling logic for clang 13+, it turns out that we have used `createDeviceMangleContext()` too liberally in the host pass. It should only be used when the ABIs are incompatible, and the regular mangler otherwise.

The previous code could result in mangling mismatches between host and device in integrated multipass scenarios, which can lead to kernel launch failures.

This PR resolves those issues by replicating the logic that clang itself uses (e.g. in `CGCUDANV.cpp`) more closely.

Hopefully fixes #718 