### PR TITLE
Check number of `Args...` of `vec` constructor in template parameter to allow SFINAE

### DIFF
--- a/include/hipSYCL/sycl/libkernel/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/builtins.hpp
@@ -388,8 +388,9 @@ using ulonglong16 = vec<unsigned long long, 16>;
 #define HIPSYCL_BUILTIN_GENERATOR_TRINARY_T_T_T(T, name, impl_name)            \
   HIPSYCL_BUILTIN T name(T a, T b, T c) noexcept {                             \
     if constexpr (std::is_arithmetic_v<T>) {                                   \
-      return impl_name(detail::data_element(a, 0), detail::data_element(b, 0), \
-                       detail::data_element(c, 0));                            \
+      return static_cast<T>(impl_name(detail::data_element(a, 0),              \
+                                      detail::data_element(b, 0),              \
+                                      detail::data_element(c, 0)));            \
     } else {                                                                   \
       T result;                                                                \
       for (int i = 0; i < detail::builtin_type_traits<T>::num_elements; ++i) { \
@@ -405,8 +406,8 @@ using ulonglong16 = vec<unsigned long long, 16>;
 #define HIPSYCL_BUILTIN_GENERATOR_BINARY_T_T(T, name, impl_name)               \
   HIPSYCL_BUILTIN T name(T a, T b) noexcept {                                  \
     if constexpr (std::is_arithmetic_v<T>) {                                   \
-      return impl_name(detail::data_element(a, 0),                             \
-                       detail::data_element(b, 0));                            \
+      return static_cast<T>(impl_name(detail::data_element(a, 0),              \
+                                      detail::data_element(b, 0)));            \
     } else {                                                                   \
       T result;                                                                \
       for (int i = 0; i < detail::builtin_type_traits<T>::num_elements; ++i) { \
@@ -474,7 +475,7 @@ using ulonglong16 = vec<unsigned long long, 16>;
 #define HIPSYCL_BUILTIN_GENERATOR_UNARY_T(T, name, impl_name)                  \
   HIPSYCL_BUILTIN T name(T a) noexcept {                                       \
     if constexpr (std::is_arithmetic_v<T>) {                                   \
-      return impl_name(detail::data_element(a, 0));                            \
+      return static_cast<T>(impl_name(detail::data_element(a, 0)));            \
     } else {                                                                   \
       T result;                                                                \
       for (int i = 0; i < detail::builtin_type_traits<T>::num_elements; ++i) { \
@@ -490,7 +491,10 @@ using ulonglong16 = vec<unsigned long long, 16>;
   typename detail::builtin_type_traits<T>::alternative_data_type<int> name(    \
       T a) noexcept {                                                          \
     if constexpr (std::is_arithmetic_v<T>) {                                   \
-      return impl_name(detail::data_element(a, 0));                            \
+      return static_cast<                                                      \
+          typename detail::builtin_type_traits<T>                              \
+                         ::alternative_data_type<int>>                         \
+                             (impl_name(detail::data_element(a, 0)));          \
     } else {                                                                   \
       typename detail::builtin_type_traits<T>::alternative_data_type<int>      \
           result;                                                              \
@@ -507,7 +511,10 @@ using ulonglong16 = vec<unsigned long long, 16>;
   typename detail::builtin_type_traits<T>::alternative_data_type<int64_t> name(\
       T a) noexcept {                                                          \
     if constexpr (std::is_arithmetic_v<T>) {                                   \
-      return impl_name(detail::data_element(a, 0));                            \
+      return static_cast<                                                      \
+          typename detail::builtin_type_traits<T>                              \
+                         ::alternative_data_type<int64_t>>                     \
+                             (impl_name(detail::data_element(a, 0)));          \
     } else {                                                                   \
       typename detail::builtin_type_traits<T>::alternative_data_type<int64_t>  \
           result;                                                              \

--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -295,6 +295,7 @@ public:
   }
 
   template <typename... Args, class S = VectorStorage,
+            std::enable_if_t<(sizeof...(Args) > 0), bool> = true,
             std::enable_if_t<std::is_same_v<S, detail::vec_storage<T, N>>,
                              bool> = true,
             std::enable_if_t<(detail::count_num_elements<Args, T> + ...) == N,

--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -182,9 +182,15 @@ template <class Vector_type, class Function>
 HIPSYCL_UNIVERSAL_TARGET
 void for_each_vector_element(const Vector_type& v, Function&& f);
 
-template <typename Arg, typename T, typename = void,
-          typename = std::enable_if_t<std::is_scalar_v<T>>>
+template <typename Arg, typename T,
+          typename = void, typename = void>
 struct get_size {
+  static constexpr int size = -1;
+};
+
+template <typename Arg, typename T>
+struct get_size<Arg, T,
+                std::enable_if_t<std::is_scalar_v<Arg>>> {
   static constexpr int size = 1;
 };
 

--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -876,7 +876,7 @@ private:
       ++current_init_index;
     } else {
       // Assume we are dealing with another vector
-      constexpr int count = count_num_elements<Arg>();
+      constexpr int count = detail::count_num_elements<Arg, T>();
       
       for(int i = 0; i < count; ++i) {
         _data[i + current_init_index] = x[i];

--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -182,7 +182,8 @@ template <class Vector_type, class Function>
 HIPSYCL_UNIVERSAL_TARGET
 void for_each_vector_element(const Vector_type& v, Function&& f);
 
-template <typename Arg, typename T, typename = void, typename = void>
+template <typename Arg, typename T, typename = void,
+          typename = std::enable_if_t<std::is_scalar_v<T>>>
 struct get_size {
   static constexpr int size = 1;
 };

--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -287,6 +287,11 @@ public:
   template <typename... Args, class S = VectorStorage,
             std::enable_if_t<std::is_same_v<S, detail::vec_storage<T, N>>,
                              bool> = true,
+            std::enable_if_t<(sizeof...(Args) > 1), bool> = true,
+            std::enable_if_t<!std::is_convertible_v<
+                               std::tuple_element_t<0, std::tuple<Args...>>,
+                               vector_t>,
+                             bool> = true,
             std::enable_if_t<(detail::count_num_elements<Args, T>() + ...) == N,
                              bool> = true>
   HIPSYCL_UNIVERSAL_TARGET vec(const Args &...args) {


### PR DESCRIPTION
Previously, the `vec(const Args &...)` constructor was sometimes hiding the `vec(const T& value)` constructor even in cases where it is not applicable since `count_num_elements != N` was only checked inside the constructor (i.e., after the compiler had already chosen this constructor) . Now `count_num_elements == N` is checked in the template arguments, allowing to choose the correct constructor using SFINAE.