### PR TITLE
[Doc] Update install-llvm.md

### DIFF
--- a/doc/install-llvm.md
+++ b/doc/install-llvm.md
@@ -28,7 +28,7 @@ apt install -y libclang-13-dev clang-tools-13 libomp-13-dev llvm-13-dev lld-13
 It is generally not necessary to compile LLVM by yourself. However, if you wish to do this, during LLVM cmake make sure to:
 
 - Disable assertions as hipSYCL can potentially trigger some (false positive) debug assertions in some LLVM versions: `-DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=OFF -DLLVM_ENABLE_DUMP=OFF` 
-- Generate `libLLVM.so`: `-DLLVM_BUILD_LLVM_DYLIB=ON`
+- Generate `libLLVM.so`: `-DLLVM_BUILD_LLVM_DYLIB=ON` (only required if the SSCP compilation flow is enabled when building hipSYCL, which is true by default for supported versions of LLVM)
 - Enable the correct backends for your hardware: `nvptx` for NVIDIA GPUs and `amdgpu` for AMD GPUs.
 
 ## Pointing hipSYCL to the right LLVM

--- a/doc/install-llvm.md
+++ b/doc/install-llvm.md
@@ -25,8 +25,11 @@ apt install -y libclang-13-dev clang-tools-13 libomp-13-dev llvm-13-dev lld-13
 
 #### Only if you wish to compile LLVM from source (not recommended)
 
-It is generally not necessary to compile LLVM by yourself, but if you wish to do this, make sure to disable assertions (`-DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=OFF -DLLVM_ENABLE_DUMP=OFF` during LLVM cmake) as hipSYCL can potentially trigger some (false positive) debug assertions in some LLVM versions.
-Also make sure to enable the correct backends for your hardware (`nvptx` for NVIDIA GPUs and `amdgpu` for AMD GPUs)
+It is generally not necessary to compile LLVM by yourself. However, if you wish to do this, during LLVM cmake make sure to:
+
+- Disable assertions as hipSYCL can potentially trigger some (false positive) debug assertions in some LLVM versions: `-DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=OFF -DLLVM_ENABLE_DUMP=OFF` 
+- Generate `libLLVM.so`: `-DLLVM_BUILD_LLVM_DYLIB=ON`
+- Enable the correct backends for your hardware: `nvptx` for NVIDIA GPUs and `amdgpu` for AMD GPUs.
 
 ## Pointing hipSYCL to the right LLVM
 


### PR DESCRIPTION
Since e092e65, the build process requires `libLLVM.so` (`-lLLVM`) due to a cmake call to `llvm_config` in the new llvm-to-backend module:

https://github.com/illuhad/hipSYCL/blob/21d99ef0434d81cb071cc38e3999e8dda1cf21a9/src/compiler/llvm-to-backend/CMakeLists.txt#L30

This just asks the user to make sure to generate said library when compiling LLVM.
