### PR TITLE
Apply LLVM EH/RTTI settings to LLVM dependent libs/tools.

### DIFF
--- a/doc/install-llvm.md
+++ b/doc/install-llvm.md
@@ -28,7 +28,7 @@ apt install -y libclang-13-dev clang-tools-13 libomp-13-dev llvm-13-dev lld-13
 It is generally not necessary to compile LLVM by yourself. However, if you wish to do this, during LLVM cmake make sure to:
 
 - Disable assertions as hipSYCL can potentially trigger some (false positive) debug assertions in some LLVM versions: `-DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=OFF -DLLVM_ENABLE_DUMP=OFF` 
-- Generate `libLLVM.so`: `-DLLVM_BUILD_LLVM_DYLIB=ON` (only required if the SSCP compilation flow is enabled when building hipSYCL, which is true by default for supported versions of LLVM)
+- Generate `libLLVM.so` and enable RTTI: `-DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_ENABLE_RTTI=ON` (only required if the SSCP compilation flow is enabled when building hipSYCL, which is true by default for supported versions of LLVM)
 - Enable the correct backends for your hardware: `nvptx` for NVIDIA GPUs and `amdgpu` for AMD GPUs.
 
 ## Pointing hipSYCL to the right LLVM

--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -71,13 +71,17 @@ if(HIPSYCL_NO_DEVICE_MANGLER)
   target_compile_definitions(hipSYCL_clang PRIVATE -DHIPSYCL_NO_DEVICE_MANGLER)
 endif()
 
+set(LLVM_DEP_COMPILE_OPTIONS "")
+
 if(NOT ${LLVM_ENABLE_EH})
-  target_compile_options(hipSYCL_clang PRIVATE -fno-exceptions)
+  list(APPEND LLVM_DEP_COMPILE_OPTIONS -fno-exceptions)
 endif()
 
 if(NOT ${LLVM_ENABLE_RTTI})
-  target_compile_options(hipSYCL_clang PRIVATE -fno-rtti)
+list(APPEND LLVM_DEP_COMPILE_OPTIONS -fno-rtti)
 endif()
+
+target_compile_options(hipSYCL_clang PRIVATE ${LLVM_DEP_COMPILE_OPTIONS})
 
 target_link_libraries(hipSYCL_clang
   ${LLVM_LIBS})

--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -5,7 +5,6 @@ set(LLVM_TO_BACKEND_INCLUDE_DIRS
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_BINARY_DIR}/include)
 
-
 function(create_llvm_based_library)
   set(options)
   set(one_value_keywords TARGET)
@@ -28,6 +27,7 @@ function(create_llvm_based_library)
   
   target_compile_definitions(${target} PRIVATE ${LLVM_DEFINITIONS} -DHIPSYCL_COMPILER_COMPONENT)
   llvm_config(${target} USE_SHARED core support irreader passes)
+  target_compile_options(${target} PRIVATE ${LLVM_DEP_COMPILE_OPTIONS})
 
   install(TARGETS ${target} DESTINATION lib/hipSYCL/llvm-to-backend)
 endfunction()
@@ -70,6 +70,7 @@ function(create_llvm_to_backend_tool)
     ${LLVM_TO_BACKEND_INCLUDE_DIRS})
   
   target_compile_definitions(${target}-tool PRIVATE ${LLVM_DEFINITIONS} -DHIPSYCL_TOOL_COMPONENT)
+  target_compile_options(${target}-tool PRIVATE ${LLVM_DEP_COMPILE_OPTIONS})
   target_link_libraries(${target}-tool PRIVATE ${target})
 
   install(TARGETS ${target}-tool DESTINATION lib/hipSYCL/llvm-to-backend)
@@ -97,6 +98,11 @@ endfunction()
 include(ExternalProject)
 
 if(WITH_SSCP_COMPILER)
+  if(NOT ${LLVM_ENABLE_RTTI})
+    message(FATAL_ERROR "hipSYCL SSCP cannot be used with LLVM that was built without RTTI. "
+                        "Either use an RTTI enabled LLVM (-DLLVM_ENABLE_RTTI=ON) or disable hipSYCL's SSCP (-DWITH_SSCP_COMPILER=OFF).")
+  endif()
+
   create_llvm_based_library(
     TARGET llvm-to-backend
     SOURCES LLVMToBackend.cpp AddressSpaceInferencePass.cpp ../sscp/KernelOutliningPass.cpp)


### PR DESCRIPTION
Also document that SSCP requires LLVM to have been built with RTTI atm.

This is just to document the current state and enforce it before having more obscure issues later.
One might want to consider whether the `typeid` call in `LLVMToBackendTranslator` can somehow be replaced to remove that requirement.

I don't know what distros typically build their LLVM with, with or without RTTI. Manjaro e.g. does with..