### PR TITLE
[Doc] Tweak instructions to build w/ LLVM

### DIFF
--- a/doc/install-llvm.md
+++ b/doc/install-llvm.md
@@ -36,7 +36,7 @@ It is generally not necessary to compile LLVM by yourself. However, if you wish 
 When invoking cmake, the Open SYCL build infrastructure will attempt to find LLVM automatically (see below for how to invoke cmake).
 
 If Open SYCL does not automatically configure the build for the desired clang/LLVM installation, the following cmake variables can be used to point Open SYCL to the right one:
-* `-DLLVM_DIR=/path/to/llvm/cmake` must be pointed to your LLVM installation, specifically, the **subdirectory containing the LLVM cmake files**. 
+* `-DLLVM_DIR=/path/to/llvm/cmake` must be pointed to your LLVM installation, specifically, the **subdirectory containing the LLVM cmake files**. Note that different LLVM installations may have the LLVM cmake files in different subdirectories that don't necessarily end with `cmake` (e.g. it might also be `/path/to/llvm/lib/cmake/llvm`). Alternatively, you can try `-DLLVM_ROOT` which might be more forgiving.
 
 Verify from the cmake that the selected `clang++` and include headers match the LLVM that you have requested. Example output:
 ```

--- a/doc/install-rocm.md
+++ b/doc/install-rocm.md
@@ -2,7 +2,7 @@
 
 Please install ROCm 4.0 or later as described in the ROCm readme. Make sure to also install HIP (runtime libraries and headers).
 
-*Note: Newer ROCm versions may require building Open SYCL against newer clang versios as well. For example, ROCm 4.5 requires clang 13+.*
+*Note: Newer ROCm versions may require building Open SYCL against newer clang versions as well. For example, ROCm 4.5 requires clang 13+.*
 
 *Note: Instead of building Open SYCL against a regular clang/LLVM, it is also possible to build Open SYCL against the clang/LLVM that ships with ROCm. This can be interesting if other available clang/LLVM installations are not new enough to work with the ROCm installation.* 
 * **Such configurations typically work, but are generally less tested.**


### PR DESCRIPTION
Hi @illuhad,

Minor change again.

It turns out when installing LLVM from source you don't get the symlink in `/path/to/llvm/cmake` to `/path/to/llvm/lib/cmake/llvm` and specifying `-DLLVM_DIR=/path/to/llvm/lib/cmake` does not seem to work.

Curiously, `-DLLVM_ROOT=/path/to/llvm/cmake` (which, if it exists, will just point to `/path/to/llvm/lib/cmake/llvm`) and `-DLLVM_ROOT=/path/to/llvm/lib/cmake` (notice I didn't need to specify the llvm subdirectory as above for `LLVM_DIR`) both work...
I think using `LLVM_ROOT`, if the user specifies whichever path ending in `cmake` within the LLVM installation directory, it should (hopefully) always work, increasing the chances of success at first try.

I think it's at least the second time I've spent more than a couple of minutes fighting this out, so I thought I'd share it, even if it's just for my future self.

Cheers,
-Nuno