### PR TITLE
Use weak_ptr in node requirements list

### DIFF
--- a/include/hipSYCL/runtime/dag_node.hpp
+++ b/include/hipSYCL/runtime/dag_node.hpp
@@ -98,7 +98,7 @@ public:
   // Add requirement if not already present
   void add_requirement(dag_node_ptr requirement);
   operation* get_operation() const;
-  const std::vector<dag_node_ptr>& get_requirements() const;
+  const std::vector<std::weak_ptr<dag_node>>& get_requirements() const;
 
   // Wait until the associated event has completed.
   // Can be invoked before the event has been set (pre-submission),
@@ -124,7 +124,7 @@ public:
   runtime* get_runtime() const;
 private:
   execution_hints _hints;
-  std::vector<dag_node_ptr> _requirements;
+  std::vector<std::weak_ptr<dag_node>> _requirements;
 
   device_id _assigned_device;
   backend_executor *_assigned_executor;

--- a/include/hipSYCL/runtime/dag_submitted_ops.hpp
+++ b/include/hipSYCL/runtime/dag_submitted_ops.hpp
@@ -47,9 +47,11 @@ public:
   void wait_for_all();
   void wait_for_group(std::size_t node_group);
   std::vector<dag_node_ptr> get_group(std::size_t node_group);
+
+  bool contains_node(dag_node_ptr node) const;
 private:
   std::vector<dag_node_ptr> _ops;
-  std::mutex _lock;
+  mutable std::mutex _lock;
 };
 
 

--- a/include/hipSYCL/runtime/operations.hpp
+++ b/include/hipSYCL/runtime/operations.hpp
@@ -334,8 +334,6 @@ public:
   kernel_launcher& get_launcher();
   const kernel_launcher& get_launcher() const;
 
-  const std::vector<memory_requirement*>& get_memory_requirements() const;
-
   void dump(std::ostream & ostr, int indentation=0) const override;
 
   result dispatch(operation_dispatcher* dispatcher, dag_node_ptr node) override {
@@ -347,7 +345,11 @@ public:
   /// variables.
   template <typename... KernelComponents>
   void initialize_embedded_pointers(KernelComponents &...kernel_components) {
-    for(auto* req : _requirements) {
+    for(auto req_node : _requirements) {
+
+      memory_requirement *req =
+          static_cast<memory_requirement *>(req_node->get_operation());
+
       if(req->is_buffer_requirement()){
         buffer_memory_requirement *bmem_req =
             static_cast<buffer_memory_requirement *>(req);
@@ -375,7 +377,11 @@ public:
 private:
   std::string _kernel_name;
   kernel_launcher _launcher;
-  std::vector<memory_requirement*> _requirements;
+  // We store shared_ptr to the memory requirement nodes to make sure
+  // that they are alive as long as kernel operations live.
+  // This is required to guarantee the functionality of
+  // initialize_embedded_pointers()
+  std::vector<dag_node_ptr> _requirements;
 };
 
 // To describe memcpy operations, we need an abstract

--- a/include/hipSYCL/sycl/event.hpp
+++ b/include/hipSYCL/sycl/event.hpp
@@ -62,9 +62,10 @@ public:
     if(_node) {
       std::vector<event> events;
 
-      for(auto node : _node->get_requirements()) {
+      for(auto weak_node : _node->get_requirements()) {
         // TODO Is it correct to just use our handler here?
-        events.push_back(event{node, _handler});
+        if(auto node = weak_node.lock())
+          events.push_back(event{node, _handler});
       }
 
       return events;

--- a/src/runtime/dag.cpp
+++ b/src/runtime/dag.cpp
@@ -38,9 +38,11 @@ namespace hipsycl {
 namespace rt {
 
 void dag::add_command_group(dag_node_ptr node) {
-  for (auto req : node->get_requirements()) {
-    if (req->get_operation()->is_requirement())
-      _memory_requirements.push_back(req);
+  for (auto weak_req : node->get_requirements()) {
+    if(auto req = weak_req.lock()) {
+      if (req->get_operation()->is_requirement())
+        _memory_requirements.push_back(req);
+    }
   }
   _command_groups.push_back(node);
 }

--- a/src/runtime/dag_direct_scheduler.cpp
+++ b/src/runtime/dag_direct_scheduler.cpp
@@ -335,6 +335,9 @@ void dag_direct_scheduler::submit(dag_node_ptr node) {
           abort_submission(node);
           return;
         }
+
+        // Need to make sure that we also remember the requirements
+        _rt->dag().register_submitted_ops(req);
       }
     }
   }

--- a/src/runtime/dag_direct_scheduler.cpp
+++ b/src/runtime/dag_direct_scheduler.cpp
@@ -44,9 +44,11 @@ namespace rt {
 namespace {
 
 void abort_submission(dag_node_ptr node) {
-  for (auto req : node->get_requirements()) {
-    if (!req->is_submitted()) {
-      req->cancel();
+  for (auto weak_req : node->get_requirements()) {
+    if(auto req = weak_req.lock()) {
+      if (!req->is_submitted()) {
+        req->cancel();
+      }
     }
   }
   node->cancel();
@@ -309,26 +311,30 @@ void dag_direct_scheduler::submit(dag_node_ptr node) {
                                 ->get_device_id();
   node->assign_to_device(target_device);
   
-  for (auto req : node->get_requirements())
-    assign_devices_or_default(req, target_device);
+  for (auto weak_req : node->get_requirements()) {
+    if(auto req = weak_req.lock())
+      assign_devices_or_default(req, target_device);
+  }
 
-  for (auto req : node->get_requirements()) {
-    if (!req->get_operation()->is_requirement()) {
-      if (!req->is_submitted()) {
-        register_error(__hipsycl_here(),
-                   error_info{"dag_direct_scheduler: Direct scheduler does not "
-                              "support processing multiple unsubmitted nodes",
-                              error_type::feature_not_supported});
-        abort_submission(node);
-        return;
-      }
-    } else {
-      result res = submit_requirement(_rt, req);
+  for (auto weak_req : node->get_requirements()) {
+    if(auto req = weak_req.lock()) {
+      if (!req->get_operation()->is_requirement()) {
+        if (!req->is_submitted()) {
+          register_error(__hipsycl_here(),
+                    error_info{"dag_direct_scheduler: Direct scheduler does not "
+                                "support processing multiple unsubmitted nodes",
+                                error_type::feature_not_supported});
+          abort_submission(node);
+          return;
+        }
+      } else {
+        result res = submit_requirement(_rt, req);
 
-      if (!res.is_success()) {
-        register_error(res);
-        abort_submission(node);
-        return;
+        if (!res.is_success()) {
+          register_error(res);
+          abort_submission(node);
+          return;
+        }
       }
     }
   }
@@ -348,7 +354,6 @@ void dag_direct_scheduler::submit(dag_node_ptr node) {
     rt::submit(exec, node, node->get_operation());
   }
   // Register node as submitted with the runtime
-  // (only relevant for queue::wait() operations)
   _rt->dag().register_submitted_ops(node);
 }
 

--- a/src/runtime/dag_direct_scheduler.cpp
+++ b/src/runtime/dag_direct_scheduler.cpp
@@ -335,9 +335,6 @@ void dag_direct_scheduler::submit(dag_node_ptr node) {
           abort_submission(node);
           return;
         }
-
-        // Need to make sure that we also remember the requirements
-        _rt->dag().register_submitted_ops(req);
       }
     }
   }
@@ -356,8 +353,6 @@ void dag_direct_scheduler::submit(dag_node_ptr node) {
     backend_executor *exec = select_executor(_rt, node, node->get_operation());
     rt::submit(exec, node, node->get_operation());
   }
-  // Register node as submitted with the runtime
-  _rt->dag().register_submitted_ops(node);
 }
 
 }

--- a/src/runtime/dag_manager.cpp
+++ b/src/runtime/dag_manager.cpp
@@ -137,6 +137,13 @@ void dag_manager::flush_async()
         HIPSYCL_DEBUG_INFO << "dag_manager [async]: DAG flush complete."
                           << std::endl;
       
+        for(auto node : new_dag.get_command_groups())
+          // Register node as submitted with the runtime
+          this->register_submitted_ops(node);
+        
+        for(auto node : new_dag.get_memory_requirements())
+          this->register_submitted_ops(node);
+        
       });
     }
   } else {

--- a/src/runtime/dag_submitted_ops.cpp
+++ b/src/runtime/dag_submitted_ops.cpp
@@ -120,5 +120,15 @@ std::vector<dag_node_ptr> dag_submitted_ops::get_group(std::size_t node_group) {
   return ops;
 }
 
+bool dag_submitted_ops::contains_node(dag_node_ptr node) const {
+  std::lock_guard lock{_lock};
+
+  for(dag_node_ptr n : _ops) {
+    if(n == node)
+      return true;
+  }
+  return false;
+}
+
 }
 }

--- a/src/runtime/operations.cpp
+++ b/src/runtime/operations.cpp
@@ -51,8 +51,7 @@ kernel_operation::kernel_operation(
     if(op->is_requirement()){
       requirement* req = cast<requirement>(op);
       if(req->is_memory_requirement()){
-        memory_requirement* mreq = cast<memory_requirement>(req);
-        _requirements.push_back(mreq);
+        _requirements.push_back(req_node);
       }
     }
   }
@@ -65,10 +64,6 @@ kernel_operation::get_launcher()
 const kernel_launcher& 
 kernel_operation::get_launcher() const
 { return _launcher; }
-
-const std::vector<memory_requirement*>& 
-kernel_operation::get_memory_requirements() const
-{ return _requirements; }
 
 
 

--- a/src/runtime/serialization/serialization.cpp
+++ b/src/runtime/serialization/serialization.cpp
@@ -109,7 +109,8 @@ void kernel_operation::dump(std::ostream &ostr, int indentation) const {
   std::string indent = get_indentation(indentation);
   ostr << indent << "kernel: " << _kernel_name;
   for (auto requirement : _requirements) {
-    ostr << std::endl; requirement->dump(ostr, indentation + 1);
+    ostr << std::endl;
+    requirement->get_operation()->dump(ostr, indentation + 1);
   }
 }
 

--- a/src/runtime/serialization/serialization.cpp
+++ b/src/runtime/serialization/serialization.cpp
@@ -147,8 +147,9 @@ void dag::dump(std::ostream &ostr) const {
     ostr << HIPSYCL_DUMP_INDENTATION << "Has requirement on: ";
     auto requirement_list = node_ptr->get_requirements();
     if (!requirement_list.empty()) {
-      for (auto req : requirement_list) {
-        ostr << req << " ";
+      for (auto weak_req : requirement_list) {
+        if(auto req = weak_req.lock())
+          ostr << req << " ";
       }
     } else {
       std::cout << "None";

--- a/tests/sycl/profiler.cpp
+++ b/tests/sycl/profiler.cpp
@@ -170,6 +170,9 @@ BOOST_AUTO_TEST_CASE(queue_profiling)
   auto t83 = evt8.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
   // run time may be zero if prefetching is a no-op
   BOOST_CHECK(t81 <= t82 && t82 <= t83);
+
+  cl::sycl::free(src, queue);
+  cl::sycl::free(dest, queue);
 }
 
 // update_host is an explicit operation, but implemented as a requirement and thus not profiled.


### PR DESCRIPTION
Previously, `dag_node` has maintained `shared_ptr` objects to its requirements in the dependency graph. For deep dependency graphs, this can prevent nodes from being deleted even if the underlying operation has already completed since they might still be referenced.
So far, this has not been a huge issue. However, with the introduction of event pools in #757, this becomes important: If the DAG node cannot be deleted, its event stays alive and cannot be returned to the pool. In the worst case, this can prevent us from benefiting from the event pool at all, having to create individual events for each operation again.

To fix this, this PR changes the requirements list to `weak_ptr` so that DAG nodes can be deleted as soon as their operation has finished.

TODO: ~Seems to work on GPU, but still crashes on CPU. Presumably because CPU backend has its own worker thread to execute kernels, and this additional asynchronous behavior probably changes the lifetime guarantees of DAG nodes.~