### PR TITLE
Expose `Dimensions` template paramter for `{nd_}range`, `{nd_,h_}item` and `id`

### DIFF
--- a/include/hipSYCL/sycl/libkernel/h_item.hpp
+++ b/include/hipSYCL/sycl/libkernel/h_item.hpp
@@ -37,55 +37,56 @@
 namespace hipsycl {
 namespace sycl {
 
-template<int dimensions>
+template<int Dimensions>
 struct group;
 
-template <int dimensions>
+template <int Dimensions>
 struct h_item
 {
-  friend struct group<dimensions>;
+  friend struct group<Dimensions>;
 
   HIPSYCL_KERNEL_TARGET
   h_item(){}
 public:
   /* -- common interface members -- */
+  static constexpr int dimensions = Dimensions;
 
   /// \return The global id with respect to the parallel_for_work_group
   /// invocation. Flexlible local ranges are not taken into account.
   HIPSYCL_KERNEL_TARGET
-  item<dimensions, false> get_global() const
+  item<Dimensions, false> get_global() const
   {
-    return detail::make_item<dimensions>(
+    return detail::make_item<Dimensions>(
       this->get_global_id(),
       this->get_global_range());
   }
 
   HIPSYCL_KERNEL_TARGET
-  item<dimensions, false> get_local() const
+  item<Dimensions, false> get_local() const
   {
     return get_logical_local();
   }
 
   /// \return The local id in the logical iteration space.
   HIPSYCL_KERNEL_TARGET
-  item<dimensions, false> get_logical_local() const
+  item<Dimensions, false> get_logical_local() const
   {
-    return detail::make_item<dimensions>(this->_logical_local_id,
+    return detail::make_item<Dimensions>(this->_logical_local_id,
                                          this->_logical_range);
   }
 
   HIPSYCL_KERNEL_TARGET
-  item<dimensions, false> get_physical_local() const
+  item<Dimensions, false> get_physical_local() const
   {
-    return detail::make_item<dimensions>(this->get_physical_local_id(),
+    return detail::make_item<Dimensions>(this->get_physical_local_id(),
                                          this->get_physical_local_range());
   }
 
   HIPSYCL_KERNEL_TARGET
-  range<dimensions> get_global_range() const
+  range<Dimensions> get_global_range() const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_grid_size<dimensions>() * this->_logical_range;
+    return detail::get_grid_size<Dimensions>() * this->_logical_range;
 #else
     return this->_num_groups * this->_logical_range;
 #endif
@@ -95,17 +96,17 @@ public:
   size_t get_global_range(int dimension) const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_grid_size<dimensions>(dimension) * this->_logical_range[dimension];
+    return detail::get_grid_size<Dimensions>(dimension) * this->_logical_range[dimension];
 #else
     return this->_num_groups[dimension] * this->_logical_range[dimension];
 #endif
   }
 
   HIPSYCL_KERNEL_TARGET
-  id<dimensions> get_global_id() const
+  id<Dimensions> get_global_id() const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_group_id<dimensions>() * this->_logical_range + this->_logical_local_id;
+    return detail::get_group_id<Dimensions>() * this->_logical_range + this->_logical_local_id;
 #else
     return this->_group_id * this->_logical_range + this->_logical_local_id;
 #endif
@@ -115,15 +116,15 @@ public:
   size_t get_global_id(int dimension) const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_group_id<dimensions>(dimension) * _logical_range[dimension] + _logical_local_id[dimension];
+    return detail::get_group_id<Dimensions>(dimension) * _logical_range[dimension] + _logical_local_id[dimension];
 #else
     return _group_id[dimension] * _logical_range[dimension] + _logical_local_id[dimension];
 #endif
   }
 
-  HIPSYCL_KERNEL_TARGET friend bool operator ==(const h_item<dimensions> lhs, const h_item<dimensions> rhs)
+  HIPSYCL_KERNEL_TARGET friend bool operator ==(const h_item<Dimensions> lhs, const h_item<Dimensions> rhs)
   {
-  const range<dimensions> _num_groups;
+  const range<Dimensions> _num_groups;
   #if defined(HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO)
     return lhs._logical_local_id == rhs._logical_local_id && 
            lhs._logical_range == rhs._logical_range;
@@ -135,13 +136,13 @@ public:
   #endif
   }
 
-  HIPSYCL_KERNEL_TARGET friend bool operator !=(const h_item<dimensions> lhs, const h_item<dimensions> rhs)
+  HIPSYCL_KERNEL_TARGET friend bool operator !=(const h_item<Dimensions> lhs, const h_item<Dimensions> rhs)
   {
     return !(lhs==rhs);
   }
 
   HIPSYCL_KERNEL_TARGET
-  range<dimensions> get_local_range() const
+  range<Dimensions> get_local_range() const
   {
     return get_logical_local_range();
   }
@@ -153,7 +154,7 @@ public:
   }
 
   HIPSYCL_KERNEL_TARGET
-  id<dimensions> get_local_id() const
+  id<Dimensions> get_local_id() const
   {
     return get_logical_local_id();
   }
@@ -165,7 +166,7 @@ public:
   }
 
   HIPSYCL_KERNEL_TARGET
-  range<dimensions> get_logical_local_range() const
+  range<Dimensions> get_logical_local_range() const
   {
     return _logical_range;
   }
@@ -177,7 +178,7 @@ public:
   }
 
   HIPSYCL_KERNEL_TARGET
-  id<dimensions> get_logical_local_id() const
+  id<Dimensions> get_logical_local_id() const
   {
     return _logical_local_id;
   }
@@ -189,14 +190,14 @@ public:
   }
 
   HIPSYCL_KERNEL_TARGET
-  range<dimensions> get_physical_local_range() const
+  range<Dimensions> get_physical_local_range() const
   {
     __hipsycl_if_target_device(
-      return detail::get_local_size<dimensions>();
+      return detail::get_local_size<Dimensions>();
     );
     __hipsycl_if_target_host(
-      range<dimensions> size;
-      for(int i = 0; i < dimensions; ++i)
+      range<Dimensions> size;
+      for(int i = 0; i < Dimensions; ++i)
         size[i] = 1; 
       return size;
     );
@@ -207,20 +208,20 @@ public:
   size_t get_physical_local_range(int dimension) const
   {
     __hipsycl_if_target_device(
-      return detail::get_local_size<dimensions>(dimension);
+      return detail::get_local_size<Dimensions>(dimension);
     );
     __hipsycl_if_target_host(return 1;);
   }
 
   HIPSYCL_KERNEL_TARGET
-  id<dimensions> get_physical_local_id() const
+  id<Dimensions> get_physical_local_id() const
   {
     __hipsycl_if_target_device(
-      return detail::get_local_id<dimensions>();
+      return detail::get_local_id<Dimensions>();
     );
     __hipsycl_if_target_host(
-      id<dimensions> local_id;
-      for(int i = 0; i < dimensions; ++i)
+      id<Dimensions> local_id;
+      for(int i = 0; i < Dimensions; ++i)
         local_id[i] = 0; 
       return local_id;
     );
@@ -230,17 +231,17 @@ public:
   size_t get_physical_local_id(int dimension) const
   {
     __hipsycl_if_target_device(
-      return detail::get_local_id<dimensions>(dimension);
+      return detail::get_local_id<Dimensions>(dimension);
     );
     __hipsycl_if_target_host(return 0;);
   }
 
 #if !defined(HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO)
   // TODO Make this private and group<> a friend
-  h_item(id<dimensions> logical_local_id,
-        range<dimensions> logical_range,
-        id<dimensions> group_id,
-        range<dimensions> num_groups)
+  h_item(id<Dimensions> logical_local_id,
+        range<Dimensions> logical_range,
+        id<Dimensions> group_id,
+        range<Dimensions> num_groups)
     : _logical_local_id{logical_local_id},
       _logical_range{logical_range},
       _group_id{group_id},
@@ -248,8 +249,8 @@ public:
   {}
 #else
   // TODO Make this private and group<> a friend
-  h_item(id<dimensions> logical_local_id,
-        range<dimensions> logical_range)
+  h_item(id<Dimensions> logical_local_id,
+        range<Dimensions> logical_range)
     : _logical_local_id{logical_local_id},
       _logical_range{logical_range}
   {}
@@ -266,12 +267,12 @@ private:
   // Note that for the support of flexible work group sizes,
   // we have to explicitly store logical ids/ranges even
   // if HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO is defined.
-  const id<dimensions> _logical_local_id;
-  const range<dimensions> _logical_range;
+  const id<Dimensions> _logical_local_id;
+  const range<Dimensions> _logical_range;
 
 #if !defined(HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO)
-  const id<dimensions> _group_id;
-  const range<dimensions> _num_groups;
+  const id<Dimensions> _group_id;
+  const range<Dimensions> _num_groups;
 #endif
 };
 

--- a/include/hipSYCL/sycl/libkernel/id.hpp
+++ b/include/hipSYCL/sycl/libkernel/id.hpp
@@ -42,19 +42,19 @@
 namespace hipsycl {
 namespace sycl {
 
-template<int dimensions>
+template<int Dimensions>
 class range;
 
-template<int dimensions, bool with_offset>
+template<int Dimensions, bool with_offset>
 struct item;
 
-template <int dimensions = 1>
+template <int Dimensions = 1>
 struct id {
 private:
   struct not_convertible_to_scalar {};
 
   static constexpr auto get_scalar_conversion_type() {
-    if constexpr(dimensions == 1)
+    if constexpr(Dimensions == 1)
       return std::size_t{};
     else
       return not_convertible_to_scalar {};
@@ -63,6 +63,7 @@ private:
   using scalar_conversion_type = decltype(get_scalar_conversion_type());
 
 public:
+  static constexpr int dimensions = Dimensions;
 
   HIPSYCL_UNIVERSAL_TARGET
   id()
@@ -70,8 +71,8 @@ public:
   {}
 
   /* The following constructor is only available in the id class
-   * specialization where: dimensions==1 */
-  template<int D = dimensions,
+   * specialization where: Dimensions==1 */
+  template<int D = Dimensions,
            typename = std::enable_if_t<D == 1>>
   HIPSYCL_UNIVERSAL_TARGET
   id(size_t dim0)
@@ -79,8 +80,8 @@ public:
   {}
 
   /* The following constructor is only available in the id class
-   * specialization where: dimensions==2 */
-  template<int D = dimensions,
+   * specialization where: Dimensions==2 */
+  template<int D = Dimensions,
            typename = std::enable_if_t<D == 2>>
   HIPSYCL_UNIVERSAL_TARGET
   id(size_t dim0, size_t dim1)
@@ -88,8 +89,8 @@ public:
   {}
 
   /* The following constructor is only available in the id class
-   * specialization where: dimensions==3 */
-  template<int D = dimensions,
+   * specialization where: Dimensions==3 */
+  template<int D = Dimensions,
            typename = std::enable_if_t<D == 3>>
   HIPSYCL_UNIVERSAL_TARGET
   id(size_t dim0, size_t dim1, size_t dim2)
@@ -99,29 +100,29 @@ public:
   /* -- common interface members -- */
 
   HIPSYCL_UNIVERSAL_TARGET
-  friend bool operator==(const id<dimensions>& lhs, const id<dimensions>& rhs){
+  friend bool operator==(const id<Dimensions>& lhs, const id<Dimensions>& rhs){
     return lhs._data == rhs._data;
   }
   
   HIPSYCL_UNIVERSAL_TARGET
-  friend bool operator!=(const id<dimensions>& lhs, const id<dimensions>& rhs){
+  friend bool operator!=(const id<Dimensions>& lhs, const id<Dimensions>& rhs){
     return lhs._data != rhs._data;
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  id(const range<dimensions> &range) {
+  id(const range<Dimensions> &range) {
     /* loop peel to help uniformity analysis */ \
     this->_data[0] = range[0];
-    for(std::size_t i = 1; i < dimensions; ++i)
+    for(std::size_t i = 1; i < Dimensions; ++i)
       this->_data[i] = range[i];
   }
 
   template<bool with_offset>
   HIPSYCL_UNIVERSAL_TARGET
-  id(const item<dimensions, with_offset> &item) {
+  id(const item<Dimensions, with_offset> &item) {
     /* loop peel to help uniformity analysis */ \
     this->_data[0] = item.get_id(0);
-    for(std::size_t i = 1; i < dimensions; ++i)
+    for(std::size_t i = 1; i < Dimensions; ++i)
       this->_data[i] = item.get_id(i);
   }
 
@@ -147,15 +148,15 @@ public:
     return this->_data[0];
   }
 
-  // Implementation of id<dimensions> operatorOP(const id &rhs) const;
+  // Implementation of id<Dimensions> operatorOP(const id &rhs) const;
   // OP is: +, -, *, /, %, <<, >>, &, |, ˆ, &&, ||, <, >, <=, >=
 #define HIPSYCL_ID_BINARY_OP_OUT_OF_PLACE(op) \
   HIPSYCL_UNIVERSAL_TARGET  \
-  friend id<dimensions> operator op(const id<dimensions> &lhs, const id<dimensions> &rhs) { \
-    id<dimensions> result; \
+  friend id<Dimensions> operator op(const id<Dimensions> &lhs, const id<Dimensions> &rhs) { \
+    id<Dimensions> result; \
     /* loop peel to help uniformity analysis */ \
     result._data[0] = static_cast<std::size_t>(lhs._data[0] op rhs._data[0]); \
-    for(std::size_t i = 1; i < dimensions; ++i) \
+    for(std::size_t i = 1; i < Dimensions; ++i) \
       result._data[i] = static_cast<std::size_t>(lhs._data[i] op rhs._data[i]); \
     return result; \
   }
@@ -180,20 +181,20 @@ public:
 #define HIPSYCL_ID_BINARY_OP_OUT_OF_PLACE_SIZE_T(op)                           \
   template<class T, std::enable_if_t<std::is_integral_v<T>, int> = 0>          \
   HIPSYCL_UNIVERSAL_TARGET                                                     \
-  friend id<dimensions> operator op(const id<dimensions> &lhs,                 \
+  friend id<Dimensions> operator op(const id<Dimensions> &lhs,                 \
                                     const T &rhs) {                            \
-    id<dimensions> result;                                                     \
+    id<Dimensions> result;                                                     \
     /* loop peel to help uniformity analysis */ \
     result._data[0] = static_cast<T>(lhs._data[0] op rhs);                                                                           \
-    for (std::size_t i = 1; i < dimensions; ++i)                               \
+    for (std::size_t i = 1; i < Dimensions; ++i)                               \
       result._data[i] = static_cast<T>(lhs._data[i] op rhs);                   \
     return result;                                                             \
   }                                                                            \
   /* Dedicated overload for range to avoid operator ambiguity due to */        \
   /* implicit conversion to size_t                                   */        \
-  template <int D = dimensions, std::enable_if_t<D == 1, int> = 0>             \
-  HIPSYCL_UNIVERSAL_TARGET friend id<dimensions> operator op(                  \
-      const id<dimensions> &lhs, const range<dimensions> &rhs) {               \
+  template <int D = Dimensions, std::enable_if_t<D == 1, int> = 0>             \
+  HIPSYCL_UNIVERSAL_TARGET friend id<Dimensions> operator op(                  \
+      const id<Dimensions> &lhs, const range<Dimensions> &rhs) {               \
     return lhs op rhs[0];                                                      \
   }
 
@@ -215,14 +216,14 @@ public:
   HIPSYCL_ID_BINARY_OP_OUT_OF_PLACE_SIZE_T(>=)
 
 
-  // Implementation of id<dimensions> &operatorOP(const id<dimensions> &rhs);
+  // Implementation of id<Dimensions> &operatorOP(const id<Dimensions> &rhs);
   // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ˆ=
 #define HIPSYCL_ID_BINARY_OP_IN_PLACE(op) \
   HIPSYCL_UNIVERSAL_TARGET \
-  friend id<dimensions>& operator op(id<dimensions> &lhs, const id<dimensions> &rhs) { \
+  friend id<Dimensions>& operator op(id<Dimensions> &lhs, const id<Dimensions> &rhs) { \
     /* loop peel to help uniformity analysis */ \
     lhs._data[0] op rhs._data[0]; \
-    for(std::size_t i = 1; i < dimensions; ++i) \
+    for(std::size_t i = 1; i < Dimensions; ++i) \
       lhs._data[i] op rhs._data[i]; \
     return lhs; \
   }
@@ -241,10 +242,10 @@ public:
 #define HIPSYCL_ID_BINARY_OP_IN_PLACE_SIZE_T(op)                          \
   template<class T, std::enable_if_t<std::is_integral_v<T>, int> = 0>     \
   HIPSYCL_UNIVERSAL_TARGET                                                \
-  friend id<dimensions>& operator op(id<dimensions> &lhs, const T &rhs) { \
+  friend id<Dimensions>& operator op(id<Dimensions> &lhs, const T &rhs) { \
     /* loop peel to help uniformity analysis */ \
     lhs._data[0] op rhs;                                                  \
-    for(std::size_t i = 1; i < dimensions; ++i)                           \
+    for(std::size_t i = 1; i < Dimensions; ++i)                           \
       lhs._data[i] op rhs;                                                \
     return lhs;                                                           \
   }
@@ -263,11 +264,11 @@ public:
 #define HIPSYCL_ID_BINARY_OP_SIZE_T(op)                                        \
   template<class T, std::enable_if_t<std::is_integral_v<T>, int> = 0>          \
   HIPSYCL_UNIVERSAL_TARGET                                                     \
-  friend id<dimensions> operator op(const T &lhs, const id<dimensions> &rhs) { \
-    id<dimensions> result;                                                     \
+  friend id<Dimensions> operator op(const T &lhs, const id<Dimensions> &rhs) { \
+    id<Dimensions> result;                                                     \
     /* loop peel to help uniformity analysis */ \
     result[0] = lhs op rhs[0];                                                 \
-    for(std::size_t i = 1; i < dimensions; ++i)                                \
+    for(std::size_t i = 1; i < Dimensions; ++i)                                \
       result[i] = lhs op rhs[i];                                               \
     return result;                                                             \
   }
@@ -285,7 +286,7 @@ public:
   HIPSYCL_ID_BINARY_OP_SIZE_T(^)
 
 private:
-  detail::device_array<std::size_t, dimensions> _data;
+  detail::device_array<std::size_t, Dimensions> _data;
 };
 
 // Deduction guides
@@ -296,9 +297,9 @@ id(size_t, size_t, size_t) -> id<3>;
 namespace detail {
 namespace id{
 
-template<int dimensions>
+template<int Dimensions>
 HIPSYCL_UNIVERSAL_TARGET
-inline sycl::id<dimensions> construct_from_first_n(size_t x, size_t y, size_t z);
+inline sycl::id<Dimensions> construct_from_first_n(size_t x, size_t y, size_t z);
 
 template<>
 HIPSYCL_UNIVERSAL_TARGET

--- a/include/hipSYCL/sycl/libkernel/nd_item.hpp
+++ b/include/hipSYCL/sycl/libkernel/nd_item.hpp
@@ -55,16 +55,17 @@ using host_barrier_type = std::function<void()>;
 
 class handler;
 
-template <int dimensions = 1>
+template <int Dimensions = 1>
 struct nd_item
 {
   /* -- common interface members -- */
+  static constexpr int dimensions = Dimensions;
 
   HIPSYCL_KERNEL_TARGET
-  id<dimensions> get_global_id() const
+  id<Dimensions> get_global_id() const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_global_id<dimensions>() + (*_offset);
+    return detail::get_global_id<Dimensions>() + (*_offset);
 #else
     return this->_global_id + (*_offset);
 #endif
@@ -74,7 +75,7 @@ struct nd_item
   size_t get_global_id(int dimension) const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_global_id<dimensions>(dimension) + _offset->get(dimension);
+    return detail::get_global_id<Dimensions>(dimension) + _offset->get(dimension);
 #else
     return this->_global_id[dimension] + (*_offset)[dimension];
 #endif
@@ -89,7 +90,7 @@ struct nd_item
 
   [[deprecated]]
   HIPSYCL_KERNEL_TARGET
-  id<dimensions> get_global() const
+  id<Dimensions> get_global() const
   {
     return this->get_global_id();
   }
@@ -97,10 +98,10 @@ struct nd_item
   HIPSYCL_KERNEL_TARGET
   size_t get_global_linear_id() const
   {
-    return detail::linear_id<dimensions>::get(get_global_id(), get_global_range());
+    return detail::linear_id<Dimensions>::get(get_global_id(), get_global_range());
   }
 
-  HIPSYCL_KERNEL_TARGET friend bool operator ==(const nd_item<dimensions>& lhs, const nd_item<dimensions>& rhs)
+  HIPSYCL_KERNEL_TARGET friend bool operator ==(const nd_item<Dimensions>& lhs, const nd_item<Dimensions>& rhs)
   {
     #if defined(HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO)
       return  lhs._offset == rhs._offset;
@@ -114,14 +115,14 @@ struct nd_item
     #endif
   }
 
-  HIPSYCL_KERNEL_TARGET friend bool operator !=(const nd_item<dimensions>& lhs, const nd_item<dimensions>& rhs)
+  HIPSYCL_KERNEL_TARGET friend bool operator !=(const nd_item<Dimensions>& lhs, const nd_item<Dimensions>& rhs)
   {
     return !(lhs==rhs);
   }
 
   [[deprecated]]
   HIPSYCL_KERNEL_TARGET
-  id<dimensions> get_local() const
+  id<Dimensions> get_local() const
   {
     return this->get_local_id();
   }
@@ -137,17 +138,17 @@ struct nd_item
   size_t get_local_id(int dimension) const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_local_id<dimensions>(dimension);
+    return detail::get_local_id<Dimensions>(dimension);
 #else
     return this->_local_id[dimension];
 #endif
   }
 
   HIPSYCL_KERNEL_TARGET
-  id<dimensions> get_local_id() const
+  id<Dimensions> get_local_id() const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_local_id<dimensions>();
+    return detail::get_local_id<Dimensions>();
 #else
     return this->_local_id;
 #endif
@@ -156,16 +157,16 @@ struct nd_item
   HIPSYCL_KERNEL_TARGET
   size_t get_local_linear_id() const
   {
-    return detail::linear_id<dimensions>::get(get_local_id(), get_local_range());
+    return detail::linear_id<Dimensions>::get(get_local_id(), get_local_range());
   }
 
   HIPSYCL_KERNEL_TARGET
-  group<dimensions> get_group() const
+  group<Dimensions> get_group() const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return group<dimensions>{};
+    return group<Dimensions>{};
 #else
-    return group<dimensions>{
+    return group<Dimensions>{
         _group_id,
         _local_range,
         _num_groups,
@@ -179,7 +180,7 @@ struct nd_item
   size_t get_group(int dimension) const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_group_id<dimensions>(dimension);
+    return detail::get_group_id<Dimensions>(dimension);
 #else
     return this->_group_id[dimension];
 #endif
@@ -189,10 +190,10 @@ struct nd_item
   size_t get_group_linear_id() const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::linear_id<dimensions>::get(detail::get_group_id<dimensions>(),
-                                              detail::get_grid_size<dimensions>());
+    return detail::linear_id<Dimensions>::get(detail::get_group_id<Dimensions>(),
+                                              detail::get_grid_size<Dimensions>());
 #else
-    return detail::linear_id<dimensions>::get(this->_group_id, this->_num_groups);
+    return detail::linear_id<Dimensions>::get(this->_group_id, this->_num_groups);
 #endif
   }
 
@@ -203,10 +204,10 @@ struct nd_item
   }
 
   HIPSYCL_KERNEL_TARGET
-  range<dimensions> get_global_range() const
+  range<Dimensions> get_global_range() const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_global_size<dimensions>();
+    return detail::get_global_size<Dimensions>();
 #else
     return this->_num_groups * this->_local_range;
 #endif
@@ -216,17 +217,17 @@ struct nd_item
   size_t get_global_range(int dimension) const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_global_size<dimensions>(dimension);
+    return detail::get_global_size<Dimensions>(dimension);
 #else
     return this->_num_groups[dimension] * this->_local_range[dimension];
 #endif
   }
 
   HIPSYCL_KERNEL_TARGET
-  range<dimensions> get_local_range() const
+  range<Dimensions> get_local_range() const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_local_size<dimensions>();
+    return detail::get_local_size<Dimensions>();
 #else
     return this->_local_range;
 #endif
@@ -236,17 +237,17 @@ struct nd_item
   size_t get_local_range(int dimension) const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_local_size<dimensions>(dimension);
+    return detail::get_local_size<Dimensions>(dimension);
 #else
     return this->_local_range[dimension];
 #endif
   }
   
   HIPSYCL_KERNEL_TARGET
-  range<dimensions> get_group_range() const
+  range<Dimensions> get_group_range() const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_grid_size<dimensions>();
+    return detail::get_grid_size<Dimensions>();
 #else
     return this->_num_groups;
 #endif
@@ -256,27 +257,27 @@ struct nd_item
   size_t get_group_range(int dimension) const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_grid_size<dimensions>(dimension);
+    return detail::get_grid_size<Dimensions>(dimension);
 #else
     return this->_num_groups[dimension];
 #endif
   }
 
   HIPSYCL_KERNEL_TARGET
-  id<dimensions> get_offset() const
+  id<Dimensions> get_offset() const
   {
     return *_offset;
   }
 
   HIPSYCL_KERNEL_TARGET
-  nd_range<dimensions> get_nd_range() const
+  nd_range<Dimensions> get_nd_range() const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return nd_range<dimensions>{detail::get_global_size<dimensions>(),
-                                detail::get_local_size<dimensions>(),
+    return nd_range<Dimensions>{detail::get_global_size<Dimensions>(),
+                                detail::get_local_size<Dimensions>(),
                                 get_offset()};
 #else
-    return nd_range<dimensions>{
+    return nd_range<Dimensions>{
       this->_num_groups * this->_local_range,
       this->_local_range,
       this->get_offset()
@@ -349,14 +350,14 @@ struct nd_item
   
 #if defined(HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO)
   HIPSYCL_KERNEL_TARGET
-  nd_item(const id<dimensions>* offset)
+  nd_item(const id<Dimensions>* offset)
     : _offset{offset}
   {}
 #else
   HIPSYCL_KERNEL_TARGET
-  nd_item(const id<dimensions>* offset,
-          id<dimensions> group_id, id<dimensions> local_id, 
-          range<dimensions> local_range, range<dimensions> num_groups,
+  nd_item(const id<Dimensions>* offset,
+          id<Dimensions> group_id, id<Dimensions> local_id, 
+          range<Dimensions> local_range, range<Dimensions> num_groups,
           detail::host_barrier_type* host_group_barrier = nullptr,
           void* local_memory_ptr = nullptr)
     : _offset{offset}, 
@@ -374,14 +375,14 @@ struct nd_item
 #endif
 
 private:
-  const id<dimensions>* _offset;
+  const id<Dimensions>* _offset;
 
 #if !defined(HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO)
-  const id<dimensions> _group_id;
-  const id<dimensions> _local_id;
-  const range<dimensions> _local_range;
-  const range<dimensions> _num_groups;
-  const id<dimensions> _global_id;
+  const id<Dimensions> _group_id;
+  const id<Dimensions> _local_id;
+  const range<Dimensions> _local_range;
+  const range<Dimensions> _num_groups;
+  const id<Dimensions> _global_id;
   void *_local_memory_ptr;
 #endif
 

--- a/include/hipSYCL/sycl/libkernel/nd_range.hpp
+++ b/include/hipSYCL/sycl/libkernel/nd_range.hpp
@@ -35,14 +35,14 @@
 namespace hipsycl {
 namespace sycl {
 
-template<int dimensions = 1>
-struct nd_range
-{
+template<int Dimensions = 1>
+struct nd_range {
+  static constexpr int dimensions = Dimensions;
 
   HIPSYCL_UNIVERSAL_TARGET
-  nd_range(range<dimensions> globalSize,
-           range<dimensions> localSize,
-           id<dimensions> offset = id<dimensions>())
+  nd_range(range<Dimensions> globalSize,
+           range<Dimensions> localSize,
+           id<Dimensions> offset = id<Dimensions>())
     : _global_range{globalSize},
       _local_range{localSize},
       _num_groups{globalSize / localSize},
@@ -50,34 +50,34 @@ struct nd_range
   {}
 
   HIPSYCL_UNIVERSAL_TARGET
-  range<dimensions> get_global() const
+  range<Dimensions> get_global() const
   { return _global_range; }
 
   HIPSYCL_UNIVERSAL_TARGET
-  range<dimensions> get_global_range() const
+  range<Dimensions> get_global_range() const
   { return get_global(); }
 
   HIPSYCL_UNIVERSAL_TARGET
-  range<dimensions> get_local() const
+  range<Dimensions> get_local() const
   { return _local_range; }
 
   HIPSYCL_UNIVERSAL_TARGET
-  range<dimensions> get_local_range() const
+  range<Dimensions> get_local_range() const
   { return get_local(); }
 
   HIPSYCL_UNIVERSAL_TARGET
-  range<dimensions> get_group() const
+  range<Dimensions> get_group() const
   { return _num_groups; }
 
   HIPSYCL_UNIVERSAL_TARGET
-  range<dimensions> get_group_range() const
+  range<Dimensions> get_group_range() const
   { return get_group(); }
 
   HIPSYCL_UNIVERSAL_TARGET
-  id<dimensions> get_offset() const
+  id<Dimensions> get_offset() const
   { return _offset; }
   
-  friend bool operator==(const nd_range<dimensions>& lhs, const nd_range<dimensions>& rhs)
+  friend bool operator==(const nd_range<Dimensions>& lhs, const nd_range<Dimensions>& rhs)
   {
     return lhs._global_range == rhs._global_range &&
            lhs._local_range == rhs._local_range &&
@@ -85,15 +85,15 @@ struct nd_range
            lhs._offset == rhs._offset;
   }
 
-  friend bool operator!=(const nd_range<dimensions>& lhs, const nd_range<dimensions>& rhs){
+  friend bool operator!=(const nd_range<Dimensions>& lhs, const nd_range<Dimensions>& rhs){
     return !(lhs == rhs);
   }
 
 private:
-  range<dimensions> _global_range;
-  range<dimensions> _local_range;
-  range<dimensions> _num_groups;
-  id<dimensions> _offset;
+  range<Dimensions> _global_range;
+  range<Dimensions> _local_range;
+  range<Dimensions> _num_groups;
+  id<Dimensions> _offset;
 };
 
 

--- a/include/hipSYCL/sycl/libkernel/range.hpp
+++ b/include/hipSYCL/sycl/libkernel/range.hpp
@@ -40,17 +40,19 @@
 namespace hipsycl {
 namespace sycl {
 
-template <int dimensions = 1>
+template <int Dimensions = 1>
 class range {
 public:
+  static constexpr int dimensions = Dimensions;
+
   HIPSYCL_UNIVERSAL_TARGET
   range()
     : _data{}
   {}
 
   /* The following constructor is only available in the range class specialization where:
-dimensions==1 */
-  template<int D = dimensions,
+Dimensions==1 */
+  template<int D = Dimensions,
            typename = std::enable_if_t<D == 1>>
   HIPSYCL_UNIVERSAL_TARGET
   range(size_t dim0)
@@ -58,8 +60,8 @@ dimensions==1 */
   {}
 
   /* The following constructor is only available in the range class specialization where:
-dimensions==2 */
-  template<int D = dimensions,
+Dimensions==2 */
+  template<int D = Dimensions,
            typename = std::enable_if_t<D == 2>>
   HIPSYCL_UNIVERSAL_TARGET
   range(size_t dim0, size_t dim1)
@@ -67,8 +69,8 @@ dimensions==2 */
   {}
 
   /* The following constructor is only available in the range class specialization where:
-dimensions==3 */
-  template<int D = dimensions,
+Dimensions==3 */
+  template<int D = Dimensions,
            typename = std::enable_if_t<D == 3>>
   HIPSYCL_UNIVERSAL_TARGET
   range(size_t dim0, size_t dim1, size_t dim2)
@@ -77,11 +79,11 @@ dimensions==3 */
 
   /* -- common interface members -- */
 
-  friend bool operator==(const range<dimensions>& lhs, const range<dimensions>& rhs){
+  friend bool operator==(const range<Dimensions>& lhs, const range<Dimensions>& rhs){
     return lhs._data == rhs._data;
   }
 
-  friend bool operator!=(const range<dimensions>& lhs, const range<dimensions>& rhs){
+  friend bool operator!=(const range<Dimensions>& lhs, const range<Dimensions>& rhs){
     return !(lhs == rhs);
   }
 
@@ -104,21 +106,21 @@ dimensions==3 */
   size_t size() const {
     // loop peel to help uniformity analysis
     size_t result = _data[0];
-    for(int i = 1; i < dimensions; ++i)
+    for(int i = 1; i < Dimensions; ++i)
       result *= _data[i];
     return result;
   }
 
-  // Implementation of id<dimensions> operatorOP(const size_t &rhs) const;
+  // Implementation of id<Dimensions> operatorOP(const size_t &rhs) const;
   // OP is: +, -, *, /, %, <<, >>, &, |, ˆ, &&, ||, <, >, <=, >=
 #define HIPSYCL_RANGE_BINARY_OP_OUT_OF_PLACE(op) \
   HIPSYCL_UNIVERSAL_TARGET \
-  friend range<dimensions> operator op(const range<dimensions> &lhs, \
-                                       const range<dimensions> &rhs) { \
+  friend range<Dimensions> operator op(const range<Dimensions> &lhs, \
+                                       const range<Dimensions> &rhs) { \
     /* loop peel to help uniformity analysis */ \
-    range<dimensions> result; \
+    range<Dimensions> result; \
     result._data[0] = static_cast<std::size_t>(lhs._data[0] op rhs._data[0]); \
-    for(std::size_t i = 1; i < dimensions; ++i) \
+    for(std::size_t i = 1; i < Dimensions; ++i) \
       result._data[i] = static_cast<std::size_t>(lhs._data[i] op rhs._data[i]); \
     return result; \
   }
@@ -142,12 +144,12 @@ dimensions==3 */
 
 #define HIPSYCL_RANGE_BINARY_OP_OUT_OF_PLACE_SIZE_T(op) \
   HIPSYCL_UNIVERSAL_TARGET \
-  friend range<dimensions> operator op(const range<dimensions> &lhs, \
+  friend range<Dimensions> operator op(const range<Dimensions> &lhs, \
                                        const std::size_t &rhs) { \
     /* loop peel to help uniformity analysis */ \
-    range<dimensions> result; \
+    range<Dimensions> result; \
     result._data[0] = static_cast<std::size_t>(lhs._data[0] op rhs); \
-    for(std::size_t i = 1; i < dimensions; ++i) \
+    for(std::size_t i = 1; i < Dimensions; ++i) \
       result._data[i] = static_cast<std::size_t>(lhs._data[i] op rhs); \
     return result; \
   }
@@ -170,15 +172,15 @@ dimensions==3 */
   HIPSYCL_RANGE_BINARY_OP_OUT_OF_PLACE_SIZE_T(>=)
 
 
-  // Implementation of id<dimensions> &operatorOP(const id<dimensions> &rhs);
+  // Implementation of id<Dimensions> &operatorOP(const id<Dimensions> &rhs);
   // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ˆ=
 #define HIPSYCL_RANGE_BINARY_OP_IN_PLACE(op) \
   HIPSYCL_UNIVERSAL_TARGET \
-  friend range<dimensions>& operator op(range<dimensions> &lhs, \
-                                 const range<dimensions> &rhs) { \
+  friend range<Dimensions>& operator op(range<Dimensions> &lhs, \
+                                 const range<Dimensions> &rhs) { \
     /* loop peel to help uniformity analysis */ \
     lhs._data[0] op rhs._data[0]; \
-    for(std::size_t i = 1; i < dimensions; ++i) \
+    for(std::size_t i = 1; i < Dimensions; ++i) \
       lhs._data[i] op rhs._data[i]; \
     return lhs; \
   }
@@ -196,10 +198,10 @@ dimensions==3 */
 
 #define HIPSYCL_RANGE_BINARY_OP_IN_PLACE_SIZE_T(op) \
   HIPSYCL_UNIVERSAL_TARGET \
-  friend range<dimensions>& operator op(range<dimensions> &lhs, const std::size_t &rhs) { \
+  friend range<Dimensions>& operator op(range<Dimensions> &lhs, const std::size_t &rhs) { \
     /* loop peel to help uniformity analysis */ \
     lhs._data[0] op rhs; \
-    for(std::size_t i = 1; i < dimensions; ++i) \
+    for(std::size_t i = 1; i < Dimensions; ++i) \
       lhs._data[i] op rhs; \
     return lhs; \
   }
@@ -218,11 +220,11 @@ dimensions==3 */
 
   #define HIPSYCL_RANGE_BINARY_OP_SIZE_T(op) \
   HIPSYCL_UNIVERSAL_TARGET \
-  friend range<dimensions> operator op(const std::size_t &lhs, const range<dimensions> &rhs) { \
+  friend range<Dimensions> operator op(const std::size_t &lhs, const range<Dimensions> &rhs) { \
     /* loop peel to help uniformity analysis */ \
-    range<dimensions> result; \
+    range<Dimensions> result; \
     result[0] = lhs op rhs[0]; \
-    for(std::size_t i = 1; i < dimensions; ++i) \
+    for(std::size_t i = 1; i < Dimensions; ++i) \
       result[i] = lhs op rhs[i]; \
     return result; \
   }
@@ -240,7 +242,7 @@ dimensions==3 */
   HIPSYCL_RANGE_BINARY_OP_SIZE_T(^)
 
 private:
-  detail::device_array<size_t, dimensions> _data;
+  detail::device_array<size_t, Dimensions> _data;
 
 };
 

--- a/include/hipSYCL/sycl/libkernel/sp_item.hpp
+++ b/include/hipSYCL/sycl/libkernel/sp_item.hpp
@@ -46,6 +46,7 @@ class sp_item
                sycl::range<D> global_range) noexcept;
 
 public:
+  static constexpr int dimensions = Dim;
 
   HIPSYCL_KERNEL_TARGET
   sycl::range<Dim> get_global_range() const noexcept {


### PR DESCRIPTION
In the newest revision of the SYCL 2020 spec, a `static constexpr int dimensions` member was added to a few classes to expose their `Dimensions` template parameter. In our case, the template parameter was typically lowercase, so I had to change it to `Dimensions` (with an uppercase D). I also changed it to uppercase in place where it wasn't strictly necessary (for instance in forward declarations) just to make the names of the template parameters consistent.