### PR TITLE
[Plugin] Resolve version macros in HIPSYCL_STRINGIFY

### DIFF
--- a/src/compiler/HipsyclClangPlugin.cpp
+++ b/src/compiler/HipsyclClangPlugin.cpp
@@ -86,7 +86,8 @@ static llvm::RegisterStandardPasses
                                          registerMarkParallelPass);
 #endif
 #if !defined(_WIN32) && LLVM_VERSION_MAJOR >= 11
-#define HIPSYCL_STRINGIFY(V) #V
+#define HIPSYCL_RESOLVE_AND_QUOTE(V) #V
+#define HIPSYCL_STRINGIFY(V) HIPSYCL_RESOLVE_AND_QUOTE(V)
 #define HIPSYCL_PLUGIN_VERSION_STRING                                                              \
   "v" HIPSYCL_STRINGIFY(HIPSYCL_VERSION_MAJOR) "." HIPSYCL_STRINGIFY(                              \
       HIPSYCL_VERSION_MINOR) "." HIPSYCL_STRINGIFY(HIPSYCL_VERSION_PATCH)


### PR DESCRIPTION
The previous variant did not work with some preprocessors, falsely resolving macros like `#define HIPSYCL_VERSION_MINOR 9` to "HIPSYCL_VERSION_MINOR" instead of "9".