### PR TITLE
[CI] fix compilation on MSVC 2017

### DIFF
--- a/include/hipSYCL/common/hcf_container.hpp
+++ b/include/hipSYCL/common/hcf_container.hpp
@@ -38,6 +38,7 @@
 #include <algorithm>
 #include <exception>
 #include <cassert>
+#include <locale>
 
 namespace hipsycl {
 namespace common {


### PR DESCRIPTION
Added the missing `#include <locale>` for `std::isspace(std::locale)`.