### PR TITLE
Optimize inorder queue::wait()

### DIFF
--- a/include/hipSYCL/sycl/queue.hpp
+++ b/include/hipSYCL/sycl/queue.hpp
@@ -290,8 +290,24 @@ public:
   }
 
   void wait() {
-    _requires_runtime.get()->dag().flush_sync();
-    _requires_runtime.get()->dag().wait(_node_group_id);
+    if(_is_in_order) {
+      rt::dag_node_ptr most_recent_event = nullptr;
+      {
+        std::lock_guard<std::mutex> lock{*_lock};
+
+        most_recent_event = _previous_submission->lock();
+      }
+      if(most_recent_event) {
+        
+        if(!most_recent_event->is_submitted())
+          _requires_runtime.get()->dag().flush_sync();
+        
+        most_recent_event->wait();
+      }
+    } else {
+      _requires_runtime.get()->dag().flush_sync();
+      _requires_runtime.get()->dag().wait(_node_group_id);
+    }
   }
 
   void wait_and_throw() {


### PR DESCRIPTION
In the case of inorder queues, we don't actually need to wait for the full node group. We can just wait for the most recent submission, which we already store anyway.