### PR TITLE
install-rocm.md: Problem with ROCm 5.0 and SSCP

### DIFF
--- a/doc/install-rocm.md
+++ b/doc/install-rocm.md
@@ -8,7 +8,7 @@ Please install ROCm 4.0 or later as described in the ROCm readme. Make sure to a
 * **Such configurations typically work, but are generally less tested.**
 * Also note that the LLVM distributions shipping with ROCm are not official LLVM releases, and depending on when the upstream development was last merged, may have slightly diverging functionality. There are multiple known cases where this causes problems: 
   * The clang 13 from ROCm 4.5 lacks functionality that is present in official clang 13 releases and that hipSYCL's clang 13 code paths need. In that case you will need to set `-DHIPSYCL_NO_DEVICE_MANGLER=ON` when compiling hipSYCL. This will however break [explicit multipass](compilation.md) support.
-  * Similarly, the clang 14 from ROCm 5.0 lacks functionality that is present in official clang 14 releases that are required by hipSYCL's compiler acceleration for CPU targets. You can work around those issues by setting `-DWITH_ACCELERATED_CPU=OFF` at the expense of reduced kernel performance on CPUs.
+  * Similarly, the clang 14 from ROCm 5.0 lacks functionality that is present in official clang 14 releases. You can work around those issues by setting `-DWITH_ACCELERATED_CPU=OFF -DWITH_SSCP_COMPILER=OFF` at the expense of reduced kernel performance on CPUs and lack of [SSCP](compilation.md) support.
 
 *Note: hipSYCL is by default configured to utilize the ROCm compilation flags that apply for recent clang and ROCm versions. If you are using an older clang (<= 10) or ROCm < 4, you might have to adjust `-DROCM_CXX_FLAGS` (not recommended!).*
 


### PR DESCRIPTION
Clang bundled with ROCm 5.0.2 is incompatible with SSCP, causing a compilation error.