### PR TITLE
Add implicit conversion for item<1> to size_t

### DIFF
--- a/include/hipSYCL/sycl/libkernel/accessor.hpp
+++ b/include/hipSYCL/sycl/libkernel/accessor.hpp
@@ -920,7 +920,12 @@ public:
   template <
       int D = dimensions, access::mode M = accessmode,
       bool IsAllowed = has_subscript_operators,
-      std::enable_if_t<(D > 0) && IsAllowed && (M != access::mode::atomic),
+      // Note: spec says D==1 here, however this can lead to ambiguity when item<1>
+      // is passed as argument
+      // with respect to the SYCL 2020 implicit conversion from id<1>/item<1> to size_t
+      // since we also have operator[](size_t).
+      // Because of this, we only enable this for D > 1.
+      std::enable_if_t<(D > 1) && IsAllowed && (M != access::mode::atomic),
                        bool> = true>
   HIPSYCL_UNIVERSAL_TARGET reference
   operator[](id<dimensions> index) const noexcept {

--- a/tests/sycl/usm.cpp
+++ b/tests/sycl/usm.cpp
@@ -209,6 +209,16 @@ BOOST_AUTO_TEST_CASE(allocations_in_kernels) {
                                        mapped_host_allocation[idx] += 1;
                                      });
 
+  q.parallel_for<class usm_alloc_pf2>(sycl::range<1>{test_size},
+                                     [=] (sycl::item<1> idx) {
+                                       // Use item directly to also make sure
+                                       // that implicit conversion to size_t
+                                       // works
+                                       shared_allocation[idx] += 1;
+                                       explicit_allocation[idx] += 1;
+                                       mapped_host_allocation[idx] += 1;
+                                     });
+
   q.parallel_for<class usm_alloc_ndrange_pf>(
       sycl::nd_range<1>{sycl::range<1>{test_size}, sycl::range<1>{128}},
       [=](sycl::nd_item<1> idx) {
@@ -223,9 +233,9 @@ BOOST_AUTO_TEST_CASE(allocations_in_kernels) {
   q.wait();
 
   for (int i = 0; i < test_size; ++i){
-    BOOST_TEST(shared_allocation[i] == i + 2);
-    BOOST_TEST(host_explicit_allocation[i] == i + 2);
-    BOOST_TEST(mapped_host_allocation[i] == i + 2);
+    BOOST_TEST(shared_allocation[i] == i + 3);
+    BOOST_TEST(host_explicit_allocation[i] == i + 3);
+    BOOST_TEST(mapped_host_allocation[i] == i + 3);
   }
 
   sycl::free(shared_allocation, q);


### PR DESCRIPTION
The implicit conversion for both id<1> and item<1> to size_t was added in SYCL 2020. We do the conversion from `id<1>`, but the one from `item<1>` was missing. This PR adds it.