### PR TITLE
[SSCP] Do not use OpenMP CXX flags/link line

### DIFF
--- a/bin/syclcc-clang
+++ b/bin/syclcc-clang
@@ -1529,8 +1529,8 @@ class llvm_sscp_invocation:
     return not self.is_integrated_multipass
 
   def __init__(self, config, targets):
-    self._linker_args = config.omp_link_line
-    self._cxx_flags = config.omp_cxx_flags
+    self._linker_args = []
+    self._cxx_flags = []
 
     if len(targets) != 0:
       raise RuntimeError("LLVM SSCP backend does not support specifiying target architecture")


### PR DESCRIPTION
Previously, SSCP has used the CXX and linker flags of the OpenMP backend.

This was probably motivated by SSCP running as part of a regular host compilation, and therefore needing similar flags. However, using OpenMP here causes SSCP to pull in flags such as `-fopenmp` even if they are not needed or wanted.

Furthermore, since at least the OpenMP sequential backend is activated by `syclcc` in any case, the necessary flags for host compilation are already there in any case and do not need to be handled by the SSCP flag generator. The current approach just causes superfluous or duplicate host flags to be emitted.