### PR TITLE
Add missing sycl::nd_range::get_group_range function

### DIFF
--- a/include/hipSYCL/sycl/libkernel/nd_range.hpp
+++ b/include/hipSYCL/sycl/libkernel/nd_range.hpp
@@ -70,6 +70,10 @@ struct nd_range
   { return _num_groups; }
 
   HIPSYCL_UNIVERSAL_TARGET
+  range<dimensions> get_group_range() const
+  { return get_group(); }
+
+  HIPSYCL_UNIVERSAL_TARGET
   id<dimensions> get_offset() const
   { return _offset; }
   


### PR DESCRIPTION
https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#subsubsec:nd-range-class