### PR TITLE
Avoid printing unprintable from memset_operation::dump

### DIFF
--- a/src/runtime/serialization/serialization.cpp
+++ b/src/runtime/serialization/serialization.cpp
@@ -132,7 +132,7 @@ void prefetch_operation::dump(std::ostream& ostr, int indentation) const {
 void memset_operation::dump(std::ostream &ostr, int indentation) const {
   ostr << get_indentation(indentation);
   ostr << "Memset: @" << _ptr << " " << _num_bytes << " bytes of value "
-       << get_pattern();
+       << static_cast<int>(get_pattern());
 }
 
 void memory_location::dump(std::ostream &ostr) const {


### PR DESCRIPTION
Since `get_pattern` returns `unsigned char`, it was printed as such.
So, for example, when zeroing an array, a NULL byte was printed to
stderr in debug mode. Nothing serious, but not very helpful either.

Since using `memset` to fill the buffer with repetitions of a printable
character is not the most common usecase, now we print the pattern as an
integer.