### PR TITLE
Add operators for +,-,*,/ for `half` with other scalar types

### DIFF
--- a/include/hipSYCL/sycl/libkernel/half.hpp
+++ b/include/hipSYCL/sycl/libkernel/half.hpp
@@ -162,18 +162,24 @@ public:
     // operator +,-,*,/ for combinations of half and other types
 #define OP_FOR_TYPE(op, type)                                         \
   friend half operator op(const half lhs, const type rhs) {           \
-    return lhs op half(rhs);                                          \
+    half res = rhs;                                                   \
+    res = lhs op res;                                                 \
+    return res;                                                       \
   }                                                                   \
                                                                       \
-  friend half operator op(const type lhs, const half rhs) {           \
-    return half(lhs) op rhs;                                          \
+  friend type operator op(const type lhs, const half rhs) {           \
+    type res = rhs;                                                   \
+    res = lhs op res;                                                 \
+    return res;                                                       \
   }
 
 #define OP(op)                                                        \
   OP_FOR_TYPE(op, int)                                                \
   OP_FOR_TYPE(op, unsigned int)                                       \
   OP_FOR_TYPE(op, long)                                               \
+  OP_FOR_TYPE(op, long long)                                          \
   OP_FOR_TYPE(op, unsigned long)                                      \
+  OP_FOR_TYPE(op, unsigned long long)                                 \
   OP_FOR_TYPE(op, float)                                              \
   OP_FOR_TYPE(op, double)
 

--- a/include/hipSYCL/sycl/libkernel/half.hpp
+++ b/include/hipSYCL/sycl/libkernel/half.hpp
@@ -145,15 +145,11 @@ public:
     // operator +,-,*,/ for combinations of half and other types
 #define OP_FOR_TYPE(op, type)                                         \
   friend half operator op(const half lhs, const type rhs) {           \
-    half res = rhs;                                                   \
-    res = lhs op res;                                                 \
-    return res;                                                       \
+    return lhs op half(rhs);                                          \
   }                                                                   \
                                                                       \
-  friend type operator op(const type lhs, const half rhs) {           \
-    type res = rhs;                                                   \
-    res = lhs op res;                                                 \
-    return res;                                                       \
+  friend half operator op(const type lhs, const half rhs) {           \
+    return half(lhs) op rhs;                                          \
   }
 
 #define OP(op)                                                        \

--- a/include/hipSYCL/sycl/libkernel/half.hpp
+++ b/include/hipSYCL/sycl/libkernel/half.hpp
@@ -54,30 +54,11 @@ private:
   friend constexpr half detail::create_half(fp16::half_storage h);
   friend constexpr fp16::half_storage detail::get_half_storage(half h);
 
-  constexpr half(fp16::half_storage f) noexcept
-  : _data{f} {}
-
 public:
   constexpr half() : _data{} {};
   
   half(float f) noexcept
   : _data{fp16::create(f)} {}
-  
-  half(double f) noexcept
-  : _data{fp16::create(f)} {}
-
-  half(int f) noexcept
-  : _data{fp16::create(static_cast<float>(f))} {}
-
-  half(long f) noexcept
-  : _data{fp16::create(static_cast<float>(f))} {}
-
-  half(unsigned int f) noexcept
-  : _data{fp16::create(static_cast<float>(f))} {}
-
-  half(unsigned long f) noexcept
-  : _data{fp16::create(static_cast<float>(f))} {}
-
 
   half(const half&) = default;
 
@@ -85,14 +66,6 @@ public:
 
   operator float() const {
     return fp16::promote_to_float(_data);
-  }
-
-  operator double() const {
-    return fp16::promote_to_double(_data);
-  }
-
-  operator int() const {
-    return static_cast<int>(fp16::promote_to_float(_data));
   }
 
   HIPSYCL_UNIVERSAL_TARGET

--- a/include/hipSYCL/sycl/libkernel/half.hpp
+++ b/include/hipSYCL/sycl/libkernel/half.hpp
@@ -60,13 +60,22 @@ private:
 public:
   constexpr half() : _data{} {};
   
-  explicit half(float f) noexcept
+  half(float f) noexcept
   : _data{fp16::create(f)} {}
   
-  explicit half(double f) noexcept
+  half(double f) noexcept
   : _data{fp16::create(f)} {}
 
-  explicit half(int f) noexcept
+  half(int f) noexcept
+  : _data{fp16::create(static_cast<float>(f))} {}
+
+  half(long f) noexcept
+  : _data{fp16::create(static_cast<float>(f))} {}
+
+  half(unsigned int f) noexcept
+  : _data{fp16::create(static_cast<float>(f))} {}
+
+  half(unsigned long f) noexcept
   : _data{fp16::create(static_cast<float>(f))} {}
 
 
@@ -149,6 +158,32 @@ public:
     a = a / b;
     return a;
   }
+
+    // operator +,-,*,/ for combinations of half and other types
+#define OP_FOR_TYPE(op, type)                                         \
+  friend half operator op(const half lhs, const type rhs) {           \
+    return lhs op half(rhs);                                          \
+  }                                                                   \
+                                                                      \
+  friend half operator op(const type lhs, const half rhs) {           \
+    return half(lhs) op rhs;                                          \
+  }
+
+#define OP(op)                                                        \
+  OP_FOR_TYPE(op, int)                                                \
+  OP_FOR_TYPE(op, unsigned int)                                       \
+  OP_FOR_TYPE(op, long)                                               \
+  OP_FOR_TYPE(op, unsigned long)                                      \
+  OP_FOR_TYPE(op, float)                                              \
+  OP_FOR_TYPE(op, double)
+
+  OP(+)
+  OP(-)
+  OP(*)
+  OP(/)
+
+#undef OP
+#undef OP_FOR_TYPE
 
   friend bool operator==(const half& a, const half& b) noexcept {
     return a._data == b._data;

--- a/include/hipSYCL/sycl/libkernel/half.hpp
+++ b/include/hipSYCL/sycl/libkernel/half.hpp
@@ -70,46 +70,56 @@ public:
 
   HIPSYCL_UNIVERSAL_TARGET
   friend half operator+(const half& a, const half& b) noexcept {
+    fp16::half_storage data;
+    // __hipsycl_backend_switch contains an if statement for sscp pass, so we
+    // cannot write `fp16::half_storage data = __hipsycl_backend_switch(...)`.
     __hipsycl_backend_switch(
-      return fp16::builtin_add(a._data, b._data),
-      return __hipsycl_sscp_half_add(a._data, b._data),
-      return fp16::create(__hadd(fp16::as_cuda_half(a._data), fp16::as_cuda_half(b._data))),
+      data = fp16::builtin_add(a._data, b._data),
+      data = __hipsycl_sscp_half_add(a._data, b._data),
+      data = fp16::create(__hadd(fp16::as_cuda_half(a._data), fp16::as_cuda_half(b._data))),
       // HIP uses compiler builtin addition for native _Float16 type
-      return fp16::builtin_add(a._data, b._data),
-      return fp16::builtin_add(a._data, b._data))
+      data = fp16::builtin_add(a._data, b._data),
+      data = fp16::builtin_add(a._data, b._data));
+    return detail::create_half(data);
   }
 
   HIPSYCL_UNIVERSAL_TARGET
   friend half operator-(const half& a, const half& b) noexcept {
+    fp16::half_storage data;
     __hipsycl_backend_switch(
-      return fp16::builtin_sub(a._data, b._data),
-      return __hipsycl_sscp_half_sub(a._data, b._data),
-      return fp16::create(__hsub(fp16::as_cuda_half(a._data), fp16::as_cuda_half(b._data))),
+      data = fp16::builtin_sub(a._data, b._data),
+      data = __hipsycl_sscp_half_sub(a._data, b._data),
+      data = fp16::create(__hsub(fp16::as_cuda_half(a._data), fp16::as_cuda_half(b._data))),
       // HIP uses compiler builtin subtraction for native _Float16 type
-      return fp16::builtin_sub(a._data, b._data),
-      return fp16::builtin_sub(a._data, b._data))
+      data = fp16::builtin_sub(a._data, b._data),
+      data = fp16::builtin_sub(a._data, b._data));
+    return detail::create_half(data);
   }
 
   HIPSYCL_UNIVERSAL_TARGET
   friend half operator*(const half& a, const half& b) noexcept {
+    fp16::half_storage data;
     __hipsycl_backend_switch(
-      return fp16::builtin_mul(a._data, b._data),
-      return __hipsycl_sscp_half_mul(a._data, b._data),
-      return fp16::create(__hmul(fp16::as_cuda_half(a._data), fp16::as_cuda_half(b._data))),
+      data = fp16::builtin_mul(a._data, b._data),
+      data = __hipsycl_sscp_half_mul(a._data, b._data),
+      data = fp16::create(__hmul(fp16::as_cuda_half(a._data), fp16::as_cuda_half(b._data))),
       // HIP uses compiler builtin mul for native _Float16 type
-      return fp16::builtin_mul(a._data, b._data),
-      return fp16::builtin_mul(a._data, b._data))
+      data = fp16::builtin_mul(a._data, b._data),
+      data = fp16::builtin_mul(a._data, b._data));
+    return detail::create_half(data);
   }
 
   HIPSYCL_UNIVERSAL_TARGET
   friend half operator/(const half& a, const half& b) noexcept {
+    fp16::half_storage data;
     __hipsycl_backend_switch(
-      return fp16::builtin_div(a._data, b._data),
-      return __hipsycl_sscp_half_div(a._data, b._data),
-      return fp16::create(__hdiv(fp16::as_cuda_half(a._data), fp16::as_cuda_half(b._data))),
+      data = fp16::builtin_div(a._data, b._data),
+      data = __hipsycl_sscp_half_div(a._data, b._data),
+      data = fp16::create(__hdiv(fp16::as_cuda_half(a._data), fp16::as_cuda_half(b._data))),
       // HIP uses compiler builtin div for native _Float16 type
-      return fp16::builtin_div(a._data, b._data),
-      return fp16::builtin_div(a._data, b._data))
+      data = fp16::builtin_div(a._data, b._data),
+      data = fp16::builtin_div(a._data, b._data));
+    return detail::create_half(data);
   }
 
   friend half& operator+=(half& a, const half& b) noexcept {

--- a/tests/sycl/half.cpp
+++ b/tests/sycl/half.cpp
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(half_operators, T, half_test_types) {
   s::half b{2.0f};
 
   constexpr std::size_t num_ops = 4;
-  s::buffer<T, 1> buff_T{s::range{num_ops}}; // T as lhs operand
+  s::buffer<s::half, 1> buff_T{s::range{num_ops}}; // T as lhs operand
   s::buffer<s::half, 1> buff_half{s::range{num_ops}}; // half as lhs operand
   q.submit([&](s::handler& cgh){
     s::accessor acc_half{buff_half, cgh};
@@ -105,13 +105,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(half_operators, T, half_test_types) {
   T f1{1};
   float f2 = 2.0f;
   
-  T reference_T [num_ops];
+  float reference_T [num_ops]; // T as lhs operand
   reference_T[0] = f1 + f2;
   reference_T[1] = f1 - f2;
   reference_T[2] = f1 * f2;
   reference_T[3] = f1 / f2;
 
-  float reference_half [num_ops];
+  float reference_half [num_ops]; // half as lhs operand
   reference_half[0] = f2 + f1;
   reference_half[1] = f2 - f1;
   reference_half[2] = f2 * f1;


### PR DESCRIPTION
This also required removing the `explicit` keyword for the constructors and adding three new constructors for `unsigned int`, `unsigned long` and `long`.