### PR TITLE
Remove OpenMP dependency for sequential backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,7 +245,7 @@ set(DEFAULT_WIN32_SEQUENTIAL_LINK_LINE "-L${Boost_LIBRARY_DIR} ${DEFAULT_LINK_PR
 set(DEFAULT_APPLE_OMP_LINK_LINE "${DEFAULT_BOOST_LIBRARIES} ${DEFAULT_OMP_FLAG} ${hipSYCL_OpenMP_CXX_LIBRARIES}")
 set(DEFAULT_APPLE_SEQUENTIAL_LINK_LINE "${DEFAULT_BOOST_LIBRARIES} ${hipSYCL_OpenMP_CXX_LIBRARIES}")
 set(DEFAULT_OMP_LINK_LINE "-L${Boost_LIBRARY_DIR} -lboost_context -lboost_fiber -Wl,-rpath=${Boost_LIBRARY_DIR} ${DEFAULT_OMP_FLAG}")
-set(DEFAULT_SEQUENTIAL_LINK_LINE "-L${Boost_LIBRARY_DIR} -lboost_context -lboost_fiber -lomp -Wl,-rpath=${Boost_LIBRARY_DIR}")
+set(DEFAULT_SEQUENTIAL_LINK_LINE "-L${Boost_LIBRARY_DIR} -lboost_context -lboost_fiber -Wl,-rpath=${Boost_LIBRARY_DIR}")
 
 # If no link lines given, set to default.
 if(NOT ROCM_LINK_LINE)

--- a/include/hipSYCL/glue/generic/host/range_decomposition.hpp
+++ b/include/hipSYCL/glue/generic/host/range_decomposition.hpp
@@ -29,7 +29,6 @@
 #ifndef HIPSYCL_RANGE_DECOMPOSITION_HPP
 #define HIPSYCL_RANGE_DECOMPOSITION_HPP
 
-#include <omp.h>
 #include <vector>
 #include <cassert>
 


### PR DESCRIPTION
The OpenMP kernel launcher has used some OpenMP runtime functionality, e.g. to query thread id. This has forced us to have OpenMP as a dependency, even when we don't want to use OpenMP parallelization in the sequential dummy backend.

This PR removes the OpenMP dependency by only enabling the affected functionality if `_OPENMP` is defined.

Hopefully fixes #785 