### PR TITLE
Add -DWITH_SSCP_COMPILER=OFF to minimal install script

### DIFF
--- a/install/scripts/hipsycl-minimal-install.sh
+++ b/install/scripts/hipsycl-minimal-install.sh
@@ -20,5 +20,5 @@ mkdir -p ./hipsycl-build
 git clone https://github.com/illuhad/hipSYCL ./hipsycl-build
 mkdir -p ./hipsycl-build/build
 cd ./hipsycl-build/build
-cmake -DCMAKE_INSTALL_PREFIX=`pwd`/../.. -DWITH_CUDA_BACKEND=OFF -DWITH_ROCM_BACKEND=OFF -DWITH_LEVEL_ZERO_BACKEND=OFF -DWITH_ACCELERATED_CPU=OFF ..
+cmake -DCMAKE_INSTALL_PREFIX=`pwd`/../.. -DWITH_CUDA_BACKEND=OFF -DWITH_ROCM_BACKEND=OFF -DWITH_LEVEL_ZERO_BACKEND=OFF -DWITH_ACCELERATED_CPU=OFF -DWITH_SSCP_COMPILER=OFF ..
 make install


### PR DESCRIPTION
By default, if LLVM is installed, this can trigger cmake to want to enable the SSCP compiler. That can break the purpose of the minimal install script and cause issues e.g. if only a partial LLVM installation is available.