### PR TITLE
Update `sycl::vec` class to reflect SYCL 2020 requirements 

### DIFF
--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp
@@ -473,7 +473,7 @@ HIPSYCL_HIPLIKE_BUILTIN T __hipsycl_dot(T a, T b) noexcept {
 template <class T, std::enable_if_t<!std::is_arithmetic_v<T>, int> = 0>
 HIPSYCL_HIPLIKE_BUILTIN typename T::element_type __hipsycl_dot(T a, T b) noexcept {
   typename T::element_type result = 0;
-  for (int i = 0; i < a.get_count(); ++i) {
+  for (int i = 0; i < a.size(); ++i) {
     result += a[i] * b[i];
   }
   return result;

--- a/include/hipSYCL/sycl/libkernel/host/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/host/builtins.hpp
@@ -614,7 +614,7 @@ HIPSYCL_BUILTIN T __hipsycl_dot(T a, T b) noexcept {
 template <class T, std::enable_if_t<!std::is_arithmetic_v<T>, int> = 0>
 HIPSYCL_BUILTIN typename T::element_type __hipsycl_dot(T a, T b) noexcept {
   typename T::element_type result = 0;
-  for (int i = 0; i < a.get_count(); ++i) {
+  for (int i = 0; i < a.size(); ++i) {
     result += a[i] * b[i];
   }
   return result;

--- a/include/hipSYCL/sycl/libkernel/spirv/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/spirv/builtins.hpp
@@ -427,7 +427,7 @@ HIPSYCL_BUILTIN T __hipsycl_dot(T a, T b) noexcept {
 template <class T, std::enable_if_t<!std::is_arithmetic_v<T>, int> = 0>
 HIPSYCL_BUILTIN typename T::element_type __hipsycl_dot(T a, T b) noexcept {
   typename T::element_type result = 0;
-  for (int i = 0; i < a.get_count(); ++i) {
+  for (int i = 0; i < a.size(); ++i) {
     result += a[i] * b[i];
   }
   return result;

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins.hpp
@@ -498,7 +498,7 @@ HIPSYCL_BUILTIN T __hipsycl_dot(T a, T b) noexcept {
 template <class T, std::enable_if_t<!std::is_arithmetic_v<T>, int> = 0>
 HIPSYCL_BUILTIN typename T::element_type __hipsycl_dot(T a, T b) noexcept {
   typename T::element_type result = 0;
-  for (int i = 0; i < a.get_count(); ++i) {
+  for (int i = 0; i < a.size(); ++i) {
     result += a[i] * b[i];
   }
   return result;

--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -859,7 +859,7 @@ private:
     if constexpr(std::is_scalar_v<Arg>)
       return 1;
     else if(std::is_same_v<typename Arg::element_type, T>)
-      return Arg::get_count();
+      return Arg::size();
     // ToDo: Trigger error
     return 0;
   }

--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -309,6 +309,7 @@ public:
   HIPSYCL_UNIVERSAL_TARGET
   operator T() const { return _data.template get<0>(); }
 
+  [[deprecated("renamed to 'size' in SYCL 2020 Specification")]]
   HIPSYCL_UNIVERSAL_TARGET
   static constexpr int get_count() { return N; }
 

--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -336,18 +336,18 @@ public:
     return result;
   }
 
-  template<typename AsT, int OtherN>
+  template<typename asT>
   HIPSYCL_UNIVERSAL_TARGET
-  vec<AsT, OtherN> as() const {
-    static_assert(sizeof(vec<AsT, OtherN>) == sizeof(vec<T,N>),
+  asT as() const {
+    static_assert(sizeof(asT) == sizeof(vec<T,N>),
                   "Reinterpreted vector must have same size");
     static_assert(std::is_same_v<VectorStorage, detail::vec_storage<T, N>>,
                   "Reinterpreting swizzled vectors directly is not supported");
 
-    vec<AsT, N> result;
+    asT result;
     
-    AsT* in_ptr = reinterpret_cast<AsT*>(&_data[0]);
-    for(int i = 0; i < OtherN; ++i)
+    auto in_ptr = reinterpret_cast<typename asT::element_type*>(&_data[0]);
+    for(int i = 0; i < N; ++i)
       result[i] = in_ptr[i];
 
     return result;

--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -312,8 +312,15 @@ public:
   HIPSYCL_UNIVERSAL_TARGET
   static constexpr int get_count() { return N; }
 
+  [[deprecated("renamed to 'byte_size' in SYCL 2020 Specification")]]
   HIPSYCL_UNIVERSAL_TARGET
   static constexpr std::size_t get_size() { return sizeof(VectorStorage); }
+
+  HIPSYCL_UNIVERSAL_TARGET
+  static constexpr std::size_t byte_size() { return sizeof(VectorStorage); }
+
+  HIPSYCL_UNIVERSAL_TARGET
+  static constexpr size_t size() noexcept { return N; }
 
   template <typename ConvertT, rounding_mode RM = rounding_mode::automatic>
   HIPSYCL_UNIVERSAL_TARGET

--- a/tests/sycl/extensions.cpp
+++ b/tests/sycl/extensions.cpp
@@ -371,7 +371,7 @@ BOOST_AUTO_TEST_CASE(scoped_parallelism_memory_environment) {
           s::distribute_items(grp, [&](s::s_item<1> idx) {
             int res = 0;
             auto v = priv_mem(idx) + init_val;
-            for(int i = 0; i < init_val.get_count(); ++i) {
+            for(int i = 0; i < init_val.size(); ++i) {
               res += v[i];
             }
             acc[idx.get_global_linear_id()] = res;
@@ -393,7 +393,7 @@ BOOST_AUTO_TEST_CASE(scoped_parallelism_memory_environment) {
       } else if(grp == 4) {
         const s::vec<int,8> expected_v{0,2,4,6,8,10,12,14};
         int expected = 0; 
-        for (int i = 0; i < expected_v.get_count(); ++i)
+        for (int i = 0; i < expected_v.size(); ++i)
           expected += expected_v[i];
         BOOST_CHECK(hacc[gid] == expected);
       }

--- a/tests/sycl/group_functions/group_functions.hpp
+++ b/tests/sycl/group_functions/group_functions.hpp
@@ -207,15 +207,6 @@ T get_offset(size_t margin, size_t divisor = 1) {
   return initialize_type<T>(get_offset<eT>(margin + 16, divisor));
 }
 
-template<typename T>
-HIPSYCL_KERNEL_TARGET
-elementType<T> local_value(size_t id, size_t offsetBase) {
-  const size_t N = T{}.get_count();
-
-  auto offset = get_offset<elementType<T>>(offsetBase);
-  return static_cast<elementType<T>>(id + offset);
-}
-
 inline void create_bool_test_data(std::vector<char> &buffer, size_t local_size,
                                   size_t global_size) {
   BOOST_REQUIRE(global_size == 4 * local_size);


### PR DESCRIPTION
This PR introduces the following small changes in the `sycl::vec` class to reflect the SYCL 2020 spec:
- A `size` method is added which replaces the `get_count` method (which is now marked deprecated)
- A `byte_size` method is added which replaces the `get_size` (which is now marked deprecated)
- The signature of the `as` method is changed: according to Table 144 of the SYCL 2020 spec, the template parameter `asT` should refer to the whole vector type that the vec is reinterpreted as. Previously, `asT` referred to the type of the new vec's elements.

These all came up when trying to compile the CTS `vec_api` test; it is still not compiling, but the remaining errors seem to be be CTS-related, not hipSYCL-related.