### PR TITLE
Add `buffer(Container)` constructor

### DIFF
--- a/include/hipSYCL/sycl/buffer.hpp
+++ b/include/hipSYCL/sycl/buffer.hpp
@@ -307,23 +307,23 @@ private:
 };
 
 template <typename, typename = void>
-struct HasData : std::false_type {};
+struct has_data : std::false_type {};
 
 template <typename Container>
-struct HasData<Container, std::void_t<decltype(std::data(std::declval<Container>()))>>
+struct has_data<Container, std::void_t<decltype(std::data(std::declval<Container>()))>>
   : std::true_type {};
 
 template <typename, typename = void>
-struct HasSize : std::false_type {};
+struct has_size : std::false_type {};
 
 template <typename Container>
-struct HasSize<Container, std::void_t<decltype(std::size(Container{}))>>
+struct has_size<Container, std::void_t<decltype(std::size(Container{}))>>
   : std::true_type {};
 
 template <typename Container, typename T>
-using EnableIfContiguous = std::void_t<std::enable_if_t<
-  HasData<Container>::value &&
-  HasSize<Container>::value &&
+using enable_if_contiguous = std::void_t<std::enable_if_t<
+  has_data<Container>::value &&
+  has_size<Container>::value &&
   std::is_convertible_v<decltype(std::data(std::declval<Container>())),
                         const T*>>>;
 
@@ -624,7 +624,7 @@ public:
   template <typename Container,
             int D = dimensions,
             typename = std::enable_if_t<D == 1>,
-            typename = detail::EnableIfContiguous<Container, T>>
+            typename = detail::enable_if_contiguous<Container, T>>
   buffer(Container& container, AllocatorT allocator,
          const property_list& propList = {})
     : detail::property_carrying_object{propList}
@@ -632,13 +632,13 @@ public:
     _impl = std::make_shared<detail::buffer_impl>();
     _alloc = allocator;
     
-    constexpr bool isConstContainer = std::is_const_v<
+    constexpr bool is_const_container = std::is_const_v<
       std::remove_pointer_t<decltype(std::data(container))>>;
 
     default_policies dpol;
     dpol.destructor_waits = true;
     // If std::data returns non-const pointer, enable write_back
-    if constexpr (isConstContainer) {
+    if constexpr (is_const_container) {
       dpol.writes_back = false;
       dpol.use_external_storage = false;
     } else {
@@ -650,7 +650,7 @@ public:
 
     const range<1> bufferRange(std::size(container));
 
-    if constexpr (isConstContainer) {
+    if constexpr (is_const_container) {
       if (_impl->use_external_storage) {
          HIPSYCL_DEBUG_WARNING
           << "buffer: constructed with property use_external_storage, but user "
@@ -670,7 +670,7 @@ public:
   template <typename Container,
             int D = dimensions,
             typename = std::enable_if_t<D == 1>,
-            typename = detail::EnableIfContiguous<Container, T>>
+            typename = detail::enable_if_contiguous<Container, T>>
   buffer(Container& container, const property_list& propList = {})
     : buffer(container, AllocatorT(), propList) {}
 

--- a/include/hipSYCL/sycl/buffer.hpp
+++ b/include/hipSYCL/sycl/buffer.hpp
@@ -310,7 +310,7 @@ template <typename, typename = void>
 struct has_data : std::false_type {};
 
 template <typename Container>
-struct has_data<Container, std::void_t<decltype(std::data(std::declval<Container>()))>>
+struct has_data<Container, std::void_t<decltype(std::data(Container{}))>>
   : std::true_type {};
 
 template <typename, typename = void>
@@ -324,9 +324,8 @@ template <typename Container, typename T>
 using enable_if_contiguous = std::void_t<std::enable_if_t<
   has_data<Container>::value &&
   has_size<Container>::value &&
-  std::is_convertible_v<decltype(std::data(std::declval<Container>())),
+  std::is_convertible_v<decltype(std::data(Container{})),
                         const T*>>>;
-
 }
 
 

--- a/tests/sycl/buffer.cpp
+++ b/tests/sycl/buffer.cpp
@@ -217,5 +217,29 @@ BOOST_AUTO_TEST_CASE(buffer_external_writeback_nullptr) {
   }
 }
 
+BOOST_AUTO_TEST_CASE(buffer_container_constructor) {
+  cl::sycl::queue q;
+
+  const int testVal = 42;
+
+  std::size_t size = 1024;
+  std::vector<int> host_buff(size, 0);
+  {
+    cl::sycl::buffer<int> buff{host_buff};
+
+    q.submit([&](cl::sycl::handler &cgh) {
+      auto acc =
+        buff.get_access<cl::sycl::access::mode::write>(cgh);
+
+      cgh.parallel_for(cl::sycl::range{size}, [=](auto idx) {
+        acc[idx] = testVal;
+      });
+    });
+  }
+
+  for(int i = 0; i < host_buff.size(); ++i) {
+    BOOST_CHECK(host_buff[i] == testVal);
+  }
+}
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR adds a missing constructor to the buffer class (see the description in the spec [here](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_buffer_interface)). This constructor allows to construct buffers from containers for which `std::data(container)` and `std::size(container)` are valid, e.g., `std::vector` or `std::array`.

As described by the spec, `write_back` is disabled if `std::data(container)` does return a const pointer, and enabled otherwise. Because of this extra handling, we cannot just delegate to another constructor.