### PR TITLE
Set `local_size` in reduction to default value

### DIFF
--- a/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
@@ -420,6 +420,11 @@ determine_reduction_stages(sycl::range<Dimensions> global_size,
   sycl::range<Dimensions> current_num_groups = num_groups;
   sycl::range<Dimensions> current_num_work_items = global_size;
 
+  for (int i=0; i < Dimensions; ++i)
+    // Check if local_size == 1, this would cause an infinite loop
+    if (local_size[i] == 1)
+      local_size[i] = 128;
+  
   while(current_num_groups.size() > 1) {
 
     current_num_work_items = current_num_groups;

--- a/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
@@ -426,8 +426,8 @@ determine_reduction_stages(sycl::range<Dimensions> global_size,
   for (int i=1; i<Dimensions; ++i)
     local_size[i] = 1;
   // Check if local_size == 1, this would cause an infinite loop
-  if (local_size[0] == 1)
-    local_size[0] = 128;
+  if (local_size[Dimensions - 1] == 1)
+    local_size[Dimensions - 1] = 128;
 
   num_groups[Dimensions - 1] = num_groups.size();
   for (int i=1; i<Dimensions; ++i)

--- a/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
@@ -417,15 +417,22 @@ determine_reduction_stages(sycl::range<Dimensions> global_size,
   stages.push_back(reduction_stage<Dimensions>{
       local_size, num_groups, global_size});
 
+  // Reduce ranges of the form (N,M,L) to (N*M*L,1,1)
+  global_size[0] = global_size.size();
+  for (int i=1; i<Dimensions; ++i)
+    global_size[i] = 1;
+
+  local_size[0] = local_size.size();
+  for (int i=1; i<Dimensions; ++i)
+    local_size[i] = 1;
+  // Check if local_size == 1, this would cause an infinite loop
+  if (local_size[0] == 1)
+    local_size[0] = 128;
+
   sycl::range<Dimensions> current_num_groups = num_groups;
   sycl::range<Dimensions> current_num_work_items = global_size;
-
-  for (int i=0; i < Dimensions; ++i)
-    // Check if local_size == 1, this would cause an infinite loop
-    if (local_size[i] == 1)
-      local_size[i] = 128;
   
-  while(current_num_groups.size() > 1) {
+  while(current_num_groups[0] > 1) {
 
     current_num_work_items = current_num_groups;
     current_num_groups =
@@ -693,7 +700,6 @@ public:
         k(handle);
 
       } else {
-
         sycl::range<Dim> grid_range =
             hiplike_dispatch::determine_grid_configuration(
                 global_range, effective_local_range);

--- a/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
@@ -419,18 +419,18 @@ determine_reduction_stages(sycl::range<Dimensions> global_size,
 
   // Reduce ranges of the form (N,M,L) to (1,1,N*M*L)
   global_size[Dimensions - 1] = global_size.size();
-  for (int i=1; i<Dimensions; ++i)
+  for (int i=0; i<Dimensions-1; ++i)
     global_size[i] = 1;
 
   local_size[Dimensions - 1] = local_size.size();
-  for (int i=1; i<Dimensions; ++i)
+  for (int i=0; i<Dimensions-1; ++i)
     local_size[i] = 1;
   // Check if local_size == 1, this would cause an infinite loop
   if (local_size[Dimensions - 1] == 1)
     local_size[Dimensions - 1] = 128;
 
   num_groups[Dimensions - 1] = num_groups.size();
-  for (int i=1; i<Dimensions; ++i)
+  for (int i=0; i<Dimensions-1; ++i)
     num_groups[i] = 1;
 
   sycl::range<Dimensions> current_num_groups = num_groups;

--- a/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
@@ -417,26 +417,26 @@ determine_reduction_stages(sycl::range<Dimensions> global_size,
   stages.push_back(reduction_stage<Dimensions>{
       local_size, num_groups, global_size});
 
-  // Reduce ranges of the form (N,M,L) to (N*M*L,1,1)
-  global_size[0] = global_size.size();
+  // Reduce ranges of the form (N,M,L) to (1,1,N*M*L)
+  global_size[Dimensions - 1] = global_size.size();
   for (int i=1; i<Dimensions; ++i)
     global_size[i] = 1;
 
-  local_size[0] = local_size.size();
+  local_size[Dimensions - 1] = local_size.size();
   for (int i=1; i<Dimensions; ++i)
     local_size[i] = 1;
   // Check if local_size == 1, this would cause an infinite loop
   if (local_size[0] == 1)
     local_size[0] = 128;
 
-  num_groups[0] = num_groups.size();
+  num_groups[Dimensions - 1] = num_groups.size();
   for (int i=1; i<Dimensions; ++i)
     num_groups[i] = 1;
 
   sycl::range<Dimensions> current_num_groups = num_groups;
   sycl::range<Dimensions> current_num_work_items = global_size;
   
-  while(current_num_groups[0] > 1) {
+  while(current_num_groups[Dimensions - 1] > 1) {
 
     current_num_work_items = current_num_groups;
     current_num_groups =

--- a/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
@@ -429,6 +429,10 @@ determine_reduction_stages(sycl::range<Dimensions> global_size,
   if (local_size[0] == 1)
     local_size[0] = 128;
 
+  num_groups[0] = num_groups.size();
+  for (int i=1; i<Dimensions; ++i)
+    num_groups[i] = 1;
+
   sycl::range<Dimensions> current_num_groups = num_groups;
   sycl::range<Dimensions> current_num_work_items = global_size;
   

--- a/tests/sycl/reduction.cpp
+++ b/tests/sycl/reduction.cpp
@@ -25,6 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <boost/test/unit_test_suite.hpp>
 #include <numeric>
 #include <algorithm>
 #include <type_traits>
@@ -325,6 +326,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(oversized_group_size, T, all_test_types) {
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(two_reductions, T, large_test_types) {
   test_two_reductions<T>(128*128, 128);
+}
+
+BOOST_AUTO_TEST_CASE(local_size_one_reduction, * boost::unit_test::timeout(2)) {
+  test_single_reduction(128, 1, 0, sycl::plus<int>{});
 }
 
 BOOST_AUTO_TEST_CASE(accessor_reduction) {

--- a/tests/sycl/reduction.cpp
+++ b/tests/sycl/reduction.cpp
@@ -328,9 +328,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(two_reductions, T, large_test_types) {
   test_two_reductions<T>(128*128, 128);
 }
 
+#ifdef BOOST_SIGACTION_BASED_SIGNAL_HANDLING
 BOOST_AUTO_TEST_CASE(local_size_one_reduction, * boost::unit_test::timeout(2)) {
   test_single_reduction(128, 1, 0, sycl::plus<int>{});
 }
+#endif
 
 BOOST_AUTO_TEST_CASE(accessor_reduction) {
   sycl::queue q;


### PR DESCRIPTION
Passing a `local_size` of 1 in a `parallel_for` reduction previously caused an infinite loop. This PR sets the `local_size` to a default value of 128 if the user passed 1.

Fixes #857 