### PR TITLE
[SSCP] Fix S2 compilation for globals without initializer

### DIFF
--- a/include/hipSYCL/compiler/llvm-to-backend/AddressSpaceMap.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/AddressSpaceMap.hpp
@@ -44,7 +44,8 @@ enum class AddressSpace {
   Private = 3,
   Constant = 4,
   AllocaDefault = 5,
-  GlobalVariableDefault = 6
+  GlobalVariableDefault = 6,
+  ConstantGlobalVariableDefault = 7
 };
 
 class AddressSpaceMap {
@@ -55,7 +56,8 @@ public:
   }
 
   AddressSpaceMap(unsigned GenericAS, unsigned GlobalAS, unsigned LocalAS, unsigned PrivateAS,
-                  unsigned ConstantAS, unsigned AllocaDefaultAS, unsigned GlobalVariableDefaultAS) {
+                  unsigned ConstantAS, unsigned AllocaDefaultAS, unsigned GlobalVariableDefaultAS,
+                  unsigned ConstantGlobalVariableDefaultAS) {
     (*this)[AddressSpace::Generic] = GenericAS;
     (*this)[AddressSpace::Global] = GlobalAS;
     (*this)[AddressSpace::Local] = LocalAS;
@@ -63,11 +65,13 @@ public:
     (*this)[AddressSpace::Constant] = ConstantAS;
     (*this)[AddressSpace::AllocaDefault] = AllocaDefaultAS;
     (*this)[AddressSpace::GlobalVariableDefault] = GlobalVariableDefaultAS;
+    (*this)[AddressSpace::ConstantGlobalVariableDefault] = ConstantGlobalVariableDefaultAS;
   }
 
   AddressSpaceMap(unsigned GenericAS, unsigned GlobalAS, unsigned LocalAS, unsigned PrivateAS,
                   unsigned ConstantAS)
-      : AddressSpaceMap{GenericAS, GlobalAS, LocalAS, PrivateAS, ConstantAS, PrivateAS, GlobalAS} {}
+      : AddressSpaceMap{GenericAS,  GlobalAS,  LocalAS,  PrivateAS,
+                        ConstantAS, PrivateAS, GlobalAS, ConstantAS} {}
 
   unsigned operator[](AddressSpace AS) const {
     return ASMap[static_cast<unsigned>(AS)];
@@ -77,7 +81,7 @@ public:
     return ASMap[static_cast<unsigned>(AS)];
   }
 private:
-  std::array<unsigned, 7> ASMap;
+  std::array<unsigned, 8> ASMap;
 };
 
 }

--- a/src/compiler/llvm-to-backend/AddressSpaceInferencePass.cpp
+++ b/src/compiler/llvm-to-backend/AddressSpaceInferencePass.cpp
@@ -84,11 +84,17 @@ llvm::GlobalVariable *setGlobalVariableAddressSpace(llvm::Module &M, llvm::Globa
   std::string VarName {GV->getName()};
   GV->setName(VarName+".original");
 
-  llvm::GlobalVariable *NewVar = new llvm::GlobalVariable(
-      M, GV->getInitializer()->getType(), GV->isConstant(), GV->getLinkage(), GV->getInitializer(), VarName, nullptr,
-      GV->getThreadLocalMode(), AS);
-  NewVar->setAlignment(GV->getAlign());
+  llvm::Constant* Initalizer = nullptr;
+  
+  if(GV->hasInitializer()) {
+    Initalizer = GV->getInitializer();
+  }
 
+  llvm::GlobalVariable* NewVar = new llvm::GlobalVariable(
+      M, GV->getValueType(), GV->isConstant(), GV->getLinkage(), Initalizer, VarName, nullptr,
+      GV->getThreadLocalMode(), AS);
+  
+  NewVar->setAlignment(GV->getAlign());
   llvm::Value *V = llvm::ConstantExpr::getPointerCast(NewVar, GV->getType());
 
   GV->replaceAllUsesWith(V);

--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -353,6 +353,7 @@ AddressSpaceMap LLVMToAmdgpuTranslator::getAddressSpaceMap() const {
   ASMap[AddressSpace::Constant] = 4;
   ASMap[AddressSpace::AllocaDefault] = 5;
   ASMap[AddressSpace::GlobalVariableDefault] = 1;
+  ASMap[AddressSpace::ConstantGlobalVariableDefault] = 4;
 
   return ASMap;
 }

--- a/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
+++ b/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
@@ -267,6 +267,7 @@ AddressSpaceMap LLVMToPtxTranslator::getAddressSpaceMap() const {
   // NVVM wants to have allocas in address space 0
   ASMap[AddressSpace::AllocaDefault] = 0;
   ASMap[AddressSpace::GlobalVariableDefault] = 1;
+  ASMap[AddressSpace::ConstantGlobalVariableDefault] = 4;
 
   return ASMap;
 }

--- a/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
+++ b/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
@@ -317,6 +317,9 @@ AddressSpaceMap LLVMToSpirvTranslator::getAddressSpaceMap() const {
   ASMap[AddressSpace::Constant] = 2;
   ASMap[AddressSpace::AllocaDefault] = 4;
   ASMap[AddressSpace::GlobalVariableDefault] = 1;
+  // we cannot put constant globals into constant AS because
+  // llvm-spirv translator does not allow AS cast from constant to generic
+  ASMap[AddressSpace::ConstantGlobalVariableDefault] = 1;
 
   return ASMap;
 }


### PR DESCRIPTION
* Handle case when globals do not have an initializer
* On SPIR-V, don't attempt to put constant globals into constant address space, because llvm-spirv translator does not allow address space casts from constant AS back to generic.