### PR TITLE
[CUDA][HIP] Add event pool

### DIFF
--- a/include/hipSYCL/runtime/cuda/cuda_event_pool.hpp
+++ b/include/hipSYCL/runtime/cuda/cuda_event_pool.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2019-2020 Aksel Alpay and contributors
+ * Copyright (c) 2022 Aksel Alpay
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,40 +25,34 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef HIPSYCL_CUDA_EVENT_HPP
-#define HIPSYCL_CUDA_EVENT_HPP
+#ifndef HIPSYCL_CUDA_EVENT_POOL_HPP
+#define HIPSYCL_CUDA_EVENT_POOL_HPP
 
-#include "../event.hpp"
+#include "../event_pool.hpp"
+#include "cuda_event.hpp"
 
-// Note: CUevent_st* == cudaEvent_t 
-struct CUevent_st;
+#include <cuda_runtime_api.h>
 
 namespace hipsycl {
 namespace rt {
 
-class cuda_event_pool;
-class cuda_node_event : public dag_node_event
-{
+class cuda_event_factory {
 public:
-  /// \param evt cuda event; must have been properly initialized and recorded.
-  /// \param pool the pool managing the event. If not null, the destructor will return the event
-  /// to the pool.
-  cuda_node_event(device_id dev, CUevent_st* evt, cuda_event_pool* pool = nullptr);
-  ~cuda_node_event();
+  using event_type = CUevent_st*;
+  cuda_event_factory(int device_id);
 
-  virtual bool is_complete() const override;
-  virtual void wait() override;
-
-  CUevent_st* get_event() const;
-  device_id get_device() const;
+  result create(event_type&);
+  result destroy(event_type);
 private:
-  device_id _dev;
-  CUevent_st* _evt;
-  cuda_event_pool* _pool;
+  int _device_id;
+};
+
+class cuda_event_pool : public event_pool<cuda_event_factory> {
+public:
+  cuda_event_pool(int device_id);
 };
 
 }
 }
-
 
 #endif

--- a/include/hipSYCL/runtime/cuda/cuda_hardware_manager.hpp
+++ b/include/hipSYCL/runtime/cuda/cuda_hardware_manager.hpp
@@ -39,6 +39,9 @@ struct cudaDeviceProp;
 namespace hipsycl {
 namespace rt {
 
+class cuda_allocator;
+class cuda_event_pool;
+
 class cuda_hardware_context : public hardware_context
 {
 public:
@@ -69,8 +72,12 @@ public:
 
   virtual ~cuda_hardware_context();
 
+  cuda_allocator* get_allocator() const;
+  cuda_event_pool* get_event_pool() const;
 private:
   std::unique_ptr<cudaDeviceProp> _properties;
+  std::unique_ptr<cuda_allocator> _allocator;
+  std::unique_ptr<cuda_event_pool> _event_pool;
   int _dev;
 };
 

--- a/include/hipSYCL/runtime/cuda/cuda_queue.hpp
+++ b/include/hipSYCL/runtime/cuda/cuda_queue.hpp
@@ -35,6 +35,7 @@
 #include "cuda_instrumentation.hpp"
 #include "cuda_code_object.hpp"
 #include "hipSYCL/runtime/code_object_invoker.hpp"
+#include "hipSYCL/runtime/cuda/cuda_event.hpp"
 
 
 // Forward declare CUstream_st instead of including cuda_runtime_api.h.
@@ -48,6 +49,7 @@ namespace hipsycl {
 namespace rt {
 
 class cuda_queue;
+class cuda_backend;
 
 class cuda_code_object_invoker : public code_object_invoker{
 public:
@@ -69,7 +71,7 @@ private:
 class cuda_queue : public inorder_queue
 {
 public:
-  cuda_queue(device_id dev);
+  cuda_queue(cuda_backend* be, device_id dev);
 
   CUstream_st* get_stream() const;
 
@@ -110,6 +112,7 @@ private:
   CUstream_st *_stream;
   cuda_code_object_invoker _code_object_invoker;
   host_timestamped_event _reference_event;
+  cuda_backend* _backend;
 };
 
 }

--- a/include/hipSYCL/runtime/event_pool.hpp
+++ b/include/hipSYCL/runtime/event_pool.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2019 Aksel Alpay
+ * Copyright (c) 2022 Aksel Alpay
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,47 +25,64 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef HIPSYCL_EVENT_POOL_HPP
+#define HIPSYCL_EVENT_POOL_HPP
+
 #include <vector>
-
-#include "../backend.hpp"
-#include "../multi_queue_executor.hpp"
-
-#include "cuda_allocator.hpp"
-#include "cuda_queue.hpp"
-#include "cuda_hardware_manager.hpp"
-#include "cuda_event_pool.hpp"
-
-#ifndef HIPSYCL_CUDA_BACKEND_HPP
-#define HIPSYCL_CUDA_BACKEND_HPP
+#include <mutex>
+#include <functional>
+#include "error.hpp"
 
 namespace hipsycl {
 namespace rt {
 
-
-class cuda_backend : public backend
-{
+// BackendEventFactory must satisfy the concept:
+// - define event_type for native backend type
+// - define method to construct event: result create(event_type&)
+// - define method to destroy event: result destroy(event_type)
+template<class BackendEventFactory>
+class event_pool {
 public:
-  cuda_backend();
-  virtual api_platform get_api_platform() const override;
-  virtual hardware_platform get_hardware_platform() const override;
-  virtual backend_id get_unique_backend_id() const override;
-  
-  virtual backend_hardware_manager* get_hardware_manager() const override;
-  virtual backend_executor* get_executor(device_id dev) const override;
-  virtual backend_allocator *get_allocator(device_id dev) const override;
+  using event_type = typename BackendEventFactory::event_type;
 
-  virtual std::string get_name() const override;
-  
-  virtual ~cuda_backend(){}
+  event_pool(const BackendEventFactory& event_factory)
+      : _event_factory{event_factory} {}
 
-  cuda_event_pool* get_event_pool(device_id dev) const;
+  ~event_pool() {
+    for(event_type& evt : _available_events) {
+      auto err = _event_factory.destroy(evt);
+      if(!err.is_success()) {
+        register_error(err);
+      }
+    }
+  }
+
+  // Obtain event from pool. Obtained event
+  // must be returned to the pool using release_event()
+  // when it is no longer needed.
+  result obtain_event(event_type& out) {
+    std::lock_guard<std::mutex> lock {_mutex};
+    if(!_available_events.empty()) {
+      out = _available_events.back();
+      _available_events.pop_back();
+      return make_success();
+    }
+    return _event_factory.create(out);
+  }
+
+  // Return event to pool.
+  void release_event(event_type evt) {
+    std::lock_guard<std::mutex> lock {_mutex};
+    _available_events.push_back(evt);
+  }
+
 private:
-  mutable cuda_hardware_manager _hw_manager;
-  mutable multi_queue_executor _executor;
+  BackendEventFactory _event_factory;
+  std::vector<event_type> _available_events;
+  std::mutex _mutex;
 };
 
 }
 }
-
 
 #endif

--- a/include/hipSYCL/runtime/hip/hip_backend.hpp
+++ b/include/hipSYCL/runtime/hip/hip_backend.hpp
@@ -33,6 +33,7 @@
 #include "hip_allocator.hpp"
 #include "hip_queue.hpp"
 #include "hip_hardware_manager.hpp"
+#include "hip_event_pool.hpp"
 
 #ifndef HIPSYCL_HIP_BACKEND_HPP
 #define HIPSYCL_HIP_BACKEND_HPP
@@ -57,10 +58,10 @@ public:
 
   virtual ~hip_backend(){}
 
+  hip_event_pool* get_event_pool(device_id dev) const;
 private:
   mutable hip_hardware_manager _hw_manager;
   mutable multi_queue_executor _executor;
-  mutable std::vector<hip_allocator> _allocators;
 };
 
 }

--- a/include/hipSYCL/runtime/hip/hip_event.hpp
+++ b/include/hipSYCL/runtime/hip/hip_event.hpp
@@ -35,12 +35,14 @@ struct ihipEvent_t;
 namespace hipsycl {
 namespace rt {
 
-
+class hip_event_pool;
 class hip_node_event : public dag_node_event
 {
 public:
-  /// \c evt Must have been properly initialized and recorded.
-  hip_node_event(device_id dev, ihipEvent_t* evt);
+  /// \param evt Must have been properly initialized and recorded.
+  /// \param pool the pool managing the event. If not null, the destructor
+  /// will return the event to the pool.
+  hip_node_event(device_id dev, ihipEvent_t* evt, hip_event_pool* pool = nullptr);
   ~hip_node_event();
 
   virtual bool is_complete() const override;
@@ -51,6 +53,7 @@ public:
 private:
   device_id _dev;
   ihipEvent_t* _evt;
+  hip_event_pool* _pool;
 };
 
 }

--- a/include/hipSYCL/runtime/hip/hip_event_pool.hpp
+++ b/include/hipSYCL/runtime/hip/hip_event_pool.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2019-2020 Aksel Alpay and contributors
+ * Copyright (c) 2022 Aksel Alpay
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,40 +25,34 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef HIPSYCL_CUDA_EVENT_HPP
-#define HIPSYCL_CUDA_EVENT_HPP
+#ifndef HIPSYCL_HIP_EVENT_POOL_HPP
+#define HIPSYCL_HIP_EVENT_POOL_HPP
 
-#include "../event.hpp"
+#include "../event_pool.hpp"
+#include "hip_event.hpp"
 
-// Note: CUevent_st* == cudaEvent_t 
-struct CUevent_st;
+
 
 namespace hipsycl {
 namespace rt {
 
-class cuda_event_pool;
-class cuda_node_event : public dag_node_event
-{
+class hip_event_factory {
 public:
-  /// \param evt cuda event; must have been properly initialized and recorded.
-  /// \param pool the pool managing the event. If not null, the destructor will return the event
-  /// to the pool.
-  cuda_node_event(device_id dev, CUevent_st* evt, cuda_event_pool* pool = nullptr);
-  ~cuda_node_event();
+  using event_type = ihipEvent_t*;
+  hip_event_factory(int device_id);
 
-  virtual bool is_complete() const override;
-  virtual void wait() override;
-
-  CUevent_st* get_event() const;
-  device_id get_device() const;
+  result create(event_type&);
+  result destroy(event_type);
 private:
-  device_id _dev;
-  CUevent_st* _evt;
-  cuda_event_pool* _pool;
+  int _device_id;
+};
+
+class hip_event_pool : public event_pool<hip_event_factory> {
+public:
+  hip_event_pool(int device_id);
 };
 
 }
 }
-
 
 #endif

--- a/include/hipSYCL/runtime/hip/hip_hardware_manager.hpp
+++ b/include/hipSYCL/runtime/hip/hip_hardware_manager.hpp
@@ -40,6 +40,9 @@ struct hipDeviceProp_t;
 namespace hipsycl {
 namespace rt {
 
+class hip_allocator;
+class hip_event_pool;
+
 class hip_hardware_context : public hardware_context
 {
 public:
@@ -70,8 +73,12 @@ public:
 
   virtual ~hip_hardware_context() {}
 
+  hip_allocator* get_allocator() const;
+  hip_event_pool* get_event_pool() const;
 private:
   std::unique_ptr<hipDeviceProp_t> _properties;
+  std::unique_ptr<hip_allocator> _allocator;
+  std::unique_ptr<hip_event_pool> _event_pool;
   int _dev;
 };
 

--- a/include/hipSYCL/runtime/hip/hip_queue.hpp
+++ b/include/hipSYCL/runtime/hip/hip_queue.hpp
@@ -40,10 +40,12 @@ struct ihipStream_t;
 namespace hipsycl {
 namespace rt {
 
+class hip_backend;
+
 class hip_queue : public inorder_queue
 {
 public:
-  hip_queue(device_id dev);
+  hip_queue(hip_backend* be, device_id dev);
 
   ihipStream_t* get_stream() const;
 
@@ -76,6 +78,7 @@ private:
   device_id _dev;
   ihipStream_t* _stream;
   host_timestamped_event _reference_event;
+  hip_backend* _backend;
 };
 
 }

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -71,6 +71,7 @@ install(TARGETS hipSYCL-rt
 if(WITH_CUDA_BACKEND)
   add_library(rt-backend-cuda SHARED
     cuda/cuda_event.cpp
+    cuda/cuda_event_pool.cpp
     cuda/cuda_queue.cpp
     cuda/cuda_instrumentation.cpp
     cuda/cuda_allocator.cpp
@@ -96,6 +97,7 @@ if(WITH_ROCM_BACKEND)
 
   add_library(rt-backend-hip SHARED
     hip/hip_event.cpp
+    hip/hip_event_pool.cpp
     hip/hip_queue.cpp
     hip/hip_instrumentation.cpp
     hip/hip_allocator.cpp

--- a/src/runtime/cuda/cuda_backend.cpp
+++ b/src/runtime/cuda/cuda_backend.cpp
@@ -28,6 +28,7 @@
 #include "hipSYCL/runtime/backend_loader.hpp"
 
 #include "hipSYCL/runtime/cuda/cuda_backend.hpp"
+#include "hipSYCL/runtime/cuda/cuda_event.hpp"
 #include "hipSYCL/runtime/cuda/cuda_queue.hpp"
 
 HIPSYCL_PLUGIN_API_EXPORT
@@ -47,16 +48,9 @@ namespace rt {
 
 cuda_backend::cuda_backend()
     : _hw_manager{get_hardware_platform()},
-      _executor{*this, [](device_id dev) {
-                  return std::make_unique<cuda_queue>(dev);
-                }} {
-
-  backend_descriptor backend_desc{get_hardware_platform(), get_api_platform()};
-
-  for (int i = 0; i < static_cast<int>(_hw_manager.get_num_devices()); ++i) {
-    _allocators.push_back(cuda_allocator{backend_desc, i});
-  }
-}
+      _executor{*this, [this](device_id dev) {
+                  return std::make_unique<cuda_queue>(this, dev);
+                }} {}
 
 api_platform cuda_backend::get_api_platform() const {
   return api_platform::cuda;
@@ -85,17 +79,18 @@ backend_executor *cuda_backend::get_executor(device_id dev) const {
   return &_executor;
 }
 
-backend_allocator *cuda_backend::get_allocator(device_id dev) const {
-  if (dev.get_full_backend_descriptor().sw_platform != api_platform::cuda) {
-    register_error(
-        __hipsycl_here(),
-        error_info{"cuda_backend: Passed device id from other backend to CUDA backend"});
-    return nullptr;
-  }
-  if (static_cast<std::size_t>(dev.get_id()) >= _allocators.size()) {
-    register_error(__hipsycl_here(), error_info{"cuda_backend: Device id is out of bounds"});
-  }
-  return &(_allocators[dev.get_id()]);
+backend_allocator* cuda_backend::get_allocator(device_id dev) const {
+  assert(dev.get_backend() == this->get_unique_backend_id());
+  return static_cast<cuda_hardware_context *>(
+             get_hardware_manager()->get_device(dev.get_id()))
+      ->get_allocator();
+}
+
+cuda_event_pool* cuda_backend::get_event_pool(device_id dev) const {
+  assert(dev.get_backend() == this->get_unique_backend_id());
+  return static_cast<cuda_hardware_context *>(
+             get_hardware_manager()->get_device(dev.get_id()))
+      ->get_event_pool();
 }
 
 std::string cuda_backend::get_name() const {

--- a/src/runtime/cuda/cuda_event.cpp
+++ b/src/runtime/cuda/cuda_event.cpp
@@ -26,6 +26,7 @@
  */
 
 #include "hipSYCL/runtime/cuda/cuda_event.hpp"
+#include "hipSYCL/runtime/cuda/cuda_event_pool.hpp"
 #include "hipSYCL/runtime/error.hpp"
 
 #include <cuda_runtime_api.h>
@@ -34,16 +35,13 @@ namespace hipsycl {
 namespace rt {
 
 
-cuda_node_event::cuda_node_event(device_id dev, cudaEvent_t evt)
-: _dev{dev}, _evt{evt}
+cuda_node_event::cuda_node_event(device_id dev, cudaEvent_t evt, cuda_event_pool* pool)
+: _dev{dev}, _evt{evt}, _pool{pool}
 {}
 
 cuda_node_event::~cuda_node_event() {
-  auto err = cudaEventDestroy(_evt);
-  if (err != cudaSuccess) {
-    register_error(__hipsycl_here(),
-                   error_info{"cuda_node_event: Couldn't destroy event",
-                              error_code{"CUDA", err}});
+  if(_pool) {
+    _pool->release_event(_evt);
   }
 }
 

--- a/src/runtime/cuda/cuda_event_pool.cpp
+++ b/src/runtime/cuda/cuda_event_pool.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2019-2020 Aksel Alpay and contributors
+ * Copyright (c) 2022 Aksel Alpay
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,40 +25,46 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef HIPSYCL_CUDA_EVENT_HPP
-#define HIPSYCL_CUDA_EVENT_HPP
 
-#include "../event.hpp"
-
-// Note: CUevent_st* == cudaEvent_t 
-struct CUevent_st;
+#include "hipSYCL/runtime/cuda/cuda_event_pool.hpp"
+#include "hipSYCL/runtime/cuda/cuda_device_manager.hpp"
+#include "hipSYCL/runtime/error.hpp"
+#include <cuda_runtime_api.h>
 
 namespace hipsycl {
 namespace rt {
 
-class cuda_event_pool;
-class cuda_node_event : public dag_node_event
-{
-public:
-  /// \param evt cuda event; must have been properly initialized and recorded.
-  /// \param pool the pool managing the event. If not null, the destructor will return the event
-  /// to the pool.
-  cuda_node_event(device_id dev, CUevent_st* evt, cuda_event_pool* pool = nullptr);
-  ~cuda_node_event();
+cuda_event_factory::cuda_event_factory(int device_id)
+: _device_id{device_id} {}
 
-  virtual bool is_complete() const override;
-  virtual void wait() override;
+result cuda_event_factory::create(cudaEvent_t& out) {
+  cuda_device_manager::get().activate_device(_device_id);
 
-  CUevent_st* get_event() const;
-  device_id get_device() const;
-private:
-  device_id _dev;
-  CUevent_st* _evt;
-  cuda_event_pool* _pool;
-};
+  cudaEvent_t evt;
+  auto err = cudaEventCreate(&evt);
+  if(err != cudaSuccess) {
+    return make_error(
+        __hipsycl_here(),
+        error_info{"cuda_event_factory: Couldn't create event", error_code{"CUDA", err}});
+    
+  }
+  out = evt;
+  
+  return make_success();
+}
+
+result cuda_event_factory::destroy(cudaEvent_t evt) {
+  auto err = cudaEventDestroy(evt);
+  if (err != cudaSuccess) {
+    return make_error(__hipsycl_here(),
+                   error_info{"cuda_event_factory: Couldn't destroy event",
+                              error_code{"CUDA", err}});
+  }
+  return make_success();
+}
+
+cuda_event_pool::cuda_event_pool(int device_id)
+: event_pool<cuda_event_factory>{cuda_event_factory{device_id}} {}
 
 }
 }
-
-
-#endif

--- a/src/runtime/hip/hip_event.cpp
+++ b/src/runtime/hip/hip_event.cpp
@@ -27,22 +27,20 @@
 
 #include "hipSYCL/runtime/hip/hip_event.hpp"
 #include "hipSYCL/runtime/hip/hip_target.hpp"
+#include "hipSYCL/runtime/hip/hip_event_pool.hpp"
 #include "hipSYCL/runtime/error.hpp"
 
 namespace hipsycl {
 namespace rt {
 
 
-hip_node_event::hip_node_event(device_id dev, hipEvent_t evt)
-: _dev{dev}, _evt{evt}
+hip_node_event::hip_node_event(device_id dev, hipEvent_t evt, hip_event_pool* pool)
+: _dev{dev}, _evt{evt}, _pool{pool}
 {}
 
 hip_node_event::~hip_node_event() {
-  auto err = hipEventDestroy(_evt);
-  if (err != hipSuccess) {
-    register_error(__hipsycl_here(),
-                   error_info{"hip_node_event: Couldn't destroy event",
-                              error_code{"HIP", err}});
+  if(_pool) {
+    _pool->release_event(_evt);
   }
 }
 

--- a/src/runtime/hip/hip_hardware_manager.cpp
+++ b/src/runtime/hip/hip_hardware_manager.cpp
@@ -26,6 +26,8 @@
  */
 
 #include "hipSYCL/runtime/hip/hip_hardware_manager.hpp"
+#include "hipSYCL/runtime/hip/hip_event_pool.hpp"
+#include "hipSYCL/runtime/hip/hip_allocator.hpp"
 #include "hipSYCL/runtime/hip/hip_target.hpp"
 #include "hipSYCL/runtime/error.hpp"
 #include <exception>
@@ -97,6 +99,18 @@ hip_hardware_context::hip_hardware_context(int dev) : _dev{dev} {
         error_info{"hip_hardware_manager: Could not query device properties ",
                    error_code{"HIP", err}});
   }
+
+  _allocator = std::make_unique<hip_allocator>(
+      backend_descriptor{hardware_platform::rocm, api_platform::hip}, _dev);
+  _event_pool = std::make_unique<hip_event_pool>(_dev);
+}
+
+hip_allocator* hip_hardware_context::get_allocator() const {
+  return _allocator.get();
+}
+
+hip_event_pool* hip_hardware_context::get_event_pool() const {
+  return _event_pool.get();
 }
 
 bool hip_hardware_context::is_cpu() const {

--- a/src/runtime/hip/hip_queue.cpp
+++ b/src/runtime/hip/hip_queue.cpp
@@ -27,6 +27,7 @@
 
 #include "hipSYCL/runtime/hip/hip_target.hpp"
 #include "hipSYCL/runtime/hip/hip_queue.hpp"
+#include "hipSYCL/runtime/hip/hip_backend.hpp"
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/hip/hip_event.hpp"
 #include "hipSYCL/runtime/hip/hip_device_manager.hpp"
@@ -122,7 +123,8 @@ void hip_queue::activate_device() const {
   hip_device_manager::get().activate_device(_dev.get_id());
 }
 
-hip_queue::hip_queue(device_id dev) : _dev{dev}, _stream{nullptr} {
+hip_queue::hip_queue(hip_backend *be, device_id dev)
+    : _dev{dev}, _stream{nullptr}, _backend{be} {
   this->activate_device();
 
   auto err = hipStreamCreateWithFlags(&_stream, hipStreamNonBlocking);
@@ -149,19 +151,15 @@ hip_queue::~hip_queue() {
 
 /// Inserts an event into the stream
 std::shared_ptr<dag_node_event> hip_queue::insert_event() {
-  this->activate_device();
-
   hipEvent_t evt;
-  auto err = hipEventCreate(&evt);
-  if(err != hipSuccess) {
-    register_error(
-        __hipsycl_here(),
-        error_info{"hip_queue: Couldn't create event", error_code{"HIP", err}});
+  auto event_creation_result =
+      _backend->get_event_pool(_dev)->obtain_event(evt);
+  if(!event_creation_result.is_success()) {
+    register_error(event_creation_result);
     return nullptr;
   }
 
-
-  err = hipEventRecord(evt, this->get_stream());
+  hipError_t err = hipEventRecord(evt, this->get_stream());
   if (err != hipSuccess) {
     register_error(
         __hipsycl_here(),
@@ -169,7 +167,8 @@ std::shared_ptr<dag_node_event> hip_queue::insert_event() {
     return nullptr;
   }
 
-  return std::make_shared<hip_node_event>(_dev, std::move(evt));
+  return std::make_shared<hip_node_event>(_dev, std::move(evt),
+                                          _backend->get_event_pool(_dev));
 }
 
 


### PR DESCRIPTION
Previously, a new CUDA or HIP event was created for every new operation. Calls to `cudaEventCreate()` or `hipEventCreate` can however be costly.

This PR adds an event pool for the CUDA and HIP backends. It works as follows:
- We maintain a per-device list of events that are currently unused (event pool).
- When we need a new event, we first check in the event pool whether there are unused events available
    - if so, we pop one from there and use it. 
    - If not, we construct a new one using `cudaEventCreate()`/`hipEventCreate()`.
- In the event destructor, the backend event is returned to the event pool.

This should allow us to elide most calls to event creation functions.

CC @al42and @pszi1ard