### PR TITLE
[SSCP][llvm-to-spirv] Handle freeze instruction, which is unsupported by llvm-spirv translator

### DIFF
--- a/include/hipSYCL/compiler/llvm-to-backend/spirv/LLVMToSpirv.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/spirv/LLVMToSpirv.hpp
@@ -50,6 +50,7 @@ protected:
   virtual bool applyBuildOption(const std::string &Option, const std::string &Value) override;
   virtual bool isKernelAfterFlavoring(llvm::Function& F) override;
   virtual AddressSpaceMap getAddressSpaceMap() const override;
+  virtual bool optimizeFlavoredIR(llvm::Module& M, PassHandler& PH) override;
 private:
   std::vector<std::string> KernelNames;
   unsigned DynamicLocalMemSize = 0;


### PR DESCRIPTION
llvm-spirv translator does not support the freeze instruction, which can appear after optimizations:
https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/1140

We adopt the workaround proposed in the linked issue.