### PR TITLE
Addendum to #832 for CUDA/HIP devices

### DIFF
--- a/src/runtime/cuda/cuda_hardware_manager.cpp
+++ b/src/runtime/cuda/cuda_hardware_manager.cpp
@@ -219,14 +219,16 @@ cuda_hardware_context::get_property(device_uint_property prop) const {
     return _properties->multiProcessorCount;
     break;
   case device_uint_property::max_global_size0:
-    return _properties->maxThreadsDim[0] * _properties->maxGridSize[0];
+    return static_cast<std::size_t>(_properties->maxThreadsDim[0]) *
+                                    _properties->maxGridSize[0];
     break;
   case device_uint_property::max_global_size1:
-    return _properties->maxThreadsDim[1] * _properties->maxGridSize[1];
+    return static_cast<std::size_t>(_properties->maxThreadsDim[1]) *
+                                    _properties->maxGridSize[1];
     break;
   case device_uint_property::max_global_size2:
-    return _properties->maxThreadsDim[2] * _properties->maxGridSize[2];
-    break;
+    return static_cast<std::size_t>(_properties->maxThreadsDim[2]) *
+                                    _properties->maxGridSize[2];
   case device_uint_property::max_group_size0:
     return _properties->maxThreadsDim[0];
     break;

--- a/src/runtime/hip/hip_hardware_manager.cpp
+++ b/src/runtime/hip/hip_hardware_manager.cpp
@@ -227,13 +227,16 @@ hip_hardware_context::get_property(device_uint_property prop) const {
     return _properties->multiProcessorCount;
     break;
   case device_uint_property::max_global_size0:
-    return _properties->maxThreadsPerBlock * _properties->maxGridSize[0];
+    return static_cast<std::size_t>(_properties->maxThreadsDim[0]) *
+                                    _properties->maxGridSize[0];
     break;
   case device_uint_property::max_global_size1:
-    return _properties->maxThreadsPerBlock * _properties->maxGridSize[1];
+    return static_cast<std::size_t>(_properties->maxThreadsDim[1]) *
+                                    _properties->maxGridSize[1];
     break;
   case device_uint_property::max_global_size2:
-    return _properties->maxThreadsPerBlock * _properties->maxGridSize[2];
+    return static_cast<std::size_t>(_properties->maxThreadsDim[2]) *
+                                    _properties->maxGridSize[2];
     break;
   case device_uint_property::max_group_size0:
     return _properties->maxThreadsDim[0];


### PR DESCRIPTION
Hi Aksel,

While checking what we did in #832, I realised we overlooked a fix for one of the device properties for the HIP backend.
`maxThreadsDim[x]` seems to be the same for all `x`, at least on the MI200s, so the cast is actually the most important bit here... since the multiplication is otherwise performed in 32 bits 🥶.

Cheers,
-N