### PR TITLE
Update comment on nvc++ workaround in mem_fence()

### DIFF
--- a/include/hipSYCL/sycl/libkernel/detail/mem_fence.hpp
+++ b/include/hipSYCL/sycl/libkernel/detail/mem_fence.hpp
@@ -52,8 +52,8 @@ struct mem_fence_impl
                           __spv::MemorySemanticsMask::WorkgroupMemory);
     );
     // TODO What about CPU?
-    // Empty __hipsycl_if_target_* breaks nvc++ due to nvc++ bug;
-    // so comment out that statement for now
+    // Empty __hipsycl_if_target_* breaks at compile time w/ nvc++ 22.7 or
+    // older, so comment out that statement for now.
     //__hipsycl_if_target_host(/* todo */);
   }
 


### PR DESCRIPTION
Hi @illuhad,

It seems Nvidia has indeed fixed the compiler errors with empty if target statements.
See #767 (happy to close if you are) and #798.

Cheers :)