### PR TITLE
replace activemask with ballot function

### DIFF
--- a/include/hipSYCL/sycl/libkernel/cuda/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/cuda/group_functions.hpp
@@ -96,7 +96,7 @@ __device__ T __hipsycl_reduce_over_group(sub_group g, T x,
                                          BinaryOperation binary_op) {
   const size_t       lid        = g.get_local_linear_id();
   const size_t       lrange     = g.get_local_linear_range();
-  const unsigned int activemask = __activemask();
+  const unsigned int activemask = __ballot_sync(0xffffffff, 1);
 
   auto local_x = x;
 
@@ -114,7 +114,7 @@ __device__ T __hipsycl_exclusive_scan_over_group(sub_group g, V x, T init,
                                                  BinaryOperation binary_op) {
   const size_t       lid        = g.get_local_linear_id();
   const size_t       lrange     = g.get_local_linear_range();
-  const unsigned int activemask = __activemask();
+  const unsigned int activemask = __ballot_sync(0xffffffff, 1);
 
   auto local_x = x;
 
@@ -146,7 +146,7 @@ __device__ T __hipsycl_inclusive_scan_over_group(sub_group g, T x,
                                                  BinaryOperation binary_op) {
   const size_t       lid        = g.get_local_linear_id();
   const size_t       lrange     = g.get_local_linear_range();
-  const unsigned int activemask = __activemask();
+  const unsigned int activemask = __ballot_sync(0xffffffff, 1);
 
   auto local_x = x;
 

--- a/include/hipSYCL/sycl/libkernel/hip/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/hip/group_functions.hpp
@@ -93,8 +93,7 @@ template <typename T, typename BinaryOperation>
 __device__ T __hipsycl_reduce_over_group(sub_group g, T x,
                                          BinaryOperation binary_op) {
   auto     local_x = x;
-  uint64_t activemask;
-  asm("s_mov_b64 %0, exec" : "=r"(activemask));
+  uint64_t activemask = __ballot(1);
 
   auto lid = g.get_local_linear_id();
 
@@ -119,8 +118,7 @@ __device__ T __hipsycl_inclusive_scan_over_group(sub_group g, T x,
   auto         local_x = x;
   const size_t lid     = g.get_local_linear_id();
 
-  uint64_t activemask;
-  asm("s_mov_b64 %0, exec" : "=r"(activemask));
+  uint64_t activemask = __ballot(1);
 
   size_t lrange = g.get_local_linear_range();
 


### PR DESCRIPTION
This is done to prevent retrieving the wrong thread mask. This is also implemented in hip, but most likely not necessary.

I tested this on an AMD GPU, but didn't do any performance measurements.

fixes #823