### PR TITLE
Add option to compile tests with reduced local mem usage

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.12)
 
 set(Boost_USE_STATIC_LIBS off)
 set(BUILD_SHARED_LIBS on)
+set(REDUCED_LOCAL_MEM_USAGE OFF CACHE BOOL "Only run tests with reduced local memory usage to allow running on hardware with little local memory.")
+
 find_package(Boost COMPONENTS unit_test_framework REQUIRED)
 
 find_package(hipSYCL REQUIRED)
@@ -31,6 +33,10 @@ if(CMAKE_GENERATOR STREQUAL "Ninja" AND
   # Force colored warnings in Ninja's output, if the compiler has -fdiagnostics-color support.
   # Rationale in https://github.com/ninja-build/ninja/issues/814
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always")
+endif()
+
+if(REDUCED_LOCAL_MEM_USAGE)
+  add_definitions(-DREDUCED_LOCAL_MEM_USAGE)
 endif()
 
 #add_compile_definitions(HIPSYCL_DEBUG_LEVEL="${HIPSYCL_DEBUG_LEVEL}")

--- a/tests/sycl/group_functions/group_functions_misc.cpp
+++ b/tests/sycl/group_functions/group_functions_misc.cpp
@@ -297,7 +297,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_broadcast, T, test_types) {
   }
 }
 
-
+#if !defined(REDUCED_LOCAL_MEM_USAGE)
 BOOST_AUTO_TEST_CASE_TEMPLATE(group_shuffle_like, T, test_types) {
   const size_t elements_per_thread = 1;
   const auto   data_generator      = [](std::vector<T> &v, size_t local_size,
@@ -446,7 +446,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_shuffle_like, T, test_types) {
                                            tested_function, validation_function);
   }
 }
-
+#endif
 BOOST_AUTO_TEST_CASE_TEMPLATE(subgroup_shuffle_like, T, test_types) {
   if(!sycl::queue{}.get_device().is_host()) {
     const size_t elements_per_thread = 1;


### PR DESCRIPTION
Adds `-DREDUCED_LOCAL_MEM_USAGE=ON/OFF` (default: OFF) to cmake of the tests, which will then disable tests that require large amounts of local memory. This can help compiling tests for more resource-constrained hardware targets.

Fixes #789