### PR TITLE
Work around nvc++ bug by not having empty if target branches in mem_fence()

### DIFF
--- a/include/hipSYCL/sycl/libkernel/detail/mem_fence.hpp
+++ b/include/hipSYCL/sycl/libkernel/detail/mem_fence.hpp
@@ -52,7 +52,9 @@ struct mem_fence_impl
                           __spv::MemorySemanticsMask::WorkgroupMemory);
     );
     // TODO What about CPU?
-    __hipsycl_if_target_host(/* todo */);
+    // Empty __hipsycl_if_target_* breaks nvc++ due to nvc++ bug;
+    // so comment out that statement for now
+    //__hipsycl_if_target_host(/* todo */);
   }
 
 };


### PR DESCRIPTION
Bug has been reported: https://forums.developer.nvidia.com/t/nvc-up-to-22-7-undefined-reference-to-builtin-is-device-code-for-empty-if-target-paths/223232

See #767 