### PR TITLE
Fix LLVM 16 compat.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # CMake out-of-source
-build/
+build*/
 *-build-*/
 
 # vscode in-source configs

--- a/src/compiler/HipsyclClangPlugin.cpp
+++ b/src/compiler/HipsyclClangPlugin.cpp
@@ -48,6 +48,7 @@ namespace compiler {
 static clang::FrontendPluginRegistry::Add<hipsycl::compiler::FrontendASTAction>
     HipsyclFrontendPlugin{"hipsycl_frontend", "enable hipSYCL frontend action"};
 
+#if LLVM_VERSION_MAJOR < 16
 static void registerGlobalsPruningPass(const llvm::PassManagerBuilder &,
                                        llvm::legacy::PassManagerBase &PM) {
   PM.add(new GlobalsPruningPassLegacy{});
@@ -84,7 +85,9 @@ static void registerMarkParallelPass(const llvm::PassManagerBuilder &,
 static llvm::RegisterStandardPasses
     RegisterMarkParallelBeforeVectorizer(llvm::PassManagerBuilder::EP_VectorizerStart,
                                          registerMarkParallelPass);
-#endif
+#endif // HIPSYCL_WITH_ACCELERATED_CPU
+#endif // LLVM_VERSION_MAJOR < 16
+
 #if !defined(_WIN32) && LLVM_VERSION_MAJOR >= 11
 #define HIPSYCL_RESOLVE_AND_QUOTE(V) #V
 #define HIPSYCL_STRINGIFY(V) HIPSYCL_RESOLVE_AND_QUOTE(V)

--- a/src/compiler/cbs/SubCfgFormation.cpp
+++ b/src/compiler/cbs/SubCfgFormation.cpp
@@ -84,7 +84,7 @@ getLocalSizeArgumentFromAnnotation(llvm::Function &F) {
   for (auto &BB : F)
     for (auto &I : BB)
       if (auto *UI = llvm::dyn_cast<llvm::CallInst>(&I))
-        if (UI->getCalledFunction()->getName().equals("llvm.var.annotation")) {
+        if (UI->getCalledFunction()->getName().startswith("llvm.var.annotation")) {
           HIPSYCL_DEBUG_INFO << *UI << '\n';
           llvm::GlobalVariable *AnnotateStr = nullptr;
           if (auto *CE = llvm::dyn_cast<llvm::ConstantExpr>(UI->getOperand(1));

--- a/tests/compiler/lit.cfg.py
+++ b/tests/compiler/lit.cfg.py
@@ -13,4 +13,5 @@ config.substitutions.append(('%syclcc', config.hipsycl_syclcc))
 
 if "HIPSYCL_DEBUG_LEVEL" in os.environ:
   config.environment["HIPSYCL_DEBUG_LEVEL"] = os.environ["HIPSYCL_DEBUG_LEVEL"]
-  
+if "HIPSYCL_VISIBILITY_MASK" in os.environ:
+  config.environment["HIPSYCL_VISIBILITY_MASK"] = os.environ["HIPSYCL_VISIBILITY_MASK"]


### PR DESCRIPTION
Seems LLVM 16 will remove the plugin extension points for the legacy pass manager.
Macroing out for LLVM 16+.

This should not be a problem for older LLVM 16 dev builds, since the default PM already is the new one anyways...

Also fixing two more small API / naming issues that I encountered while testing the fix.

Fixes: #892 