### PR TITLE
Fix API compat with LLVM 16 ToT.

### DIFF
--- a/include/hipSYCL/compiler/cbs/SplitterAnnotationAnalysis.hpp
+++ b/include/hipSYCL/compiler/cbs/SplitterAnnotationAnalysis.hpp
@@ -32,6 +32,8 @@
 #include <llvm/IR/LegacyPassManagers.h>
 #include <llvm/IR/PassManager.h>
 
+#include <optional>
+
 namespace hipsycl {
 namespace compiler {
 
@@ -68,7 +70,7 @@ public:
  *       As the annotations should not change from call to call, we cache the result in an Optional.
  */
 class SplitterAnnotationAnalysisLegacy : public llvm::FunctionPass {
-  llvm::Optional<SplitterAnnotationInfo> SplitterAnnotation_;
+  std::optional<SplitterAnnotationInfo> SplitterAnnotation_;
 
 public:
   static char ID;

--- a/src/compiler/cbs/PHIsToAllocas.cpp
+++ b/src/compiler/cbs/PHIsToAllocas.cpp
@@ -74,9 +74,7 @@ llvm::Instruction *breakPHIToAllocas(llvm::PHINode *Phi) {
 bool demotePHIsToAllocas(llvm::Function &F) {
   std::vector<llvm::PHINode *> PHIs;
 
-  auto &BBsInWI = F.getBasicBlockList();
-
-  for (auto &BB : BBsInWI)
+  for (auto &BB : F)
     for (auto &I : BB)
       if (auto *PHI = llvm::dyn_cast<llvm::PHINode>(&I))
         PHIs.push_back(PHI);

--- a/src/compiler/llvm-to-backend/AddressSpaceInferencePass.cpp
+++ b/src/compiler/llvm-to-backend/AddressSpaceInferencePass.cpp
@@ -131,9 +131,9 @@ llvm::PreservedAnalyses AddressSpaceInferencePass::run(llvm::Module &M,
   // need to fix this now.
   unsigned AllocaAddrSpace = ASMap[AddressSpace::AllocaDefault];
   llvm::SmallVector<llvm::Instruction*, 16> InstsToRemove;
-  for(auto& F : M.getFunctionList()) {
-    for(auto& BB : F.getBasicBlockList()) {
-      for(auto& I : BB.getInstList()) {
+  for(auto& F : M) {
+    for(auto& BB : F) {
+      for(auto& I : BB) {
         if(auto* AI = llvm::dyn_cast<llvm::AllocaInst>(&I)) {
           if(AI->getAddressSpace() != AllocaAddrSpace) {
             HIPSYCL_DEBUG_INFO << "AddressSpaceInferencePass: Found alloca in address space "

--- a/src/compiler/llvm-to-backend/LLVMToBackend.cpp
+++ b/src/compiler/llvm-to-backend/LLVMToBackend.cpp
@@ -183,11 +183,11 @@ bool LLVMToBackendTranslator::prepareIR(llvm::Module &M) {
     // Before optimizing, make sure everything has internal linkage to
     // help inlining. All linking should have occured by now, except
     // for backend builtin libraries like libdevice etc
-    for(auto & F : M.getFunctionList()) {
+    for(auto & F : M) {
       // Ignore kernels and intrinsics
       if(!F.isIntrinsic() && !this->isKernelAfterFlavoring(F)) {
         // Ignore undefined functions
-        if(!F.getBasicBlockList().empty())
+        if(!F.empty())
           F.setLinkage(llvm::GlobalValue::InternalLinkage);
       }
     }

--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -145,9 +145,9 @@ bool LLVMToAmdgpuTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
   // amdgpu does not like some function calls, so try to inline
   // everything. Note: This should be done after ASI pass has fixed
   // alloca address spaces, in case alloca values are passed as arguments!
-  for(auto& F: M.getFunctionList()) {
+  for(auto& F: M) {
     if(F.getCallingConv() != llvm::CallingConv::AMDGPU_KERNEL) {
-      if(!F.getBasicBlockList().empty()) {
+      if(!F.empty()) {
         F.addFnAttr(llvm::Attribute::AlwaysInline);
       }
     }

--- a/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
+++ b/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
@@ -126,7 +126,7 @@ bool LLVMToSpirvTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
     }
   }
 
-  for(auto& F : M.getFunctionList()) {
+  for(auto& F : M) {
     if(F.getCallingConv() != llvm::CallingConv::SPIR_KERNEL){
       // All functions must be marked as spir_func
       if(F.getCallingConv() != llvm::CallingConv::SPIR_FUNC)
@@ -165,9 +165,9 @@ bool LLVMToSpirvTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
   // pointers. TODO: We should only remove them when we actually need to, and attempt
   // to fix them otherwise.
   llvm::SmallVector<llvm::CallBase*, 16> Calls;
-  for(auto& F : M.getFunctionList()) {
-    for(auto& BB : F.getBasicBlockList()) {
-      for(auto& I : BB.getInstList()) {
+  for(auto& F : M) {
+    for(auto& BB : F) {
+      for(auto& I : BB) {
         if(llvm::CallBase* CB = llvm::dyn_cast<llvm::CallBase>(&I)) {
           if (CB->getCalledFunction()->getName().startswith("llvm.lifetime.start") ||
               CB->getCalledFunction()->getName().startswith("llvm.lifetime.end")) {
@@ -287,9 +287,9 @@ bool LLVMToSpirvTranslator::optimizeFlavoredIR(llvm::Module& M, PassHandler& PH)
   // We adopt the workaround proposed there.
 
   llvm::SmallVector<llvm::Instruction*> InstsToRemove;
-  for(auto& F : M.getFunctionList()) {
-    for(auto& BB : F.getBasicBlockList()) {
-      for(auto& I : BB.getInstList()) {
+  for(auto& F : M) {
+    for(auto& BB : F) {
+      for(auto& I : BB) {
         if(auto* FI = llvm::dyn_cast<llvm::FreezeInst>(&I)) {
           FI->replaceAllUsesWith(FI->getOperand(0));
           FI->dropAllReferences();

--- a/src/compiler/sscp/HostKernelNameExtractionPass.cpp
+++ b/src/compiler/sscp/HostKernelNameExtractionPass.cpp
@@ -50,7 +50,7 @@ llvm::PreservedAnalyses HostKernelNameExtractionPass::run(llvm::Module &M,
 
   llvm::SmallVector<llvm::Function*> SSCPKernelNameExtractionFunctions;
 
-  for(auto& F : M.getFunctionList()) {
+  for(auto& F : M) {
     if(F.getName().find(SSCPExtractKernelNameIdentifier) != std::string::npos) {
       SSCPKernelNameExtractionFunctions.push_back(&F);
       for(auto U : F.users()) {

--- a/src/compiler/sscp/KernelOutliningPass.cpp
+++ b/src/compiler/sscp/KernelOutliningPass.cpp
@@ -113,8 +113,8 @@ public:
 
 private:
   void scanAllocas(llvm::Function *F, llvm::SmallDenseMap<llvm::Type *, int> &Scores) {
-    for(auto& BB : F->getBasicBlockList()) {
-      for(auto& I : BB.getInstList()) {
+    for(auto& BB : *F) {
+      for(auto& I : BB) {
         if(auto* AI = llvm::dyn_cast<llvm::AllocaInst>(&I)) {
           if(isKernelArgumentStruct(AI->getAllocatedType())) {
             Scores[AI->getAllocatedType()] = 0;
@@ -264,7 +264,7 @@ EntrypointPreparationPass::run(llvm::Module &M, llvm::ModuleAnalysisManager &AM)
         // however this cannot really happen as clang does not codegen our
         // attribute((annotate("hipsycl_sscp_outlining"))) for declarations
         // without definition.
-        if(F->getBasicBlockList().size() > 0)
+        if(F->size() > 0)
           this->OutliningEntrypoints.push_back(F->getName().str());
       }
     }
@@ -322,7 +322,7 @@ KernelOutliningPass::run(llvm::Module &M, llvm::ModuleAnalysisManager &AM) {
   }
   
   llvm::SmallVector<llvm::Function*, 16> PureHostFunctions;
-  for(auto& F: M.getFunctionList()) {
+  for(auto& F: M) {
     // Called Intrinsics don't show up in our device functions list,
     // so we need to treat them specially
     if(F.isIntrinsic()) {

--- a/src/compiler/sscp/TargetSeparationPass.cpp
+++ b/src/compiler/sscp/TargetSeparationPass.cpp
@@ -220,7 +220,7 @@ std::unique_ptr<llvm::Module> generateDeviceIR(llvm::Module &M,
   StringAttrsToRemove.push_back("target-cpu");
   StringAttrsToRemove.push_back("target-features");
   StringAttrsToRemove.push_back("tune-cpu");
-  for(auto& F : DeviceModule->getFunctionList()) {
+  for(auto& F : *DeviceModule) {
     for(auto& A : AttrsToRemove) {
       if(F.hasFnAttribute(A))
         F.removeFnAttr(A);
@@ -262,8 +262,8 @@ std::unique_ptr<llvm::Module> generateDeviceIR(llvm::Module &M,
 
    // Scan for imported function definitions
    ImportedSymbolsOutput.clear();
-  for(auto& F : DeviceModule->getFunctionList()) {
-    if(F.getBasicBlockList().size() == 0) {
+  for(auto& F : *DeviceModule) {
+    if(F.size() == 0) {
       // We currently use the heuristic that functions are imported
       // if they are not defined, not an intrinsic and don't start with
       // __ like our hipSYCL builtins. This is a hack, it would


### PR DESCRIPTION
This adopts to some API changes in upstream LLVM (e.g. using std::optional instead of llvm::Optional) and also makes iterating over the IR more idiomatic (and API compatible) by just using the module/function/bb as containers (which are iterable thanks to their `begin` and `end` functions.

Fixes #917 