### PR TITLE
dag_node: Only use backend wait() functionality if we are not yet complete

### DIFF
--- a/src/runtime/dag_node.cpp
+++ b/src/runtime/dag_node.cpp
@@ -225,6 +225,8 @@ const std::vector<dag_node_ptr> &dag_node::get_requirements() const
 void dag_node::wait() const
 {
   while (!_is_submitted);
+  if(_is_complete)
+    return;
 
   _event->wait();
   _is_complete = true;


### PR DESCRIPTION
If we have already cached that the node has completed, there is no need to invoked backend `wait()` functionality. This can maybe improve performance of multiple `wait()` calls to the same object.
More importantly, it works around #740 by avoid calls to backend functionality in the buffer destructor, if the event has already been waited for before.

#740 is probably part of larger issues around shutdown behavior, but this is at least a work around. Hopefully fixes #740.