### PR TITLE
Ensure that `device{} == device{default_selector{}}`

### DIFF
--- a/include/hipSYCL/sycl/device.hpp
+++ b/include/hipSYCL/sycl/device.hpp
@@ -64,7 +64,6 @@ rt::device_id extract_rt_device(const device&);
 
 }
 
-class device_selector;
 class platform;
 
 class device {
@@ -75,11 +74,10 @@ class device {
 public:
   device(rt::device_id id)
       : _device_id{id} {}
- 
-  device()
-      : _device_id(detail::get_host_device()) {}
 
   // Implemented in device_selector.hpp
+  device();
+  
   template <class DeviceSelector>
   explicit device(const DeviceSelector &deviceSelector);
 
@@ -231,8 +229,7 @@ public:
           for (std::size_t dev = 0; dev < num_devices; ++dev) {
             rt::device_id d_id{bd, static_cast<int>(dev)};
 
-            device d;
-            d._device_id = d_id;
+            device d{d_id};
 
             if (deviceType == info::device_type::all ||
                 (deviceType == info::device_type::accelerator &&

--- a/include/hipSYCL/sycl/device_selector.hpp
+++ b/include/hipSYCL/sycl/device_selector.hpp
@@ -265,11 +265,15 @@ auto aspect_selector() {
   return aspect_selector(aspectList...);
 }
 
+inline device::device()
+  : device::device(default_selector_v)
+{}
+  
 template <class DeviceSelector>
 inline device::device(const DeviceSelector &deviceSelector) {
   this->_device_id = detail::select_devices(deviceSelector)[0]._device_id;
 }
-
+  
 namespace detail {
 
 template <class Selector>


### PR DESCRIPTION
The SYCL 2020 specification requires that a default constructed device is the same as a device constructed with the default selector. This PR implements this by forward declaring the `sycl::device` default constructor and defining it in `device_selector.hpp` where `default_selector_v` is available. The default constructor then just delegates to the already defined constructor that takes any device selector as its argument.