### PR TITLE
[SSCP] Use information from llvm::DataLayout to correctly calculate parameter offset in kernel lambda

### DIFF
--- a/include/hipSYCL/compiler/sscp/AggregateArgumentExpansionPass.hpp
+++ b/include/hipSYCL/compiler/sscp/AggregateArgumentExpansionPass.hpp
@@ -32,10 +32,19 @@
 #include <llvm/IR/PassManager.h>
 #include <vector>
 #include <string>
+#include <unordered_map>
 
 namespace hipsycl {
 namespace compiler {
 
+
+struct OriginalParamInfo {
+  OriginalParamInfo(std::size_t Offset, std::size_t OriginalIndex)
+  : OffsetInOriginalParam{Offset}, OriginalParamIndex{OriginalIndex} {}
+
+  std::size_t OffsetInOriginalParam;
+  std::size_t OriginalParamIndex;
+};
 // Expands aggregates into primitive function arguments. Aggregate types to expand are
 // expected to be marked using the ByVal attribute.
 class AggregateArgumentExpansionPass : public llvm::PassInfoMixin<AggregateArgumentExpansionPass> {
@@ -43,8 +52,11 @@ public:
   AggregateArgumentExpansionPass(const std::vector<std::string>& FunctionNames);
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
+  // Returns offsets of expanded arg in the original aggregate
+  const std::vector<OriginalParamInfo>* getInfosOnOriginalParams(const std::string& FunctionName) const;
 private:
   std::vector<std::string> AffectedFunctionNames;
+  std::unordered_map<std::string, std::vector<OriginalParamInfo>> OriginalParamInfos;
 };
 
 }

--- a/include/hipSYCL/glue/llvm-sscp/jit.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/jit.hpp
@@ -61,10 +61,12 @@ public:
     
     for(int i = 0; i < num_params; ++i) {
       std::size_t arg_size = kernel_info.get_argument_size(i);
-      std::size_t arg_offset = kernel_info.get_global_argument_offset(i);
+      std::size_t arg_offset = kernel_info.get_argument_offset(i);
+      std::size_t arg_original_index = kernel_info.get_original_argument_index(i);
 
-      void *data_ptr =
-          get_offset_pointer(args, arg_sizes, num_args, arg_offset);
+      assert(arg_original_index < num_args);
+
+      void *data_ptr = add_offset(args[arg_original_index], arg_offset);
       
       if(!data_ptr)
         return;
@@ -94,27 +96,6 @@ public:
 private:
   void *add_offset(void *ptr, std::size_t offset_bytes) const {
     return static_cast<void *>(static_cast<char *>(ptr) + offset_bytes);
-  }
-
-  // Provides an offset pointer into the data segments, calculated
-  // as if the data segments would form a consecutive memory region
-  // and the provided offset was an offset into that memory region.
-  void *get_offset_pointer(void **data_segments, const std::size_t *sizes,
-                           std::size_t num_sizes,
-                           std::size_t byte_offset) const {
-    if(num_sizes == 0)
-      return nullptr;
-    
-    std::size_t current_offset = 0;
-
-    for(int i = 0; i < num_sizes; ++i) {
-      if(byte_offset < current_offset+sizes[i]) {
-        return add_offset(data_segments[i], byte_offset);
-      }
-      current_offset += sizes[i];
-    }
-
-    return nullptr;
   }
 
   bool _mapping_result = false;

--- a/include/hipSYCL/runtime/kernel_cache.hpp
+++ b/include/hipSYCL/runtime/kernel_cache.hpp
@@ -99,16 +99,15 @@ public:
                   const common::hcf_container::node *kernel_node);
 
   std::size_t get_num_parameters() const;
-  const std::vector<std::size_t>& get_global_argument_offsets() const;
-  const std::vector<std::size_t>& get_argument_sizes() const;
 
   enum argument_type {
     pointer,
     other
   };
 
-  std::size_t get_global_argument_offset(std::size_t i) const;
+  std::size_t get_argument_offset(std::size_t i) const;
   std::size_t get_argument_size(std::size_t i) const;
+  std::size_t get_original_argument_index(std::size_t i) const;
   argument_type get_argument_type(std::size_t i) const;
 
   bool is_valid() const;
@@ -116,8 +115,9 @@ public:
   const std::vector<std::string> &get_images_containing_kernel() const;
   hcf_object_id get_hcf_object_id() const;
 private:
-  std::vector<std::size_t> _global_arg_offsets;
+  std::vector<std::size_t> _arg_offsets;
   std::vector<std::size_t> _arg_sizes;
+  std::vector<std::size_t> _original_arg_indices;
   std::vector<argument_type> _arg_types;
   std::vector<std::string> _image_providers;
   hcf_object_id _id;

--- a/src/runtime/kernel_cache.cpp
+++ b/src/runtime/kernel_cache.cpp
@@ -85,6 +85,7 @@ hcf_kernel_info::hcf_kernel_info(
 
     auto *byte_size = param_info_node->get_value("byte-size");
     auto *byte_offset = param_info_node->get_value("byte-offset");
+    auto *original_index = param_info_node->get_value("original-index");
     auto *type = param_info_node->get_value("type");
 
     if (!byte_size)
@@ -96,13 +97,15 @@ hcf_kernel_info::hcf_kernel_info(
 
     std::size_t arg_size = std::stoll(*byte_size);
     std::size_t arg_offset = std::stoll(*byte_offset);
+    std::size_t arg_original_index = std::stoll(*original_index);
     if(*type == "pointer") {
       _arg_types.push_back(pointer);
     } else {
       _arg_types.push_back(other);
     }
-    _global_arg_offsets.push_back(arg_offset);
+    _arg_offsets.push_back(arg_offset);
     _arg_sizes.push_back(arg_size);
+    _original_arg_indices.push_back(arg_original_index);
   }
 
   _parsing_successful = true;
@@ -112,26 +115,21 @@ std::size_t hcf_kernel_info::get_num_parameters() const {
   return _arg_sizes.size();
 }
 
-const std::vector<std::size_t> &
-hcf_kernel_info::get_global_argument_offsets() const {
-  return _global_arg_offsets;
-}
-
-const std::vector<std::size_t> &hcf_kernel_info::get_argument_sizes() const {
-  return _arg_sizes;
-}
-
 bool hcf_kernel_info::is_valid() const {
   return _parsing_successful;
 }
 
 
-std::size_t hcf_kernel_info::get_global_argument_offset(std::size_t i) const {
-  return _global_arg_offsets[i];
+std::size_t hcf_kernel_info::get_argument_offset(std::size_t i) const {
+  return _arg_offsets[i];
 }
 
 std::size_t hcf_kernel_info::get_argument_size(std::size_t i) const {
   return _arg_sizes[i];
+}
+
+std::size_t hcf_kernel_info::get_original_argument_index(std::size_t i) const {
+  return _original_arg_indices[i];
 }
 
 hcf_kernel_info::argument_type hcf_kernel_info::get_argument_type(std::size_t i) const {
@@ -260,8 +258,10 @@ hcf_object_id hcf_cache::register_hcf_object(const common::hcf_container &obj) {
           for(int i = 0; i < kernel_info->get_num_parameters(); ++i) {
             HIPSYCL_DEBUG_INFO
                 << "  kernel_info: parameter " << i
-                << ": offset = " << kernel_info->get_global_argument_offset(i)
-                << " size = " << kernel_info->get_argument_size(i) << std::endl;
+                << ": offset = " << kernel_info->get_argument_offset(i)
+                << " size = " << kernel_info->get_argument_size(i)
+                << " original index = "
+                << kernel_info->get_original_argument_index(i) << std::endl;
           }
           _hcf_kernel_info[std::make_pair(id, kernel_name)] =
               std::move(kernel_info);


### PR DESCRIPTION
Previously, the position of the kernel arguments inside the kernel lambda object was not calculated reliably. This PR fixes this by extracting the offset information directly from `llvm::DataLayout`.