### PR TITLE
Fix multi-threaded task processing

### DIFF
--- a/include/hipSYCL/runtime/dag_manager.hpp
+++ b/include/hipSYCL/runtime/dag_manager.hpp
@@ -28,6 +28,8 @@
 #ifndef HIPSYCL_DAG_MANAGER_HPP
 #define HIPSYCL_DAG_MANAGER_HPP
 
+#include <mutex>
+
 #include "dag.hpp"
 #include "dag_builder.hpp"
 #include "dag_direct_scheduler.hpp"
@@ -71,6 +73,9 @@ private:
   dag_direct_scheduler _direct_scheduler;
   dag_unbound_scheduler _unbound_scheduler;
   dag_submitted_ops _submitted_ops;
+
+  // Should only be used for flush_async()
+  std::mutex _flush_mutex;
 };
 
 class dag_build_guard

--- a/src/runtime/dag_builder.cpp
+++ b/src/runtime/dag_builder.cpp
@@ -269,14 +269,18 @@ dag dag_builder::finish_and_reset()
   dag final_dag = _current_dag;
   _current_dag = dag{};
 
-  final_dag.for_each_node([](dag_node_ptr node) {
-    HIPSYCL_DEBUG_INFO << "dag_builder: DAG contains operation: "
-                       << dump(node->get_operation()) << " @node " << node.get()
-                       << std::endl;
+  HIPSYCL_DEBUG_INFO << "dag_builder: DAG contains operations: " << std::endl;
+  int operation_index = 0;
+  final_dag.for_each_node([&](dag_node_ptr node) {
+    HIPSYCL_DEBUG_INFO << operation_index << ". " << dump(node->get_operation())
+                       << " @node " << node.get() << std::endl;
+
     for (dag_node_ptr req : node->get_requirements()) {
-      HIPSYCL_DEBUG_INFO << "    --> requires: " << dump(req->get_operation())
-                         << " @node " << req.get() << std::endl;
+      HIPSYCL_DEBUG_INFO << "    --> requires node @" << req.get()
+                         << " " << dump(req->get_operation()) << std::endl;
     }
+
+    ++operation_index;
   });
 
   return final_dag;

--- a/src/runtime/dag_direct_scheduler.cpp
+++ b/src/runtime/dag_direct_scheduler.cpp
@@ -195,7 +195,7 @@ void submit(backend_executor *executor, dag_node_ptr node, operation *op) {
   node->assign_to_executor(executor);
   
   executor->submit_directly(node, op, reqs);
-
+  assert(node->is_submitted());
   // After node submission, no additional instrumentations can be added.
   // Marking as complete causes code that waits for instrumentation results
   // to proceed to waiting on the requested instrumentation.

--- a/src/runtime/dag_manager.cpp
+++ b/src/runtime/dag_manager.cpp
@@ -26,6 +26,7 @@
  */
 
 #include <memory>
+#include <mutex>
 
 #include "hipSYCL/common/debug.hpp"
 #include "hipSYCL/runtime/dag_manager.hpp"
@@ -71,57 +72,69 @@ void dag_manager::flush_async()
 {
   HIPSYCL_DEBUG_INFO << "dag_manager: Submitting asynchronous flush..."
                      << std::endl;
+  // This lock ensures that the submission process has atomic semantics.
+  // In particular, it is important that once we have popped the latest
+  // nodes from the DAG builder using finish_and_reset(), we directly submit them
+  // to the worker thread.
+  // Otherwise, the order in which submissions are processed in the worker thread
+  // can be incorrect. This can cause queue::submit();flush_sync() to fail in
+  // actually ensuring submission, or introduce dependencies in nodes during submission
+  //  to other nodes that have not yet been submitted.
+  std::lock_guard<std::mutex> lock{_flush_mutex};
+
   if(_builder->get_current_dag_size() > 0){
     dag new_dag = _builder->finish_and_reset();
 
-    _worker([this, new_dag](){
-      // Construct new DAG
-      HIPSYCL_DEBUG_INFO << "dag_manager [async]: Flushing!" << std::endl;
-      
-      // Release any old users of memory buffers used in this dag
-      for(dag_node_ptr req : new_dag.get_memory_requirements()){
-        assert_is<memory_requirement>(req->get_operation());
+    if(new_dag.num_nodes() > 0) {
+      _worker([this, new_dag](){
+        // Construct new DAG
+        HIPSYCL_DEBUG_INFO << "dag_manager [async]: Flushing!" << std::endl;
+        
+        // Release any old users of memory buffers used in this dag
+        for(dag_node_ptr req : new_dag.get_memory_requirements()){
+          assert_is<memory_requirement>(req->get_operation());
 
-        memory_requirement *mreq =
-            cast<memory_requirement>(req->get_operation());
+          memory_requirement *mreq =
+              cast<memory_requirement>(req->get_operation());
 
-        if(mreq->is_buffer_requirement()) {
-          
+          if(mreq->is_buffer_requirement()) {
+            
+            HIPSYCL_DEBUG_INFO
+                << "dag_manager [async]: Releasing dead users of data region "
+                << cast<buffer_memory_requirement>(mreq)->get_data_region().get()
+                << std::endl;
+
+            cast<buffer_memory_requirement>(mreq)
+                ->get_data_region()
+                ->get_users()
+                .release_dead_users();
+          }
+          else
+            assert(false && "Non-buffer requirements are unsupported");
+        }
+
+        // Go!!!
+        scheduler_type stype =
+            application::get_settings().get<setting::scheduler_type>();
+        
+        // This is okay because get_command_groups() returns
+        // the nodes in the order they were submitted. This
+        // makes it safe to submit them in this order to the direct scheduler.
+        for(auto node : new_dag.get_command_groups()){
           HIPSYCL_DEBUG_INFO
-              << "dag_manager [async]: Releasing dead users of data region "
-              << cast<buffer_memory_requirement>(mreq)->get_data_region().get()
-              << std::endl;
-
-          cast<buffer_memory_requirement>(mreq)
-              ->get_data_region()
-              ->get_users()
-              .release_dead_users();
+                << "dag_manager [async]: Submitting node to scheduler!"
+                << std::endl;
+          if(stype == scheduler_type::direct) {
+            _direct_scheduler.submit(node);
+          } else if(stype == scheduler_type::unbound) {
+            _unbound_scheduler.submit(node);
+          }
         }
-        else
-          assert(false && "Non-buffer requirements are unsupported");
-      }
-
-      // Go!!!
-      scheduler_type stype =
-          application::get_settings().get<setting::scheduler_type>();
+        HIPSYCL_DEBUG_INFO << "dag_manager [async]: DAG flush complete."
+                          << std::endl;
       
-      // This is okay because get_command_groups() returns
-      // the nodes in the order they were submitted. This
-      // makes it safe to submit them in this order to the direct scheduler.
-      for(auto node : new_dag.get_command_groups()){
-        HIPSYCL_DEBUG_INFO
-              << "dag_manager [async]: Submitting node to scheduler!"
-              << std::endl;
-        if(stype == scheduler_type::direct) {
-          _direct_scheduler.submit(node);
-        } else if(stype == scheduler_type::unbound) {
-          _unbound_scheduler.submit(node);
-        }
-      }
-      HIPSYCL_DEBUG_INFO << "dag_manager [async]: DAG flush complete."
-                         << std::endl;
-    
-    });
+      });
+    }
   } else {
     HIPSYCL_DEBUG_INFO << "dag_manager: Nothing to do" << std::endl;
   }

--- a/src/runtime/generic/async_worker.cpp
+++ b/src/runtime/generic/async_worker.cpp
@@ -81,7 +81,7 @@ void worker_thread::work()
   // The loop is executed as long as there are enqueued operations,
   // (_is_operation_pending) or we should wait for new operations
   // (_continue).
-  while(_continue || _enqueued_operations.size() > 0)
+  while(_continue || queue_size() > 0)
   {
     {
       std::unique_lock<std::mutex> lock(_mutex);


### PR DESCRIPTION
Hopefully fixes #728 

The main change is that this introduces a mutex to lock `dag_manager::flush_async()`, thereby giving task submission atomic semantics.
Task submission involves two main steps:
1. Popping all DAG nodes that have been collected by the `dag_builder` from all threads
2. Enqueuing work to the worker thread to process and submit those nodes for execution.
When task submission from another thread jumps in between those steps, it can happen it grabs those DAG nodes for processing. In this case, since `flush_async()` did not have atomic semantics, an incorrect submission order can arise.

This can lead to nodes, that should have already been submitted, being submitted too late, and the `submit(); flush_sync()` pattern not actually guaranteeing that everything is submitted.

This PR fixes this. 

Also adds some minor improvements in this area, like improving diagnostic output, and additional debug assertions.