### PR TITLE
Remove unnecessary/wrong consts

### DIFF
--- a/include/hipSYCL/sycl/libkernel/item.hpp
+++ b/include/hipSYCL/sycl/libkernel/item.hpp
@@ -171,7 +171,7 @@ private:
     : detail::item_base<dimensions>(my_id, global_size), offset{offset}
   {}
 
-  const sycl::id<dimensions> offset;
+  sycl::id<dimensions> offset;
 };
 
 template <int dimensions>

--- a/include/hipSYCL/sycl/libkernel/nd_range.hpp
+++ b/include/hipSYCL/sycl/libkernel/nd_range.hpp
@@ -90,10 +90,10 @@ struct nd_range
   }
 
 private:
-  const range<dimensions> _global_range;
-  const range<dimensions> _local_range;
-  const range<dimensions> _num_groups;
-  const id<dimensions> _offset;
+  range<dimensions> _global_range;
+  range<dimensions> _local_range;
+  range<dimensions> _num_groups;
+  id<dimensions> _offset;
 };
 
 

--- a/include/hipSYCL/sycl/queue.hpp
+++ b/include/hipSYCL/sycl/queue.hpp
@@ -397,7 +397,7 @@ public:
   }
 
   template <typename T>
-  event submit(T cgf, const queue &secondaryQueue,
+  event submit(T cgf, queue &secondaryQueue,
                const property_list &prop_list = {}) {
     try {
 


### PR DESCRIPTION
This PR removes a few `const`s, namely:
- in `include/hipSYCL/sycl/libkernel/item.hpp`, the `const` for the member `offset` is removed to make objects of type item copyable;
- in `include/hipSYCL/sycl/libkernel/nd_range.hpp`, the `const` for the members is removed for the same reason as above;
- in `include/hipSYCL/sycl/queue.hpp`, the `const` in the second argument `secondaryQueue` of the `submit` method is removed, since inside the method, a non-const function of `secondaryQueue` is called, therefore causing a compile error.