### PR TITLE
Use device managers in allocators instead of setting device directly

### DIFF
--- a/src/runtime/cuda/cuda_allocator.cpp
+++ b/src/runtime/cuda/cuda_allocator.cpp
@@ -41,8 +41,8 @@ cuda_allocator::cuda_allocator(backend_descriptor desc, int cuda_device)
 void *cuda_allocator::allocate(size_t min_alignment, size_t size_bytes)
 {
   void *ptr;
-  auto err = cudaSetDevice(_dev);
-  err = cudaMalloc(&ptr, size_bytes);
+  cuda_device_manager::get().activate_device(_dev);
+  cudaError_t err = cudaMalloc(&ptr, size_bytes);
 
   if (err != cudaSuccess) {
     register_error(__hipsycl_here(),
@@ -58,9 +58,9 @@ void *cuda_allocator::allocate(size_t min_alignment, size_t size_bytes)
 void *cuda_allocator::allocate_optimized_host(size_t min_alignment,
                                              size_t bytes) {
   void *ptr;
-  auto err = cudaSetDevice(_dev);
+  cuda_device_manager::get().activate_device(_dev);
 
-  err = cudaMallocHost(&ptr, bytes);
+  cudaError_t err = cudaMallocHost(&ptr, bytes);
 
   if (err != cudaSuccess) {
     register_error(__hipsycl_here(),

--- a/src/runtime/cuda/cuda_allocator.cpp
+++ b/src/runtime/cuda/cuda_allocator.cpp
@@ -98,6 +98,8 @@ void cuda_allocator::free(void *mem) {
 
 void * cuda_allocator::allocate_usm(size_t bytes)
 {
+  cuda_device_manager::get().activate_device(_dev);
+  
   void *ptr;
   auto err = cudaMallocManaged(&ptr, bytes);
   if (err != cudaSuccess) {

--- a/src/runtime/hip/hip_allocator.cpp
+++ b/src/runtime/hip/hip_allocator.cpp
@@ -97,6 +97,8 @@ void hip_allocator::free(void *mem) {
 
 void * hip_allocator::allocate_usm(size_t bytes)
 {
+  hip_device_manager::get().activate_device(_dev);
+
   void *ptr;
   auto err = hipMallocManaged(&ptr, bytes);
   if (err != hipSuccess) {

--- a/src/runtime/hip/hip_allocator.cpp
+++ b/src/runtime/hip/hip_allocator.cpp
@@ -40,8 +40,8 @@ hip_allocator::hip_allocator(backend_descriptor desc, int hip_device)
 void *hip_allocator::allocate(size_t min_alignment, size_t size_bytes)
 {
   void *ptr;
-  auto err = hipSetDevice(_dev);
-  err = hipMalloc(&ptr, size_bytes);
+  hip_device_manager::get().activate_device(_dev);
+  hipError_t err = hipMalloc(&ptr, size_bytes);
 
   if (err != hipSuccess) {
     register_error(__hipsycl_here(),
@@ -57,9 +57,9 @@ void *hip_allocator::allocate(size_t min_alignment, size_t size_bytes)
 void *hip_allocator::allocate_optimized_host(size_t min_alignment,
                                              size_t bytes) {
   void *ptr;
-  auto err = hipSetDevice(_dev);
+  hip_device_manager::get().activate_device(_dev);
 
-  err = hipHostMalloc(&ptr, bytes, hipHostMallocDefault);
+  hipError_t err = hipHostMalloc(&ptr, bytes, hipHostMallocDefault);
 
   if (err != hipSuccess) {
     register_error(__hipsycl_here(),


### PR DESCRIPTION
It seems the CUDA and HIP allocators have invoked `cudaSetDevice()` and `hipSetDevice()` directly, which they should never do because it can invalidate the state of the `hip_device_manager` and `cuda_device_manager`, which are used to manage the active device by the rest of the runtime.

This is a terrible oversight. I don't know why these function calls are used here instead of the device managers; the files even include them but then don't use them. This seems to be a very old bug that may have been as old as when we introduced the current runtime.

There might be a case for invoking both the `device_manager::activate_device()` *as well as* `cuda/hipSetDevice()` directly, as this would make USM memory management functions more robust in backend interop scenarios where the user also sets device explicitly.

I believe this fixes the issues described in #770 

CC @al42and 