### PR TITLE
Restrict queries of event state

### DIFF
--- a/include/hipSYCL/runtime/dag_submitted_ops.hpp
+++ b/include/hipSYCL/runtime/dag_submitted_ops.hpp
@@ -41,6 +41,7 @@ namespace rt {
 class dag_submitted_ops
 {
 public:
+  void purge_completed();
   void update_with_submission(dag_node_ptr single_node);
   
   void wait_for_all();

--- a/src/runtime/dag_builder.cpp
+++ b/src/runtime/dag_builder.cpp
@@ -160,7 +160,7 @@ dag_node_ptr dag_builder::build_node(std::unique_ptr<operation> op,
             if(user_ptr && is_conflicting_access(mem_req, user))
             {
               // No reason to take a dependency into account that is alreay completed
-              if(!user_ptr->is_complete())
+              if(!user_ptr->is_known_complete())
                 req_node->add_requirement(user_ptr);
             }
           });

--- a/src/runtime/dag_direct_scheduler.cpp
+++ b/src/runtime/dag_direct_scheduler.cpp
@@ -189,11 +189,10 @@ void submit(backend_executor *executor, dag_node_ptr node, operation *op) {
       reqs.push_back(req);
   });
   // Compress requirements by removing complete requirements
-  reqs.erase(
-      std::remove_if(reqs.begin(), reqs.end(),
-                     [](dag_node_ptr elem) { return elem->is_complete(); }),
-      reqs.end());
-
+  reqs.erase(std::remove_if(
+                 reqs.begin(), reqs.end(),
+                 [](dag_node_ptr elem) { return elem->is_known_complete(); }),
+             reqs.end());
 
   node->assign_to_executor(executor);
   

--- a/src/runtime/dag_manager.cpp
+++ b/src/runtime/dag_manager.cpp
@@ -92,10 +92,13 @@ void dag_manager::flush_async()
 
     if(new_dag.num_nodes() > 0) {
       _worker([this, new_dag](){
-        // Construct new DAG
         HIPSYCL_DEBUG_INFO << "dag_manager [async]: Flushing!" << std::endl;
         
         // Release any old users of memory buffers used in this dag
+        // purge_completed() not only removes old users from the submitted ops list,
+        // it also queries event state and updates the cached value
+        // in case operations have completed.
+        this->_submitted_ops.purge_completed();
         for(dag_node_ptr req : new_dag.get_memory_requirements()){
           assert_is<memory_requirement>(req->get_operation());
 

--- a/src/runtime/dag_submitted_ops.cpp
+++ b/src/runtime/dag_submitted_ops.cpp
@@ -44,11 +44,14 @@ void erase_completed_nodes(std::vector<dag_node_ptr> &ops) {
 }
 }
 
-
-void dag_submitted_ops::update_with_submission(dag_node_ptr single_node) {
+void dag_submitted_ops::purge_completed() {
   std::lock_guard lock{_lock};
 
   erase_completed_nodes(_ops);
+}
+
+void dag_submitted_ops::update_with_submission(dag_node_ptr single_node) {
+  std::lock_guard lock{_lock};
 
   assert(single_node->is_submitted());
   _ops.push_back(single_node);

--- a/src/runtime/data.cpp
+++ b/src/runtime/data.cpp
@@ -82,7 +82,7 @@ void data_user_tracker::release_dead_users()
                                 auto u = user.user.lock();
                                 if (!u)
                                   return true;
-                                return u->is_complete();
+                                return u->is_known_complete();
                               }),
                _users.end());
 }


### PR DESCRIPTION
In order to limit size of the task graph that is processed by the runtime, it is important to not consider operations that have already completed.
Previously, these queries happened at multiple places using `dag_node::is_complete()`, which will invoke backend queries (e.g. `hipEventQuery`) if the event is not complete. Once such a backend query returns that the event has completed, this information is cached and backend queries are no longer invoked.

These backend queries can negatively impact submission latencies.

This PR restricts invoking `dag_node::is_complete()` to a single point in the beginning submission process. All other places just query the cache using `dag_node::is_known_complete()`. Because the `is_complete()` invocation at the beginning will update the cache, this should have very little impact on the optimizations that the runtime can do, while potentially significantly reducing the amount of backend event queries.

Using SYCL-Bench's sequential DAG task throughput benchmark, I see a roughly 20% higher task throughput with this PR.

@al42and @pszi1ard - this might be interesting for you.