### PR TITLE
[L0] Resolve API failures for USM pointer queries

### DIFF
--- a/src/runtime/ze/ze_allocator.cpp
+++ b/src/runtime/ze/ze_allocator.cpp
@@ -135,6 +135,8 @@ bool ze_allocator::is_usm_accessible_from(backend_descriptor b) const {
 result ze_allocator::query_pointer(const void* ptr, pointer_info& out) const {
 
   ze_memory_allocation_properties_t props;
+  props.pNext = nullptr;
+
   ze_device_handle_t dev;
 
   ze_result_t err = zeMemGetAllocProperties(_ctx, ptr, &props, &dev);


### PR DESCRIPTION
The `ze_memory_allocation_properties_t` argument of `zeMemGetAllocProperties()` is not only an output argument, but also used by the Level Zero API as input, particularly to define the extensions that should be queried as well.

Previously, the extension pointer was not set to null, causing UB inside Level Zero as well as failure codes returned from `zeMemGetAllocProperties()`.  Since USM pointer queries are also internally used for the implementation of `queue/handler::memcpy()`, this could cause memory transfers being dispatched to the wrong backend, or in the wrong mode. This in turn can potentially crash any application working with USM device allocations.

This PR fixes all these issues by properly initializing the `ze_memory_allocation_properties_t` struct.