### PR TITLE
Add hipsycl-info tool

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,11 @@
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
 if(BUILD_CLANG_PLUGIN)
   add_subdirectory(compiler)
 endif()
+
+list( APPEND CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib )
+
 add_subdirectory(runtime)
 add_subdirectory(tools)
 

--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
 project(hipSYCL_clang)
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
 
 get_filename_component(CLANG_BINARY_PREFIX ${CLANG_EXECUTABLE_PATH} DIRECTORY)
 

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -1,6 +1,8 @@
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
+find_package(Threads REQUIRED)
+
 set(HIPSYCL_RT_EXTRA_CXX_FLAGS "")
 set(HIPSYCL_RT_EXTRA_LINKER_FLAGS "")
 set(HIPSYCL_RT_SANITIZE "" CACHE STRING
@@ -36,7 +38,7 @@ add_library(hipSYCL-rt SHARED
   serialization/serialization.cpp)
 
 target_compile_options(hipSYCL-rt PRIVATE ${HIPSYCL_RT_EXTRA_CXX_FLAGS})
-target_link_libraries(hipSYCL-rt PRIVATE ${HIPSYCL_RT_EXTRA_LINKER_FLAGS})
+target_link_libraries(hipSYCL-rt PRIVATE ${HIPSYCL_RT_EXTRA_LINKER_FLAGS} Threads::Threads)
 
 # syclcc already knows about these include directories, but clangd-based tooling does not.
 # Specifying them explicitly ensures that IDEs can resolve all hipSYCL includes correctly.

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -1,6 +1,3 @@
-
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
 find_package(Threads REQUIRED)
 
 set(HIPSYCL_RT_EXTRA_CXX_FLAGS "")

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,2 +1,3 @@
 
 add_subdirectory(hipsycl-hcf-tool)
+add_subdirectory(hipsycl-info)

--- a/src/tools/hipsycl-info/CMakeLists.txt
+++ b/src/tools/hipsycl-info/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(hipsycl-info hipsycl-info.cpp)
+
+target_compile_definitions(hipsycl-info PRIVATE -DHIPSYCL_TOOL_COMPONENT)
+target_include_directories(hipsycl-info PRIVATE 
+    ${HIPSYCL_SOURCE_DIR}
+    ${HIPSYCL_SOURCE_DIR}/include
+    ${PROJECT_BINARY_DIR}/include)
+target_link_libraries(hipsycl-info PRIVATE hipSYCL-rt)
+install(TARGETS hipsycl-info DESTINATION bin)

--- a/src/tools/hipsycl-info/hipsycl-info.cpp
+++ b/src/tools/hipsycl-info/hipsycl-info.cpp
@@ -1,0 +1,208 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2019-2022 Aksel Alpay and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "hipSYCL/runtime/application.hpp"
+#include "hipSYCL/runtime/backend.hpp"
+#include "hipSYCL/runtime/runtime.hpp"
+#include "hipSYCL/runtime/hardware.hpp"
+#include "hipSYCL/runtime/executor.hpp"
+
+using namespace hipsycl;
+
+void list_backends(rt::runtime* rt) {
+  std::vector<rt::backend*> backends;
+  rt->backends().for_each_backend([&](rt::backend* b){
+    backends.push_back(b);
+  });
+
+  for(std::size_t i = 0; i < backends.size(); ++i) {
+    std::cout << "Loaded backend " << i << ": " << backends[i]->get_name()
+              << std::endl;
+    int num_devices = backends[i]->get_hardware_manager()->get_num_devices();
+    if(num_devices == 0) {
+      std::cout << "  (no devices found)" << std::endl;
+    }
+
+    for (int dev = 0;
+         dev < num_devices; ++dev) {
+      std::cout << "  Found device: "
+                << backends[i]
+                       ->get_hardware_manager()
+                       ->get_device(dev)
+                       ->get_device_name()
+                << std::endl;
+    }
+  }
+}
+
+template<class T>
+void print_info(const std::string& info_name, const T& val, int indentation = 0) {
+  for(int i = 0; i < indentation; ++i)
+    std::cout << " ";
+  std::cout << info_name << ": " << val << std::endl;
+}
+
+template <class T>
+void print_info(const std::string &info_name, const std::vector<T> &val,
+                int indentation = 0) {
+  for(int i = 0; i < indentation; ++i)
+    std::cout << " ";
+  std::cout << info_name << ": ";
+  for(int i = 0; i < val.size(); ++i) {
+    std::cout << val[i] << " ";
+  }
+  std::cout << std::endl;
+}
+
+void list_device_details(rt::device_id dev, rt::backend *b,
+                         rt::hardware_context *hw) {
+
+  std::cout << "Device " << dev.get_id() << ":" <<std::endl;
+  std::cout << " General device information:" << std::endl;
+  print_info("Name", hw->get_device_name(), 2);
+  print_info("Backend", b->get_name(), 2);
+  print_info("Vendor", hw->get_vendor_name(), 2);
+  print_info("Arch", hw->get_device_arch(), 2);
+  print_info("Driver version", hw->get_driver_version(), 2);
+  print_info("Is CPU", hw->is_cpu(), 2);
+  print_info("Is GPU", hw->is_gpu(), 2);
+
+  std::cout << " Default executor information:" << std::endl;
+  print_info("Is in-order queue", b->get_executor(dev)->is_inorder_queue(), 2);
+  print_info("Is out-of-order queue", b->get_executor(dev)->is_outoforder_queue(), 2);
+  print_info("Is task graph", b->get_executor(dev)->is_taskgraph(), 2);
+  print_info(
+      "Number of execution lanes for kernels",
+      b->get_executor(dev)->get_kernel_execution_lane_range(dev).num_lanes, 2);
+  print_info(
+      "Number of execution lanes for data transfers",
+      b->get_executor(dev)->get_memcpy_execution_lane_range(dev).num_lanes, 2);
+  
+  std::cout << " Device support queries:" << std::endl;
+#define PRINT_DEVICE_SUPPORT_ASPECT(name) \
+  print_info(#name, hw->has(rt::device_support_aspect::name), 2);
+  
+  PRINT_DEVICE_SUPPORT_ASPECT(images)
+  PRINT_DEVICE_SUPPORT_ASPECT(error_correction)
+  PRINT_DEVICE_SUPPORT_ASPECT(host_unified_memory)
+  PRINT_DEVICE_SUPPORT_ASPECT(little_endian)
+  PRINT_DEVICE_SUPPORT_ASPECT(global_mem_cache)
+  PRINT_DEVICE_SUPPORT_ASPECT(global_mem_cache_read_only)
+  PRINT_DEVICE_SUPPORT_ASPECT(global_mem_cache_write_only)
+  PRINT_DEVICE_SUPPORT_ASPECT(emulated_local_memory)
+  PRINT_DEVICE_SUPPORT_ASPECT(sub_group_independent_forward_progress)
+  PRINT_DEVICE_SUPPORT_ASPECT(usm_device_allocations)
+  PRINT_DEVICE_SUPPORT_ASPECT(usm_host_allocations)
+  PRINT_DEVICE_SUPPORT_ASPECT(usm_atomic_host_allocations)
+  PRINT_DEVICE_SUPPORT_ASPECT(usm_shared_allocations)
+  PRINT_DEVICE_SUPPORT_ASPECT(usm_atomic_shared_allocations)
+  PRINT_DEVICE_SUPPORT_ASPECT(usm_system_allocations)
+  PRINT_DEVICE_SUPPORT_ASPECT(execution_timestamps)
+  std::cout << " Device properties:" << std::endl;
+
+#define PRINT_DEVICE_UINT_PROPERTY(name)                                       \
+  print_info(#name, hw->get_property(rt::device_uint_property::name), 2);
+#define PRINT_DEVICE_UINT_LIST_PROPERTY(name)                                   \
+  print_info(#name, hw->get_property(rt::device_uint_list_property::name), 2);
+
+  PRINT_DEVICE_UINT_PROPERTY(max_compute_units);
+  PRINT_DEVICE_UINT_PROPERTY(max_global_size0);
+  PRINT_DEVICE_UINT_PROPERTY(max_global_size1);
+  PRINT_DEVICE_UINT_PROPERTY(max_global_size2);
+  PRINT_DEVICE_UINT_PROPERTY(max_group_size);
+  PRINT_DEVICE_UINT_PROPERTY(max_num_sub_groups);
+  PRINT_DEVICE_UINT_PROPERTY(preferred_vector_width_char);
+  PRINT_DEVICE_UINT_PROPERTY(preferred_vector_width_double);
+  PRINT_DEVICE_UINT_PROPERTY(preferred_vector_width_float);
+  PRINT_DEVICE_UINT_PROPERTY(preferred_vector_width_half);
+  PRINT_DEVICE_UINT_PROPERTY(preferred_vector_width_int);
+  PRINT_DEVICE_UINT_PROPERTY(preferred_vector_width_long);
+  PRINT_DEVICE_UINT_PROPERTY(preferred_vector_width_short);
+  PRINT_DEVICE_UINT_PROPERTY(native_vector_width_char);
+  PRINT_DEVICE_UINT_PROPERTY(native_vector_width_double);
+  PRINT_DEVICE_UINT_PROPERTY(native_vector_width_float);
+  PRINT_DEVICE_UINT_PROPERTY(native_vector_width_half);
+  PRINT_DEVICE_UINT_PROPERTY(native_vector_width_int);
+  PRINT_DEVICE_UINT_PROPERTY(native_vector_width_long);
+  PRINT_DEVICE_UINT_PROPERTY(native_vector_width_short);
+  PRINT_DEVICE_UINT_PROPERTY(max_clock_speed);
+  PRINT_DEVICE_UINT_PROPERTY(max_malloc_size);
+  PRINT_DEVICE_UINT_PROPERTY(address_bits);
+  PRINT_DEVICE_UINT_PROPERTY(max_read_image_args);
+  PRINT_DEVICE_UINT_PROPERTY(max_write_image_args);
+  PRINT_DEVICE_UINT_PROPERTY(image2d_max_width);
+  PRINT_DEVICE_UINT_PROPERTY(image2d_max_height);
+  PRINT_DEVICE_UINT_PROPERTY(image3d_max_width);
+  PRINT_DEVICE_UINT_PROPERTY(image3d_max_height);
+  PRINT_DEVICE_UINT_PROPERTY(image3d_max_depth);
+  PRINT_DEVICE_UINT_PROPERTY(image_max_buffer_size);
+  PRINT_DEVICE_UINT_PROPERTY(image_max_array_size);
+  PRINT_DEVICE_UINT_PROPERTY(max_samplers);
+  PRINT_DEVICE_UINT_PROPERTY(max_parameter_size);
+  PRINT_DEVICE_UINT_PROPERTY(mem_base_addr_align);
+  PRINT_DEVICE_UINT_PROPERTY(global_mem_cache_line_size);
+  PRINT_DEVICE_UINT_PROPERTY(global_mem_cache_size);
+  PRINT_DEVICE_UINT_PROPERTY(global_mem_size);
+  PRINT_DEVICE_UINT_PROPERTY(max_constant_buffer_size);
+  PRINT_DEVICE_UINT_PROPERTY(max_constant_args);
+  PRINT_DEVICE_UINT_PROPERTY(local_mem_size);
+  PRINT_DEVICE_UINT_PROPERTY(printf_buffer_size);
+  PRINT_DEVICE_UINT_PROPERTY(partition_max_sub_devices);
+  PRINT_DEVICE_UINT_PROPERTY(vendor_id);
+  PRINT_DEVICE_UINT_LIST_PROPERTY(sub_group_sizes);
+}
+
+void list_devices(rt::runtime* rt) {
+  rt->backends().for_each_backend([&](rt::backend* b){
+    std::size_t num_devices = b->get_hardware_manager()->get_num_devices();
+
+    std::cout << "***************** Devices for backend " << b->get_name()
+              << " *****************" << std::endl;
+    if(num_devices == 0)
+      std::cout << "  (no devices)\n\n" << std::endl;
+
+    for(std::size_t i = 0; i < num_devices; ++i) {
+      rt::hardware_context* hw = b->get_hardware_manager()->get_device(i);
+      list_device_details(b->get_hardware_manager()->get_device_id(i), b, hw);
+
+      std::cout << "\n" << std::endl;
+    }
+  });
+}
+
+int main() {
+  rt::runtime_keep_alive_token rt_token;
+  rt::runtime* rt = rt_token.get();
+
+  std::cout << "=================Backend information==================="
+            << std::endl;
+  list_backends(rt);
+  std::cout << std::endl;
+  std::cout << "=================Device information==================="
+            << std::endl;
+  list_devices(rt);
+}


### PR DESCRIPTION
This adds the `hipsycl-info` tool to list backends, available devices and their properties. It is similar to e.g. https://github.com/illuhad/syclinfo, but additionally prints more hipSYCL-specific information. Bundling such functionality with hipSYCL is probably more convenient for users.

Sample output:
```
=================Backend information===================
Loaded backend 0: HIP
  Found device: 
Loaded backend 1: CUDA
  (no devices found)
Loaded backend 2: OpenMP
  Found device: hipSYCL OpenMP host device

=================Device information===================
***************** Devices for backend HIP*****************
Device 0:
 General device information:
  Name: 
  Backend: HIP
  Vendor: AMD
  Arch: gfx90c:xnack-
  Driver version: 50221152
  Is CPU: 0
  Is GPU: 1
 Default executor information:
  Is in-order queue: 1
  Is out-of-order queue: 0
  Is task graph: 0
  Number of execution lanes for kernels: 2
  Number of execution lanes for data transfers: 2
 Device support queries:
  images: 0
  error_correction: 0
  host_unified_memory: 0
  little_endian: 1
  global_mem_cache: 1
  global_mem_cache_read_only: 0
  global_mem_cache_write_only: 0
  emulated_local_memory: 0
  sub_group_independent_forward_progress: 1
  usm_device_allocations: 1
  usm_host_allocations: 1
  usm_atomic_host_allocations: 0
  usm_shared_allocations: 1
  usm_atomic_shared_allocations: 0
  usm_system_allocations: 0
  execution_timestamps: 1
 Device properties:
  max_compute_units: 7
  max_global_size0: 18446744073709550592
  max_global_size1: 18446744073709550592
  max_global_size2: 18446744073709550592
  max_group_size: 1024
  max_num_sub_groups: 16
  preferred_vector_width_char: 4
  preferred_vector_width_double: 1
  preferred_vector_width_float: 1
  preferred_vector_width_half: 2
  preferred_vector_width_int: 1
  preferred_vector_width_long: 1
  preferred_vector_width_short: 2
  native_vector_width_char: 4
  native_vector_width_double: 1
  native_vector_width_float: 1
  native_vector_width_half: 2
  native_vector_width_int: 1
  native_vector_width_long: 1
  native_vector_width_short: 2
  max_clock_speed: 1600
  max_malloc_size: 536870912
  address_bits: 64
  max_read_image_args: 0
  max_write_image_args: 0
  image2d_max_width: 0
  image2d_max_height: 0
  image3d_max_width: 0
  image3d_max_height: 0
  image3d_max_depth: 0
  image_max_buffer_size: 0
  image_max_array_size: 0
  max_samplers: 0
  max_parameter_size: 18446744073709551615
  mem_base_addr_align: 8
  global_mem_cache_line_size: 128
  global_mem_cache_size: 1048576
  global_mem_size: 536870912
  max_constant_buffer_size: 536870912
  max_constant_args: 18446744073709551615
  local_mem_size: 65536
  printf_buffer_size: 18446744073709551615
  partition_max_sub_devices: 0
  vendor_id: 1022
  sub_group_sizes: 64 


***************** Devices for backend CUDA*****************
  (no devices)


***************** Devices for backend OpenMP*****************
Device 0:
 General device information:
  Name: hipSYCL OpenMP host device
  Backend: OpenMP
  Vendor: the hipSYCL project
  Arch: <native-cpu>
  Driver version: 1.2
  Is CPU: 1
  Is GPU: 0
 Default executor information:
  Is in-order queue: 1
  Is out-of-order queue: 0
  Is task graph: 0
  Number of execution lanes for kernels: 1
  Number of execution lanes for data transfers: 1
 Device support queries:
  images: 0
  error_correction: 0
  host_unified_memory: 1
  little_endian: 1
  global_mem_cache: 1
  global_mem_cache_read_only: 0
  global_mem_cache_write_only: 0
  emulated_local_memory: 1
  sub_group_independent_forward_progress: 0
  usm_device_allocations: 1
  usm_host_allocations: 1
  usm_atomic_host_allocations: 1
  usm_shared_allocations: 1
  usm_atomic_shared_allocations: 1
  usm_system_allocations: 1
  execution_timestamps: 1
 Device properties:
  max_compute_units: 16
  max_global_size0: 18446744073709551615
  max_global_size1: 18446744073709551615
  max_global_size2: 18446744073709551615
  max_group_size: 1024
  max_num_sub_groups: 18446744073709551615
  preferred_vector_width_char: 4
  preferred_vector_width_double: 1
  preferred_vector_width_float: 1
  preferred_vector_width_half: 2
  preferred_vector_width_int: 1
  preferred_vector_width_long: 1
  preferred_vector_width_short: 2
  native_vector_width_char: 4
  native_vector_width_double: 1
  native_vector_width_float: 1
  native_vector_width_half: 2
  native_vector_width_int: 1
  native_vector_width_long: 1
  native_vector_width_short: 2
  max_clock_speed: 0
  max_malloc_size: 18446744073709551615
  address_bits: 64
  max_read_image_args: 0
  max_write_image_args: 0
  image2d_max_width: 0
  image2d_max_height: 0
  image3d_max_width: 0
  image3d_max_height: 0
  image3d_max_depth: 0
  image_max_buffer_size: 0
  image_max_array_size: 0
  max_samplers: 0
  max_parameter_size: 18446744073709551615
  mem_base_addr_align: 8
  global_mem_cache_line_size: 64
  global_mem_cache_size: 1
  global_mem_size: 18446744073709551615
  max_constant_buffer_size: 18446744073709551615
  max_constant_args: 18446744073709551615
  local_mem_size: 18446744073709551615
  printf_buffer_size: 18446744073709551615
  partition_max_sub_devices: 0
  vendor_id: 18446744073709551615
  sub_group_sizes: 1 
```

~One issue currently is that it does not yet link against `libhipSYCL-rt` using rpath, so `LD_LIBRARY_PATH` might be required. I'll have to see if I can fix this before merging.~