### PR TITLE
Explicitly convert paths to `std::string` 

### DIFF
--- a/src/common/filesystem.cpp
+++ b/src/common/filesystem.cpp
@@ -68,8 +68,8 @@ std::string get_install_directory() {
   
 #endif
   if(paths.empty() || !fs::is_directory(paths.back()))
-    return fs::path{HIPSYCL_INSTALL_PREFIX};
-  return paths.back();
+    return fs::path{HIPSYCL_INSTALL_PREFIX}.string();
+  return paths.back().string();
 }
 
 std::string join_path(const std::string& base, const std::string& extra) {


### PR DESCRIPTION
I am currently trying to fix the Windows Github CI and clang complained that it can't convert `fs::path` types to `std::string` (no idea why that's not a problem on Linux). This PR just calls the `.string()` method on the `fs::path` objects to explicitly convert them to `std::string`s.