### PR TITLE
Mark get_access for target::host_buffer as deprecated

### DIFF
--- a/include/hipSYCL/sycl/buffer.hpp
+++ b/include/hipSYCL/sycl/buffer.hpp
@@ -655,8 +655,8 @@ public:
         *this, commandGroupHandler};
   }
 
-  // Deprecated
   template <access::mode mode>
+  [[deprecated("Use get_host_access() instead")]]
   auto get_access()
   {
     return accessor<T, dimensions, mode, access::target::host_buffer,
@@ -679,8 +679,8 @@ public:
     };
   }
 
-  // Deprecated
   template <access::mode mode>
+  [[deprecated("Use get_host_access() instead")]]
   auto get_access(
       range<dimensions> accessRange, id<dimensions> accessOffset = {})
   {


### PR DESCRIPTION
This PR fixes [Issue #973](https://github.com/OpenSYCL/OpenSYCL/issues/973).