### PR TITLE
[SSCP][llvm-to-spirv] Add support for pointer wrapping

### DIFF
--- a/include/hipSYCL/compiler/llvm-to-backend/Utils.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/Utils.hpp
@@ -28,8 +28,11 @@
 #ifndef HIPSYCL_LLVM_TO_BACKEND_UTILS_HPP
 #define HIPSYCL_LLVM_TO_BACKEND_UTILS_HPP
 
+#include <atomic>
+
 #include "hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp"
 #include "hipSYCL/common/debug.hpp"
+#include <llvm/ADT/DenseMap.h>
 #include <llvm/IR/Attributes.h>
 #include <llvm/ADT/SmallSet.h>
 #include <llvm/IR/Function.h>
@@ -131,10 +134,13 @@ public:
   /// to by-value arguments should have
   /// \param DesiredPointerAddressSpace Address space that actual pointers
   /// should have
+  /// \param WrapPointers If true, wrap pointer arguments in their own byval/byref
+  /// struct. This can be used to hide the pointer from the runtime backend, which
+  /// may be desirable if it does overzealous pointer validation (e.g. level zero)
   KernelFunctionParameterRewriter(ByValueArgAttribute Attr, unsigned DesiredByValueArgAddressSpace,
-                                  unsigned DesiredPointerAddressSpace)
+                                  unsigned DesiredPointerAddressSpace, bool WrapPointers = false)
       : Attr{Attr}, ByValueArgAddressSpace{DesiredByValueArgAddressSpace},
-        PointerAddressSpace{DesiredPointerAddressSpace} {}
+        PointerAddressSpace{DesiredPointerAddressSpace}, WrapPointers{WrapPointers} {}
 
   void run(llvm::Module &M, const std::vector<std::string> &KernelNames,
            llvm::ModuleAnalysisManager &MAM) {
@@ -155,6 +161,10 @@ public:
     F->setLinkage(llvm::GlobalValue::InternalLinkage);
 
     llvm::SmallVector<llvm::Type*, 8> Params;
+    // If pointer wrapping is enabled, maps the parameter index
+    // to the generated pointer wrapper type, if available.
+    llvm::SmallDenseMap<int, llvm::Type*> WrapperTypes;
+
     for(int i = 0; i < OldFType->getNumParams(); ++i){
       llvm::Type* CurrentParamType = OldFType->getParamType(i);
 
@@ -162,17 +172,23 @@ public:
         bool HasByRefAttr = F->hasParamAttribute(i, llvm::Attribute::ByRef);
         bool HasByValAttr = F->hasParamAttribute(i, llvm::Attribute::ByVal);
 
-        unsigned TargetAddressSpace = 0;
+        llvm::Type* NewT = nullptr;
+
         if(!HasByRefAttr && !HasByValAttr) {
           // Regular pointer
-          TargetAddressSpace = PointerAddressSpace;
+          if(shouldWrapPointer(*F, i)) {
+            llvm::Type* WrapperType;
+            NewT = getWrappedGlobalPointerType(M, PT, WrapperType);
+            WrapperTypes[i] = WrapperType;
+          } else {
+            NewT = llvm::PointerType::getWithSamePointeeType(PT, PointerAddressSpace);
+          }
         } else {
           // ByVal or ByRef - this probably means that
           // some struct is passed into the kernel by value.
           // (the attribute will be handled later)
-          TargetAddressSpace = ByValueArgAddressSpace;
+          NewT = llvm::PointerType::getWithSamePointeeType(PT, ByValueArgAddressSpace);
         }
-        llvm::Type *NewT = llvm::PointerType::getWithSamePointeeType(PT, TargetAddressSpace);
         Params.push_back(NewT);
       
       } else {
@@ -190,22 +206,22 @@ public:
       for(int i = 0; i < NewF->getFunctionType()->getNumParams(); ++i) {
         bool HasByRefAttr = NewF->hasParamAttribute(i, llvm::Attribute::ByRef);
         bool HasByValAttr = NewF->hasParamAttribute(i, llvm::Attribute::ByVal);
+        // If byval/byref are present, ensure the right one is set
         if(HasByRefAttr || HasByValAttr) {
-          llvm::Attribute::AttrKind DesiredAttr = (Attr == ByValueArgAttribute::ByRef)
-                                                     ? llvm::Attribute::ByRef
-                                                     : llvm::Attribute::ByVal;
           llvm::Attribute::AttrKind PresentAttr =
               HasByRefAttr ? llvm::Attribute::ByRef : llvm::Attribute::ByVal;
-          if(PresentAttr != DesiredAttr) {
+          if(PresentAttr != getDesiredByValueArgAttribute()) {
             llvm::Type* ValT = F->getParamAttribute(i, PresentAttr).getValueAsType();
             assert(ValT);
 
             NewF->removeParamAttr(i, PresentAttr);
-            if(DesiredAttr == llvm::Attribute::ByRef)
-              NewF->addParamAttr(i, llvm::Attribute::getWithByRefType(M.getContext(), ValT));
-            else
-              NewF->addParamAttr(i, llvm::Attribute::getWithByValType(M.getContext(), ValT));            
+            addByValueArgAttribute(M, *NewF, i, ValT);          
           }
+        // Otherwise we might be dealing with a pointer that needs to be wrapped in
+        // a by-value struct
+        } else if (WrapperTypes.find(i) != WrapperTypes.end()) {
+          llvm::Type* WrapperT = WrapperTypes[i];
+          addByValueArgAttribute(M, *NewF, i, WrapperT);
         }
       }
 
@@ -215,23 +231,51 @@ public:
       llvm::SmallVector<llvm::Value*, 8> CallArgs;
 
       for(int i = 0; i < Params.size(); ++i) {
+        // By default, just pass in the function argument ...
+        llvm::Value* CallArg = NewF->getArg(i);
+        // ... but if pointers are involved, we may have to insert additional
+        // instructions, such as address space casts.
         if (llvm::PointerType *NewPT =
                 llvm::dyn_cast<llvm::PointerType>(NewF->getArg(i)->getType())) {
-
           assert(llvm::isa<llvm::PointerType>(F->getArg(i)->getType()));
           llvm::PointerType *OldPT = llvm::dyn_cast<llvm::PointerType>(F->getArg(i)->getType());
 
-          if (NewPT->getAddressSpace() != OldPT->getAddressSpace()) {
-            auto *ASCastInst = new llvm::AddrSpaceCastInst{NewF->getArg(i), OldPT, "", BB};
-            CallArgs.push_back(ASCastInst);
-          } else {
-            CallArgs.push_back(NewF->getArg(i));
-          }
-        } else {
-          CallArgs.push_back(NewF->getArg(i));
-        }
-      }
+          // Check if this is a wrapped pointer
+          auto it = WrapperTypes.find(i);
+          if(it != WrapperTypes.end()) {
+            llvm::Type* WrapperType = it->second;
+            // Wrapped pointer, so we need an additional getelementptr(ptr,0,0) instruction.
+            auto Zero = llvm::ConstantInt::get(llvm::Type::getInt32Ty(M.getContext()), 0);
+            llvm::SmallVector<llvm::Value*> GEPIndices{Zero, Zero};
+            auto *GEPInst = llvm::GetElementPtrInst::CreateInBounds(
+              WrapperType, NewF->getArg(i), llvm::ArrayRef<llvm::Value *>{GEPIndices}, "", BB);
+            
+            
+            auto* WrappedTy = GEPInst->getResultElementType();
+            auto* LoadInst = new llvm::LoadInst{WrappedTy, GEPInst, "", BB};
 
+            auto* WrappedPointerTy = llvm::dyn_cast<llvm::PointerType>(WrappedTy);
+            if(WrappedPointerTy && (WrappedPointerTy->getAddressSpace() != OldPT->getAddressSpace())) {
+              auto *ASCastInst = new llvm::AddrSpaceCastInst{LoadInst, OldPT, "", BB};
+              CallArg = ASCastInst;
+            } else {
+              CallArg = LoadInst;
+            }
+            
+          } else {
+            // We are dealing with a USM pointer
+            if (NewPT->getAddressSpace() != OldPT->getAddressSpace()) {
+              auto *ASCastInst = new llvm::AddrSpaceCastInst{NewF->getArg(i), OldPT, "", BB};
+              CallArg = ASCastInst;
+            }
+            // The else branch is unnecessary, because by default we just
+            // pass in the original function argument.
+          }
+        } 
+        
+        CallArgs.push_back(CallArg);
+      }
+  
       assert(CallArgs.size() == F->getFunctionType()->getNumParams());
       for(int i = 0; i < CallArgs.size(); ++i) {
         assert(CallArgs[i]->getType() == F->getFunctionType()->getParamType(i));
@@ -240,12 +284,71 @@ public:
       auto *Call = llvm::CallInst::Create(llvm::FunctionCallee(F), CallArgs,
                                             "", BB);
       llvm::ReturnInst::Create(M.getContext(), BB);
+
+      if(!F->hasFnAttribute(llvm::Attribute::AlwaysInline))
+        F->addFnAttr(llvm::Attribute::AlwaysInline);
     }
   }
 private:
+
+  bool shouldWrapPointer(llvm::Function& F, int Param) {
+    bool HasByRefAttr = F.hasParamAttribute(Param, llvm::Attribute::ByRef);
+    bool HasByValAttr = F.hasParamAttribute(Param, llvm::Attribute::ByVal);
+    if(!HasByRefAttr && !HasByValAttr) {
+      if(F.getFunctionType()->getParamType(Param)->isPointerTy()) {
+        return WrapPointers;
+      }
+    }
+    return false;
+  }
+
+
+  llvm::Attribute::AttrKind getDesiredByValueArgAttribute() const {
+    return (Attr == ByValueArgAttribute::ByRef) ? llvm::Attribute::ByRef : llvm::Attribute::ByVal;
+  }
+
+  void addByValueArgAttribute(llvm::Module &M, llvm::Function &F, int i, llvm::Type *ValT) const {
+    if (getDesiredByValueArgAttribute() == llvm::Attribute::ByRef)
+      F.addParamAttr(i, llvm::Attribute::getWithByRefType(M.getContext(), ValT));
+    else
+      F.addParamAttr(i, llvm::Attribute::getWithByValType(M.getContext(), ValT));
+  }
+
+  llvm::Type *getWrappedGlobalPointerType(llvm::Module &M, llvm::PointerType *OriginalPointerType,
+                                          llvm::Type *&WrapperType) {
+    WrapperType = getWrapperType(M, OriginalPointerType);
+#if LLVM_VERSION_MAJOR < 16
+    return llvm::PointerType::get(WrapperType, ByValueArgAddressSpace);
+#else
+    return llvm::PointerType::get(M.getContext(), ByValueArgAddressSpace);
+#endif
+  }
+
+  llvm::Type *getWrapperType(llvm::Module &M, llvm::PointerType *OriginalPointerType) {
+    static std::atomic<std::size_t> WrapperCounter = 0;
+
+    llvm::Type *WrappedType =
+        llvm::PointerType::getWithSamePointeeType(OriginalPointerType, PointerAddressSpace);
+    
+    auto it = PointerWrapperTypes.find(WrappedType);
+    if(it != PointerWrapperTypes.end())
+      return it->second;
+    
+    std::string Name = "__hipsycl_sscp_pointer_wrapper." + std::to_string(++WrapperCounter);
+    llvm::SmallVector<llvm::Type*> Elements {WrappedType};
+    
+    llvm::Type* NewType = llvm::StructType::create(M.getContext(), Elements, Name);
+
+    PointerWrapperTypes[WrappedType] = NewType;
+
+    return NewType;
+  }
+
   ByValueArgAttribute Attr;
   unsigned ByValueArgAddressSpace;
   unsigned PointerAddressSpace;
+  bool WrapPointers;
+  llvm::SmallDenseMap<llvm::Type*, llvm::Type*> PointerWrapperTypes;
 };
 
 

--- a/include/hipSYCL/compiler/sscp/AggregateArgumentExpansionPass.hpp
+++ b/include/hipSYCL/compiler/sscp/AggregateArgumentExpansionPass.hpp
@@ -32,10 +32,19 @@
 #include <llvm/IR/PassManager.h>
 #include <vector>
 #include <string>
+#include <unordered_map>
 
 namespace hipsycl {
 namespace compiler {
 
+
+struct OriginalParamInfo {
+  OriginalParamInfo(std::size_t Offset, std::size_t OriginalIndex)
+  : OffsetInOriginalParam{Offset}, OriginalParamIndex{OriginalIndex} {}
+
+  std::size_t OffsetInOriginalParam;
+  std::size_t OriginalParamIndex;
+};
 // Expands aggregates into primitive function arguments. Aggregate types to expand are
 // expected to be marked using the ByVal attribute.
 class AggregateArgumentExpansionPass : public llvm::PassInfoMixin<AggregateArgumentExpansionPass> {
@@ -43,8 +52,11 @@ public:
   AggregateArgumentExpansionPass(const std::vector<std::string>& FunctionNames);
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
+  // Returns offsets of expanded arg in the original aggregate
+  const std::vector<OriginalParamInfo>* getInfosOnOriginalParams(const std::string& FunctionName) const;
 private:
   std::vector<std::string> AffectedFunctionNames;
+  std::unordered_map<std::string, std::vector<OriginalParamInfo>> OriginalParamInfos;
 };
 
 }

--- a/include/hipSYCL/glue/llvm-sscp/jit.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/jit.hpp
@@ -61,10 +61,12 @@ public:
     
     for(int i = 0; i < num_params; ++i) {
       std::size_t arg_size = kernel_info.get_argument_size(i);
-      std::size_t arg_offset = kernel_info.get_global_argument_offset(i);
+      std::size_t arg_offset = kernel_info.get_argument_offset(i);
+      std::size_t arg_original_index = kernel_info.get_original_argument_index(i);
 
-      void *data_ptr =
-          get_offset_pointer(args, arg_sizes, num_args, arg_offset);
+      assert(arg_original_index < num_args);
+
+      void *data_ptr = add_offset(args[arg_original_index], arg_offset);
       
       if(!data_ptr)
         return;
@@ -94,27 +96,6 @@ public:
 private:
   void *add_offset(void *ptr, std::size_t offset_bytes) const {
     return static_cast<void *>(static_cast<char *>(ptr) + offset_bytes);
-  }
-
-  // Provides an offset pointer into the data segments, calculated
-  // as if the data segments would form a consecutive memory region
-  // and the provided offset was an offset into that memory region.
-  void *get_offset_pointer(void **data_segments, const std::size_t *sizes,
-                           std::size_t num_sizes,
-                           std::size_t byte_offset) const {
-    if(num_sizes == 0)
-      return nullptr;
-    
-    std::size_t current_offset = 0;
-
-    for(int i = 0; i < num_sizes; ++i) {
-      if(byte_offset < current_offset+sizes[i]) {
-        return add_offset(data_segments[i], byte_offset);
-      }
-      current_offset += sizes[i];
-    }
-
-    return nullptr;
   }
 
   bool _mapping_result = false;

--- a/include/hipSYCL/runtime/kernel_cache.hpp
+++ b/include/hipSYCL/runtime/kernel_cache.hpp
@@ -99,16 +99,15 @@ public:
                   const common::hcf_container::node *kernel_node);
 
   std::size_t get_num_parameters() const;
-  const std::vector<std::size_t>& get_global_argument_offsets() const;
-  const std::vector<std::size_t>& get_argument_sizes() const;
 
   enum argument_type {
     pointer,
     other
   };
 
-  std::size_t get_global_argument_offset(std::size_t i) const;
+  std::size_t get_argument_offset(std::size_t i) const;
   std::size_t get_argument_size(std::size_t i) const;
+  std::size_t get_original_argument_index(std::size_t i) const;
   argument_type get_argument_type(std::size_t i) const;
 
   bool is_valid() const;
@@ -116,8 +115,9 @@ public:
   const std::vector<std::string> &get_images_containing_kernel() const;
   hcf_object_id get_hcf_object_id() const;
 private:
-  std::vector<std::size_t> _global_arg_offsets;
+  std::vector<std::size_t> _arg_offsets;
   std::vector<std::size_t> _arg_sizes;
+  std::vector<std::size_t> _original_arg_indices;
   std::vector<argument_type> _arg_types;
   std::vector<std::string> _image_providers;
   hcf_object_id _id;

--- a/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
+++ b/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
@@ -42,6 +42,7 @@
 #include <llvm/IR/CallingConv.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
+#include <llvm/Transforms/IPO/AlwaysInliner.h>
 #include <llvm/Passes/PassBuilder.h>
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/MemoryBuffer.h>
@@ -115,7 +116,9 @@ bool LLVMToSpirvTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
     // Those pointers to by-value data should be in private AS
     ASMap[AddressSpace::Private],
     // Actual pointers should be in global memory
-    ASMap[AddressSpace::Global]};
+    ASMap[AddressSpace::Global],
+    // We need to wrap pointer types
+    true};
 
   ParamRewriter.run(M, KernelNames, *PH.ModuleAnalysisManager);
 

--- a/src/runtime/kernel_cache.cpp
+++ b/src/runtime/kernel_cache.cpp
@@ -85,6 +85,7 @@ hcf_kernel_info::hcf_kernel_info(
 
     auto *byte_size = param_info_node->get_value("byte-size");
     auto *byte_offset = param_info_node->get_value("byte-offset");
+    auto *original_index = param_info_node->get_value("original-index");
     auto *type = param_info_node->get_value("type");
 
     if (!byte_size)
@@ -96,13 +97,15 @@ hcf_kernel_info::hcf_kernel_info(
 
     std::size_t arg_size = std::stoll(*byte_size);
     std::size_t arg_offset = std::stoll(*byte_offset);
+    std::size_t arg_original_index = std::stoll(*original_index);
     if(*type == "pointer") {
       _arg_types.push_back(pointer);
     } else {
       _arg_types.push_back(other);
     }
-    _global_arg_offsets.push_back(arg_offset);
+    _arg_offsets.push_back(arg_offset);
     _arg_sizes.push_back(arg_size);
+    _original_arg_indices.push_back(arg_original_index);
   }
 
   _parsing_successful = true;
@@ -112,26 +115,21 @@ std::size_t hcf_kernel_info::get_num_parameters() const {
   return _arg_sizes.size();
 }
 
-const std::vector<std::size_t> &
-hcf_kernel_info::get_global_argument_offsets() const {
-  return _global_arg_offsets;
-}
-
-const std::vector<std::size_t> &hcf_kernel_info::get_argument_sizes() const {
-  return _arg_sizes;
-}
-
 bool hcf_kernel_info::is_valid() const {
   return _parsing_successful;
 }
 
 
-std::size_t hcf_kernel_info::get_global_argument_offset(std::size_t i) const {
-  return _global_arg_offsets[i];
+std::size_t hcf_kernel_info::get_argument_offset(std::size_t i) const {
+  return _arg_offsets[i];
 }
 
 std::size_t hcf_kernel_info::get_argument_size(std::size_t i) const {
   return _arg_sizes[i];
+}
+
+std::size_t hcf_kernel_info::get_original_argument_index(std::size_t i) const {
+  return _original_arg_indices[i];
 }
 
 hcf_kernel_info::argument_type hcf_kernel_info::get_argument_type(std::size_t i) const {
@@ -260,8 +258,10 @@ hcf_object_id hcf_cache::register_hcf_object(const common::hcf_container &obj) {
           for(int i = 0; i < kernel_info->get_num_parameters(); ++i) {
             HIPSYCL_DEBUG_INFO
                 << "  kernel_info: parameter " << i
-                << ": offset = " << kernel_info->get_global_argument_offset(i)
-                << " size = " << kernel_info->get_argument_size(i) << std::endl;
+                << ": offset = " << kernel_info->get_argument_offset(i)
+                << " size = " << kernel_info->get_argument_size(i)
+                << " original index = "
+                << kernel_info->get_original_argument_index(i) << std::endl;
           }
           _hcf_kernel_info[std::make_pair(id, kernel_name)] =
               std::move(kernel_info);


### PR DESCRIPTION
Level Zero validates all pointers that are passed into the device. This causes errors if a host pointer is captured, even if it is not actually dereferenced inside the kernel.
This PR wraps pointer kernel arguments in a struct to hide from Level Zero that this is a pointer.