### PR TITLE
Add support for HIP explicit multipass

### DIFF
--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -334,6 +334,11 @@ class syclcc_config:
       * hip  - HIP backend
                Requires specification of targets of the form gfxXYZ,
                e.g. gfx906 for Vega 20, gfx900 for Vega 10
+               Backend Flavors:
+               - hip.explicit-multipass: HIP backend in explicit multipass mode
+                                         (see --hipsycl-explicit-multipass)
+               - hip.integrated-multipass: Force HIP backend to operate in integrated
+                                           multipass mode.
       * spirv - use clang SYCL driver to generate spirv""")
     }
     self._flags = {
@@ -942,6 +947,131 @@ class cuda_multipass_invocation:
     
     header.write_header(self._integration_header)
 
+class hip_multipass_invocation:
+  @property
+  def unique_name(self):
+    return "hip.explicit-multipass"
+
+  @property
+  def is_integrated_multipass(self):
+    return False
+
+  @property
+  def is_explicit_multipass(self):
+    return not self.is_integrated_multipass
+
+  def __init__(self, config, target_list):
+    self._config = config
+    self._enable_hip_host_pass = False
+    self._targets = target_list
+    self._host_compiler = self._config.clang_path
+    self.set_temp_dir("/tmp")
+
+  def set_temp_dir(self, temp_dir):
+    self._temp_dir = temp_dir
+    self._integration_header = os.path.join(
+      self._temp_dir,"__hipsycl_embedded_hip_kernels.hpp")
+
+  def get_requested_targets(self):
+    return self._targets
+
+  def get_device_compiler(self):
+    return self._config.clang_path
+
+  def get_compiler_preference(self):
+    return (self._config.clang_path, 100)
+
+  def enable_extended_host_pass(self):
+    self._enable_hip_host_pass = True
+
+  @property
+  def is_extended_host_pass_enabled(self):
+    return self._enable_hip_host_pass
+
+  def set_host_compiler(self, host_compiler):
+    self._host_compiler = host_compiler
+
+  def get_host_pass_requirements(self):
+    requires_extended_host_pass = True
+    caveats = []
+
+    if self._host_compiler != self._config.clang_path:
+      requires_extended_host_pass = False
+      caveats = [
+        'Unnamed kernel lambdas are unsupported in this configuration because the selected host compiler '
+        +self._host_compiler+' does not match the device compiler of the backend '+self.get_device_compiler()
+        ]
+      
+
+    return {
+      'requires-extended-host-pass' : requires_extended_host_pass,
+      'extended-host-pass-providers' : [
+        'cuda.explicit-multipass', 'hip.explicit-multipass', 
+        'cuda.integrated-multipass', 'hip.integrated-multipass'],
+      'conflicts' : [],
+      'caveats' : caveats
+    }
+
+  def get_flags(self, target):
+    flags = self._config.rocm_cxx_flags
+    flags += [
+        "-x", "hip",
+        "-D__HIPSYCL_ENABLE_HIP_TARGET__",
+        "-D__HIPSYCL_CLANG__",
+        "-fplugin=" + self._config.hipsycl_plugin_path,
+        "--cuda-device-only",
+        "--cuda-gpu-arch=" + target,
+        "-c","-o",self._explicit_pass_output_file(target)
+      ]
+
+    if self._host_compiler != self._config.clang_path:
+      flags += ["-D__HIPSYCL_SPLIT_COMPILER__"]
+
+    if not sys.platform.startswith("win32"):
+      flags += ["-fpass-plugin=" + self._config.hipsycl_plugin_path]
+    return flags
+
+  # CXX flags for main pass
+  def get_cxx_flags(self):
+    hip_host_flags = []
+
+    if self._enable_hip_host_pass:
+      hip_host_flags = [
+        "-x","hip",
+        "--cuda-host-only"
+      ] + self._config.rocm_cxx_flags
+
+    return [
+      "-D__HIPSYCL_MULTIPASS_HIP_HEADER__=\"{}\"".format(
+            self._integration_header),
+      "-D__HIPSYCL_ENABLE_HIP_TARGET__"
+    ] + hip_host_flags
+
+
+
+  # Linker flags for main pass
+  def get_linker_flags(self):
+    return self._config.rocm_link_line
+
+  def _explicit_pass_output_file(self, target):
+    return os.path.join(self._temp_dir, "hipfb-"+target+".hipsycl_kernels")
+
+
+  def create_code_objects(self, targets):
+    kernel_files = [self._explicit_pass_output_file(target) for target in targets]
+
+    hipfb_content = []
+    for filename in kernel_files:
+      with open(filename, 'rb') as f:
+        hipfb_content.append(f.read())
+
+    header = integration_header("hip")
+    for target,hipfb in zip(targets, hipfb_content):
+      target_node = header.hcf_object.root.make_subnode(target)
+      header.hcf_object.attach_binary_content(target_node, hipfb)
+    
+    header.write_header(self._integration_header)
+
 class spirv_multipass_invocation:
   @property
   def unique_name(self):
@@ -1405,7 +1535,17 @@ class compiler:
         self._backends.append(
           cuda_nvcxx_invocation(config, config.targets["cuda-nvcxx"]))
       elif backend == "hip":
-        self._backends.append(hip_invocation(config, config.targets["hip"]))
+        targets = config.targets["hip"]
+        if self._is_explicit_multipass:
+          self._multipass_backends.append(hip_multipass_invocation(config, targets))
+        else:
+          self._backends.append(hip_invocation(config, targets))
+      elif backend == "hip.integrated-multipass":
+        self._backends.append(
+          hip_invocation(config, config.targets["hip.integrated-multipass"]))
+      elif backend == "hip.explicit-multipass":
+        self._multipass_backends.append(
+          hip_multipass_invocation(config, config.targets["hip.explicit-multipass"]))
       elif backend == 'spirv':
         self._multipass_backends.append(
           spirv_multipass_invocation(config))

--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -967,6 +967,9 @@ class hip_multipass_invocation:
     self._host_compiler = self._config.clang_path
     self.set_temp_dir("/tmp")
 
+    if config.plugin_llvm_version < 13:
+      raise RuntimeError("hip.explicit-multipass is not supported for clang < 13.")
+
   def set_temp_dir(self, temp_dir):
     self._temp_dir = temp_dir
     self._integration_header = os.path.join(

--- a/doc/compilation.md
+++ b/doc/compilation.md
@@ -20,9 +20,10 @@ Not all backends support all modes. The following compilation flows are currentl
 | `cuda.explicit-multipass` | NVIDIA GPUs | Explicit | CUDA backend |
 | `cuda-nvcxx` | NVIDIA GPUs | Integrated (single-pass host/device compiler) | CUDA backend using nvc++ |
 | `hip.integrated-multipass` | AMD GPUs (supported by ROCm) | Integrated | HIP backend |
+| `hip.explicit-multipass` | AMD GPUs (supported by ROCm) | Explicit | HIP backend |
 | `spirv` | Intel GPUs | Explicit | SPIR-V/Level Zero backend |
 
-**Note:** Explicit multipass requires building hipSYCL against a clang that supports `__builtin_unique_stable_name()` (available in clang 11), or clang 13 or newer as described in the [installation documentation](installing.md).
+**Note:** Explicit multipass requires building hipSYCL against a clang that supports `__builtin_unique_stable_name()` (available in clang 11), or clang 13 or newer as described in the [installation documentation](installing.md). `hip.explicit-multipass` requires clang 13 or newer.
 
 ## Language extension guarantees
 

--- a/include/hipSYCL/runtime/kernel_cache.hpp
+++ b/include/hipSYCL/runtime/kernel_cache.hpp
@@ -43,7 +43,6 @@ namespace rt {
 
 enum class code_format {
   ptx,
-  amdgpu,
   spirv,
   native_isa
 };
@@ -67,7 +66,11 @@ public:
   virtual hcf_object_id hcf_source() const = 0;
   virtual std::string target_arch() const = 0;
   
+  // Do we really need this? Cannot be implemented on all backends,
+  // and may return empty vector in this case. Maybe better to not
+  // have as part of the general interface?
   virtual std::vector<std::string> supported_backend_kernel_names() const = 0;
+
   virtual bool contains(const std::string& backend_kernel_name) const = 0;
 };
 

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -118,7 +118,8 @@ if(WITH_ROCM_BACKEND)
     hip/hip_allocator.cpp
     hip/hip_device_manager.cpp
     hip/hip_hardware_manager.cpp
-    hip/hip_backend.cpp)
+    hip/hip_backend.cpp
+    hip/hip_code_object.cpp)
 
   target_compile_definitions(rt-backend-hip PRIVATE HIPSYCL_RT_HIP_TARGET_ROCM=1)
   if(ENABLE_ROCM_UNIFIED_MEMORY_API)

--- a/src/runtime/hip/hip_code_object.cpp
+++ b/src/runtime/hip/hip_code_object.cpp
@@ -1,0 +1,132 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2022 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "hipSYCL/runtime/hip/hip_code_object.hpp"
+#include "hipSYCL/runtime/device_id.hpp"
+#include "hipSYCL/runtime/error.hpp"
+#include "hipSYCL/runtime/hip/hip_device_manager.hpp"
+#include "hipSYCL/runtime/hip/hip_target.hpp"
+#include <vector>
+
+namespace hipsycl {
+namespace rt {
+
+
+
+hip_executable_object::~hip_executable_object() {
+  if(_module) {
+    hip_device_manager::get().activate_device(_device);
+
+    auto err = hipModuleUnload(_module);
+
+    if(err != hipSuccess) {
+      register_error(
+          __hipsycl_here(),
+          error_info{"hip_executable_object: could not unload module",
+                     error_code{"HIP", static_cast<int>(err)}});
+    }
+  }
+}
+
+hip_executable_object::hip_executable_object(hcf_object_id origin,
+                                             const std::string &target,
+                                             const std::string &hip_fat_binary,
+                                             int device)
+    : _origin{origin}, _target{target}, _device{device}, _module{nullptr} {
+  _build_result = build(hip_fat_binary);
+}
+
+result hip_executable_object::get_build_result() const {
+  return _build_result;
+}
+
+code_object_state hip_executable_object::state() const {
+  return code_object_state::executable;
+}
+
+code_format hip_executable_object::format() const {
+  return code_format::native_isa;
+}
+
+backend_id hip_executable_object::managing_backend() const {
+  return backend_id::hip;
+}
+
+hcf_object_id hip_executable_object::hcf_source() const {
+  return _origin;
+}
+
+std::string hip_executable_object::target_arch() const {
+  return _target;
+}
+
+std::vector<std::string>
+hip_executable_object::supported_backend_kernel_names() const {
+  // TODO This is currently not easily implementable. Should we throw an
+  // exception? Remove it from the general interface?
+  return {};
+}
+
+bool hip_executable_object::contains(const std::string &backend_kernel_name) const {
+  if(!_build_result.is_success())
+    return false;
+  
+  // Currently just implemented by trying to query a function.
+  hipFunction_t f;
+  auto err = hipModuleGetFunction(&f, _module, backend_kernel_name.c_str());
+
+  // TODO We should actually figure out which error code exactly HIP
+  // returns in case a kernel is not present to distinguish this from other errors.
+  return err == hipSuccess;
+}
+
+hipModule_t hip_executable_object::get_module() const {
+  return _module;
+}
+
+int hip_executable_object::get_device() const {
+  return _device;
+}
+
+result hip_executable_object::build(const std::string& hip_fat_binary) {
+  // It's unclear if this is actually needed for HIP?
+  hip_device_manager::get().activate_device(_device);
+
+  auto err = hipModuleLoadData(&_module, hip_fat_binary.c_str());
+
+  if(err == hipSuccess)
+    return make_success();
+  else {
+    return make_error(
+        __hipsycl_here(),
+        error_info{"hip_executable_object: could not create module",
+                   error_code{"HIP", static_cast<int>(err)}});
+  }
+}
+
+}
+}

--- a/src/runtime/hip/hip_queue.cpp
+++ b/src/runtime/hip/hip_queue.cpp
@@ -26,14 +26,18 @@
  */
 
 #include "hipSYCL/runtime/hip/hip_target.hpp"
+#include "hipSYCL/common/hcf_container.hpp"
 #include "hipSYCL/runtime/hip/hip_queue.hpp"
 #include "hipSYCL/runtime/hip/hip_backend.hpp"
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/hip/hip_event.hpp"
 #include "hipSYCL/runtime/hip/hip_device_manager.hpp"
 #include "hipSYCL/runtime/hip/hip_target.hpp"
+#include "hipSYCL/runtime/hip/hip_code_object.hpp"
 #include "hipSYCL/runtime/util.hpp"
 #include "hipSYCL/runtime/queue_completion_event.hpp"
+#include "hipSYCL/runtime/kernel_cache.hpp"
+
 
 #include <cassert>
 #include <memory>
@@ -125,7 +129,7 @@ void hip_queue::activate_device() const {
 }
 
 hip_queue::hip_queue(hip_backend *be, device_id dev)
-    : _dev{dev}, _stream{nullptr}, _backend{be} {
+    : _dev{dev}, _stream{nullptr}, _backend{be}, _code_object_invoker{this} {
   this->activate_device();
 
   auto err = hipStreamCreateWithFlags(&_stream, hipStreamNonBlocking);
@@ -421,8 +425,157 @@ void *hip_queue::get_native_type() const {
 }
 
 code_object_invoker* hip_queue::get_code_object_invoker() {
-  return nullptr;
+  return &_code_object_invoker;
 }
+
+result hip_queue::submit_kernel_from_code_object(
+      const kernel_operation &op, hcf_object_id hcf_object,
+      const std::string &backend_kernel_name, const rt::range<3> &grid_size,
+      const rt::range<3> &block_size, unsigned dynamic_shared_mem,
+      void **kernel_args, std::size_t* arg_sizes, std::size_t num_args) {
+
+  this->activate_device();
+  
+  std::string global_kernel_name = op.get_global_kernel_name();
+  const kernel_cache::kernel_name_index_t *kidx =
+      kernel_cache::get().get_global_kernel_index(global_kernel_name);
+
+  if(!kidx) {
+    return make_error(
+        __hipsycl_here(),
+        error_info{"hip_queue: Could not obtain kernel index for kernel " +
+                   global_kernel_name});
+  }
+
+  const common::hcf_container *hcf =
+        rt::kernel_cache::get().get_hcf(hcf_object);
+  if (!hcf)
+    return make_error(
+        __hipsycl_here(),
+        error_info{"hip_queue: Could not access requested HCF object"});
+
+  assert(hcf->root_node());
+  std::vector<std::string> available_targets = hcf->root_node()->get_subnodes();
+  assert(!available_targets.empty());
+
+  // TODO Select correct target based on actual device - currently
+  // we just use the first device image no matter which device it was
+  // compiled for
+  std::string selected_target = available_targets[0];
+  int device = _dev.get_id();
+
+  auto code_object_selector = [&](const code_object* candidate) -> bool {
+    // Also no need to check for HIP backend since the kernel cache already
+    // guarantees that we are only given candidates for the requested backend (CUDA).
+    return (candidate->target_arch() == selected_target) &&
+           (candidate->state() == code_object_state::executable) &&
+           (static_cast<const hip_executable_object *>(candidate)
+                ->get_device() == device);
+  };
+
+  // Will be invoked by the kernel cache in case there is a miss in the kernel
+  // cache and we have to construct a new code object
+
+  auto code_object_constructor = [&]() -> code_object * {
+
+    const common::hcf_container::node* target_node =
+      hcf->root_node()->get_subnode(selected_target);
+    if(!target_node)
+      return nullptr;
+    if(!target_node->has_binary_data_attached())
+      return nullptr;
+
+    std::string kernel_image;
+    if(!hcf->get_binary_attachment(target_node, kernel_image)){
+      HIPSYCL_DEBUG_ERROR
+          << "hip_queue: Could not extract hip fat binary code from "
+             "HCF node; invalid HCF data?"
+          << std::endl;
+      return nullptr;
+    }
+
+    hip_executable_object *exec_obj =
+        new hip_executable_object{hcf_object, selected_target, kernel_image, device};
+    result r = exec_obj->get_build_result();
+
+    if (!r.is_success()) {
+      register_error(r);
+      delete exec_obj;
+      return nullptr;
+    }
+
+    return exec_obj;
+  };
+
+  const code_object *obj = kernel_cache::get().get_or_construct_code_object(
+      *kidx, backend_kernel_name, backend_id::hip, hcf_object,
+      code_object_selector, code_object_constructor);
+
+  
+  if(!obj) {
+    return make_error(__hipsycl_here(),
+                      error_info{"hip_queue: Code object construction failed"});
+  }
+
+  // Since we only support explicit multipass in HIP with clang >= 13 and therefore
+  // are in the new kernel name mangling logic path, we can assume that we know
+  // the full kernel name, and don't need to query available kernels in the device image
+  // as in the CUDA backend.
+  hipFunction_t kernel_func;
+  hipError_t err = hipModuleGetFunction(
+      &kernel_func,
+      static_cast<const hip_executable_object *>(obj)->get_module(),
+      backend_kernel_name.c_str());
+
+  if(err != hipSuccess) {
+    return make_error(__hipsycl_here(),
+                      error_info{"hip_queue: could not extract kernel from module",
+                                 error_code{"HIP", static_cast<int>(err)}});
+  }
+
+  err = hipModuleLaunchKernel(kernel_func, 
+    static_cast<unsigned>(grid_size.get(0)),
+                       static_cast<unsigned>(grid_size.get(1)),
+                       static_cast<unsigned>(grid_size.get(2)),
+                       static_cast<unsigned>(block_size.get(0)),
+                       static_cast<unsigned>(block_size.get(1)),
+                       static_cast<unsigned>(block_size.get(2)),
+                       dynamic_shared_mem, _stream, kernel_args, nullptr);
+
+  if (err != hipSuccess) {
+    return make_error(__hipsycl_here(),
+                      error_info{"hip_queue: could not submit kernel from module",
+                                 error_code{"HIP", static_cast<int>(err)}});
+  }
+  
+  return make_success();
+}
+
+hip_code_object_invoker::hip_code_object_invoker(hip_queue *q) : _queue{q} {}
+
+
+result hip_code_object_invoker::submit_kernel(
+    const kernel_operation& op,
+    hcf_object_id hcf_object,
+    const rt::range<3> &num_groups,
+    const rt::range<3> &group_size,
+    unsigned local_mem_size, void **args,
+    std::size_t *arg_sizes, std::size_t num_args,
+    const std::string &kernel_name_tag,
+    const std::string &kernel_body_name) {
+
+  assert(_queue);
+
+  std::string kernel_name = kernel_body_name;
+  if(kernel_name_tag.find("__hipsycl_unnamed_kernel") == std::string::npos)
+    kernel_name = kernel_name_tag;
+
+  return _queue->submit_kernel_from_code_object(op, hcf_object, kernel_name,
+                                                num_groups, group_size,
+                                                local_mem_size, args,
+                                                arg_sizes, num_args);
+}
+
 
 }
 }


### PR DESCRIPTION
This PR adds support for the `hip.explicit-multipass` compilation flow in the HIP backend. In hipSYCL explicit multipass flows, hipSYCL takes control over multipass compilation, kernel embedding, kernel caching and low-level module management. It also uses low-level kernel launch mechanisms instead of relying on clang-generated kernel launch stubs.

The motivation for this PR is the discussion regarding latency of `hipLaunchKernel` itself in PR #761 (CC @sbalint98). On the CUDA side, explicit multipass is known to substantially outperform the CUDA runtime API as far as kernel launch latencies are concerned - presumably because our kernel cache is better than whatever the CUDA runtime does. Because of this, I wanted to see if a similar speedup could be achieved on the HIP side.

With a quick test on my APU, so far unfortunately I do not see evidence for a difference in kernel launch latency between the new HIP explicit multipass and the old integrated multipass flows. But to draw proper conclusions, we will have to try again with a proper discrete GPU and look at profiler timelines which I have not done yet.
It might also be the case that on HIP there is no such difference, because the HIP API ingests compiled binaries, not an IR like PTX on the CUDA side, and therefore the kernel cache performance is potentially less important.


HIP explicit multipass is only supported on clang 13+.
~TODO: We actually need to enforce that limitation; currently things just will not work with earlier clangs without clear error message.~