### PR TITLE
[cbs] Fix compatibility issues with upstream Clang/LLVM

### DIFF
--- a/src/compiler/cbs/LoopSimplify.cpp
+++ b/src/compiler/cbs/LoopSimplify.cpp
@@ -31,6 +31,7 @@
 #include "hipSYCL/compiler/cbs/SplitterAnnotationAnalysis.hpp"
 
 #include <llvm/Analysis/ScalarEvolution.h>
+#include <llvm/IR/Dominators.h>
 
 namespace hipsycl::compiler {
 char LoopSimplifyPassLegacy::ID = 0;

--- a/src/compiler/cbs/VectorShapeTransformer.cpp
+++ b/src/compiler/cbs/VectorShapeTransformer.cpp
@@ -57,7 +57,7 @@ static Type *getElementType(Type *Ty) {
     return VecTy->getElementType();
   }
   if (auto PtrTy = dyn_cast<PointerType>(Ty)) {
-    return PtrTy->getElementType();
+    return PtrTy->getPointerElementType();
   }
   if (auto ArrTy = dyn_cast<ArrayType>(Ty)) {
     return ArrTy->getElementType();

--- a/src/compiler/cbs/VectorizationInfo.cpp
+++ b/src/compiler/cbs/VectorizationInfo.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Adaptations: Get rid of unnecessary dependencies (VectorMapping)
-// 
+//
 //===----------------------------------------------------------------------===//
 //
 
@@ -14,6 +14,7 @@
 #include <hipSYCL/common/debug.hpp>
 #include <llvm/Analysis/LoopInfo.h>
 #include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/Constants.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Instruction.h>
 


### PR DESCRIPTION
This commit adds two missing headers whose contents have
been moved in upstream Clang/LLVM. It also changes a call
from `PointerType::getElementType()` to
`Type::getPointerElementType()` as a temporary fix
until opaque pointers are introduced. The former was already
deprecated in Clang/LLVM 14 and has been removed in upstream.