### PR TITLE
Fix zero dimensional accessors

### DIFF
--- a/include/hipSYCL/sycl/handler.hpp
+++ b/include/hipSYCL/sycl/handler.hpp
@@ -255,13 +255,20 @@ public:
           "because it is not bound to a buffer."};
     }
 
-    auto offset = acc.get_offset();
-    auto range = acc.get_range();
+    // get_offset and get_range are only defined for dimensions > 0
+    id<dimensions == 0 ? 1 : dimensions> offset;
+    if constexpr (dimensions == 0)
+      offset = id<1>(0);
+    else
+      offset = acc.get_offset();
 
-    using AccessorT =
-        accessor<dataT, dimensions, accessMode, accessTarget, isPlaceholder>;
+    range<dimensions == 0 ? 1 : dimensions> range;
+    if constexpr (dimensions == 0)
+      range = range<1>(1);
+    else
+      range = acc.get_range();
 
-    detail::accessor_data<dimensions> data{
+    detail::accessor_data<dimensions == 0 ? 1 : dimensions> data{
       acc.get_data_region(),
       offset,
       range,

--- a/include/hipSYCL/sycl/libkernel/accessor.hpp
+++ b/include/hipSYCL/sycl/libkernel/accessor.hpp
@@ -799,7 +799,8 @@ public:
       return false;
 
     if constexpr (AccessorVariant != accessor_variant::raw &&
-                  OtherV != accessor_variant::raw) {
+                  OtherV != accessor_variant::raw &&
+                  dimensions > 0) {
       if (lhs.get_offset() != rhs.get_offset())
         return false;
       if (lhs.get_range() != rhs.get_range())

--- a/include/hipSYCL/sycl/libkernel/accessor.hpp
+++ b/include/hipSYCL/sycl/libkernel/accessor.hpp
@@ -500,11 +500,13 @@ class HIPSYCL_EMPTY_BASES accessor
       public detail::accessor::conditional_buffer_pointer_storage<
           detail::accessor::stores_buffer_pointer(AccessorVariant)>,
       public detail::accessor::conditional_access_range_storage<
-          detail::accessor::stores_access_range(AccessorVariant), dimensions>,
+          detail::accessor::stores_access_range(AccessorVariant), dimensions == 0 ? 1 : dimensions>,
       public detail::accessor::conditional_buffer_range_storage<
-          detail::accessor::stores_buffer_range(AccessorVariant), dimensions>,
+          detail::accessor::stores_buffer_range(AccessorVariant), dimensions == 0 ? 1 : dimensions>,
       public detail::accessor::conditional_accessor_properties_storage<
           detail::accessor::stores_accessor_properties(AccessorVariant)> {
+
+  static constexpr int adjDimensions = dimensions == 0 ? 1 : dimensions;
 
   static constexpr bool has_buffer_pointer =
       detail::accessor::stores_buffer_pointer(AccessorVariant);
@@ -1033,8 +1035,8 @@ private:
   }
 
   template <class BufferT>
-  void init(BufferT &buff, id<dimensions> offset,
-            range<dimensions> access_range, const property_list &prop_list) {
+  void init(BufferT &buff, id<adjDimensions> offset,
+            range<adjDimensions> access_range, const property_list &prop_list) {
     
     bool is_no_init_access = false;
     bool is_placeholder_access = true;
@@ -1057,12 +1059,12 @@ private:
   
   template <class BufferT>
   void init(BufferT& buff, const property_list& prop_list) {
-    init(buff, id<dimensions>{}, detail::extract_buffer_range(buff), prop_list);
+    init(buff, id<adjDimensions>{}, detail::extract_buffer_range(buff), prop_list);
   }
 
   template <class BufferT>
-  void init(BufferT &buff, handler &cgh, id<dimensions> offset,
-            range<dimensions> access_range, const property_list &prop_list) {
+  void init(BufferT &buff, handler &cgh, id<adjDimensions> offset,
+            range<adjDimensions> access_range, const property_list &prop_list) {
 
     bool is_no_init_access = this->is_no_init(prop_list);
     bool is_placeholder_access = false;
@@ -1082,7 +1084,7 @@ private:
 
   template <class BufferT>
   void init(BufferT& buff, handler& cgh, const property_list& prop_list) {
-    init(buff, cgh, id<dimensions>{}, detail::extract_buffer_range(buff),
+    init(buff, cgh, id<adjDimensions>{}, detail::extract_buffer_range(buff),
          prop_list);
   }
   
@@ -1100,12 +1102,12 @@ private:
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  range<dimensions> get_buffer_shape() const noexcept {
+  range<adjDimensions> get_buffer_shape() const noexcept {
     if constexpr(has_buffer_range) {
       return this->detail::accessor::conditional_buffer_range_storage<
-          has_buffer_range, dimensions>::get();
+          has_buffer_range, adjDimensions>::get();
     } else {
-      return range<dimensions>{};
+      return range<adjDimensions>{};
     }
   }
 
@@ -1122,8 +1124,8 @@ private:
 
   template <class BufferType>
   void bind_to_buffer(BufferType &buff,
-                      sycl::id<dimensions> accessOffset,
-                      sycl::range<dimensions> accessRange) {
+                      sycl::id<adjDimensions> accessOffset,
+                      sycl::range<adjDimensions> accessRange) {
     __hipsycl_if_target_host(
       auto buffer_region = detail::extract_buffer_data_region(buff);
       this->detail::accessor::
@@ -1133,12 +1135,12 @@ private:
 
     this->detail::accessor::conditional_access_range_storage<
         has_access_range,
-        dimensions>::attempt_set(detail::accessor::access_range<dimensions>{
+        adjDimensions>::attempt_set(detail::accessor::access_range<adjDimensions>{
         accessOffset, accessRange});
 
     this->detail::accessor::conditional_buffer_range_storage<
         has_buffer_range,
-        dimensions>::attempt_set(detail::extract_buffer_range(buff));
+        adjDimensions>::attempt_set(detail::extract_buffer_range(buff));
   }
 
   void init_host_buffer(rt::runtime* rt, bool is_no_init) {
@@ -1154,14 +1156,31 @@ private:
     rt::dag_node_ptr node;
     {
       rt::dag_build_guard build{rt->dag()};
+
+      // get_offset and get_range are only defined for dimensions > 0
+      id<adjDimensions> acc_offset;
+      if constexpr (dimensions == 0)
+        acc_offset = id<1>{0};
+      else
+        acc_offset = get_offset();
+
+      range<adjDimensions> acc_range;
+      if constexpr (dimensions == 0)
+        acc_range = range<1>{1};
+      else
+        acc_range = get_range();
       
-      const rt::range<dimensions> buffer_shape = rt::make_range(get_buffer_shape());
+      const rt::range<adjDimensions> buffer_shape = rt::make_range(get_buffer_shape());
       auto explicit_requirement = rt::make_operation<rt::buffer_memory_requirement>(
         data,
-        detail::get_effective_offset<dataT>(data, rt::make_id(get_offset()),
-                                            buffer_shape, has_access_range),
-        detail::get_effective_range<dataT>(data, rt::make_range(get_range()),
-                                            buffer_shape, has_access_range),
+        detail::get_effective_offset<dataT, adjDimensions>(data,
+                                                           rt::make_id(acc_offset),
+                                                           buffer_shape,
+                                                           has_access_range),
+        detail::get_effective_range<dataT, adjDimensions>(data,
+                                                          rt::make_range(acc_range),
+                                                          buffer_shape,
+                                                          has_access_range),
         detail::get_effective_access_mode(accessmode, is_no_init),
         accessTarget
       );

--- a/tests/sycl/accessor.cpp
+++ b/tests/sycl/accessor.cpp
@@ -427,4 +427,26 @@ BOOST_AUTO_TEST_CASE(accessor_simplifications) {
   q.wait();
 }
 
+BOOST_AUTO_TEST_CASE(zero_dim_accessor) {
+  namespace s = cl::sycl;
+
+  int val[1] = {0};
+
+  s::buffer<int,1> buf{&val[0], 1};
+
+  s::queue q;
+  q.submit([&](auto &h){
+    s::accessor<int, 0> acc{buf, h};
+
+    q.parallel_for(s::range<1>{1}, [&](auto &) {
+      int &ref = acc;
+      ref = 123;
+    });
+  });
+
+  q.wait();
+
+  BOOST_CHECK(val[0] == 123);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/sycl/accessor.cpp
+++ b/tests/sycl/accessor.cpp
@@ -430,15 +430,15 @@ BOOST_AUTO_TEST_CASE(accessor_simplifications) {
 BOOST_AUTO_TEST_CASE(zero_dim_accessor) {
   namespace s = cl::sycl;
 
-  int val[1] = {0};
+  int val = 1;
 
-  s::buffer<int,1> buf{&val[0], 1};
+  s::buffer<int,1> buf{&val, 1};
 
   s::queue q;
   q.submit([&](auto &h){
     s::accessor<int, 0> acc{buf, h};
 
-    q.parallel_for(s::range<1>{1}, [&](auto &) {
+    h.parallel_for(s::range<1>{1}, [=](auto &) {
       int &ref = acc;
       ref = 123;
     });
@@ -446,7 +446,7 @@ BOOST_AUTO_TEST_CASE(zero_dim_accessor) {
 
   q.wait();
 
-  BOOST_CHECK(val[0] == 123);
+  BOOST_CHECK(val == 123);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Zero dimensional accessors can be used to access the first element of a 1D buffer. However, the methods in the accessor class expected the `dimensions` of the accessor and the buffer to match, causing a compilation error when trying to define a zero dimensional accessor. 
To fix this, a compile time constant `adjDimensions` is introduced that is set to 1 if `dimensions == 0` and set to the value of `dimensions` if `dimensions > 0`. This is then used instead of `dimensions` where necessary.