### PR TITLE
Remove extraneous `kernel_configuration` include

### DIFF
--- a/include/hipSYCL/runtime/kernel_launcher.hpp
+++ b/include/hipSYCL/runtime/kernel_launcher.hpp
@@ -37,7 +37,6 @@
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/hints.hpp"
 #include "hipSYCL/runtime/util.hpp"
-#include "hipSYCL/glue/kernel_configuration.hpp"
 
 #include "backend.hpp"
 
@@ -100,7 +99,6 @@ public:
 
 private:
   std::vector<std::unique_ptr<backend_kernel_launcher>> _kernels;
-  glue::kernel_configuration _kernel_config;
 };
 
 


### PR DESCRIPTION
There is no such file located at this header path. Removing these lines allowed the generic LLVM branch to compile.