### PR TITLE
dag_submitted_ops: Manage node lifetime by asynchronously waiting instead of event queries

### DIFF
--- a/include/hipSYCL/runtime/dag_node.hpp
+++ b/include/hipSYCL/runtime/dag_node.hpp
@@ -104,6 +104,9 @@ public:
   // Can be invoked before the event has been set (pre-submission),
   // in which case the function will additionally wait
   // until the event exists.
+  //
+  // Waiting will cause the node and all its requirements to return true
+  // for is_known_complete().
   void wait() const;
 
   std::shared_ptr<dag_node_event> get_event() const;

--- a/include/hipSYCL/runtime/dag_submitted_ops.hpp
+++ b/include/hipSYCL/runtime/dag_submitted_ops.hpp
@@ -33,6 +33,7 @@
 #include <vector>
 
 #include "dag_node.hpp"
+#include "generic/async_worker.hpp"
 
 namespace hipsycl {
 namespace rt {
@@ -41,15 +42,23 @@ namespace rt {
 class dag_submitted_ops
 {
 public:
-  void purge_completed();
+  // Asynchronously waits on the nodes to complete, and, once complete,
+  // removes them (and other completed) nodes from the submitted list.
+  //
+  // All nodes in the provided argument vector must have been registered
+  // previously with update_with_submission()
+  void async_wait_and_unregister(const std::vector<dag_node_ptr>& nodes);
   void update_with_submission(dag_node_ptr single_node);
   
   void wait_for_all();
   void wait_for_group(std::size_t node_group);
   std::vector<dag_node_ptr> get_group(std::size_t node_group);
 private:
+  void purge_known_completed();
+
   std::vector<dag_node_ptr> _ops;
   std::mutex _lock;
+  worker_thread _updater_thread;
 };
 
 

--- a/include/hipSYCL/runtime/dag_submitted_ops.hpp
+++ b/include/hipSYCL/runtime/dag_submitted_ops.hpp
@@ -47,6 +47,8 @@ public:
   //
   // All nodes in the provided argument vector must have been registered
   // previously with update_with_submission()
+  //
+  // For best performance, the provided nodes should be in submission order.
   void async_wait_and_unregister(const std::vector<dag_node_ptr>& nodes);
   void update_with_submission(dag_node_ptr single_node);
   

--- a/src/runtime/dag_manager.cpp
+++ b/src/runtime/dag_manager.cpp
@@ -138,11 +138,15 @@ void dag_manager::flush_async()
         for(auto node : new_dag.get_memory_requirements())
           this->register_submitted_ops(node);
               
-        
+        // We do not need to wait for the requirements explicitly
+        // because they will also have completed by the time
+        // their command groups have finished and can
+        // be purged together with them.
+        //
+        // This is the case, because dag_node::wait() also
+        // marks all its requirements as complete.
         this->_submitted_ops.async_wait_and_unregister(
             new_dag.get_command_groups());
-        this->_submitted_ops.async_wait_and_unregister(
-            new_dag.get_memory_requirements());
       });
     }
   } else {


### PR DESCRIPTION
We need to know when nodes have completed in order to be able to perform e.g. buffer memory management and not deallocate buffers while they are still in use.
Previously this was done by querying event state prior to submitting new tasks. This can be a bottleneck when many small tasks are submitted.
This PR changes this by instead waiting on all nodes from a DAG batch in an asynchronous worker thread. Once the wait is complete, we can release the nodes.
This should theoretically allow us to circumvent *all* of the event queries.

However, it is currently still unclear how this interacts with coarse grained events #754, where waiting on an event might map to a `cudaStreamSynchronize()` or `hipStreamSynchronize()` call. Also the practical performance impact needs to be investigated, therefore this is still a draft PR.

@al42and @pszi1ard This can also be interesting for you, as it cuts out any event queries completely from the submission path.