### PR TITLE
Rename `global_mem_cache_type::write_only` to `read_write`

### DIFF
--- a/include/hipSYCL/runtime/hardware.hpp
+++ b/include/hipSYCL/runtime/hardware.hpp
@@ -42,7 +42,7 @@ enum class device_support_aspect {
   little_endian,
   global_mem_cache,
   global_mem_cache_read_only,
-  global_mem_cache_write_only,
+  global_mem_cache_read_write,
   emulated_local_memory,
   sub_group_independent_forward_progress,
   usm_device_allocations,

--- a/include/hipSYCL/sycl/device.hpp
+++ b/include/hipSYCL/sycl/device.hpp
@@ -541,8 +541,8 @@ HIPSYCL_SPECIALIZE_GET_INFO(device, global_mem_cache_type)
           rt::device_support_aspect::global_mem_cache_read_only))
     return info::global_mem_cache_type::read_only;
   else if (get_rt_device()->has(
-          rt::device_support_aspect::global_mem_cache_write_only))
-    return info::global_mem_cache_type::write_only;
+          rt::device_support_aspect::global_mem_cache_read_write))
+    return info::global_mem_cache_type::read_write;
 
   return info::global_mem_cache_type::none;
 }

--- a/include/hipSYCL/sycl/info/device.hpp
+++ b/include/hipSYCL/sycl/info/device.hpp
@@ -168,7 +168,7 @@ enum class fp_config : int {
   soft_float
 };
 
-enum class global_mem_cache_type : int { none, read_only, write_only };
+enum class global_mem_cache_type : int { none, read_only, read_write };
 
 enum class execution_capability : unsigned int {
   exec_kernel,

--- a/src/runtime/cuda/cuda_hardware_manager.cpp
+++ b/src/runtime/cuda/cuda_hardware_manager.cpp
@@ -165,7 +165,8 @@ bool cuda_hardware_context::has(device_support_aspect aspect) const {
     return false;
     break;
   case device_support_aspect::global_mem_cache_read_write:
-    return false;
+    // NVIDIA GPUs have read/write cache at least since Fermi architecture
+    return true;
     break;
   case device_support_aspect::images:
     return false;

--- a/src/runtime/cuda/cuda_hardware_manager.cpp
+++ b/src/runtime/cuda/cuda_hardware_manager.cpp
@@ -164,7 +164,7 @@ bool cuda_hardware_context::has(device_support_aspect aspect) const {
   case device_support_aspect::global_mem_cache_read_only:
     return false;
     break;
-  case device_support_aspect::global_mem_cache_write_only:
+  case device_support_aspect::global_mem_cache_read_write:
     return false;
     break;
   case device_support_aspect::images:

--- a/src/runtime/hip/hip_hardware_manager.cpp
+++ b/src/runtime/hip/hip_hardware_manager.cpp
@@ -172,7 +172,8 @@ bool hip_hardware_context::has(device_support_aspect aspect) const {
     return false;
     break;
   case device_support_aspect::global_mem_cache_read_write:
-    return false;
+    // AMD GPUs have read/write cache at least since GCN1 architecture
+    return true;
     break;
   case device_support_aspect::images:
     return false;

--- a/src/runtime/hip/hip_hardware_manager.cpp
+++ b/src/runtime/hip/hip_hardware_manager.cpp
@@ -171,7 +171,7 @@ bool hip_hardware_context::has(device_support_aspect aspect) const {
   case device_support_aspect::global_mem_cache_read_only:
     return false;
     break;
-  case device_support_aspect::global_mem_cache_write_only:
+  case device_support_aspect::global_mem_cache_read_write:
     return false;
     break;
   case device_support_aspect::images:

--- a/src/runtime/omp/omp_hardware_manager.cpp
+++ b/src/runtime/omp/omp_hardware_manager.cpp
@@ -83,7 +83,7 @@ bool omp_hardware_context::has(device_support_aspect aspect) const {
   case device_support_aspect::global_mem_cache_read_only:
     return false;
     break;
-  case device_support_aspect::global_mem_cache_write_only:
+  case device_support_aspect::global_mem_cache_read_write:
     return false;
     break;
   case device_support_aspect::images:

--- a/src/runtime/omp/omp_hardware_manager.cpp
+++ b/src/runtime/omp/omp_hardware_manager.cpp
@@ -84,7 +84,7 @@ bool omp_hardware_context::has(device_support_aspect aspect) const {
     return false;
     break;
   case device_support_aspect::global_mem_cache_read_write:
-    return false;
+    return true;
     break;
   case device_support_aspect::images:
     return false;

--- a/src/runtime/ze/ze_hardware_manager.cpp
+++ b/src/runtime/ze/ze_hardware_manager.cpp
@@ -261,10 +261,10 @@ bool ze_hardware_context::has(device_support_aspect aspect) const {
     return true;
     break;
   case device_support_aspect::global_mem_cache_read_only:
-    return true;
+    return false;
     break;
   case device_support_aspect::global_mem_cache_read_write:
-    return false;
+    return true;
     break;
   case device_support_aspect::images:
     return false;

--- a/src/runtime/ze/ze_hardware_manager.cpp
+++ b/src/runtime/ze/ze_hardware_manager.cpp
@@ -261,7 +261,7 @@ bool ze_hardware_context::has(device_support_aspect aspect) const {
     return true;
     break;
   case device_support_aspect::global_mem_cache_read_only:
-    return false;
+    return true;
     break;
   case device_support_aspect::global_mem_cache_read_write:
     return false;

--- a/src/runtime/ze/ze_hardware_manager.cpp
+++ b/src/runtime/ze/ze_hardware_manager.cpp
@@ -263,7 +263,7 @@ bool ze_hardware_context::has(device_support_aspect aspect) const {
   case device_support_aspect::global_mem_cache_read_only:
     return false;
     break;
-  case device_support_aspect::global_mem_cache_write_only:
+  case device_support_aspect::global_mem_cache_read_write:
     return false;
     break;
   case device_support_aspect::images:

--- a/src/tools/hipsycl-info/hipsycl-info.cpp
+++ b/src/tools/hipsycl-info/hipsycl-info.cpp
@@ -106,7 +106,7 @@ void list_device_details(rt::device_id dev, rt::backend *b,
   PRINT_DEVICE_SUPPORT_ASPECT(little_endian)
   PRINT_DEVICE_SUPPORT_ASPECT(global_mem_cache)
   PRINT_DEVICE_SUPPORT_ASPECT(global_mem_cache_read_only)
-  PRINT_DEVICE_SUPPORT_ASPECT(global_mem_cache_write_only)
+  PRINT_DEVICE_SUPPORT_ASPECT(global_mem_cache_read_write)
   PRINT_DEVICE_SUPPORT_ASPECT(emulated_local_memory)
   PRINT_DEVICE_SUPPORT_ASPECT(sub_group_independent_forward_progress)
   PRINT_DEVICE_SUPPORT_ASPECT(usm_device_allocations)


### PR DESCRIPTION
According to Table 25 in section A.3 of the [SYCL 2020 Specification](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#appendix.device.descriptors), the enum `global_mem_cache_type` should contain the entries `none`, `read_only`, and `read_write`. The last one was called `write_only` in hipSYCL, this PR renames it (and also other "linked"  names to be consistent with naming).

Should fix #432 