### PR TITLE
Fix ThreadSanitizer complaint about worker_thread::_continue

### DIFF
--- a/include/hipSYCL/runtime/generic/async_worker.hpp
+++ b/include/hipSYCL/runtime/generic/async_worker.hpp
@@ -75,7 +75,7 @@ private:
 
   std::thread _worker_thread;
 
-  bool _continue;
+  std::atomic<bool> _continue;
 
   std::condition_variable _condition_wait;
   mutable std::mutex _mutex;


### PR DESCRIPTION
```cpp
#include <SYCL/sycl.hpp>
#include <iostream>
void run_kernel(const sycl::device& syclDevice){
    static const int     numThreads = 8;
    sycl::queue          queue      = sycl::queue(syclDevice);
    sycl::buffer<int, 1> buffer(numThreads);
    queue.submit([&](sycl::handler& cgh) {
             auto buffer_dev = buffer.get_access<sycl::access::mode::discard_write>(cgh);
             cgh.parallel_for<class DummyKernel>(sycl::range<1>{ numThreads }, [=](sycl::id<1> threadId) {
                 buffer_dev[threadId] = threadId.get(0);
             });
         }).wait_and_throw();
}
int main() {
    for (const auto& dev : sycl::device::get_devices()) {
        run_kernel(dev);
    }
}
```

```
syclcc --hipsycl-targets=hip:gfx906 -fsanitize=thread test.cpp -o test && ./test
==================
WARNING: ThreadSanitizer: data race (pid=2623516)
  Read of size 1 at 0x7b5400000400 by thread T5:
    #0 hipsycl::rt::worker_thread::work() ??:? (libhipSYCL-rt.so+0x6053f)
    #1 std::thread::_State_impl<std::thread::_Invoker<std::tuple<hipsycl::rt::worker_thread::worker_thread()::$_0> > >::_M_run() async_worker.cpp:? (libhipSYCL-rt.so+0x60d9f)
    #2 std::error_code::default_error_condition() const ??:? (libstdc++.so.6+0xd6de3)

  Previous write of size 1 at 0x7b5400000400 by main thread (mutexes: write M3164):
    #0 hipsycl::rt::worker_thread::halt() ??:? (libhipSYCL-rt.so+0x602fb)
    #1 hipsycl::rt::worker_thread::~worker_thread() ??:? (libhipSYCL-rt.so+0x60268)
    #2 hipsycl::rt::dag_manager::~dag_manager() ??:? (libhipSYCL-rt.so+0x58ceb)
    #3 hipsycl::rt::runtime::~runtime() ??:? (libhipSYCL-rt.so+0x264a8)
    #4 std::_Sp_counted_ptr_inplace<hipsycl::rt::runtime, std::allocator<hipsycl::rt::runtime>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() ??:? (libhipSYCL-rt.so+0x26019)
    #5 std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() ??:? (test+0x35fdce)
    #6 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() ??:? (test+0x35fd5c)
    #7 std::__shared_ptr<hipsycl::rt::runtime, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() ??:? (test+0x35fb69)
    #8 std::shared_ptr<hipsycl::rt::runtime>::~shared_ptr() ??:? (test+0x35f8c5)
    #9 hipsycl::rt::runtime_keep_alive_token::~runtime_keep_alive_token() ??:? (test+0x3640f5)
    #10 hipsycl::sycl::device::~device() ??:? (test+0x3602f9)
    #11 void std::_Destroy<hipsycl::sycl::device>(hipsycl::sycl::device*) ??:? (test+0x36aa65)
    #12 void std::_Destroy_aux<false>::__destroy<hipsycl::sycl::device*>(hipsycl::sycl::device*, hipsycl::sycl::device*) ??:? (test+0x36aa17)
    #13 void std::_Destroy<hipsycl::sycl::device*>(hipsycl::sycl::device*, hipsycl::sycl::device*) ??:? (test+0x36a995)
    #14 void std::_Destroy<hipsycl::sycl::device*, hipsycl::sycl::device>(hipsycl::sycl::device*, hipsycl::sycl::device*, std::allocator<hipsycl::sycl::device>&) ??:? (test+0x37fa24)
    #15 std::vector<hipsycl::sycl::device, std::allocator<hipsycl::sycl::device> >::~vector() ??:? (test+0x35f76e)
    #16 main ??:? (test+0x358d8a)
```