### PR TITLE
[SSCP] Avoid using typeid in LLVMToBackend to allow RTTI-less LLVM

### DIFF
--- a/include/hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp
@@ -66,6 +66,8 @@ public:
 
   virtual ~LLVMToBackendTranslator() {}
 
+  // Do not use inside llvm-to-backend infrastructure targets to avoid
+  // requiring RTTI-enabled LLVM
   template<auto& ConstantName, class T>
   void setS2IRConstant(const T& value) {
     static_assert(std::is_integral_v<T> || std::is_floating_point_v<T>,
@@ -119,6 +121,9 @@ public:
     return Result;
   }
 
+  int getBackendId() const {
+    return S2IRConstantBackendId;
+  }
 
   using SymbolListType = std::vector<std::string>;
 

--- a/include/hipSYCL/glue/llvm-sscp/jit.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/jit.hpp
@@ -238,6 +238,8 @@ inline rt::result compile(compiler::LLVMToBackendTranslator *translator,
   runtime_linker configure_linker {translator, imported_symbol_names};
 
   // Apply configuration
+  translator->setS2IRConstant<sycl::sscp::current_backend, int>(
+      translator->getBackendId());
   for(const auto& entry : config.entries()) {
     translator->setS2IRConstant(entry.get_name(), entry.get_data_buffer());
   }

--- a/src/compiler/llvm-to-backend/LLVMToBackend.cpp
+++ b/src/compiler/llvm-to-backend/LLVMToBackend.cpp
@@ -68,10 +68,7 @@ bool linkBitcode(llvm::Module &M, std::unique_ptr<llvm::Module> OtherM,
 
 LLVMToBackendTranslator::LLVMToBackendTranslator(int S2IRConstantCurrentBackendId,
   const std::vector<std::string>& OutliningEPs)
-: S2IRConstantBackendId(S2IRConstantCurrentBackendId), OutliningEntrypoints{OutliningEPs} {
-  setS2IRConstant<sycl::sscp::current_backend, int>(
-      S2IRConstantCurrentBackendId);
-}
+: S2IRConstantBackendId(S2IRConstantCurrentBackendId), OutliningEntrypoints{OutliningEPs} {}
 
 bool LLVMToBackendTranslator::setBuildFlag(const std::string &Flag) { 
   HIPSYCL_DEBUG_INFO << "LLVMToBackend: Using build flag: " << Flag << "\n";


### PR DESCRIPTION
@fodinabor Does this do the trick?