### PR TITLE
Fix CMake error with ROCm 4.5 Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,7 @@ if(BUILD_CLANG_PLUGIN)
       set(ROCM_VERSION_PATCH ${CMAKE_MATCH_3})
       message(STATUS "AMD clang version: ${ROCM_VERSION_MAJOR}.${ROCM_VERSION_MINOR}.${ROCM_VERSION_PATCH}")
 
-      if(${LLVM_VERSION_MAJOR} EQUAL 13 AND NOT DEFINED ${HIPSYCL_NO_DEVICE_MANGLER})
+      if(${LLVM_VERSION_MAJOR} EQUAL 13 AND NOT DEFINED HIPSYCL_NO_DEVICE_MANGLER)
         message(SEND_ERROR "AMD clang version not compatible with hipSYCL explicit multipass. "
                            "To disable explicit multipass set -DHIPSYCL_NO_DEVICE_MANGLER=ON. "
                            "This also disables simultaneous compilation for CUDA and HIP devices.")


### PR DESCRIPTION
It should be `DEFINED var`, not `DEFINED ${var}`.

Follow-up to #800.