### PR TITLE
[CBS] Fix runtime issues with opaque pointers

### DIFF
--- a/include/hipSYCL/compiler/cbs/IRUtils.hpp
+++ b/include/hipSYCL/compiler/cbs/IRUtils.hpp
@@ -165,6 +165,20 @@ void copyDgbValues(llvm::Value *From, llvm::Value *To, llvm::Instruction *Insert
 void dropDebugLocation(llvm::Instruction &I);
 void dropDebugLocation(llvm::BasicBlock *BB);
 
+/// opaque ptr abstraction
+/// we have some cases where originally we had to look through a bitcast / gep
+/// but since opaque ptrs, they're gone, so now we check, if \a V is the type we're looking for
+template <class T> T *getValueOneLevel(llvm::Constant *V, unsigned idx = 0) {
+  // opaque ptr
+  if (auto *R = llvm::dyn_cast<T>(V))
+    return R;
+
+  // typed ptr -> look through bitcast
+  if (V->getNumOperands() == 0)
+    return nullptr;
+  return llvm::dyn_cast<T>(V->getOperand(idx));
+}
+
 } // namespace utils
 } // namespace hipsycl::compiler
 #endif // HIPSYCL_IRUTILS_HPP

--- a/src/compiler/cbs/LoopSimplify.cpp
+++ b/src/compiler/cbs/LoopSimplify.cpp
@@ -31,6 +31,7 @@
 #include "hipSYCL/compiler/cbs/SplitterAnnotationAnalysis.hpp"
 
 #include <llvm/Analysis/ScalarEvolution.h>
+#include <llvm/IR/Dominators.h>
 
 namespace hipsycl::compiler {
 char LoopSimplifyPassLegacy::ID = 0;

--- a/src/compiler/cbs/SplitterAnnotationAnalysis.cpp
+++ b/src/compiler/cbs/SplitterAnnotationAnalysis.cpp
@@ -48,10 +48,11 @@ bool hipsycl::compiler::SplitterAnnotationInfo::analyzeModule(llvm::Module &M) {
     if (I.getName() == "llvm.global.annotations") {
       auto *CA = llvm::dyn_cast<llvm::ConstantArray>(I.getOperand(0));
       for (auto *OI = CA->op_begin(); OI != CA->op_end(); ++OI) {
-        if (auto *CS = llvm::dyn_cast<llvm::ConstantStruct>(OI->get()))
-          if (auto *F = llvm::dyn_cast<llvm::Function>(CS->getOperand(0)->getOperand(0)))
+        if (auto *CS = llvm::dyn_cast<llvm::ConstantStruct>(OI->get());
+            CS && CS->getNumOperands() >= 2)
+          if (auto *F = utils::getValueOneLevel<llvm::Function>(CS->getOperand(0)))
             if (auto *AnnotationGL =
-                    llvm::dyn_cast<llvm::GlobalVariable>(CS->getOperand(1)->getOperand(0)))
+                    utils::getValueOneLevel<llvm::GlobalVariable>(CS->getOperand(1)))
               if (auto *Initializer =
                       llvm::dyn_cast<llvm::ConstantDataArray>(AnnotationGL->getInitializer())) {
                 llvm::StringRef Annotation = Initializer->getAsCString();

--- a/src/compiler/cbs/SubCfgFormation.cpp
+++ b/src/compiler/cbs/SubCfgFormation.cpp
@@ -95,15 +95,17 @@ getLocalSizeArgumentFromAnnotation(llvm::Function &F) {
                          llvm::dyn_cast<llvm::GlobalVariable>(UI->getOperand(1))) // opaque-ptr
             AnnotateStr = AnnoteStr;
 
-          if (AnnotateStr)
+          if (AnnotateStr) {
             if (auto *Data =
-                    llvm::dyn_cast<llvm::ConstantDataSequential>(AnnotateStr->getInitializer()))
+                    llvm::dyn_cast<llvm::ConstantDataSequential>(AnnotateStr->getInitializer())) {
               if (Data->isString() &&
                   Data->getAsString().startswith("hipsycl_nd_kernel_local_size_arg")) {
                 if (auto *BC = llvm::dyn_cast<llvm::BitCastInst>(UI->getOperand(0)))
                   return {BC->getOperand(0), UI};
                 return {UI->getOperand(0), UI};
               }
+            }
+          }
         }
 
   assert(false && "Didn't find annotated argument!");

--- a/src/compiler/cbs/VectorShapeTransformer.cpp
+++ b/src/compiler/cbs/VectorShapeTransformer.cpp
@@ -57,7 +57,7 @@ static Type *getElementType(Type *Ty) {
     return VecTy->getElementType();
   }
   if (auto PtrTy = dyn_cast<PointerType>(Ty)) {
-    return PtrTy->getElementType();
+    return PtrTy->getPointerElementType();
   }
   if (auto ArrTy = dyn_cast<ArrayType>(Ty)) {
     return ArrTy->getElementType();

--- a/src/compiler/cbs/VectorShapeTransformer.cpp
+++ b/src/compiler/cbs/VectorShapeTransformer.cpp
@@ -73,7 +73,10 @@ static Type *getElementType(Type *Ty) {
   if (auto PtrTy = dyn_cast<PointerType>(Ty)) {
     if IS_OPAQUE (PtrTy)
       return nullptr;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     return PtrTy->getPointerElementType();
+#pragma GCC diagnostic pop
   }
 #endif
   if (auto ArrTy = dyn_cast<ArrayType>(Ty)) {
@@ -507,7 +510,10 @@ bool returnsVoidPtr(const Instruction &inst) {
     return true;
 
 #if HAS_TYPED_PTR // otherwise return true from above holds.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return inst.getType()->getPointerElementType()->isIntegerTy(8);
+#pragma GCC diagnostic pop
 #endif
 }
 
@@ -531,7 +537,10 @@ VectorShape VectorShapeTransformer::computeShapeForCastInst(const CastInst &cast
       return VectorShape::strided(castOpStride, 1);
 
 #if HAS_TYPED_PTR
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     Type *DestPointsTo = DestType->getPointerElementType();
+#pragma GCC diagnostic pop
 
     // FIXME: void pointers are char pointers (i8*), but what
     // difference is there between a real i8* and a void pointer?
@@ -553,7 +562,10 @@ VectorShape VectorShapeTransformer::computeShapeForCastInst(const CastInst &cast
       return VectorShape::strided(castOpStride, aligned);
 
 #if HAS_TYPED_PTR
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     Type *SrcElemType = SrcType->getPointerElementType();
+#pragma GCC diagnostic pop
 
     unsigned typeSize = (unsigned)layout.getTypeStoreSize(SrcElemType);
 

--- a/src/compiler/cbs/VectorizationInfo.cpp
+++ b/src/compiler/cbs/VectorizationInfo.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Adaptations: Get rid of unnecessary dependencies (VectorMapping)
-// 
+//
 //===----------------------------------------------------------------------===//
 //
 
@@ -14,6 +14,7 @@
 #include <hipSYCL/common/debug.hpp>
 #include <llvm/Analysis/LoopInfo.h>
 #include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/Constants.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Instruction.h>
 


### PR DESCRIPTION
As a follow-up for #763 and should fix #764

This fixes a bunch of (SYCL compilation time) issues that are introduced with LLVM 15, due to defaulting to opaque pointers now.

The issues range from `getPointerElementType` being illegal on opaque ptrs to the annotations no longer using `bitcast` or `getelementptr` inline to specify their targets.

Should make hipSYCL ready for LLVM 15 and hopefully LLVM 16 as well, where according to https://llvm.org/docs/OpaquePointers.html#version-support, the non-opaque ptrs shall be fully removed.

cc @aaronmondal