### PR TITLE
[CI] Add LLVM 16.

### DIFF
--- a/.github/workflows/linux-cbs.yml
+++ b/.github/workflows/linux-cbs.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        clang_version: [11, 12, 13, 14, 15]
+        clang_version: [11, 12, 13, 14, 15, 16]
         os: [ubuntu-20.04]
     steps:
       - uses: actions/checkout@v2
@@ -22,6 +22,10 @@ jobs:
           sudo apt install libclang-${{matrix.clang_version}}-dev clang-tools-${{matrix.clang_version}} libomp-${{matrix.clang_version}}-dev llvm-${{matrix.clang_version}}-dev
           sudo python -m pip install lit
           sudo ln -s /usr/bin/FileCheck-${{matrix.clang_version}} /usr/bin/FileCheck
+          if [[ "${{matrix.clang_version}}" == "16" ]]; then
+            sudo rm -r /usr/lib/clang/16*
+            sudo ln -s /usr/lib/llvm-16/lib/clang/16 /usr/lib/clang/16
+          fi
       - name: install boost (from apt)
         if: matrix.os == 'ubuntu-20.04'
         run: |
@@ -29,7 +33,7 @@ jobs:
       - name: setup build env
         run: |
           export CXXFLAGS="$CXXFLAGS"
-          if [[ "${{matrix.clang_version}}" != "11" ]]; then
+          if [[ "${{matrix.clang_version}}" != "11" && "${{matrix.clang_version}}" -lt "16" ]]; then
             export OMP_CXX_FLAGS="$CXXFLAGS -fexperimental-new-pass-manager"
             export CC=clang-${{matrix.clang_version}}
             export CXX=clang++-${{matrix.clang_version}}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        clang_version: [11, 12, 13, 14, 15]
+        clang_version: [11, 12, 13, 14, 15, 16]
         rocm_version: ['4.0.1']
         os: [ubuntu-20.04, ubuntu-18.04]
         cuda: [11.0]
@@ -53,6 +53,10 @@ jobs:
         chmod +x llvm.sh
         sudo ./llvm.sh ${{matrix.clang_version}}
         sudo apt install libclang-${{matrix.clang_version}}-dev clang-tools-${{matrix.clang_version}} libomp-${{matrix.clang_version}}-dev
+        if [[ "${{matrix.clang_version}}" == "16" ]]; then
+          sudo rm -r /usr/lib/clang/16*
+          sudo ln -s /usr/lib/llvm-16/lib/clang/16 /usr/lib/clang/16
+        fi
     - name: install boost (from source)
       if: matrix.os == 'ubuntu-18.04'
       run: |


### PR DESCRIPTION
Since LLVM 16 is released now, add it to the CI.

Annoyingly, the packages seem to have broken symlinks, so there are a few extra lines to create working ones. Upstream bug: https://github.com/llvm/llvm-project/issues/61550