### PR TITLE
Add __HIPSYCL_FORCE_INLINE_ALL__ macro to force inlining

### DIFF
--- a/include/hipSYCL/compiler/Frontend.hpp
+++ b/include/hipSYCL/compiler/Frontend.hpp
@@ -325,6 +325,11 @@ public:
 
   void applyAttributes()
   {
+    const auto& PPMacros = Instance.getPreprocessor().getPreprocessorOpts().Macros;
+    const bool ForceInlineAll = std::any_of(PPMacros.begin(), PPMacros.end(),
+            [](const auto& v){ return v.first == "__HIPSYCL_FORCE_INLINE_ALL__";});
+    HIPSYCL_DEBUG_INFO << "AST processing: Adding always_inline attribute to all device functions\n";
+
     for(auto F : MarkedHostDeviceFunctions)
     {
       // Strictly speaking, setting these attributes is not even necessary!
@@ -361,6 +366,9 @@ public:
         {
           RD->addAttr(clang::CUDAHostAttr::CreateImplicit(Instance.getASTContext()));
           RD->addAttr(clang::CUDADeviceAttr::CreateImplicit(Instance.getASTContext()));
+        }
+        if (ForceInlineAll && !RD->hasAttr<clang::AlwaysInlineAttr>()) {
+          RD->addAttr(clang::AlwaysInlineAttr::CreateImplicit(Instance.getASTContext()));
         }
       }
 


### PR DESCRIPTION
If `__HIPSYCL_FORCE_INLINE_ALL__` is defined, the hipSYCL plugin will attach always_inline attribute to all functions called from kernels.

For some reason, adding the `flatten` attribute to kernels does not help.

For GROMACS on NVIDIA devices, this speeds up some kernels up to 9x:

Results on RTX3060, with and without setting this flag (`-DSYCL_CXX_FLAGS_EXTRA=-D__HIPSYCL_FORCE_INLINE_ALL__`). Native CUDA shown for reference.

  | With inlining | Default | Native CUDA
-- | -- | -- | --
NbnxmKernelPruneOnly<bool=0> | 42.143us | 97.431us | 40.149us
BondedKernel<bool=0, bool=0> | 58.143us | 285.26us | 57.636us
PmeSplineAndSpreadKernel<int=4, bool=1, bool=1, bool=1, bool=1, int=1, bool=0, ThreadsPerAtom=0, int=32> | 219.91us | 759.48us | 221.41us
PmeGatherKernel<int=4, bool=1, bool=1, int=1, bool=0, ThreadsPerAtom=0, int=32> | 88.017us | 793.58us | 88.826us


</body>

</html>
