### PR TITLE
Resolve -Wpessimizing-move warning

### DIFF
--- a/src/compiler/sscp/TargetSeparationPass.cpp
+++ b/src/compiler/sscp/TargetSeparationPass.cpp
@@ -301,7 +301,7 @@ std::unique_ptr<llvm::Module> generateDeviceIR(llvm::Module &M,
     KernelInfoOutput.push_back(KI);
   }
 
-  return std::move(DeviceModule);
+  return DeviceModule;
 }
 
 std::string generateHCF(llvm::Module& DeviceModule,

--- a/src/runtime/cuda/cuda_hardware_manager.cpp
+++ b/src/runtime/cuda/cuda_hardware_manager.cpp
@@ -59,7 +59,7 @@ cuda_hardware_manager::cuda_hardware_manager(hardware_platform hw_platform)
   }
   
   for (int dev = 0; dev < num_devices; ++dev) {
-    _devices.push_back(std::move(cuda_hardware_context{dev}));
+    _devices.emplace_back(dev);
   }
 
 }

--- a/src/runtime/cuda/cuda_queue.cpp
+++ b/src/runtime/cuda/cuda_queue.cpp
@@ -661,7 +661,7 @@ result cuda_queue::submit_sscp_kernel_from_code_object(
 
     // Construct PTX translator to compile the specified kernels
     std::unique_ptr<compiler::LLVMToBackendTranslator> translator = 
-      std::move(compiler::createLLVMToPtxTranslator(kernel_names));
+      compiler::createLLVMToPtxTranslator(kernel_names);
 
     // TODO Shouldn't we compile with the most recent ptx version supported
     // by clang/CUDA?

--- a/src/runtime/hip/hip_hardware_manager.cpp
+++ b/src/runtime/hip/hip_hardware_manager.cpp
@@ -56,7 +56,7 @@ hip_hardware_manager::hip_hardware_manager(hardware_platform hw_platform)
   }
   
   for (int dev = 0; dev < num_devices; ++dev) {
-    _devices.push_back(std::move(hip_hardware_context{dev}));
+    _devices.emplace_back(dev);
   }
 
 }

--- a/src/runtime/hip/hip_queue.cpp
+++ b/src/runtime/hip/hip_queue.cpp
@@ -646,7 +646,7 @@ result hip_queue::submit_sscp_kernel_from_code_object(
 
     // Construct amdgpu translator to compile the specified kernels
     std::unique_ptr<compiler::LLVMToBackendTranslator> translator = 
-      std::move(compiler::createLLVMToAmdgpuTranslator(kernel_names));
+      compiler::createLLVMToAmdgpuTranslator(kernel_names);
 
     translator->setBuildOption("amdgpu-target-device", target_arch_name);
 

--- a/src/runtime/kernel_cache.cpp
+++ b/src/runtime/kernel_cache.cpp
@@ -224,7 +224,7 @@ hcf_object_id hcf_cache::register_hcf_object(const common::hcf_container &obj) {
         << std::endl;
   } else {
     common::hcf_container* stored_obj = new common::hcf_container{obj};
-    _hcf_objects[id] = std::move(std::unique_ptr<common::hcf_container>{stored_obj});
+    _hcf_objects[id] = std::unique_ptr<common::hcf_container>{stored_obj};
     // Check if the HCF exports some symbols
     for_each_exported_symbol_list(
         // Don't use obj here, since we have copied it into the cache, and need


### PR DESCRIPTION
std::move is not necessary when returning things or dealing with temporaries.