### PR TITLE
[SSCP][llvm-to-amdgpu][HIP] Add SSCP JIT support for AMD GPUs

### DIFF
--- a/include/hipSYCL/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.hpp
@@ -48,8 +48,12 @@ public:
   virtual bool translateToBackendFormat(llvm::Module &FlavoredModule, std::string &Out) override;
   
   virtual bool setBuildOption(const std::string &Option, const std::string &Value) override;
+  virtual bool setBuildFlag(const std::string& Flag) override;
 private:
   std::vector<std::string> KernelNames;
+  std::string RocmDeviceLibsPath;
+  std::string TargetDevice = "gfx900";
+  bool OnlyGenerateAssembly = false;
 };
 
 }

--- a/include/hipSYCL/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2018-2022 Aksel Alpay and contributors
+ * Copyright (c) 2019-2022 Aksel Alpay
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,43 +25,34 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef HIPSYCL_S2_IR_CONSTANTS_HPP
-#define HIPSYCL_S2_IR_CONSTANTS_HPP
+#ifndef HIPSYCL_LLVM_TO_AMDGPU_HPP
+#define HIPSYCL_LLVM_TO_AMDGPU_HPP
 
-/// \brief This file contains S2 IR constant definitions that may
-/// be shared across the hipSYCL compiler code. 
-///
-/// As such, no undefined globals should be pulled into this file.
-///
-/// Unlike Stage 1 IR constants, Stage 2 IR constants can be constructed
-/// programmatically by the user.
 
-// S2 IR constants can be identified from their usage of
-// __hipsycl_sscp_s2_ir_constant
-template<auto& ConstantName, class ValueT>
-struct __hipsycl_sscp_s2_ir_constant {
-  static ValueT get(ValueT default_value) noexcept;
+#include "../LLVMToBackend.hpp"
 
-  using value_type = ValueT;
+#include <vector>
+#include <string>
+
+namespace hipsycl {
+namespace compiler {
+
+class LLVMToAmdgpuTranslator : public LLVMToBackendTranslator{
+public:
+  LLVMToAmdgpuTranslator(const std::vector<std::string>& KernelNames);
+
+  virtual ~LLVMToAmdgpuTranslator() {}
+
+  virtual bool prepareBackendFlavor(llvm::Module& M) override {return true;}
+  virtual bool toBackendFlavor(llvm::Module &M, PassHandler& PH) override;
+  virtual bool translateToBackendFormat(llvm::Module &FlavoredModule, std::string &Out) override;
+  
+  virtual bool setBuildOption(const std::string &Option, const std::string &Value) override;
+private:
+  std::vector<std::string> KernelNames;
 };
 
-
-namespace hipsycl::glue::sscp {
-  struct ir_constant_name {};
 }
-
-namespace hipsycl::sycl::sscp {
-
-namespace backend {
-
-inline constexpr int spirv = 0;
-inline constexpr int ptx = 1;
-inline constexpr int amdgpu = 2;
-
-}
-
-constexpr glue::sscp::ir_constant_name current_backend;
-
 }
 
 #endif

--- a/include/hipSYCL/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpuFactory.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpuFactory.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2018-2022 Aksel Alpay and contributors
+ * Copyright (c) 2019-2022 Aksel Alpay
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,43 +25,21 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef HIPSYCL_S2_IR_CONSTANTS_HPP
-#define HIPSYCL_S2_IR_CONSTANTS_HPP
+#ifndef HIPSYCL_LLVM_TO_AMDGPU_FACTORY_HPP
+#define HIPSYCL_LLVM_TO_AMDGPU_FACTORY_HPP
 
-/// \brief This file contains S2 IR constant definitions that may
-/// be shared across the hipSYCL compiler code. 
-///
-/// As such, no undefined globals should be pulled into this file.
-///
-/// Unlike Stage 1 IR constants, Stage 2 IR constants can be constructed
-/// programmatically by the user.
+#include <memory>
+#include <vector>
+#include <string>
+#include "../LLVMToBackend.hpp"
 
-// S2 IR constants can be identified from their usage of
-// __hipsycl_sscp_s2_ir_constant
-template<auto& ConstantName, class ValueT>
-struct __hipsycl_sscp_s2_ir_constant {
-  static ValueT get(ValueT default_value) noexcept;
+namespace hipsycl {
+namespace compiler {
 
-  using value_type = ValueT;
-};
-
-
-namespace hipsycl::glue::sscp {
-  struct ir_constant_name {};
-}
-
-namespace hipsycl::sycl::sscp {
-
-namespace backend {
-
-inline constexpr int spirv = 0;
-inline constexpr int ptx = 1;
-inline constexpr int amdgpu = 2;
+std::unique_ptr<LLVMToBackendTranslator>
+createLLVMToAmdgpuTranslator(const std::vector<std::string> &KernelNames);
 
 }
-
-constexpr glue::sscp::ir_constant_name current_backend;
-
 }
 
 #endif

--- a/include/hipSYCL/runtime/hip/hip_code_object.hpp
+++ b/include/hipSYCL/runtime/hip/hip_code_object.hpp
@@ -31,6 +31,7 @@
 #include <vector>
 #include <string>
 
+#include "hipSYCL/glue/kernel_configuration.hpp"
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
 #include "hipSYCL/runtime/kernel_cache.hpp"
@@ -41,14 +42,21 @@ struct ihipModule_t;
 namespace hipsycl {
 namespace rt {
 
-
 class hip_executable_object : public code_object {
 public:
-  virtual ~hip_executable_object();
-  hip_executable_object(hcf_object_id origin, const std::string &target,
+  virtual ~hip_executable_object() {}
+  virtual ihipModule_t* get_module() const = 0;
+  virtual result get_build_result() const = 0;
+  virtual int get_device() const = 0;
+};
+
+class hip_multipass_executable_object : public hip_executable_object {
+public:
+  virtual ~hip_multipass_executable_object();
+  hip_multipass_executable_object(hcf_object_id origin, const std::string &target,
                         const std::string &hip_fat_binary, int device);
 
-  result get_build_result() const;
+  virtual result get_build_result() const override;
 
   virtual code_object_state state() const override;
   virtual code_format format() const override;
@@ -62,14 +70,52 @@ public:
 
   virtual bool contains(const std::string &backend_kernel_name) const override;
 
-  ihipModule_t* get_module() const;
-  int get_device() const;
+  virtual ihipModule_t* get_module() const override;
+  virtual int get_device() const override;
 private:
   result build(const std::string& hip_fat_binary);
 
   hcf_object_id _origin;
   std::string _target;
   result _build_result;
+  int _device;
+  ihipModule_t* _module;
+};
+
+class hip_sscp_executable_object : public hip_executable_object {
+public:
+  virtual ~hip_sscp_executable_object();
+  hip_sscp_executable_object(const std::string &hip_fat_binary,
+                             const std::string &target_arch,
+                             hcf_object_id source,
+                             const std::vector<std::string> &kernel_name,
+                             int device,
+                             const glue::kernel_configuration &config);
+
+  virtual result get_build_result() const override;
+
+  virtual code_object_state state() const override;
+  virtual code_format format() const override;
+  virtual backend_id managing_backend() const override;
+  virtual hcf_object_id hcf_source() const override;
+  virtual std::string target_arch() const override;
+  virtual compilation_flow source_compilation_flow() const override;
+
+  virtual std::vector<std::string>
+  supported_backend_kernel_names() const override;
+
+  virtual bool contains(const std::string &backend_kernel_name) const override;
+
+  virtual ihipModule_t* get_module() const override;
+  virtual int get_device() const override;
+private:
+  result build(const std::string& hip_fat_binary);
+
+  std::string _target;
+  hcf_object_id _origin;
+  std::vector<std::string> _kernel_names;
+  result _build_result;
+  glue::kernel_configuration::id_type _id;
   int _device;
   ihipModule_t* _module;
 };

--- a/include/hipSYCL/runtime/hip/hip_queue.hpp
+++ b/include/hipSYCL/runtime/hip/hip_queue.hpp
@@ -44,10 +44,9 @@ namespace rt {
 class hip_queue;
 class hip_backend;
 
-
-class hip_code_object_invoker : public multipass_code_object_invoker{
+class hip_multipass_code_object_invoker : public multipass_code_object_invoker {
 public:
-  hip_code_object_invoker(hip_queue* q);
+  hip_multipass_code_object_invoker(hip_queue* q);
 
   virtual result submit_kernel(const kernel_operation& op,
                                hcf_object_id hcf_object,
@@ -57,7 +56,27 @@ public:
                                std::size_t *arg_sizes, std::size_t num_args,
                                const std::string &kernel_name_tag,
                                const std::string &kernel_body_name) override;
-  virtual ~hip_code_object_invoker(){}
+  virtual ~hip_multipass_code_object_invoker(){}
+private:
+  hip_queue* _queue;
+};
+
+
+class hip_sscp_code_object_invoker : public sscp_code_object_invoker {
+public:
+  hip_sscp_code_object_invoker(hip_queue* q)
+  : _queue{q} {}
+
+  virtual ~hip_sscp_code_object_invoker(){}
+
+  virtual result submit_kernel(const kernel_operation& op,
+                               hcf_object_id hcf_object,
+                               const rt::range<3> &num_groups,
+                               const rt::range<3> &group_size,
+                               unsigned local_mem_size, void **args,
+                               std::size_t *arg_sizes, std::size_t num_args,
+                               const std::string &kernel_name,
+                               const glue::kernel_configuration& config) override;
 private:
   hip_queue* _queue;
 };
@@ -92,11 +111,18 @@ public:
 
   virtual result query_status(inorder_queue_status& status) override;
 
-  result submit_kernel_from_code_object(
+  result submit_multipass_kernel_from_code_object(
       const kernel_operation &op, hcf_object_id hcf_object,
       const std::string &backend_kernel_name, const rt::range<3> &grid_size,
       const rt::range<3> &block_size, unsigned dynamic_shared_mem,
       void **kernel_args, std::size_t* arg_sizes, std::size_t num_args);
+
+  result submit_sscp_kernel_from_code_object(
+      const kernel_operation &op, hcf_object_id hcf_object,
+      const std::string &kernel_name, const rt::range<3> &num_groups,
+      const rt::range<3> &group_size, unsigned local_mem_size, void **args,
+      std::size_t *arg_sizes, std::size_t num_args,
+      const glue::kernel_configuration &config);
 
   const host_timestamped_event& get_timing_reference() const {
     return _reference_event;
@@ -108,7 +134,8 @@ private:
   ihipStream_t* _stream;
   host_timestamped_event _reference_event;
   hip_backend* _backend;
-  hip_code_object_invoker _code_object_invoker;
+  hip_multipass_code_object_invoker _multipass_code_object_invoker;
+  hip_sscp_code_object_invoker _sscp_code_object_invoker;
 };
 
 }

--- a/src/compiler/llvm-to-backend/AddressSpaceInferencePass.cpp
+++ b/src/compiler/llvm-to-backend/AddressSpaceInferencePass.cpp
@@ -127,8 +127,9 @@ void rewriteKernelArgumentAddressSpacesTo(unsigned AddressSpace, llvm::Module &M
         llvm::Type* CurrentParamType = OriginalFType->getParamType(i);
         if(llvm::PointerType* PT = llvm::dyn_cast<llvm::PointerType>(CurrentParamType)) {
           if(PT->getAddressSpace() != AddressSpace) {
-            Params.push_back(
-                llvm::PointerType::getWithSamePointeeType(PT, AddressSpace));
+            llvm::Type *NewT =
+                llvm::PointerType::getWithSamePointeeType(PT, AddressSpace);
+            Params.push_back(NewT);
           }
         } else {
           Params.push_back(CurrentParamType);

--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -138,13 +138,25 @@ if(WITH_SSCP_COMPILER)
    BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config Release --target install
    PATCH_COMMAND patch -N -p0 -c --fuzz=4 --ignore-whitespace -i llvm-spirv.patch lib/SPIRV/SPIRVInternal.h ${CMAKE_CURRENT_SOURCE_DIR}/spirv/llvm-spirv.patch || true
   )
-  
+
   target_compile_definitions(llvm-to-spirv PRIVATE
     -DHIPSYCL_RELATIVE_LLVMSPIRV_PATH="${LLVMSPIRV_RELATIVE_PATH}")
   target_compile_definitions(llvm-to-ptx PRIVATE
     -DHIPSYCL_CLANG_PATH="${CLANG_EXECUTABLE_PATH}" 
     -DHIPSYCL_CUDA_PATH="${CUDA_TOOLKIT_ROOT_DIR}")
+
   target_compile_definitions(llvm-to-amdgpu PRIVATE
-    -DHIPSYCL_CLANG_PATH="${CLANG_EXECUTABLE_PATH}" 
     -DHIPSYCL_ROCM_PATH="${ROCM_PATH}")
+  if(HIPSYCL_SSCP_AMDGPU_USE_ROCM_CLANG)
+    find_program(ROCM_CLANG_PATH NAMES clang++ HINTS ${ROCM_PATH}/llvm/bin)
+    target_compile_definitions(llvm-to-amdgpu PRIVATE
+      -DHIPSYCL_CLANG_PATH="${ROCM_CLANG_PATH}")
+  else()
+    target_compile_definitions(llvm-to-amdgpu PRIVATE
+      -DHIPSYCL_CLANG_PATH="${CLANG_EXECUTABLE_PATH}")
+  endif()
+  if(HIPSYCL_SSCP_AMDGPU_FORCE_OCLC_ABI_VERSION)
+    target_compile_definitions(llvm-to-amdgpu PRIVATE
+      -DHIPSYCL_SSCP_AMDGPU_FORCE_OCLC_ABI_VERSION)
+  endif()
 endif()

--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -111,6 +111,11 @@ if(WITH_SSCP_COMPILER)
     LIBRARY ptx/LLVMToPtx.cpp 
     TOOL ptx/LLVMToPtxTool.cpp)
 
+  add_hipsycl_llvm_backend(
+    BACKEND amdgpu 
+    LIBRARY amdgpu/LLVMToAmdgpu.cpp 
+    TOOL amdgpu/LLVMToAmdgpuTool.cpp)
+
 # Install LLVM-SPIRV translator for llvm-to-spirv
   set(LLVMSPIRV_BRANCH llvm_release_${LLVM_VERSION_MAJOR}0)
   set(LLVMSPIRV_RELATIVE_INSTALLDIR lib/hipSYCL/ext/llvm-spirv)
@@ -139,4 +144,7 @@ if(WITH_SSCP_COMPILER)
   target_compile_definitions(llvm-to-ptx PRIVATE
     -DHIPSYCL_CLANG_PATH="${CLANG_EXECUTABLE_PATH}" 
     -DHIPSYCL_CUDA_PATH="${CUDA_TOOLKIT_ROOT_DIR}")
+  target_compile_definitions(llvm-to-amdgpu PRIVATE
+    -DHIPSYCL_CLANG_PATH="${CLANG_EXECUTABLE_PATH}" 
+    -DHIPSYCL_ROCM_PATH="${ROCM_PATH}")
 endif()

--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -1,0 +1,172 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2019-2022 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "hipSYCL/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.hpp"
+#include "hipSYCL/compiler/llvm-to-backend/AddressSpaceInferencePass.hpp"
+#include "hipSYCL/compiler/llvm-to-backend/Utils.hpp"
+#include "hipSYCL/compiler/sscp/IRConstantReplacer.hpp"
+#include "hipSYCL/glue/llvm-sscp/s2_ir_constants.hpp"
+#include "hipSYCL/common/filesystem.hpp"
+#include "hipSYCL/common/debug.hpp"
+#include <llvm/IR/GlobalVariable.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/Bitcode/BitcodeWriter.h>
+#include <llvm/IR/Attributes.h>
+#include <llvm/IR/CallingConv.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Passes/PassBuilder.h>
+#include <llvm/Support/FileSystem.h>
+#include <llvm/Support/MemoryBuffer.h>
+#include <llvm/Support/raw_ostream.h>
+#include <llvm/Support/Program.h>
+#include <memory>
+#include <cassert>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace hipsycl {
+namespace compiler {
+
+
+LLVMToAmdgpuTranslator::LLVMToAmdgpuTranslator(const std::vector<std::string> &KN)
+    : LLVMToBackendTranslator{sycl::sscp::backend::amdgpu, KN}, KernelNames{KN} {}
+
+
+bool LLVMToAmdgpuTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
+  
+  M.setTargetTriple("amdgcn-amd-amdhsa");
+  M.setDataLayout(
+      "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-"
+      "v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7");
+
+
+  // TODO: Do we need to rewrite kernel argument address spaces?
+
+  for(auto KernelName : KernelNames) {
+    HIPSYCL_DEBUG_INFO << "LLVMToAmdgpu: Setting up kernel " << KernelName << "\n";
+    if(auto* F = M.getFunction(KernelName)) {
+      F->setCallingConv(llvm::CallingConv::AMDGPU_KERNEL);
+    }
+  }
+  
+  // TODO Link ocml/ockl bitcode libraries
+  
+  for(auto& F : M.getFunctionList()) {
+    if(F.getCallingConv() != llvm::CallingConv::AMDGPU_KERNEL) {
+      // When we are already lowering to device specific format,
+      // we can expect that we have no external users anymore.
+      // All linking should be done by now. The exception are intrinsics.
+      
+      F.setLinkage(llvm::GlobalValue::InternalLinkage);
+    }
+  }
+
+  // TODO handle address spaces
+
+  return true;
+}
+
+
+bool LLVMToAmdgpuTranslator::translateToBackendFormat(llvm::Module &FlavoredModule, std::string &out) {
+
+  auto InputFile = llvm::sys::fs::TempFile::create("hipsycl-sscp-amdgpu-%%%%%%.bc");
+  auto OutputFile = llvm::sys::fs::TempFile::create("hipsycl-sscp-amdgpu-%%%%%%.hipfb");
+  
+  std::string OutputFilename = OutputFile->TmpName;
+  
+  auto E = InputFile.takeError();
+  if(E){
+    this->registerError("LLVMToPtx: Could not create temp file: "+InputFile->TmpName);
+    return false;
+  }
+
+  AtScopeExit DestroyInputFile([&]() { auto Err = InputFile->discard(); });
+  AtScopeExit DestroyOutputFile([&]() { auto Err = OutputFile->discard(); });
+
+  std::error_code EC;
+  llvm::raw_fd_ostream InputStream{InputFile->FD, false};
+  
+  llvm::WriteBitcodeToFile(FlavoredModule, InputStream);
+  InputStream.flush();
+
+  std::string ClangPath = HIPSYCL_CLANG_PATH;
+
+  llvm::SmallVector<llvm::StringRef, 16> Invocation{ClangPath,
+                                                    "-cc1",
+                                                    "-triple",
+                                                    "amdgcn-amd-amdhsa",
+                                                    // TODO Set AMD target CPU
+                                                    "-O3",
+                                                    "-S",
+                                                    "-x",
+                                                    "ir",
+                                                    "-o",
+                                                    OutputFilename,
+                                                    InputFile->TmpName};
+
+  std::string ArgString;
+  for(const auto& S : Invocation) {
+    ArgString += S;
+    ArgString += " ";
+  }
+  HIPSYCL_DEBUG_INFO << "LLVMToAmdgpu: Invoking " << ArgString << "\n";
+
+  int R = llvm::sys::ExecuteAndWait(
+      ClangPath, Invocation);
+  
+  if(R != 0) {
+    this->registerError("LLVMToAmdgpu: clang invocation failed with exit code " +
+                        std::to_string(R));
+    return false;
+  }
+  
+  auto ReadResult =
+      llvm::MemoryBuffer::getFile(OutputFile->TmpName, -1);
+  
+  if(auto Err = ReadResult.getError()) {
+    this->registerError("LLVMToPtx: Could not read result file"+Err.message());
+    return false;
+  }
+  
+  out = ReadResult->get()->getBuffer();
+
+  return true;
+}
+
+bool LLVMToAmdgpuTranslator::setBuildOption(const std::string &Option, const std::string &Value) {
+  return true;
+}
+
+std::unique_ptr<LLVMToBackendTranslator>
+createLLVMToAmdgpuTranslator(const std::vector<std::string> &KernelNames) {
+  return std::make_unique<LLVMToAmdgpuTranslator>(KernelNames);
+}
+
+}
+}

--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpuTool.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpuTool.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2018-2022 Aksel Alpay and contributors
+ * Copyright (c) 2019-2022 Aksel Alpay
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,43 +25,23 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef HIPSYCL_S2_IR_CONSTANTS_HPP
-#define HIPSYCL_S2_IR_CONSTANTS_HPP
+#include "hipSYCL/common/hcf_container.hpp"
+#include "hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp"
+#include "hipSYCL/compiler/llvm-to-backend/LLVMToBackendTool.hpp"
+#include "hipSYCL/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpuFactory.hpp"
+#include <memory>
 
-/// \brief This file contains S2 IR constant definitions that may
-/// be shared across the hipSYCL compiler code. 
-///
-/// As such, no undefined globals should be pulled into this file.
-///
-/// Unlike Stage 1 IR constants, Stage 2 IR constants can be constructed
-/// programmatically by the user.
+namespace tool = hipsycl::compiler::translation_tool;
 
-// S2 IR constants can be identified from their usage of
-// __hipsycl_sscp_s2_ir_constant
-template<auto& ConstantName, class ValueT>
-struct __hipsycl_sscp_s2_ir_constant {
-  static ValueT get(ValueT default_value) noexcept;
-
-  using value_type = ValueT;
-};
-
-
-namespace hipsycl::glue::sscp {
-  struct ir_constant_name {};
+std::unique_ptr<hipsycl::compiler::LLVMToBackendTranslator>
+createAmdgpuTranslator(const hipsycl::common::hcf_container& HCF) {
+  std::vector<std::string> KernelNames;
+  if(!tool::getHcfKernelNames(HCF, KernelNames)) {
+    return nullptr;
+  }
+  return hipsycl::compiler::createLLVMToAmdgpuTranslator(KernelNames);
 }
 
-namespace hipsycl::sycl::sscp {
-
-namespace backend {
-
-inline constexpr int spirv = 0;
-inline constexpr int ptx = 1;
-inline constexpr int amdgpu = 2;
-
+int main(int argc, char* argv[]) {
+  return tool::LLVMToBackendToolMain(argc, argv, createAmdgpuTranslator);
 }
-
-constexpr glue::sscp::ir_constant_name current_backend;
-
-}
-
-#endif

--- a/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
+++ b/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
@@ -28,7 +28,6 @@
 #include "hipSYCL/compiler/llvm-to-backend/spirv/LLVMToSpirv.hpp"
 #include "hipSYCL/compiler/llvm-to-backend/AddressSpaceInferencePass.hpp"
 #include "hipSYCL/compiler/llvm-to-backend/Utils.hpp"
-#include "hipSYCL/compiler/llvm-to-backend/AddressSpaceInferencePass.hpp"
 #include "hipSYCL/compiler/sscp/IRConstantReplacer.hpp"
 #include "hipSYCL/glue/llvm-sscp/s2_ir_constants.hpp"
 #include "hipSYCL/common/filesystem.hpp"

--- a/src/libkernel/sscp/CMakeLists.txt
+++ b/src/libkernel/sscp/CMakeLists.txt
@@ -71,3 +71,4 @@ endfunction()
 
 add_subdirectory(spirv)
 add_subdirectory(ptx)
+add_subdirectory(amdgpu)

--- a/src/libkernel/sscp/CMakeLists.txt
+++ b/src/libkernel/sscp/CMakeLists.txt
@@ -2,7 +2,7 @@
 function(libkernel_generate_bitcode_library)
   set(options)
   set(one_value_keywords OUTPUT TRIPLE SOURCE)
-  set(multi_value_keywords )
+  set(multi_value_keywords ADDITIONAL_ARGS)
   cmake_parse_arguments(GENERATE_BITCODE_LIBRARY
     "${options}"
     "${one_value_keywords}"
@@ -13,12 +13,13 @@ function(libkernel_generate_bitcode_library)
   set(output ${GENERATE_BITCODE_LIBRARY_OUTPUT})
   set(source ${GENERATE_BITCODE_LIBRARY_SOURCE})
   set(triple ${GENERATE_BITCODE_LIBRARY_TRIPLE})
+  set(additional ${GENERATE_BITCODE_LIBRARY_ADDITIONAL_ARGS})
 
   set(target_output_file ${output})
   add_custom_command(
       OUTPUT ${target_output_file}
       COMMAND ${CLANG_EXECUTABLE_PATH} -target ${triple} -fno-exceptions -fno-rtti -O3 -emit-llvm
-                    -I ${HIPSYCL_SOURCE_DIR}/include -o ${target_output_file} -c ${CMAKE_CURRENT_SOURCE_DIR}/${source}
+                    -I ${HIPSYCL_SOURCE_DIR}/include ${additional} -o ${target_output_file} -c ${CMAKE_CURRENT_SOURCE_DIR}/${source}
       DEPENDS ${source}
       VERBATIM)
 
@@ -28,7 +29,7 @@ endfunction()
 function(libkernel_generate_bitcode_target)
   set(options)
   set(one_value_keywords TARGETNAME TRIPLE)
-  set(multi_value_keywords SOURCES)
+  set(multi_value_keywords SOURCES ADDITIONAL_ARGS)
 
   cmake_parse_arguments(GENERATE_BITCODE_TARGET
     "${options}"
@@ -40,6 +41,7 @@ function(libkernel_generate_bitcode_target)
   set(target ${GENERATE_BITCODE_TARGET_TARGETNAME})
   set(sources ${GENERATE_BITCODE_TARGET_SOURCES})
   set(triple ${GENERATE_BITCODE_TARGET_TRIPLE})
+  set(additional ${GENERATE_BITCODE_TARGET_ADDITIONAL_ARGS})
 
   set(output_files )
   foreach(source ${sources})
@@ -50,7 +52,8 @@ function(libkernel_generate_bitcode_target)
     libkernel_generate_bitcode_library(
       OUTPUT ${output_file}
       TRIPLE ${triple} 
-      SOURCE ${source})
+      SOURCE ${source}
+      ADDITIONAL_ARGS ${additional})
   endforeach()
 
   set(linked_output ${CMAKE_CURRENT_BINARY_DIR}/libkernel-sscp-${target}-full.bc)

--- a/src/libkernel/sscp/amdgpu/CMakeLists.txt
+++ b/src/libkernel/sscp/amdgpu/CMakeLists.txt
@@ -2,4 +2,5 @@
 libkernel_generate_bitcode_target(
     TARGETNAME amdgpu-amdhsa 
     TRIPLE amdgcn-amd-amdhsa
-    SOURCES core.cpp )
+    SOURCES core.cpp
+    ADDITIONAL_ARGS -nogpulib)

--- a/src/libkernel/sscp/amdgpu/CMakeLists.txt
+++ b/src/libkernel/sscp/amdgpu/CMakeLists.txt
@@ -1,0 +1,5 @@
+
+libkernel_generate_bitcode_target(
+    TARGETNAME amdgpu-amdhsa 
+    TRIPLE amdgcn-amd-amdhsa
+    SOURCES core.cpp )

--- a/src/libkernel/sscp/amdgpu/core.cpp
+++ b/src/libkernel/sscp/amdgpu/core.cpp
@@ -1,0 +1,89 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2019-2022 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "hipSYCL/sycl/libkernel/sscp/builtins/core.hpp"
+#include <stddef.h>
+
+extern "C" size_t __ockl_get_global_offset(unsigned);
+extern "C" size_t __ockl_get_global_id(unsigned);
+extern "C" size_t __ockl_get_local_id(unsigned);
+extern "C" size_t __ockl_get_group_id(unsigned);
+extern "C" size_t __ockl_get_global_size(unsigned);
+extern "C" size_t __ockl_get_local_size(unsigned);
+extern "C" size_t __ockl_get_num_groups(unsigned);
+extern "C" unsigned __ockl_get_work_dim(unsigned);
+extern "C" size_t __ockl_get_enqueued_local_size(unsigned);
+extern "C" size_t __ockl_get_global_linear_id(unsigned);
+extern "C" size_t __ockl_get_local_linear_id(unsigned);
+
+HIPSYCL_SSCP_BUILTIN size_t __hipsycl_sscp_get_local_id_x() {
+  return __ockl_get_local_id(0);
+}
+
+HIPSYCL_SSCP_BUILTIN size_t __hipsycl_sscp_get_local_id_y() {
+  return __ockl_get_local_id(1);
+}
+
+HIPSYCL_SSCP_BUILTIN size_t __hipsycl_sscp_get_local_id_z() {
+  return __ockl_get_local_id(2);
+}
+
+HIPSYCL_SSCP_BUILTIN size_t __hipsycl_sscp_get_group_id_x() {
+  return __ockl_get_group_id(0);
+}
+
+HIPSYCL_SSCP_BUILTIN size_t __hipsycl_sscp_get_group_id_y() {
+  return __ockl_get_group_id(1);
+}
+
+HIPSYCL_SSCP_BUILTIN size_t __hipsycl_sscp_get_group_id_z() {
+  return __ockl_get_group_id(2);
+}
+
+HIPSYCL_SSCP_BUILTIN size_t __hipsycl_sscp_get_local_size_x() {
+  return __ockl_get_local_size(0);
+}
+
+HIPSYCL_SSCP_BUILTIN size_t __hipsycl_sscp_get_local_size_y() {
+  return __ockl_get_local_size(1);
+}
+
+HIPSYCL_SSCP_BUILTIN size_t __hipsycl_sscp_get_local_size_z() {
+  return __ockl_get_local_size(2);
+}
+
+HIPSYCL_SSCP_BUILTIN size_t __hipsycl_sscp_get_num_groups_x() {
+  return __ockl_get_num_groups(0);
+}
+
+HIPSYCL_SSCP_BUILTIN size_t __hipsycl_sscp_get_num_groups_y() {
+  return __ockl_get_num_groups(1);
+}
+
+HIPSYCL_SSCP_BUILTIN size_t __hipsycl_sscp_get_num_groups_z() {
+  return __ockl_get_num_groups(2);
+}

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -149,6 +149,11 @@ if(WITH_ROCM_BACKEND)
   target_compile_options(rt-backend-hip PRIVATE ${HIPSYCL_RT_EXTRA_CXX_FLAGS})
   target_link_libraries(rt-backend-hip PRIVATE ${HIPSYCL_RT_EXTRA_LINKER_FLAGS})
 
+  if(WITH_SSCP_COMPILER)
+    target_compile_definitions(rt-backend-hip PRIVATE -DHIPSYCL_WITH_SSCP_COMPILER)
+    target_link_libraries(rt-backend-hip PRIVATE llvm-to-amdgpu)
+  endif()
+
   install(TARGETS rt-backend-hip
         RUNTIME DESTINATION bin/hipSYCL
         LIBRARY DESTINATION lib/hipSYCL

--- a/src/runtime/hip/hip_code_object.cpp
+++ b/src/runtime/hip/hip_code_object.cpp
@@ -26,6 +26,7 @@
  */
 
 #include "hipSYCL/runtime/hip/hip_code_object.hpp"
+#include "hipSYCL/glue/kernel_configuration.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/hip/hip_device_manager.hpp"
@@ -35,13 +36,13 @@
 namespace hipsycl {
 namespace rt {
 
+namespace {
 
+void unload_hip_module(ihipModule_t* module, int device) {
+  if(module) {
+    hip_device_manager::get().activate_device(device);
 
-hip_executable_object::~hip_executable_object() {
-  if(_module) {
-    hip_device_manager::get().activate_device(_device);
-
-    auto err = hipModuleUnload(_module);
+    auto err = hipModuleUnload(module);
 
     if(err != hipSuccess) {
       register_error(
@@ -52,50 +53,72 @@ hip_executable_object::~hip_executable_object() {
   }
 }
 
-hip_executable_object::hip_executable_object(hcf_object_id origin,
-                                             const std::string &target,
-                                             const std::string &hip_fat_binary,
-                                             int device)
+result build_hip_module(ihipModule_t *&module, int device,
+                        const std::string &hip_fat_binary) {
+  // It's unclear if this is actually needed for HIP?
+  hip_device_manager::get().activate_device(device);
+
+  auto err = hipModuleLoadData(&module, hip_fat_binary.c_str());
+
+  if(err == hipSuccess)
+    return make_success();
+  else {
+    return make_error(
+        __hipsycl_here(),
+        error_info{"hip_executable_object: could not create module",
+                   error_code{"HIP", static_cast<int>(err)}});
+  }
+}
+}
+
+hip_multipass_executable_object::~hip_multipass_executable_object() {
+  unload_hip_module(_module, _device);
+}
+
+hip_multipass_executable_object::hip_multipass_executable_object(
+    hcf_object_id origin, const std::string &target,
+    const std::string &hip_fat_binary, int device)
     : _origin{origin}, _target{target}, _device{device}, _module{nullptr} {
   _build_result = build(hip_fat_binary);
 }
 
-result hip_executable_object::get_build_result() const {
+result hip_multipass_executable_object::get_build_result() const {
   return _build_result;
 }
 
-code_object_state hip_executable_object::state() const {
+code_object_state hip_multipass_executable_object::state() const {
   return code_object_state::executable;
 }
 
-code_format hip_executable_object::format() const {
+code_format hip_multipass_executable_object::format() const {
   return code_format::native_isa;
 }
 
-backend_id hip_executable_object::managing_backend() const {
+backend_id hip_multipass_executable_object::managing_backend() const {
   return backend_id::hip;
 }
 
-hcf_object_id hip_executable_object::hcf_source() const {
+hcf_object_id hip_multipass_executable_object::hcf_source() const {
   return _origin;
 }
 
-std::string hip_executable_object::target_arch() const {
+std::string hip_multipass_executable_object::target_arch() const {
   return _target;
 }
 
-compilation_flow hip_executable_object::source_compilation_flow() const {
+compilation_flow hip_multipass_executable_object::source_compilation_flow() const {
   return compilation_flow::explicit_multipass;
 }
 
 std::vector<std::string>
-hip_executable_object::supported_backend_kernel_names() const {
+hip_multipass_executable_object::supported_backend_kernel_names() const {
   // TODO This is currently not easily implementable. Should we throw an
   // exception? Remove it from the general interface?
   return {};
 }
 
-bool hip_executable_object::contains(const std::string &backend_kernel_name) const {
+bool hip_multipass_executable_object::contains(
+    const std::string &backend_kernel_name) const {
   if(!_build_result.is_success())
     return false;
   
@@ -108,28 +131,84 @@ bool hip_executable_object::contains(const std::string &backend_kernel_name) con
   return err == hipSuccess;
 }
 
-hipModule_t hip_executable_object::get_module() const {
+hipModule_t hip_multipass_executable_object::get_module() const {
   return _module;
 }
 
-int hip_executable_object::get_device() const {
+int hip_multipass_executable_object::get_device() const {
   return _device;
 }
 
-result hip_executable_object::build(const std::string& hip_fat_binary) {
-  // It's unclear if this is actually needed for HIP?
-  hip_device_manager::get().activate_device(_device);
+result hip_multipass_executable_object::build(const std::string& hip_fat_binary) {
+  return build_hip_module(_module, _device, hip_fat_binary);
+}
 
-  auto err = hipModuleLoadData(&_module, hip_fat_binary.c_str());
+hip_sscp_executable_object::hip_sscp_executable_object(
+    const std::string &code_image, const std::string &target_arch,
+    hcf_object_id hcf_source, const std::vector<std::string> &kernel_names,
+    int device, const glue::kernel_configuration &config)
+    : _target{target_arch}, _origin{hcf_source}, _kernel_names{kernel_names},
+      _device{device}, _id{config.generate_id()}, _module{nullptr} {
+  _build_result = build(code_image);
+}
 
-  if(err == hipSuccess)
-    return make_success();
-  else {
-    return make_error(
-        __hipsycl_here(),
-        error_info{"hip_executable_object: could not create module",
-                   error_code{"HIP", static_cast<int>(err)}});
+hip_sscp_executable_object::~hip_sscp_executable_object() {
+  unload_hip_module(_module, _device);
+}
+
+result hip_sscp_executable_object::get_build_result() const {
+  return _build_result;
+}
+
+code_object_state hip_sscp_executable_object::state() const {
+  return _build_result.is_success() ? code_object_state::executable
+                                    : code_object_state::invalid;
+}
+
+code_format hip_sscp_executable_object::format() const {
+  return code_format::native_isa;
+}
+
+backend_id hip_sscp_executable_object::managing_backend() const {
+  return backend_id::hip;
+}
+
+hcf_object_id hip_sscp_executable_object::hcf_source() const {
+  return _origin;
+}
+
+std::string hip_sscp_executable_object::target_arch() const {
+  return _target;
+}
+
+compilation_flow hip_sscp_executable_object::source_compilation_flow() const {
+  return compilation_flow::sscp;
+}
+
+std::vector<std::string>
+hip_sscp_executable_object::supported_backend_kernel_names() const {
+  return _kernel_names;
+}
+
+bool hip_sscp_executable_object::contains(
+    const std::string &backend_kernel_name) const {
+  for(const auto& name : _kernel_names) {
+    if(name == backend_kernel_name)
+      return true;
   }
+  return false;
+}
+
+ihipModule_t* hip_sscp_executable_object::get_module() const {
+  return _module;
+}
+
+int hip_sscp_executable_object::get_device() const {
+  return _device;
+}
+
+result hip_sscp_executable_object::build(const std::string& hip_fat_binary) {
+  return build_hip_module(_module, _device, hip_fat_binary);
 }
 
 }

--- a/src/runtime/hip/hip_hardware_manager.cpp
+++ b/src/runtime/hip/hip_hardware_manager.cpp
@@ -208,7 +208,7 @@ bool hip_hardware_context::has(device_support_aspect aspect) const {
     return true;
     break;
   case device_support_aspect::sscp_kernels:
-    return false;
+    return true;
     break;
   }
   assert(false && "Unknown device aspect");

--- a/src/runtime/hip/hip_queue.cpp
+++ b/src/runtime/hip/hip_queue.cpp
@@ -27,6 +27,7 @@
 
 #include "hipSYCL/runtime/hip/hip_target.hpp"
 #include "hipSYCL/common/hcf_container.hpp"
+#include "hipSYCL/runtime/hip/hip_hardware_manager.hpp"
 #include "hipSYCL/runtime/hip/hip_queue.hpp"
 #include "hipSYCL/runtime/hip/hip_backend.hpp"
 #include "hipSYCL/runtime/error.hpp"
@@ -38,6 +39,12 @@
 #include "hipSYCL/runtime/queue_completion_event.hpp"
 #include "hipSYCL/runtime/kernel_cache.hpp"
 
+#ifdef HIPSYCL_WITH_SSCP_COMPILER
+
+#include "hipSYCL/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpuFactory.hpp"
+#include "hipSYCL/glue/llvm-sscp/jit.hpp"
+
+#endif
 
 #include <cassert>
 #include <memory>
@@ -121,6 +128,42 @@ private:
   std::shared_ptr<dag_node_event> _task_start;
 };
 
+result launch_kernel_from_module(ihipModule_t *module,
+                                 const std::string &kernel_name,
+                                 const rt::range<3> &grid_size,
+                                 const rt::range<3> &block_size,
+                                 unsigned dynamic_shared_mem,
+                                 hipStream_t stream, void **kernel_args,
+                                 std::size_t *arg_sizes, std::size_t num_args) {
+
+  hipFunction_t kernel_func;
+  hipError_t err =
+      hipModuleGetFunction(&kernel_func, module, kernel_name.c_str());
+
+  if(err != hipSuccess) {
+    return make_error(__hipsycl_here(),
+                      error_info{"hip_queue: could not extract kernel from module",
+                                 error_code{"HIP", static_cast<int>(err)}});
+  }
+
+  err = hipModuleLaunchKernel(kernel_func, 
+    static_cast<unsigned>(grid_size.get(0)),
+                       static_cast<unsigned>(grid_size.get(1)),
+                       static_cast<unsigned>(grid_size.get(2)),
+                       static_cast<unsigned>(block_size.get(0)),
+                       static_cast<unsigned>(block_size.get(1)),
+                       static_cast<unsigned>(block_size.get(2)),
+                       dynamic_shared_mem, stream, kernel_args, nullptr);
+
+  if (err != hipSuccess) {
+    return make_error(__hipsycl_here(),
+                      error_info{"hip_queue: could not submit kernel from module",
+                                 error_code{"HIP", static_cast<int>(err)}});
+  }
+  
+
+  return make_success();
+}
 }
 
 
@@ -129,7 +172,8 @@ void hip_queue::activate_device() const {
 }
 
 hip_queue::hip_queue(hip_backend *be, device_id dev, int priority)
-    : _dev{dev}, _stream{nullptr}, _backend{be}, _code_object_invoker{this} {
+    : _dev{dev}, _stream{nullptr}, _backend{be},
+      _multipass_code_object_invoker{this}, _sscp_code_object_invoker{this} {
   this->activate_device();
 
   hipError_t err;
@@ -308,7 +352,10 @@ result hip_queue::submit_kernel(kernel_operation &op, dag_node_ptr node) {
   l->set_params(this);
   
   rt::backend_kernel_launch_capabilities cap;
-  cap.provide_multipass_invoker(&_code_object_invoker);
+  
+  cap.provide_multipass_invoker(&_multipass_code_object_invoker);
+  cap.provide_sscp_invoker(&_sscp_code_object_invoker);
+
   l->set_backend_capabilities(cap);
 
   hip_instrumentation_guard instrumentation{this, op, node};
@@ -434,7 +481,7 @@ void *hip_queue::get_native_type() const {
   return static_cast<void*>(get_stream());
 }
 
-result hip_queue::submit_kernel_from_code_object(
+result hip_queue::submit_multipass_kernel_from_code_object(
       const kernel_operation &op, hcf_object_id hcf_object,
       const std::string &backend_kernel_name, const rt::range<3> &grid_size,
       const rt::range<3> &block_size, unsigned dynamic_shared_mem,
@@ -476,6 +523,9 @@ result hip_queue::submit_kernel_from_code_object(
     return (candidate->target_arch() == selected_target) &&
            (candidate->state() == code_object_state::executable) &&
            (static_cast<const hip_executable_object *>(candidate)
+                ->source_compilation_flow() ==
+            compilation_flow::explicit_multipass) &&
+           (static_cast<const hip_executable_object *>(candidate)
                 ->get_device() == device);
   };
 
@@ -500,8 +550,8 @@ result hip_queue::submit_kernel_from_code_object(
       return nullptr;
     }
 
-    hip_executable_object *exec_obj =
-        new hip_executable_object{hcf_object, selected_target, kernel_image, device};
+    hip_executable_object *exec_obj = new hip_multipass_executable_object{
+        hcf_object, selected_target, kernel_image, device};
     result r = exec_obj->get_build_result();
 
     if (!r.is_success()) {
@@ -527,40 +577,132 @@ result hip_queue::submit_kernel_from_code_object(
   // are in the new kernel name mangling logic path, we can assume that we know
   // the full kernel name, and don't need to query available kernels in the device image
   // as in the CUDA backend.
-  hipFunction_t kernel_func;
-  hipError_t err = hipModuleGetFunction(
-      &kernel_func,
+  return launch_kernel_from_module(
       static_cast<const hip_executable_object *>(obj)->get_module(),
-      backend_kernel_name.c_str());
-
-  if(err != hipSuccess) {
-    return make_error(__hipsycl_here(),
-                      error_info{"hip_queue: could not extract kernel from module",
-                                 error_code{"HIP", static_cast<int>(err)}});
-  }
-
-  err = hipModuleLaunchKernel(kernel_func, 
-    static_cast<unsigned>(grid_size.get(0)),
-                       static_cast<unsigned>(grid_size.get(1)),
-                       static_cast<unsigned>(grid_size.get(2)),
-                       static_cast<unsigned>(block_size.get(0)),
-                       static_cast<unsigned>(block_size.get(1)),
-                       static_cast<unsigned>(block_size.get(2)),
-                       dynamic_shared_mem, _stream, kernel_args, nullptr);
-
-  if (err != hipSuccess) {
-    return make_error(__hipsycl_here(),
-                      error_info{"hip_queue: could not submit kernel from module",
-                                 error_code{"HIP", static_cast<int>(err)}});
-  }
-  
-  return make_success();
+      backend_kernel_name, grid_size, block_size, dynamic_shared_mem, _stream,
+      kernel_args, arg_sizes, num_args);
 }
 
-hip_code_object_invoker::hip_code_object_invoker(hip_queue *q) : _queue{q} {}
+result hip_queue::submit_sscp_kernel_from_code_object(
+      const kernel_operation &op, hcf_object_id hcf_object,
+      const std::string &kernel_name, const rt::range<3> &num_groups,
+      const rt::range<3> &group_size, unsigned local_mem_size, void **args,
+      std::size_t *arg_sizes, std::size_t num_args,
+      const glue::kernel_configuration &config) {
+#ifdef HIPSYCL_WITH_SSCP_COMPILER
+  this->activate_device();
+  
+  std::string global_kernel_name = op.get_global_kernel_name();
+  const kernel_cache::kernel_name_index_t *kidx =
+      kernel_cache::get().get_global_kernel_index(global_kernel_name);
 
+  if(!kidx) {
+    return make_error(
+        __hipsycl_here(),
+        error_info{"hip_queue: Could not obtain kernel index for kernel " +
+                   global_kernel_name});
+  }
 
-result hip_code_object_invoker::submit_kernel(
+  auto configuration_id = config.generate_id();
+  int device = _dev.get_id();
+
+  hip_hardware_context *ctx = static_cast<hip_hardware_context *>(
+      this->_backend->get_hardware_manager()->get_device(device));
+
+  std::string target_arch_name = ctx->get_device_arch();
+
+  auto code_object_selector = [&](const code_object* candidate) -> bool {
+    
+    if ((candidate->managing_backend() != backend_id::hip) ||
+        (candidate->source_compilation_flow() != compilation_flow::sscp) ||
+        (candidate->state() != code_object_state::executable))
+      return false;
+
+    const hip_sscp_executable_object *obj =
+        static_cast<const hip_sscp_executable_object *>(candidate);
+    
+    if(obj->configuration_id() != configuration_id)
+      return false;
+
+    return obj->get_device() == device;
+  };
+
+  auto code_object_constructor = [&]() -> code_object * {
+    const common::hcf_container *hcf =
+        rt::kernel_cache::get().get_hcf(hcf_object);
+
+    std::vector<std::string> kernel_names;
+    // Define image selector that will also fill kernel_names with
+    // list of kernels contained in selected image
+    glue::jit::image_selector_and_kernel_list_extractor image_selector{
+        glue::jit::default_llvm_image_selector{}, kernel_name, &kernel_names,
+        hcf};
+
+    // Construct amdgpu translator to compile the specified kernels
+    std::unique_ptr<compiler::LLVMToBackendTranslator> translator = 
+      std::move(compiler::createLLVMToAmdgpuTranslator(kernel_names));
+
+    translator->setBuildOption("amdgpu-target-device", target_arch_name);
+
+    // Lower kernels
+    std::string amdgpu_image;
+    auto err = glue::jit::compile(translator.get(),
+        hcf, image_selector, config, amdgpu_image);
+    
+    if(!err.is_success()) {
+      register_error(err);
+      return nullptr;
+    }
+
+    hip_sscp_executable_object *exec_obj = new hip_sscp_executable_object{
+        amdgpu_image, target_arch_name, hcf_object,
+        kernel_names, device,           config};
+    result r = exec_obj->get_build_result();
+
+    HIPSYCL_DEBUG_INFO
+        << "hip_queue: Successfully compiled SSCP kernels to module " << exec_obj->get_module()
+        << std::endl;
+
+    if(!r.is_success()) {
+      register_error(r);
+      delete exec_obj;
+      return nullptr;
+    }
+
+    return exec_obj;
+  };
+
+  const code_object *obj = kernel_cache::get().get_or_construct_code_object(
+      *kidx, kernel_name, backend_id::hip, hcf_object,
+      code_object_selector, code_object_constructor);
+
+  
+  if(!obj) {
+    return make_error(__hipsycl_here(),
+                      error_info{"hip_queue: Code object construction failed"});
+  }
+
+  ihipModule_t *module =
+      static_cast<const hip_executable_object *>(obj)->get_module();
+  assert(module);
+
+  return launch_kernel_from_module(module, kernel_name, num_groups, group_size,
+                                   local_mem_size, _stream, args, arg_sizes,
+                                   num_args);
+#else
+  return make_error(
+      __hipsycl_here(),
+      error_info{
+          "hip_queue: SSCP kernel launch was requested, but hipSYCL was "
+          "not built with HIP SSCP support."});
+#endif
+}
+
+hip_multipass_code_object_invoker::hip_multipass_code_object_invoker(
+    hip_queue *q)
+    : _queue{q} {}
+
+result hip_multipass_code_object_invoker::submit_kernel(
     const kernel_operation& op,
     hcf_object_id hcf_object,
     const rt::range<3> &num_groups,
@@ -576,12 +718,22 @@ result hip_code_object_invoker::submit_kernel(
   if(kernel_name_tag.find("__hipsycl_unnamed_kernel") == std::string::npos)
     kernel_name = kernel_name_tag;
 
-  return _queue->submit_kernel_from_code_object(op, hcf_object, kernel_name,
-                                                num_groups, group_size,
-                                                local_mem_size, args,
-                                                arg_sizes, num_args);
+  return _queue->submit_multipass_kernel_from_code_object(
+      op, hcf_object, kernel_name, num_groups, group_size, local_mem_size, args,
+      arg_sizes, num_args);
 }
 
+result hip_sscp_code_object_invoker::submit_kernel(
+    const kernel_operation &op, hcf_object_id hcf_object,
+    const rt::range<3> &num_groups, const rt::range<3> &group_size,
+    unsigned local_mem_size, void **args, std::size_t *arg_sizes,
+    std::size_t num_args, const std::string &kernel_name,
+    const glue::kernel_configuration &config) {
+
+  return _queue->submit_sscp_kernel_from_code_object(
+      op, hcf_object, kernel_name, num_groups, group_size, local_mem_size, args,
+      arg_sizes, num_args, config);
+}
 
 }
 }


### PR DESCRIPTION
This adds initial support for AMD GPUs to the SSCP infrastructure in PR #862. Most builtins are still missing, and there are still some unclear questions about what the best approach is to generate HIP fat binaries, but it seems to work at least for simple kernels.
Which means that our generic LLVM IR representation can now be executed on GPUs from all three major vendors.

* Adds llvm-to-amdgpu target
* Add SSCP kernel JIT support to HIP runtime backend
* Add initial amdgcn-amd-amdhsa libkernel builtin library (only core builtins for now)