### PR TITLE
[SSCP][L0] Avoid passing nullptr as pointee value to zeKernelSetArgumentValue

### DIFF
--- a/include/hipSYCL/runtime/kernel_cache.hpp
+++ b/include/hipSYCL/runtime/kernel_cache.hpp
@@ -102,8 +102,14 @@ public:
   const std::vector<std::size_t>& get_global_argument_offsets() const;
   const std::vector<std::size_t>& get_argument_sizes() const;
 
+  enum argument_type {
+    pointer,
+    other
+  };
+
   std::size_t get_global_argument_offset(std::size_t i) const;
   std::size_t get_argument_size(std::size_t i) const;
+  argument_type get_argument_type(std::size_t i) const;
 
   bool is_valid() const;
 
@@ -112,6 +118,7 @@ public:
 private:
   std::vector<std::size_t> _global_arg_offsets;
   std::vector<std::size_t> _arg_sizes;
+  std::vector<argument_type> _arg_types;
   std::vector<std::string> _image_providers;
   hcf_object_id _id;
   bool _parsing_successful = false;

--- a/src/runtime/kernel_cache.cpp
+++ b/src/runtime/kernel_cache.cpp
@@ -85,14 +85,22 @@ hcf_kernel_info::hcf_kernel_info(
 
     auto *byte_size = param_info_node->get_value("byte-size");
     auto *byte_offset = param_info_node->get_value("byte-offset");
+    auto *type = param_info_node->get_value("type");
 
     if (!byte_size)
       return;
     if (!byte_offset)
       return;
+    if (!type)
+      return;
 
     std::size_t arg_size = std::stoll(*byte_size);
     std::size_t arg_offset = std::stoll(*byte_offset);
+    if(*type == "pointer") {
+      _arg_types.push_back(pointer);
+    } else {
+      _arg_types.push_back(other);
+    }
     _global_arg_offsets.push_back(arg_offset);
     _arg_sizes.push_back(arg_size);
   }
@@ -124,6 +132,10 @@ std::size_t hcf_kernel_info::get_global_argument_offset(std::size_t i) const {
 
 std::size_t hcf_kernel_info::get_argument_size(std::size_t i) const {
   return _arg_sizes[i];
+}
+
+hcf_kernel_info::argument_type hcf_kernel_info::get_argument_type(std::size_t i) const {
+  return _arg_types[i];
 }
 
 const std::vector<std::string> &


### PR DESCRIPTION
Level Zero does not like when pointee value passed to `zeKernelSetArgumentValue` is nullptr. In this case, we need to directly pass a `nullptr` to `zeKernelSetArgumentValue`.