### PR TITLE
Use -isystem instead of -I for hipSYCL headers to avoid warnings with high warning levels

### DIFF
--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -1665,7 +1665,7 @@ class compiler:
   @property
   def common_cxx_flags(self):
     args = [
-      "-isystem" + self._hipsycl_include_path,
+      "-isystem", self._hipsycl_include_path,
       "-D__HIPSYCL__"
     ] + self._common_compiler_args
 

--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -1665,7 +1665,7 @@ class compiler:
   @property
   def common_cxx_flags(self):
     args = [
-      "-I" + self._hipsycl_include_path,
+      "-isystem" + self._hipsycl_include_path,
       "-D__HIPSYCL__"
     ] + self._common_compiler_args
 


### PR DESCRIPTION
@krasznaa Please check if this fixes the warning issue for you.