### PR TITLE
Implement math builtin frexp, modf, sincos

### DIFF
--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp
@@ -177,10 +177,15 @@ HIPSYCL_HIPLIKE_BUILTIN T __hipsycl_minmag(T x, T y) noexcept {
   return (abs_x < abs_y) ? x : y;
 }
 
-// Not yet supported
-template<class T, class FloatPtr>
-HIPSYCL_HIPLIKE_BUILTIN
-T __hipsycl_modf(T x, FloatPtr y) noexcept;
+template<class FloatPtr>
+HIPSYCL_HIPLIKE_BUILTIN float __hipsycl_modf(float x, FloatPtr y) noexcept {
+  return ::modff(x, y);
+};
+
+template<class FloatPtr>
+HIPSYCL_HIPLIKE_BUILTIN double __hipsycl_modf(double x, FloatPtr y) noexcept {
+  return ::modf(x, y);
+};
 
 HIPSYCL_DEFINE_HIPLIKE_MATH_BUILTIN2(__hipsycl_nextafter, nextafterf, nextafter)
 

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp
@@ -221,10 +221,18 @@ HIPSYCL_HIPLIKE_BUILTIN double __hipsycl_rsqrt(double x) noexcept {
 
 HIPSYCL_DEFINE_HIPLIKE_MATH_BUILTIN(__hipsycl_sin, sinf, sin)
 
-template<class T, class FloatPtr>
-HIPSYCL_HIPLIKE_BUILTIN T __hipsycl_sincos(T x, FloatPtr cosval) noexcept {
-  *cosval = hiplike_builtins::__hipsycl_cos(x);
-  return hiplike_builtins::__hipsycl_sin(x);
+template<class FloatPtr>
+HIPSYCL_HIPLIKE_BUILTIN float __hipsycl_sincos(float x, FloatPtr cosval) noexcept {
+  float sinval;
+  ::sincosf(x, &sinval, cosval);
+  return sinval;
+}
+
+template<class FloatPtr>
+HIPSYCL_HIPLIKE_BUILTIN double __hipsycl_sincos(double x, FloatPtr cosval) noexcept {
+  double sinval;
+  ::sincos(x, &sinval, cosval);
+  return sinval;
 }
 
 HIPSYCL_DEFINE_HIPLIKE_MATH_BUILTIN(__hipsycl_sinh, sinhf, sinh)

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp
@@ -127,10 +127,15 @@ template<class T>
 HIPSYCL_HIPLIKE_BUILTIN
 T __hipsycl_fract(T x, T* ptr) noexcept;
 
-// Unsupported
-template<class T, class IntPtr>
-HIPSYCL_HIPLIKE_BUILTIN
-T __hipsycl_frexp(T x, IntPtr y) noexcept;
+template<class IntPtr>
+HIPSYCL_HIPLIKE_BUILTIN float __hipsycl_frexp(float x, IntPtr y) noexcept {
+  return ::frexpf(x, y);
+}
+
+template<class IntPtr>
+HIPSYCL_HIPLIKE_BUILTIN double __hipsycl_frexp(double x, IntPtr y) noexcept {
+  return ::frexp(x, y);
+}
 
 HIPSYCL_DEFINE_HIPLIKE_MATH_BUILTIN2(__hipsycl_hypot, hypotf, hypot)
 HIPSYCL_DEFINE_HIPLIKE_MATH_BUILTIN(__hipsycl_ilogb, ilogbf, ilogb)

--- a/include/hipSYCL/sycl/libkernel/spirv/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/spirv/builtins.hpp
@@ -122,9 +122,10 @@ HIPSYCL_DEFINE_SPIRV_BUILTIN2(fmod)
 template<class T>
 T __hipsycl_fract(T x, T* ptr) noexcept;
 
-// Unsupported
 template<class T, class IntPtr>
-T __hipsycl_frexp(T x, IntPtr y) noexcept;
+HIPSYCL_BUILTIN T __hipsycl_frexp(T x, IntPtr y) noexcept {
+  return __spirv_ocl_frexp(x, y);
+}
 
 HIPSYCL_DEFINE_SPIRV_BUILTIN2(hypot)
 HIPSYCL_DEFINE_SPIRV_BUILTIN(ilogb)

--- a/include/hipSYCL/sycl/libkernel/spirv/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/spirv/builtins.hpp
@@ -194,8 +194,7 @@ HIPSYCL_DEFINE_SPIRV_BUILTIN(sin)
 
 template<class T, class FloatPtr>
 HIPSYCL_BUILTIN T __hipsycl_sincos(T x, FloatPtr cosval) noexcept {
-  *cosval = spirv_builtins::__hipsycl_cos(x);
-  return spirv_builtins::__hipsycl_sin(x);
+  return __spirv_ocl_sincos(x, cosval);
 }
 
 HIPSYCL_DEFINE_SPIRV_BUILTIN(sinh)

--- a/include/hipSYCL/sycl/libkernel/spirv/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/spirv/builtins.hpp
@@ -164,7 +164,6 @@ HIPSYCL_BUILTIN T __hipsycl_minmag(T x, T y) noexcept {
   return (abs_x < abs_y) ? x : y;
 }
 
-// Not yet supported
 template<class T, class FloatPtr>
 HIPSYCL_BUILTIN T __hipsycl_modf(T x, FloatPtr y) noexcept {
   return __spirv_ocl_modf(x, y);

--- a/include/hipSYCL/sycl/libkernel/spirv/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/spirv/builtins.hpp
@@ -166,7 +166,9 @@ HIPSYCL_BUILTIN T __hipsycl_minmag(T x, T y) noexcept {
 
 // Not yet supported
 template<class T, class FloatPtr>
-T __hipsycl_modf(T x, FloatPtr y) noexcept;
+HIPSYCL_BUILTIN T __hipsycl_modf(T x, FloatPtr y) noexcept {
+  return __spirv_ocl_modf(x, y);
+}
 
 HIPSYCL_DEFINE_SPIRV_BUILTIN2(nextafter)
 HIPSYCL_DEFINE_SPIRV_BUILTIN2(powr)


### PR DESCRIPTION
Implemented frexp, modf and sincos using existing math builtins for hiplike and ze backend.

Re-implementation of sincos is intended for better performance, although haven't benchmarked.

Tested ROCm backend on gfx906, CUDA backend on sm_86; currently I have no access to Intel GPUs, so cannot test ze backend...
