### PR TITLE
Fix fiinding boost library path for boost with cmake intgeration 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,7 @@ else()
   if(NOT FIBER_IMPORT_LIBRARY)
     get_target_property(FIBER_IMPORT_LIBRARY Boost::fiber IMPORTED_LOCATION_RELEASE)
   endif()
-  get_filename_component(Boost_LIBRARY_DIR "${FIBER_IMPORT_LIBRARY}" ABSOLUTE)
+  get_filename_component(Boost_LIBRARY_DIR "${FIBER_IMPORT_LIBRARY}" DIRECTORY)
   get_target_property(Boost_INCLUDE_DIR Boost::fiber INTERFACE_INCLUDE_DIRECTORIES)
 endif()
 


### PR DESCRIPTION
For boost libraries that provide cmake integration, we extract the Library location from the exported target. Before this change, the entire path to the boost library was added to the -L flag. This change makes sure that only the directory is included. This is possibly a fix for #726 