### PR TITLE
[SSCP] Fix SSCP issues for LLVM 17

### DIFF
--- a/include/hipSYCL/compiler/Frontend.hpp
+++ b/include/hipSYCL/compiler/Frontend.hpp
@@ -484,12 +484,14 @@ private:
 
     // Need to iterate over all attributes to support the case
     // where multiple annotate attributes are present.
-    for(auto* Attr : f->getAttrs()) {
-      if(auto* AAttr = clang::dyn_cast<clang::AnnotateAttr>(Attr)) {
-        if (AAttr->getAnnotation() == "hipsycl_nd_kernel") {
-          markAsNDKernel(f);
-        } else if (AAttr->getAnnotation() == "hipsycl_sscp_outlining") {
-          markAsSSCPOutliningEntrypoint(f);
+    if(f->hasAttrs()) {
+      for(auto* Attr : f->getAttrs()) {
+        if(auto* AAttr = clang::dyn_cast<clang::AnnotateAttr>(Attr)) {
+          if (AAttr->getAnnotation() == "hipsycl_nd_kernel") {
+            markAsNDKernel(f);
+          } else if (AAttr->getAnnotation() == "hipsycl_sscp_outlining") {
+            markAsSSCPOutliningEntrypoint(f);
+          }
         }
       }
     }

--- a/include/hipSYCL/compiler/GlobalsPruningPass.hpp
+++ b/include/hipSYCL/compiler/GlobalsPruningPass.hpp
@@ -36,7 +36,6 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/Transforms/IPO/PassManagerBuilder.h"
 
 #include "CompilationState.hpp"
 

--- a/include/hipSYCL/compiler/cbs/SyncDependenceAnalysis.hpp
+++ b/include/hipSYCL/compiler/cbs/SyncDependenceAnalysis.hpp
@@ -20,14 +20,14 @@
 
 #include <llvm/Config/llvm-config.h>
 
-#if LLVM_VERSION_MAJOR < 12
+#if LLVM_VERSION_MAJOR < 12 || LLVM_VERSION_MAJOR >= 17
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Analysis/LoopInfo.h"
 #include <memory>
-#include <unordered_map>
+#include <map>
 
 namespace llvm {
 

--- a/include/hipSYCL/compiler/cbs/UniformityAnalysis.hpp
+++ b/include/hipSYCL/compiler/cbs/UniformityAnalysis.hpp
@@ -33,7 +33,8 @@
 #include "llvm/Support/GenericDomTree.h"
 #include "llvm/Support/raw_ostream.h"
 
-#if LLVM_VERSION_MAJOR < 12
+// Todo: for LLVM >= 17, we probably want to use the llvm::UniformityAnalysis at some point..
+#if LLVM_VERSION_MAJOR < 12 || LLVM_VERSION_MAJOR >= 17
 #include "SyncDependenceAnalysis.hpp"
 #else
 #include "llvm/Analysis/SyncDependenceAnalysis.h"
@@ -49,7 +50,7 @@ class LoopInfo;
 }
 
 namespace hipsycl::compiler {
-#if LLVM_VERSION_MAJOR < 12
+#if LLVM_VERSION_MAJOR < 12 || LLVM_VERSION_MAJOR >= 17
 using SDAnalysis = pre_llvm12_compat::SyncDependenceAnalysis;
 #else
 using SDAnalysis = llvm::SyncDependenceAnalysis;

--- a/include/hipSYCL/compiler/sscp/IRConstantReplacer.hpp
+++ b/include/hipSYCL/compiler/sscp/IRConstantReplacer.hpp
@@ -208,7 +208,7 @@ public:
 
   template<class F>
   static void forEachS2IRConstant(llvm::Module& M, F&& Handler) {
-    for(auto& V : M.getGlobalList()) {
+    for(auto& V : M.globals()) {
       llvm::StringRef Name = V.getName();
       if (isS2IRConstantName(Name)) {
         Handler(S2IRConstant{M, V});
@@ -217,7 +217,7 @@ public:
   }
 
   static S2IRConstant getFromConstantName(llvm::Module& M, const std::string& IrConstantName) {
-    for(auto& V: M.getGlobalList()) {
+    for(auto& V: M.globals()) {
       llvm::StringRef Name = V.getName();
       if(isS2IRConstantName(Name)) {
         if(Name.contains(IrConstantName))
@@ -228,7 +228,7 @@ public:
   }
 
   static S2IRConstant getFromFullName(llvm::Module& M, const std::string& FullName) {
-    for(auto& V : M.getGlobalList()) {
+    for(auto& V : M.globals()) {
       llvm::StringRef Name = V.getName();
       if(Name == FullName)
         return S2IRConstant{M, V};

--- a/include/hipSYCL/sycl/libkernel/cuda/cuda_backend.hpp
+++ b/include/hipSYCL/sycl/libkernel/cuda/cuda_backend.hpp
@@ -49,7 +49,8 @@
  #define HIPSYCL_LIBKERNEL_COMPILER_SUPPORTS_CUDA 0
 #endif
 
-#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ != 0) \
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ != 0 \
+  && !defined(HIPSYCL_SSCP_LIBKERNEL_LIBRARY)) \
   || defined(HIPSYCL_LIBKERNEL_CUDA_NVCXX)
 
  #define HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_CUDA 1

--- a/include/hipSYCL/sycl/libkernel/detail/fp16/bitcasts.h
+++ b/include/hipSYCL/sycl/libkernel/detail/fp16/bitcasts.h
@@ -12,7 +12,7 @@ HIPSYCL_UNIVERSAL_TARGET // So that CUDA calls are possible
 static inline float fp32_from_bits(__hipsycl_uint32 w) {
 #if defined(__OPENCL_VERSION__)
 	return as_float(w);
-#elif HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_CUDA == 1
+#elif HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_CUDA == 1 && !defined(HIPSYCL_LIBKERNEL_CUDA_NVCXX)
 	return __uint_as_float((unsigned int) w);
 #elif defined(__INTEL_COMPILER)
 	return _castu32_f32(w);
@@ -31,7 +31,7 @@ HIPSYCL_UNIVERSAL_TARGET // So that CUDA calls are possible
 static inline __hipsycl_uint32 fp32_to_bits(float f) {
 #if defined(__OPENCL_VERSION__)
 	return as_uint(f);
-#elif HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_CUDA == 1
+#elif HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_CUDA == 1 && !defined(HIPSYCL_LIBKERNEL_CUDA_NVCXX)
 	return (__hipsycl_uint32) __float_as_uint(f);
 #elif defined(__INTEL_COMPILER)
 	return _castf32_u32(f);
@@ -50,7 +50,7 @@ HIPSYCL_UNIVERSAL_TARGET // So that CUDA calls are possible
 static inline double fp64_from_bits(__hipsycl_uint64 w) {
 #if defined(__OPENCL_VERSION__)
 	return as_double(w);
-#elif HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_CUDA == 1
+#elif HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_CUDA == 1 && !defined(HIPSYCL_LIBKERNEL_CUDA_NVCXX)
 	return __longlong_as_double((long long) w);
 #elif defined(__INTEL_COMPILER)
 	return _castu64_f64(w);
@@ -69,7 +69,7 @@ HIPSYCL_UNIVERSAL_TARGET // So that CUDA calls are possible
 static inline __hipsycl_uint64 fp64_to_bits(double f) {
 #if defined(__OPENCL_VERSION__)
 	return as_ulong(f);
-#elif HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_CUDA == 1
+#elif HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_CUDA == 1 && !defined(HIPSYCL_LIBKERNEL_CUDA_NVCXX)
 	return (__hipsycl_uint64) __double_as_longlong(f);
 #elif defined(__INTEL_COMPILER)
 	return _castf64_u64(f);

--- a/include/hipSYCL/sycl/libkernel/detail/fp16/bitcasts.h
+++ b/include/hipSYCL/sycl/libkernel/detail/fp16/bitcasts.h
@@ -12,7 +12,7 @@ HIPSYCL_UNIVERSAL_TARGET // So that CUDA calls are possible
 static inline float fp32_from_bits(__hipsycl_uint32 w) {
 #if defined(__OPENCL_VERSION__)
 	return as_float(w);
-#elif defined(__CUDA_ARCH__)
+#elif HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_CUDA == 1
 	return __uint_as_float((unsigned int) w);
 #elif defined(__INTEL_COMPILER)
 	return _castu32_f32(w);
@@ -31,7 +31,7 @@ HIPSYCL_UNIVERSAL_TARGET // So that CUDA calls are possible
 static inline __hipsycl_uint32 fp32_to_bits(float f) {
 #if defined(__OPENCL_VERSION__)
 	return as_uint(f);
-#elif defined(__CUDA_ARCH__)
+#elif HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_CUDA == 1
 	return (__hipsycl_uint32) __float_as_uint(f);
 #elif defined(__INTEL_COMPILER)
 	return _castf32_u32(f);
@@ -50,7 +50,7 @@ HIPSYCL_UNIVERSAL_TARGET // So that CUDA calls are possible
 static inline double fp64_from_bits(__hipsycl_uint64 w) {
 #if defined(__OPENCL_VERSION__)
 	return as_double(w);
-#elif defined(__CUDA_ARCH__)
+#elif HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_CUDA == 1
 	return __longlong_as_double((long long) w);
 #elif defined(__INTEL_COMPILER)
 	return _castu64_f64(w);
@@ -69,7 +69,7 @@ HIPSYCL_UNIVERSAL_TARGET // So that CUDA calls are possible
 static inline __hipsycl_uint64 fp64_to_bits(double f) {
 #if defined(__OPENCL_VERSION__)
 	return as_ulong(f);
-#elif defined(__CUDA_ARCH__)
+#elif HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_CUDA == 1
 	return (__hipsycl_uint64) __double_as_longlong(f);
 #elif defined(__INTEL_COMPILER)
 	return _castf64_u64(f);

--- a/include/hipSYCL/sycl/libkernel/detail/fp16/bitcasts.h
+++ b/include/hipSYCL/sycl/libkernel/detail/fp16/bitcasts.h
@@ -1,9 +1,6 @@
 #pragma once
-#ifndef FP16_BITCASTS_H
-#define FP16_BITCASTS_H
-#include "hipSYCL/sycl/libkernel/host/host_backend.hpp"
-#include "hipSYCL/sycl/libkernel/detail/int_types.hpp"
 #include "hipSYCL/sycl/libkernel/backend.hpp"
+#include "hipSYCL/sycl/libkernel/detail/int_types.hpp"
 
 namespace hipsycl::fp16 {
 
@@ -85,5 +82,3 @@ static inline __hipsycl_uint64 fp64_to_bits(double f) {
 }
 
 }
-
-#endif /* FP16_BITCASTS_H */

--- a/include/hipSYCL/sycl/libkernel/detail/fp16/bitcasts.h
+++ b/include/hipSYCL/sycl/libkernel/detail/fp16/bitcasts.h
@@ -1,7 +1,7 @@
 #pragma once
-#include "hipSYCL/sycl/libkernel/host/host_backend.hpp"
 #ifndef FP16_BITCASTS_H
 #define FP16_BITCASTS_H
+#include "hipSYCL/sycl/libkernel/host/host_backend.hpp"
 #include "hipSYCL/sycl/libkernel/detail/int_types.hpp"
 #include "hipSYCL/sycl/libkernel/backend.hpp"
 

--- a/include/hipSYCL/sycl/libkernel/detail/fp16/fp16.h
+++ b/include/hipSYCL/sycl/libkernel/detail/fp16/fp16.h
@@ -4,10 +4,6 @@
 // library in order to include more easily in device bitcode libraries.
 
 #pragma once
-#ifndef FP16_FP16_H
-#define FP16_FP16_H
-
-
 
 #include "bitcasts.h"
 #include "hipSYCL/sycl/libkernel/detail/int_types.hpp"
@@ -455,5 +451,3 @@ static inline __hipsycl_uint16 fp16_alt_from_fp32_value(float f) {
 }
 
 } // hipsycl::sycl::detail
-
-#endif /* FP16_FP16_H */

--- a/include/hipSYCL/sycl/libkernel/host/host_backend.hpp
+++ b/include/hipSYCL/sycl/libkernel/host/host_backend.hpp
@@ -29,7 +29,7 @@
 #ifndef HIPSYCL_LIBKERNEL_HOST_BACKEND_HPP
 #define HIPSYCL_LIBKERNEL_HOST_BACKEND_HPP
 
-// Aby C++ compiler can do that, so this should always work
+// Any C++ compiler can do that, so this should always work
 #define HIPSYCL_LIBKERNEL_COMPILER_SUPPORTS_HOST 1
 
 // We are in the "device pass" for the host target

--- a/include/hipSYCL/sycl/libkernel/sscp/sscp_backend.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/sscp_backend.hpp
@@ -35,8 +35,6 @@
 // path since SSCP outlining happens only in the host pass.
 #if defined(__HIPSYCL_ENABLE_LLVM_SSCP_TARGET__) &&                            \
     !defined(HIPSYCL_LIBKERNEL_DEVICE_PASS)
- #include "hipSYCL/glue/llvm-sscp/ir_constants.hpp"
- #include "builtins/core.hpp"
 
  #define HIPSYCL_LIBKERNEL_COMPILER_SUPPORTS_SSCP 1
  #define HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_SSCP 1
@@ -73,6 +71,9 @@
   #define HIPSYCL_HOST_TARGET
  #endif
 
+ #include "hipSYCL/glue/llvm-sscp/ir_constants.hpp"
+ #include "builtins/core.hpp"
+ 
 #else
  #define HIPSYCL_LIBKERNEL_COMPILER_SUPPORTS_SSCP 0
  #define HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_SSCP 0

--- a/src/compiler/OpenSYCLClangPlugin.cpp
+++ b/src/compiler/OpenSYCLClangPlugin.cpp
@@ -46,6 +46,9 @@
 #include "llvm/Passes/PassPlugin.h"
 #include "llvm/Support/CommandLine.h"
 
+#if LLVM_VERSION_MAJOR < 16
+#include "llvm/Transforms/IPO/PassManagerBuilder.h"
+#endif
 
 namespace hipsycl {
 namespace compiler {

--- a/src/compiler/cbs/SyncDependenceAnalysis.cpp
+++ b/src/compiler/cbs/SyncDependenceAnalysis.cpp
@@ -100,7 +100,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "hipSYCL/compiler/cbs/SyncDependenceAnalysis.hpp"
-#if LLVM_VERSION_MAJOR < 12
+#if LLVM_VERSION_MAJOR < 12 || LLVM_VERSION_MAJOR >= 17
 
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/ADT/SmallPtrSet.h"

--- a/src/compiler/llvm-to-backend/AddressSpaceInferencePass.cpp
+++ b/src/compiler/llvm-to-backend/AddressSpaceInferencePass.cpp
@@ -127,7 +127,7 @@ llvm::PreservedAnalyses AddressSpaceInferencePass::run(llvm::Module &M,
 
   // Fix global vars
   llvm::SmallVector<std::pair<llvm::GlobalVariable *, unsigned>> GlobalVarAddressSpaceChanges;
-  for(auto& G : M.getGlobalList()) {
+  for(auto& G : M.globals()) {
     unsigned CurrentAS = G.getAddressSpace();
     // By default, all global vars should go into global var default AS
     unsigned TargetAS = ASMap[AddressSpace::GlobalVariableDefault];

--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -108,7 +108,9 @@ if(WITH_SSCP_COMPILER)
       TOOL spirv/LLVMToSpirvTool.cpp)
 
     # Install LLVM-SPIRV translator for llvm-to-spirv
-    set(LLVMSPIRV_BRANCH llvm_release_${LLVM_VERSION_MAJOR}0)
+    if(NOT LLVMSPIRV_BRANCH)
+      set(LLVMSPIRV_BRANCH llvm_release_${LLVM_VERSION_MAJOR}0)
+    endif()
     set(LLVMSPIRV_RELATIVE_INSTALLDIR lib/hipSYCL/ext/llvm-spirv)
     set(LLVMSPIRV_INSTALLDIR ${CMAKE_INSTALL_PREFIX}/${LLVMSPIRV_RELATIVE_INSTALLDIR})
     set(LLVMSPIRV_PATH ${LLVMSPIRV_INSTALLDIR}/bin/llvm-spirv)

--- a/src/compiler/sscp/KernelOutliningPass.cpp
+++ b/src/compiler/sscp/KernelOutliningPass.cpp
@@ -289,7 +289,7 @@ KernelOutliningPass::run(llvm::Module &M, llvm::ModuleAnalysisManager &AM) {
   // them early on, because it can get difficult to handle them once
   // we have removed what their aliasees. 
   llvm::SmallVector<llvm::GlobalAlias*, 16> AliasesToRemove;
-  for(auto& A : M.getAliasList()) 
+  for(auto& A : M.aliases()) 
     AliasesToRemove.push_back(&A);    
   // Need separate iteration, so that we don't erase stuff from the list
   // we are iterating over.
@@ -349,7 +349,7 @@ KernelOutliningPass::run(llvm::Module &M, llvm::ModuleAnalysisManager &AM) {
   }
 
   llvm::SmallVector<llvm::GlobalVariable*, 16> UnneededGlobals;
-  for(auto& G: M.getGlobalList()) {
+  for(auto& G: M.globals()) {
     G.removeDeadConstantUsers();
     if(G.getNumUses() == 0)
       UnneededGlobals.push_back(&G);

--- a/src/compiler/sscp/TargetSeparationPass.cpp
+++ b/src/compiler/sscp/TargetSeparationPass.cpp
@@ -257,7 +257,7 @@ std::unique_ptr<llvm::Module> generateDeviceIR(llvm::Module &M,
   // SscpIsHostIdentifier can also be used in device code.
   S1IRConstantReplacer DeviceSideReplacer{
       {{SscpIsHostIdentifier, 0}, {SscpIsDeviceIdentifier, 1}},
-      {{SscpHcfContentIdentifier, 0 /* Dummy value */}, {SscpHcfObjectSizeIdentifier, 0}},
+      {{SscpHcfObjectIdIdentifier, 0 /* Dummy value */}, {SscpHcfObjectSizeIdentifier, 0}},
       {{SscpHcfContentIdentifier, std::string{}}}};
   DeviceSideReplacer.run(*DeviceModule, DeviceMAM);
 
@@ -284,6 +284,7 @@ std::unique_ptr<llvm::Module> generateDeviceIR(llvm::Module &M,
   AggregateArgumentExpansionPass KernelArgExpansionPass{EPP.getKernelNames()};
   KernelArgExpansionPass.run(*DeviceModule, DeviceMAM);
 
+  DeviceMAM.clear();
   if(!PreoptimizeSSCPKernels) {
     llvm::ModulePassManager MPM = PB.buildPerModuleDefaultPipeline(llvm::OptimizationLevel::O0);
     MPM.run(*DeviceModule, DeviceMAM);


### PR DESCRIPTION
* Fix initialization of IR constants as discussed in #1003 
* Fix potential UB in HostKernelNameExtractionPass, although that was probably not responsible for the S1 compiler crash in #1003
* Invalidate LLVM analysis cache in S1 compilation before invoking LLVM default pipelines. This is a bit hacky. Is there a better way of making things more reliable short of running everything through LLVM pass builder?

With this PR, I can compile the unit tests and run SSCP applications with LLVM 17. So far I've only tried S2 compilation on CUDA, so not sure if the AMD S2 crash reported in #1003 is already handled.

Depends on #1003.