### PR TITLE
Change sycl::noinit to sycl::no_init

### DIFF
--- a/doc/runtime-spec.md
+++ b/doc/runtime-spec.md
@@ -57,7 +57,7 @@ If a `buffer` is reinterpreted to a data type of different size than the origina
 
 #### Data transfers
 
-Accessors of `discard` access mode (`noinit` in SYCL 2020) shall never lead to data transfers.
+Accessors of `discard` access mode (`no_init` in SYCL 2020) shall never lead to data transfers.
 
 Accessors referring to a `buffer` that does not contain any initialized data (e.g. because it was never written to and was not constructed with a user-provided input pointer) shall never lead to data transfers.
 

--- a/src/runtime/dag_direct_scheduler.cpp
+++ b/src/runtime/dag_direct_scheduler.cpp
@@ -279,9 +279,9 @@ result submit_requirement(runtime* rt, dag_node_ptr req) {
     } else {
       HIPSYCL_DEBUG_WARNING
           << "dag_direct_scheduler: Detected a requirement that is neither of "
-             "discard access mode (SYCL 1.2.1) nor noinit property (SYCL 2020) "
+             "discard access mode (SYCL 1.2.1) nor no_init property (SYCL 2020) "
              "that accesses uninitialized data. Consider changing to "
-             "discard/noinit. Optimizing potential data transfers away."
+             "discard/no_init. Optimizing potential data transfers away."
           << std::endl;
     }
   }


### PR DESCRIPTION
I got a debug warning about using `sycl::noinit`, after a while I realized the standard changed the name to sycl::no_init.
I changed the message printed by the warning and a reference to sycl::noinit in the docs.