### PR TITLE
[SSCP] Enable aggressive inlining for all backends

### DIFF
--- a/src/compiler/llvm-to-backend/LLVMToBackend.cpp
+++ b/src/compiler/llvm-to-backend/LLVMToBackend.cpp
@@ -184,8 +184,13 @@ bool LLVMToBackendTranslator::prepareIR(llvm::Module &M) {
       // Ignore kernels and intrinsics
       if(!F.isIntrinsic() && !this->isKernelAfterFlavoring(F)) {
         // Ignore undefined functions
-        if(!F.empty())
+        if(!F.empty()) {
           F.setLinkage(llvm::GlobalValue::InternalLinkage);
+          // Some backends (amdgpu) require inlining, for others it
+          // just cleans up the code.
+          if(!F.hasFnAttribute(llvm::Attribute::AlwaysInline))
+            F.addFnAttr(llvm::Attribute::AlwaysInline);
+        }
       }
     }
 


### PR DESCRIPTION
amdgpu needs it, for all other backends it cleans up code and leads to more effective handling kernel function signature rewriting steps.