### PR TITLE
Add vec deduction guides and fix swizzles when directly accessed using .elem()

### DIFF
--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -115,13 +115,13 @@ public:
   template<int Index>
   HIPSYCL_UNIVERSAL_TARGET
   value_type& get() {
-    return _original_data.template get<Index>();
+    return _original_data[_swizzled_indices[Index]];
   }
 
   template<int Index>
   HIPSYCL_UNIVERSAL_TARGET
   const value_type& get() const {
-    return _original_data.template get<Index>();
+    return _original_data[_swizzled_indices[Index]];
   }
 
   template<class F>
@@ -876,6 +876,10 @@ private:
 
   VectorStorage _data;
 };
+
+template <class T, class... U,
+          class = std::enable_if_t<(std::is_same<T, U>::value && ...)>> vec(
+                      T, U...) -> vec<T, sizeof...(U) + 1>;
 
 using char2 = vec<int8_t, 2>;
 using char3 = vec<int8_t, 3>;


### PR DESCRIPTION
* Add `vec` deduction guide to allow e.g. `vec{1,2,3,4}`
* Fix swizzle indices not being applied when the temporary swizzle object is directly queries for an element using `.x()/.y()` etc.

Fixes #865 