### PR TITLE
Remove Ubuntu 18.04 from CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         clang_version: [11, 12, 13, 14, 15, 16]
         rocm_version: ['4.0.1']
-        os: [ubuntu-20.04, ubuntu-18.04]
+        os: [ubuntu-20.04]
         cuda: [11.0]
     steps:
     - uses: actions/checkout@v2
@@ -57,15 +57,6 @@ jobs:
           sudo rm -r /usr/lib/clang/16*
           sudo ln -s /usr/lib/llvm-16/lib/clang/16 /usr/lib/clang/16
         fi
-    - name: install boost (from source)
-      if: matrix.os == 'ubuntu-18.04'
-      run: |
-        wget -q https://boostorg.jfrog.io/artifactory/main/release/1.70.0/source/boost_1_70_0.zip
-        unzip boost_1_70_0.zip
-        cd boost_1_70_0
-        ./bootstrap.sh --prefix=/usr
-        sudo ./b2 link=static,shared install -j$(nproc) || true
-        cd ..
     - name: install boost (from apt)
       if: matrix.os == 'ubuntu-20.04'
       run: |


### PR DESCRIPTION
GitHub actions no longer provides Ubuntu 18.04 images, so we need to remove it.

Independently, we should consider adding Ubuntu 22.04.