### PR TITLE
implement known_identity

### DIFF
--- a/include/hipSYCL/sycl/libkernel/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/builtins.hpp
@@ -388,8 +388,9 @@ using ulonglong16 = vec<unsigned long long, 16>;
 #define HIPSYCL_BUILTIN_GENERATOR_TRINARY_T_T_T(T, name, impl_name)            \
   HIPSYCL_BUILTIN T name(T a, T b, T c) noexcept {                             \
     if constexpr (std::is_arithmetic_v<T>) {                                   \
-      return impl_name(detail::data_element(a, 0), detail::data_element(b, 0), \
-                       detail::data_element(c, 0));                            \
+      return static_cast<T>(impl_name(detail::data_element(a, 0),              \
+                                      detail::data_element(b, 0),              \
+                                      detail::data_element(c, 0)));            \
     } else {                                                                   \
       T result;                                                                \
       for (int i = 0; i < detail::builtin_type_traits<T>::num_elements; ++i) { \
@@ -405,8 +406,8 @@ using ulonglong16 = vec<unsigned long long, 16>;
 #define HIPSYCL_BUILTIN_GENERATOR_BINARY_T_T(T, name, impl_name)               \
   HIPSYCL_BUILTIN T name(T a, T b) noexcept {                                  \
     if constexpr (std::is_arithmetic_v<T>) {                                   \
-      return impl_name(detail::data_element(a, 0),                             \
-                       detail::data_element(b, 0));                            \
+      return static_cast<T>(impl_name(detail::data_element(a, 0),              \
+                                      detail::data_element(b, 0)));            \
     } else {                                                                   \
       T result;                                                                \
       for (int i = 0; i < detail::builtin_type_traits<T>::num_elements; ++i) { \
@@ -422,7 +423,7 @@ using ulonglong16 = vec<unsigned long long, 16>;
   template <access::address_space A>                                           \
   HIPSYCL_BUILTIN T name(T a, const multi_ptr<T, A> &b) noexcept {             \
     if constexpr (std::is_arithmetic_v<T>) {                                   \
-      return impl_name(detail::data_element(a, 0), b.get());                   \
+      return static_cast<T>(impl_name(detail::data_element(a, 0), b.get()));   \
     } else {                                                                   \
       T result;                                                                \
       for (int i = 0; i < detail::builtin_type_traits<T>::num_elements; ++i) { \
@@ -440,8 +441,8 @@ using ulonglong16 = vec<unsigned long long, 16>;
                              int> = 0>                                         \
   HIPSYCL_BUILTIN T name(T a, IntType b) noexcept {                            \
     if constexpr (std::is_arithmetic_v<T>) {                                   \
-      return impl_name(detail::data_element(a, 0),                             \
-                       detail::data_element(b, 0));                            \
+      return static_cast<T>(impl_name(detail::data_element(a, 0),              \
+                                      detail::data_element(b, 0)));            \
     } else {                                                                   \
       T result;                                                                \
       for (int i = 0; i < detail::builtin_type_traits<T>::num_elements; ++i) { \
@@ -474,7 +475,7 @@ using ulonglong16 = vec<unsigned long long, 16>;
 #define HIPSYCL_BUILTIN_GENERATOR_UNARY_T(T, name, impl_name)                  \
   HIPSYCL_BUILTIN T name(T a) noexcept {                                       \
     if constexpr (std::is_arithmetic_v<T>) {                                   \
-      return impl_name(detail::data_element(a, 0));                            \
+      return static_cast<T>(impl_name(detail::data_element(a, 0)));            \
     } else {                                                                   \
       T result;                                                                \
       for (int i = 0; i < detail::builtin_type_traits<T>::num_elements; ++i) { \
@@ -485,38 +486,40 @@ using ulonglong16 = vec<unsigned long long, 16>;
     }                                                                          \
   }
 
-#define HIPSYCL_BUILTIN_GENERATOR_UNARY_T_RET_INT(T, name, impl_name)          \
-  HIPSYCL_BUILTIN                                                              \
-  typename detail::builtin_type_traits<T>::alternative_data_type<int> name(    \
-      T a) noexcept {                                                          \
-    if constexpr (std::is_arithmetic_v<T>) {                                   \
-      return impl_name(detail::data_element(a, 0));                            \
-    } else {                                                                   \
-      typename detail::builtin_type_traits<T>::alternative_data_type<int>      \
-          result;                                                              \
-      for (int i = 0; i < detail::builtin_type_traits<T>::num_elements; ++i) { \
-        auto a_i = detail::data_element(a, i);                                 \
-        detail::data_element(result, i) = impl_name(a_i);                      \
-      }                                                                        \
-      return result;                                                           \
-    }                                                                          \
+#define HIPSYCL_BUILTIN_GENERATOR_UNARY_T_RET_INT(T, name, impl_name)                 \
+  HIPSYCL_BUILTIN                                                                     \
+  typename detail::builtin_type_traits<T>::alternative_data_type<int> name(           \
+      T a) noexcept {                                                                 \
+    if constexpr (std::is_arithmetic_v<T>) {                                          \
+      return static_cast<detail::builtin_type_traits<T>::alternative_data_type<int>>( \
+                      static_cast<int>(impl_name(detail::data_element(a, 0))));       \
+    } else {                                                                          \
+      typename detail::builtin_type_traits<T>::alternative_data_type<int>             \
+          result;                                                                     \
+      for (int i = 0; i < detail::builtin_type_traits<T>::num_elements; ++i) {        \
+        auto a_i = detail::data_element(a, i);                                        \
+        detail::data_element(result, i) = impl_name(a_i);                             \
+      }                                                                               \
+      return result;                                                                  \
+    }                                                                                 \
   }
 
-#define HIPSYCL_BUILTIN_GENERATOR_UNARY_T_RET_INT64(T, name, impl_name)        \
-  HIPSYCL_BUILTIN                                                              \
-  typename detail::builtin_type_traits<T>::alternative_data_type<int64_t> name(\
-      T a) noexcept {                                                          \
-    if constexpr (std::is_arithmetic_v<T>) {                                   \
-      return impl_name(detail::data_element(a, 0));                            \
-    } else {                                                                   \
-      typename detail::builtin_type_traits<T>::alternative_data_type<int64_t>  \
-          result;                                                              \
-      for (int i = 0; i < detail::builtin_type_traits<T>::num_elements; ++i) { \
-        auto a_i = detail::data_element(a, i);                                 \
-        detail::data_element(result, i) = impl_name(a_i);                      \
-      }                                                                        \
-      return result;                                                           \
-    }                                                                          \
+#define HIPSYCL_BUILTIN_GENERATOR_UNARY_T_RET_INT64(T, name, impl_name)                   \
+  HIPSYCL_BUILTIN                                                                         \
+  typename detail::builtin_type_traits<T>::alternative_data_type<int64_t> name(           \
+      T a) noexcept {                                                                     \
+    if constexpr (std::is_arithmetic_v<T>) {                                              \
+      return static_cast<detail::builtin_type_traits<T>::alternative_data_type<int64_t>>( \
+                      static_cast<int64_t>(impl_name(detail::data_element(a, 0))));       \
+    } else {                                                                              \
+      typename detail::builtin_type_traits<T>::alternative_data_type<int64_t>             \
+          result;                                                                         \
+      for (int i = 0; i < detail::builtin_type_traits<T>::num_elements; ++i) {            \
+        auto a_i = detail::data_element(a, i);                                            \
+        detail::data_element(result, i) = impl_name(a_i);                                 \
+      }                                                                                   \
+      return result;                                                                      \
+    }                                                                                     \
   }
 
 

--- a/include/hipSYCL/sycl/libkernel/functional.hpp
+++ b/include/hipSYCL/sycl/libkernel/functional.hpp
@@ -29,6 +29,8 @@
 #ifndef HIPSYCL_SYCL_FUNCTIONAL_HPP
 #define HIPSYCL_SYCL_FUNCTIONAL_HPP
 
+#include <limits>
+
 #include "backend.hpp"
 #include "vec.hpp"
 

--- a/include/hipSYCL/sycl/libkernel/functional.hpp
+++ b/include/hipSYCL/sycl/libkernel/functional.hpp
@@ -34,50 +34,178 @@
 namespace hipsycl {
 namespace sycl {
 
-template <typename T> struct plus {
+template <typename T = void> struct plus {
   HIPSYCL_KERNEL_TARGET
   T operator()(const T &x, const T &y) const { return x + y; }
 };
 
-template <typename T> struct multiplies {
+template <> struct plus<void> {
+  template<typename T>
+  HIPSYCL_KERNEL_TARGET
+  T operator()(const T &x, const T &y) const { return x + y; }
+};
+
+template <typename T = void> struct multiplies {
   HIPSYCL_KERNEL_TARGET
   T operator()(const T &x, const T &y) const { return x * y; }
 };
 
-template <typename T> struct bit_and {
+template <> struct multiplies<void> {
+  template<typename T>
+  HIPSYCL_KERNEL_TARGET
+  T operator()(const T &x, const T &y) const { return x * y; }
+};
+
+template <typename T = void> struct bit_and {
   HIPSYCL_KERNEL_TARGET
   T operator()(const T &x, const T &y) const { return x & y; }
 };
 
-template <typename T> struct bit_or {
+template <> struct bit_and<void> {
+  template<typename T>
+  HIPSYCL_KERNEL_TARGET
+  T operator()(const T &x, const T &y) const { return x & y; }
+};
+
+template <typename T = void> struct bit_or {
   HIPSYCL_KERNEL_TARGET
   T operator()(const T &x, const T &y) const { return x | y; }
 };
 
-template <typename T> struct bit_xor {
+template <> struct bit_or<void> {
+  template<typename T>
+  HIPSYCL_KERNEL_TARGET
+  T operator()(const T &x, const T &y) const { return x | y; }
+};
+
+template <typename T = void> struct bit_xor {
   HIPSYCL_KERNEL_TARGET
   T operator()(const T &x, const T &y) const { return x ^ y; }
 };
 
-template <typename T> struct logical_and {
+template <> struct bit_xor<void> {
+  template<typename T>
+  HIPSYCL_KERNEL_TARGET
+  T operator()(const T &x, const T &y) const { return x ^ y; }
+};
+
+template <typename T = void> struct logical_and {
   HIPSYCL_KERNEL_TARGET
   T operator()(const T &x, const T &y) const { return static_cast<T>(x && y); }
 };
 
-template <typename T> struct logical_or {
+template <> struct logical_and<void> {
+  template<typename T>
+  HIPSYCL_KERNEL_TARGET
+  T operator()(const T &x, const T &y) const { return static_cast<T>(x && y); }
+};
+
+template <typename T = void> struct logical_or {
   HIPSYCL_KERNEL_TARGET
   T operator()(const T &x, const T &y) const { return static_cast<T>(x || y); }
 };
 
-template <typename T> struct minimum {
+template <> struct logical_or<void> {
+  template<typename T>
+  HIPSYCL_KERNEL_TARGET
+  T operator()(const T &x, const T &y) const { return static_cast<T>(x || y); }
+};
+
+template <typename T = void> struct minimum {
   HIPSYCL_KERNEL_TARGET
   T operator()(const T &x, const T &y) const { return (x < y) ? x : y; }
 };
 
-template <typename T> struct maximum {
+template <> struct minimum<void> {
+  template<typename T>
+  HIPSYCL_KERNEL_TARGET
+  T operator()(const T &x, const T &y) const { return (x < y) ? x : y; }
+};
+
+template <typename T = void> struct maximum {
   HIPSYCL_KERNEL_TARGET
   T operator()(const T &x, const T &y) const { return (x > y) ? x : y; }
 };
+
+template <> struct maximum<void> {
+  template<typename T>
+  HIPSYCL_KERNEL_TARGET
+  T operator()(const T &x, const T &y) const { return (x > y) ? x : y; }
+};
+
+
+namespace detail {
+
+template<typename BinaryOperation, typename AccumulatorT, typename Enable = void>
+struct known_identity_trait {
+  static constexpr bool has_known_identity = false; \
+};
+
+template<typename T, typename Enable=void>
+struct minmax_identity {
+  inline static constexpr T max_id = std::numeric_limits<T>::lowest();
+  inline static constexpr T min_id = std::numeric_limits<T>::max();
+};
+
+template<typename T>
+struct minmax_identity<T, std::enable_if_t<std::numeric_limits<T>::has_infinity>> {
+  inline static constexpr T max_id = -std::numeric_limits<T>::infinity();
+  inline static constexpr T min_id = std::numeric_limits<T>::infinity();
+};
+
+#define HIPSYCL_DEFINE_IDENTITY(op, cond, identity) \
+    template<typename T, typename U> \
+    struct known_identity_trait<op<T>, U, std::enable_if_t<cond>> { \
+      inline static constexpr bool has_known_identity = true; \
+      inline static constexpr std::remove_cv_t<T> known_identity = (identity); \
+    }; \
+    template<typename T> \
+    struct known_identity_trait<op<void>, T, std::enable_if_t<cond>> { \
+      inline static constexpr bool has_known_identity = true; \
+      inline static constexpr std::remove_cv_t<T> known_identity = (identity); \
+    }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wbool-operation"  // allow ~bool, bool & bool
+#endif
+
+// TODO is_arithmetic implicitly covers the current pseudo half = ushort type, resolve once half is implemented
+HIPSYCL_DEFINE_IDENTITY(plus, std::is_arithmetic_v<T>, T{});
+HIPSYCL_DEFINE_IDENTITY(multiplies, std::is_arithmetic_v<T>, T{1});
+HIPSYCL_DEFINE_IDENTITY(bit_or, std::is_integral_v<T>, T{});
+HIPSYCL_DEFINE_IDENTITY(bit_and, std::is_integral_v<T>, ~T{});
+HIPSYCL_DEFINE_IDENTITY(bit_xor, std::is_integral_v<T>, T{});
+HIPSYCL_DEFINE_IDENTITY(logical_or, (std::is_same_v<std::remove_cv_t<T>, bool>), false);
+HIPSYCL_DEFINE_IDENTITY(logical_and, (std::is_same_v<std::remove_cv_t<T>, bool>), true);
+HIPSYCL_DEFINE_IDENTITY(minimum, std::is_arithmetic_v<T>, minmax_identity<std::remove_cv_t<T>>::min_id);
+HIPSYCL_DEFINE_IDENTITY(maximum, std::is_arithmetic_v<T>, minmax_identity<std::remove_cv_t<T>>::max_id);
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+#undef HIPSYCL_DEFINE_IDENTITY
+
+}
+
+template<typename BinaryOperation, typename AccumulatorT>
+struct known_identity {
+  static constexpr AccumulatorT value = detail::known_identity_trait<
+      BinaryOperation, AccumulatorT>::known_identity;
+};
+
+template <typename BinaryOperation, typename AccumulatorT>
+inline constexpr AccumulatorT known_identity_v = known_identity<BinaryOperation, AccumulatorT>::value;
+
+template<typename BinaryOperation, typename AccumulatorT>
+struct has_known_identity {
+  static constexpr bool value = detail::known_identity_trait<
+      BinaryOperation, AccumulatorT>::has_known_identity;
+};
+
+template <typename BinaryOperation, typename AccumulatorT>
+inline constexpr bool has_known_identity_v = has_known_identity<BinaryOperation, AccumulatorT>::value;
 
 } // namespace sycl
 }

--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -49,10 +49,10 @@ public:
   using value_type = T;
 
   HIPSYCL_UNIVERSAL_TARGET
-  T& operator[](int i) { return _storage[i]; }
+  constexpr T& operator[](int i) { return _storage[i]; }
 
   HIPSYCL_UNIVERSAL_TARGET
-  const T& operator[](int i) const { return _storage[i]; }
+  constexpr const T& operator[](int i) const { return _storage[i]; }
 
   template<int Index>
   HIPSYCL_UNIVERSAL_TARGET
@@ -86,7 +86,7 @@ public:
   }
 
 private:
-  alignas(alignment) T _storage [effective_size];
+  alignas(alignment) T _storage [effective_size] = {0};
 };
 
 // An alternative implementation of the vec_storage concept
@@ -182,6 +182,17 @@ template <class Vector_type, class Function>
 HIPSYCL_UNIVERSAL_TARGET
 void for_each_vector_element(const Vector_type& v, Function&& f);
 
+template <typename Arg, typename T>
+HIPSYCL_UNIVERSAL_TARGET
+constexpr int external_count_num_elements() {
+  if constexpr(std::is_scalar_v<Arg>)
+    return 1;
+  else if(std::is_same_v<typename Arg::element_type, T>)
+    return Arg::get_count();
+  // ToDo: Trigger error
+  return 0;
+}
+
 }
 
 enum class rounding_mode {
@@ -251,7 +262,7 @@ public:
   using vector_t = typename VectorStorage::interop_type;
 
   HIPSYCL_UNIVERSAL_TARGET
-  vec(const VectorStorage& v)
+  constexpr vec(const VectorStorage& v)
   : _data{v} {}
 
   // The regular constructors are only available when we are not
@@ -260,7 +271,7 @@ public:
             std::enable_if_t<std::is_same_v<S, detail::vec_storage<T, N>>,
                              bool> = true>
   HIPSYCL_UNIVERSAL_TARGET
-  vec() {
+  constexpr vec() {
     for(int i = 0; i < N; ++i)
       _data[i] = T{};
   }
@@ -268,7 +279,7 @@ public:
   template <class S = VectorStorage,
             std::enable_if_t<std::is_same_v<S, detail::vec_storage<T, N>>,
                              bool> = true>
-  HIPSYCL_UNIVERSAL_TARGET explicit vec(const T &value) {
+  HIPSYCL_UNIVERSAL_TARGET explicit constexpr vec(const T &value) {
     for(int i = 0; i < N; ++i)
       _data[i] = value;
   }
@@ -276,8 +287,8 @@ public:
   template <typename... Args, class S = VectorStorage,
             std::enable_if_t<std::is_same_v<S, detail::vec_storage<T, N>>,
                              bool> = true>
-  HIPSYCL_UNIVERSAL_TARGET vec(const Args &...args) {
-    static_assert((count_num_elements<Args>() + ...) == N,
+  HIPSYCL_UNIVERSAL_TARGET constexpr vec(const Args &...args) {
+    static_assert((detail::external_count_num_elements<Args, T>() + ...) == N,
                   "Argument mismatch with vector size");
 
     int current_init_index = 0;
@@ -287,7 +298,7 @@ public:
   template <class OtherStorage, class S = VectorStorage,
             std::enable_if_t<std::is_same_v<S, detail::vec_storage<T, N>>,
                              bool> = true>
-  HIPSYCL_UNIVERSAL_TARGET vec(const vec<T, N, OtherStorage> &other)
+  HIPSYCL_UNIVERSAL_TARGET constexpr vec(const vec<T, N, OtherStorage> &other)
   {
     for(int i = 0; i < N; ++i)
       _data[i] = other[i];
@@ -864,7 +875,7 @@ private:
       ++current_init_index;
     } else {
       // Assume we are dealing with another vector
-      constexpr int count = count_num_elements<Arg>();
+      constexpr int count = detail::external_count_num_elements<Arg, T>();
       
       for(int i = 0; i < count; ++i) {
         _data[i + current_init_index] = x[i];

--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -49,6 +49,10 @@ public:
   using value_type = T;
 
   HIPSYCL_UNIVERSAL_TARGET
+  constexpr vec_storage()
+  : _storage{} {}
+
+  HIPSYCL_UNIVERSAL_TARGET
   constexpr T& operator[](int i) { return _storage[i]; }
 
   HIPSYCL_UNIVERSAL_TARGET
@@ -86,7 +90,7 @@ public:
   }
 
 private:
-  alignas(alignment) T _storage [effective_size] = {0};
+  alignas(alignment) T _storage [effective_size];
 };
 
 // An alternative implementation of the vec_storage concept

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,6 +66,7 @@ add_executable(sycl_tests
   sycl/explicit_copy.cpp
   sycl/extensions.cpp
   sycl/fill.cpp
+  sycl/functional.cpp
   sycl/group_functions/group_functions_misc.cpp
   sycl/group_functions/group_functions_binary_reduce.cpp
   sycl/group_functions/group_functions_reduce.cpp

--- a/tests/sycl/functional.cpp
+++ b/tests/sycl/functional.cpp
@@ -33,6 +33,8 @@ BOOST_FIXTURE_TEST_SUITE(functional_tests, reset_device_fixture)
 
 using known_identity_types = boost::mpl::list<float, double, char, signed char, unsigned char,
     int, long, unsigned int, unsigned long, bool, const float, const bool>;
+using known_identity_vector_types = boost::mpl::list<float, double, char, signed char, unsigned char,
+    int, long, unsigned int, unsigned long, bool>;
 
 #ifdef __GNUC__
 #pragma GCC diagnostic push
@@ -96,6 +98,81 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(known_identities, T, known_identity_types::type) {
     BOOST_TEST((s::known_identity_v<s::logical_or<>, T>) == false);
     BOOST_TEST((s::known_identity_v<s::logical_and<T>, T>) == true);
     BOOST_TEST((s::known_identity_v<s::logical_and<>, T>) == true);
+  }
+}
+
+// basically the same as the scalar known_identites tests, but with adjusted checks
+BOOST_AUTO_TEST_CASE_TEMPLATE(known_vector_identities, T, known_identity_vector_types::type) {
+  constexpr int num_elements = 4;
+  using V = s::vec<T, num_elements>;
+  static_assert(s::has_known_identity_v<s::minimum<V>, V>);
+  static_assert(s::has_known_identity_v<s::minimum<>, V>);
+  static_assert(s::has_known_identity_v<s::maximum<V>, V>);
+  static_assert(s::has_known_identity_v<s::maximum<>, V>);
+
+  for(size_t i = 0; i < num_elements; ++i) {
+    BOOST_TEST((s::known_identity_v<s::plus<V>, V>)[i] == T{0});
+    BOOST_TEST((s::known_identity_v<s::plus<>, V>)[i] == T{0});
+    BOOST_TEST((s::known_identity_v<s::multiplies<V>, V>)[i] == T{1});
+    BOOST_TEST((s::known_identity_v<s::multiplies<>, V>)[i] == T{1});
+  }
+
+  if constexpr (std::is_floating_point_v<T>) {
+    for(size_t i = 0; i < num_elements; ++i) {
+      BOOST_TEST((s::known_identity_v<s::minimum<V>, V>)[i] == std::numeric_limits<T>::infinity());
+      BOOST_TEST((s::known_identity_v<s::minimum<>, V>)[i] == std::numeric_limits<T>::infinity());
+      BOOST_TEST((s::known_identity_v<s::maximum<V>, V>)[i] == -std::numeric_limits<T>::infinity());
+      BOOST_TEST((s::known_identity_v<s::maximum<>, V>)[i] == -std::numeric_limits<T>::infinity());
+    }
+  } else {
+    for(size_t i = 0; i < num_elements; ++i) {
+      BOOST_TEST((s::known_identity_v<s::minimum<V>, V>)[i] == std::numeric_limits<T>::max());
+      BOOST_TEST((s::known_identity_v<s::minimum<>, V>)[i] == std::numeric_limits<T>::max());
+      BOOST_TEST((s::known_identity_v<s::maximum<V>, V>)[i] == std::numeric_limits<T>::lowest());
+      BOOST_TEST((s::known_identity_v<s::maximum<>, V>)[i] == std::numeric_limits<T>::lowest());
+    }
+  }
+
+  if constexpr (std::is_integral_v<T>) {
+    static_assert(s::has_known_identity_v<s::bit_or<V>, V>);
+    static_assert(s::has_known_identity_v<s::bit_or<>, V>);
+    static_assert(s::has_known_identity_v<s::bit_xor<V>, V>);
+    static_assert(s::has_known_identity_v<s::bit_xor<>, V>);
+
+    for(size_t i = 0; i < num_elements; ++i) {
+      BOOST_TEST((s::known_identity_v<s::bit_or<V>, V>)[i] == T{0});
+      BOOST_TEST((s::known_identity_v<s::bit_or<>, V>)[i] == T{0});
+      BOOST_TEST((s::known_identity_v<s::bit_xor<V>, V>)[i] == T{0});
+      BOOST_TEST((s::known_identity_v<s::bit_xor<>, V>)[i] == T{0});
+    }
+  }
+
+  if constexpr (std::is_integral_v<T> && !std::is_same_v<std::remove_cv_t<T>, bool>) {
+    static_assert(s::has_known_identity_v<s::bit_and<V>, V>);
+    static_assert(s::has_known_identity_v<s::bit_and<>, V>);
+
+    for(size_t i = 0; i < num_elements; ++i) {
+      BOOST_TEST((s::known_identity_v<s::bit_and<V>, V>)[i] == static_cast<T>(~T{0}));
+      BOOST_TEST((s::known_identity_v<s::bit_and<>, V>)[i] == static_cast<T>(~T{0}));
+    }
+  }
+
+  if constexpr (std::is_same_v<std::remove_cv_t<T>, bool>) {
+    static_assert(s::has_known_identity_v<s::bit_and<V>, V>);
+    static_assert(s::has_known_identity_v<s::bit_and<>, V>);
+    static_assert(s::has_known_identity_v<s::logical_or<V>, V>);
+    static_assert(s::has_known_identity_v<s::logical_or<>, V>);
+    static_assert(s::has_known_identity_v<s::logical_and<V>, V>);
+    static_assert(s::has_known_identity_v<s::logical_and<>, V>);
+
+    for(size_t i = 0; i < num_elements; ++i) {
+      BOOST_TEST((s::known_identity_v<s::bit_and<V>, V>)[i] == true);
+      BOOST_TEST((s::known_identity_v<s::bit_and<>, V>)[i] == true);
+      BOOST_TEST((s::known_identity_v<s::logical_or<V>, V>)[i] == false);
+      BOOST_TEST((s::known_identity_v<s::logical_or<>, V>)[i] == false);
+      BOOST_TEST((s::known_identity_v<s::logical_and<V>, V>)[i] == true);
+      BOOST_TEST((s::known_identity_v<s::logical_and<>, V>)[i] == true);
+    }
   }
 }
 

--- a/tests/sycl/functional.cpp
+++ b/tests/sycl/functional.cpp
@@ -1,0 +1,106 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018, 2019 Aksel Alpay and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sycl_test_suite.hpp"
+
+namespace s = cl::sycl;
+
+BOOST_FIXTURE_TEST_SUITE(functional_tests, reset_device_fixture)
+
+using known_identity_types = boost::mpl::list<float, double, char, signed char, unsigned char,
+    int, long, unsigned int, unsigned long, bool, const float, const bool>;
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wbool-operation"  // allow ~bool, bool & bool
+#endif
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(known_identities, T, known_identity_types::type) {
+  static_assert(s::has_known_identity_v<s::minimum<T>, T>);
+  static_assert(s::has_known_identity_v<s::minimum<>, T>);
+  static_assert(s::has_known_identity_v<s::maximum<T>, T>);
+  static_assert(s::has_known_identity_v<s::maximum<>, T>);
+
+  BOOST_TEST((s::known_identity_v<s::plus<T>, T>) == T{0});
+  BOOST_TEST((s::known_identity_v<s::plus<>, T>) == T{0});
+  BOOST_TEST((s::known_identity_v<s::multiplies<T>, T>) == T{1});
+  BOOST_TEST((s::known_identity_v<s::multiplies<>, T>) == T{1});
+
+  if constexpr (std::is_floating_point_v<T>) {
+    BOOST_TEST((s::known_identity_v<s::minimum<T>, T>) == std::numeric_limits<T>::infinity());
+    BOOST_TEST((s::known_identity_v<s::minimum<>, T>) == std::numeric_limits<T>::infinity());
+    BOOST_TEST((s::known_identity_v<s::maximum<T>, T>) == -std::numeric_limits<T>::infinity());
+    BOOST_TEST((s::known_identity_v<s::maximum<>, T>) == -std::numeric_limits<T>::infinity());
+  } else {
+    BOOST_TEST((s::known_identity_v<s::minimum<T>, T>) == std::numeric_limits<T>::max());
+    BOOST_TEST((s::known_identity_v<s::minimum<>, T>) == std::numeric_limits<T>::max());
+    BOOST_TEST((s::known_identity_v<s::maximum<T>, T>) == std::numeric_limits<T>::lowest());
+    BOOST_TEST((s::known_identity_v<s::maximum<>, T>) == std::numeric_limits<T>::lowest());
+  }
+
+  if constexpr (std::is_integral_v<T>) {
+    static_assert(s::has_known_identity_v<s::bit_or<T>, T>);
+    static_assert(s::has_known_identity_v<s::bit_or<>, T>);
+    static_assert(s::has_known_identity_v<s::bit_xor<T>, T>);
+    static_assert(s::has_known_identity_v<s::bit_xor<>, T>);
+
+    BOOST_TEST((s::known_identity_v<s::bit_or<T>, T>) == T{0});
+    BOOST_TEST((s::known_identity_v<s::bit_or<>, T>) == T{0});
+    BOOST_TEST((s::known_identity_v<s::bit_xor<T>, T>) == T{0});
+    BOOST_TEST((s::known_identity_v<s::bit_xor<>, T>) == T{0});
+  }
+
+  if constexpr (std::is_integral_v<T> && !std::is_same_v<std::remove_cv_t<T>, bool>) {
+    static_assert(s::has_known_identity_v<s::bit_and<T>, T>);
+    static_assert(s::has_known_identity_v<s::bit_and<>, T>);
+
+    BOOST_TEST((s::known_identity_v<s::bit_and<T>, T>) == static_cast<T>(~T{0}));
+    BOOST_TEST((s::known_identity_v<s::bit_and<>, T>) == static_cast<T>(~T{0}));
+  }
+
+  if constexpr (std::is_same_v<std::remove_cv_t<T>, bool>) {
+    static_assert(s::has_known_identity_v<s::bit_and<T>, T>);
+    static_assert(s::has_known_identity_v<s::bit_and<>, T>);
+    static_assert(s::has_known_identity_v<s::logical_or<T>, T>);
+    static_assert(s::has_known_identity_v<s::logical_or<>, T>);
+    static_assert(s::has_known_identity_v<s::logical_and<T>, T>);
+    static_assert(s::has_known_identity_v<s::logical_and<>, T>);
+
+    BOOST_TEST((s::known_identity_v<s::bit_and<T>, T>) == true);
+    BOOST_TEST((s::known_identity_v<s::bit_and<>, T>) == true);
+    BOOST_TEST((s::known_identity_v<s::logical_or<T>, T>) == false);
+    BOOST_TEST((s::known_identity_v<s::logical_or<>, T>) == false);
+    BOOST_TEST((s::known_identity_v<s::logical_and<T>, T>) == true);
+    BOOST_TEST((s::known_identity_v<s::logical_and<>, T>) == true);
+  }
+}
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+BOOST_AUTO_TEST_SUITE_END() // NOTE: Make sure not to add anything below this line

--- a/tests/sycl/group_functions/group_functions_scan.cpp
+++ b/tests/sycl/group_functions/group_functions_scan.cpp
@@ -53,9 +53,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan_mul, T, test_types) {
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * local_size] = detail::initialize_type<T>(10);
-        for (size_t j = 1; j < local_size; ++j)
+        for (size_t j = 1; j < local_size; ++j){
           expected[i * local_size + j] =
               expected[i * local_size + j - 1] * vOrig[i * local_size + j - 1];
+          asm(""); // prevent gcc from optimizing this loop away
+        }
 
         for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
           T computed = vIn[j];
@@ -99,9 +101,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan, T, test_types) {
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * local_size] = T{};
-        for (size_t j = 1; j < local_size; ++j)
+        for (size_t j = 1; j < local_size; ++j){
           expected[i * local_size + j] =
               expected[i * local_size + j - 1] + vOrig[i * local_size + j - 1];
+          asm (""); // prevent gcc from optimizing this loop away
+        }
 
         for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
           T computed = vIn[j];
@@ -137,9 +141,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan, T, test_types) {
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * local_size] = detail::initialize_type<T>(10);
-        for (size_t j = 1; j < local_size; ++j)
+        for (size_t j = 1; j < local_size; ++j){
           expected[i * local_size + j] =
               expected[i * local_size + j - 1] + vOrig[i * local_size + j - 1];
+          asm (""); // prevent gcc from optimizing this loop away
+        }
 
         for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
           T computed = vIn[j];
@@ -189,9 +195,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan_ptr, T, test_types) {
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * 2 * local_size] = T{};
-        for (size_t j = 1; j < local_size * 2; ++j)
+        for (size_t j = 1; j < local_size * 2; ++j){
           expected[i * 2 * local_size + j] =
               expected[i * 2 * local_size + j - 1] + vOrig[i * 2 * local_size + j - 1];
+          asm (""); // prevent gcc from optimizing this loop away
+        }
 
         for (size_t j = i * 2 * local_size; j < (i + 1) * local_size * 2; ++j) {
           T computed = vIn[j + global_size * 2];
@@ -233,9 +241,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_exclusive_scan_ptr, T, test_types) {
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * 2 * local_size] = detail::initialize_type<T>(10);
-        for (size_t j = 1; j < local_size * 2; ++j)
+        for (size_t j = 1; j < local_size * 2; ++j){
           expected[i * 2 * local_size + j] =
               expected[i * 2 * local_size + j - 1] + vOrig[i * 2 * local_size + j - 1];
+          asm (""); // prevent gcc from optimizing this loop away
+        }
 
         for (size_t j = i * 2 * local_size; j < (i + 1) * local_size * 2; ++j) {
           T computed = vIn[j + global_size * 2];
@@ -281,9 +291,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_exclusive_scan, T, test_types) {
         for (size_t i = 0; i < global_size / local_size; ++i) {
           expected[i * local_size] = T{};
           auto actual_warp_size    = local_size < subgroup_size ? local_size : subgroup_size;
-          for (size_t j = 1; j < actual_warp_size; ++j)
+          for (size_t j = 1; j < actual_warp_size; ++j){
             expected[i * local_size + j] =
                 expected[i * local_size + j - 1] + vOrig[i * local_size + j - 1];
+            asm (""); // prevent gcc from optimizing this loop away
+          }
 
           for (size_t j = i * local_size; j < (i + 1) * actual_warp_size; ++j) {
             T computed = vIn[j];
@@ -318,9 +330,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_exclusive_scan, T, test_types) {
         for (size_t i = 0; i < global_size / local_size; ++i) {
           expected[i * local_size] = detail::initialize_type<T>(10);
           auto actual_warp_size    = local_size < subgroup_size ? local_size : subgroup_size;
-          for (size_t j = 1; j < actual_warp_size; ++j)
+          for (size_t j = 1; j < actual_warp_size; ++j){
             expected[i * local_size + j] =
                 expected[i * local_size + j - 1] + vOrig[i * local_size + j - 1];
+            asm (""); // prevent gcc from optimizing this loop away
+          }
 
           for (size_t j = i * local_size; j < (i + 1) * actual_warp_size; ++j) {
             T computed = vIn[j];
@@ -362,9 +376,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan_mul, T, test_types) {
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * local_size] = vOrig[i * local_size];
-        for (size_t j = 1; j < local_size; ++j)
+        for (size_t j = 1; j < local_size; ++j){
           expected[i * local_size + j] =
               expected[i * local_size + j - 1] * vOrig[i * local_size + j];
+          asm (""); // prevent gcc from optimizing this loop away
+        }
 
         for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
           T computed = vIn[j];
@@ -408,9 +424,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan, T, test_types) {
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * local_size] = vOrig[i * local_size];
-        for (size_t j = 1; j < local_size; ++j)
+        for (size_t j = 1; j < local_size; ++j){
           expected[i * local_size + j] =
               expected[i * local_size + j - 1] + vOrig[i * local_size + j];
+          asm (""); // prevent gcc from optimizing this loop away
+        }
 
         for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
           T computed = vIn[j];
@@ -445,9 +463,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan, T, test_types) {
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * local_size] = vOrig[i * local_size] + detail::initialize_type<T>(10);
-        for (size_t j = 1; j < local_size; ++j)
+        for (size_t j = 1; j < local_size; ++j) {
           expected[i * local_size + j] =
               expected[i * local_size + j - 1] + vOrig[i * local_size + j];
+          asm (""); // prevent gcc from optimizing this loop away
+        }
 
         for (size_t j = i * local_size; j < (i + 1) * local_size; ++j) {
           T computed = vIn[j];
@@ -497,9 +517,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan_ptr, T, test_types) {
 
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * 2 * local_size] = vOrig[i * 2 * local_size];
-        for (size_t j = 1; j < local_size * 2; ++j)
+        for (size_t j = 1; j < local_size * 2; ++j){
           expected[i * 2 * local_size + j] =
               expected[i * 2 * local_size + j - 1] + vOrig[i * 2 * local_size + j];
+          asm (""); // prevent gcc from optimizing this loop away
+        }
 
         for (size_t j = i * 2 * local_size; j < (i + 1) * local_size * 2; ++j) {
           T computed = vIn[j + 2 * global_size];
@@ -541,9 +563,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan_ptr, T, test_types) {
       for (size_t i = 0; i < global_size / local_size; ++i) {
         expected[i * 2 * local_size] =
             vOrig[i * 2 * local_size] + detail::initialize_type<T>(10);
-        for (size_t j = 1; j < local_size * 2; ++j)
+        for (size_t j = 1; j < local_size * 2; ++j){
           expected[i * 2 * local_size + j] =
               expected[i * 2 * local_size + j - 1] + vOrig[i * 2 * local_size + j];
+          asm (""); // prevent gcc from optimizing this loop away
+        }
 
         for (size_t j = i * 2 * local_size; j < (i + 1) * local_size * 2; ++j) {
           T computed = vIn[j + 2 * global_size];
@@ -591,9 +615,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_inclusive_scan, T, test_types) {
         for (size_t i = 0; i < global_size / local_size; ++i) {
           expected[i * local_size] = vOrig[i * local_size];
           auto actual_warp_size    = local_size < subgroup_size ? local_size : subgroup_size;
-          for (size_t j = 1; j < actual_warp_size; ++j)
+          for (size_t j = 1; j < actual_warp_size; ++j){
             expected[i * local_size + j] =
                 expected[i * local_size + j - 1] + vOrig[i * local_size + j];
+            asm (""); // prevent gcc from optimizing this loop away
+          }
 
           for (size_t j = i * local_size; j < (i + 1) * actual_warp_size; ++j) {
             T computed = vIn[j];
@@ -627,9 +653,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_inclusive_scan, T, test_types) {
         for (size_t i = 0; i < global_size / local_size; ++i) {
           expected[i * local_size] = vOrig[i * local_size] + detail::initialize_type<T>(10);
           auto actual_warp_size    = local_size < subgroup_size ? local_size : subgroup_size;
-          for (size_t j = 1; j < actual_warp_size; ++j)
+          for (size_t j = 1; j < actual_warp_size; ++j){
             expected[i * local_size + j] =
                 expected[i * local_size + j - 1] + vOrig[i * local_size + j];
+            asm (""); // prevent gcc from optimizing this loop away
+          }
 
           for (size_t j = i * local_size; j < (i + 1) * actual_warp_size; ++j) {
             T computed = vIn[j];


### PR DESCRIPTION
This PR implements known_identities and adjusts plus, muiltiplies, etc to also accept void as template argument.

Thanks @fknorr for letting me use your code from  #578!

In addition to the code from #578, this also contains the code from #628 so known_identity also works with sycl::vec.