### PR TITLE
[CI] Add GPU-based workflows & testing to CI

### DIFF
--- a/.github/workflows/linux-self-hosted.yml
+++ b/.github/workflows/linux-self-hosted.yml
@@ -9,6 +9,7 @@ jobs:
       matrix:
         clang_version: ['15']
         cuda: ['11.0']
+        nvhpc_version: ['22.11']
     steps:
     - uses: actions/checkout@v2
     - name: build
@@ -24,16 +25,40 @@ jobs:
         cd ${GITHUB_WORKSPACE}/build/tests-sscp
         cmake -DOPENSYCL_TARGETS="generic" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
         make -j16
-    - name: build CUDA tests
+    - name: build CUDA tests (integrated multipass)
       run: |
         mkdir ${GITHUB_WORKSPACE}/build/tests-cuda
         cd ${GITHUB_WORKSPACE}/build/tests-cuda
         cmake -DOPENSYCL_TARGETS="omp;cuda:sm_61" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
         make -j16
-    - name: run CUDA tests
+    - name build CUDA tests (explicit multipass)
+      run: |
+        mkdir ${GITHUB_WORKSPACE}/build/tests-cuda-emp
+        cd ${GITHUB_WORKSPACE}/build/tests-cuda-emp
+        cmake -DOPENSYCL_TARGETS="omp;cuda.explicit-multipass:sm_61;hip:gfx906" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
+        make -j16
+    - name build CUDA tests (nvc++)
+      run: |
+        mkdir ${GITHUB_WORKSPACE}/build/tests-cuda-nvcxx
+        cd ${GITHUB_WORKSPACE}/build/tests-cuda-nvcxx
+        export NV_HPC_SDK_ROOT=/opt/nvidia/hpc_sdk/Linux_x86_64/${{matrix.nvhpc_version}}
+        export OPENSYCL_NVCXX=${NV_HPC_SDK_ROOT}/compilers/bin/nvc++ 
+        cmake -DOPENSYCL_TARGETS="cuda-nvcxx" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
+        make -j16
+    - name: run CUDA tests (integrated multipass)
       run: |
         echo "Running tests on CUDA..."
         cd ${GITHUB_WORKSPACE}/build/tests-cuda
+        ./sycl_tests
+    - name: run CUDA tests (explicit multipass)
+      run: |
+        echo "Running tests on CUDA..."
+        cd ${GITHUB_WORKSPACE}/build/tests-cuda-emp
+        ./sycl_tests
+    - name: run CUDA tests (nvcxx)
+      run: |
+        echo "Running tests on CUDA..."
+        cd ${GITHUB_WORKSPACE}/build/tests-cuda-nvcxx
         ./sycl_tests
     - name: run CPU tests
       run: |

--- a/.github/workflows/linux-self-hosted.yml
+++ b/.github/workflows/linux-self-hosted.yml
@@ -1,0 +1,48 @@
+name: Linux GPU build and test
+
+jobs:
+  test-gpu-nvidia:
+    name: clang ${{ matrix.clang_version }}, CUDA ${{matrix.cuda}}
+    runs-on: [self-hosted, gpu-nvidia]
+    strategy:
+      matrix:
+        clang_version: ['15']
+        cuda: ['11.0']
+    steps:
+    - uses: actions/checkout@v2
+    - name: build
+      run : |
+        mkdir build && cd build
+        cmake -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.clang_version}} -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.clang_version}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.clang_version}}/cmake -DWITH_CUDA_BACKEND=ON -DWITH_ROCM_BACKEND=ON -DWITH_LEVEL_ZERO_BACKEND=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install -DCUDA_TOOLKIT_ROOT_DIR=/opt/cuda-${{matrix.cuda}} -DROCM_PATH=/opt/rocm -DCMAKE_INSTALL_REFIX=`pwd`/install ..
+        make -j16 install
+        cp /.singularity.d/libs/libcuda.* `pwd`/install/lib/
+    - name: build CPU tests
+      run: |
+        mkdir ${GITHUB_WORKSPACE}/build/tests-cpu
+        cd ${GITHUB_WORKSPACE}/build/tests-cpu
+        cmake -DOPENSYCL_TARGETS="omp" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
+        make -j2
+    - name: build generic SSCP tests
+      if: matrix.clang_version >= 14
+      run: |
+        mkdir ${GITHUB_WORKSPACE}/build/tests-sscp
+        cd ${GITHUB_WORKSPACE}/build/tests-sscp
+        cmake -DOPENSYCL_TARGETS="generic" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
+        make -j2
+    - name: build CUDA tests
+      run: |
+        mkdir ${GITHUB_WORKSPACE}/build/tests-cuda
+        cd ${GITHUB_WORKSPACE}/build/tests-cuda
+        cmake -DOPENSYCL_TARGETS="cuda:sm_61" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
+        make -j2
+    - name: run CUDA tests
+      run: |
+        echo "Running tests on CUDA..."
+        cd ${GITHUB_WORKSPACE}/build/tests-cuda
+        ./sycl_tests
+    - name: run CPU tests
+      run: |
+        cd ${GITHUB_WORKSPACE}/build/tests-cpu
+        LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ./sycl_tests
+    
+

--- a/.github/workflows/linux-self-hosted.yml
+++ b/.github/workflows/linux-self-hosted.yml
@@ -1,8 +1,9 @@
 name: Linux GPU build and test
 
+on: [push, pull_request]
 jobs:
   test-gpu-nvidia:
-    name: clang ${{ matrix.clang_version }}, CUDA ${{matrix.cuda}}
+    name: NVIDIA with clang ${{ matrix.clang_version }}, CUDA ${{matrix.cuda}}
     runs-on: [self-hosted, gpu-nvidia]
     strategy:
       matrix:
@@ -13,7 +14,7 @@ jobs:
     - name: build
       run : |
         mkdir build && cd build
-        cmake -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.clang_version}} -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.clang_version}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.clang_version}}/cmake -DWITH_CUDA_BACKEND=ON -DWITH_ROCM_BACKEND=ON -DWITH_LEVEL_ZERO_BACKEND=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install -DCUDA_TOOLKIT_ROOT_DIR=/opt/cuda-${{matrix.cuda}} -DROCM_PATH=/opt/rocm -DCMAKE_INSTALL_REFIX=`pwd`/install ..
+        cmake -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.clang_version}} -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.clang_version}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.clang_version}}/cmake -DWITH_CUDA_BACKEND=ON -DWITH_ROCM_BACKEND=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install -DCUDA_TOOLKIT_ROOT_DIR=/opt/cuda-${{matrix.cuda}} -DROCM_PATH=/opt/rocm -DCMAKE_INSTALL_REFIX=`pwd`/install ..
         make -j16 install
         cp /.singularity.d/libs/libcuda.* `pwd`/install/lib/
     - name: build CPU tests

--- a/.github/workflows/linux-self-hosted.yml
+++ b/.github/workflows/linux-self-hosted.yml
@@ -79,10 +79,12 @@ jobs:
     - name: build
       run : |
         mkdir build && cd build
-        cmake -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.clang_version}} -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.clang_version}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.clang_version}}/cmake -DWITH_CUDA_BACKEND=ON -DWITH_ROCM_BACKEND=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install -DCUDA_TOOLKIT_ROOT_DIR=/opt/cuda-${{matrix.cuda}} -DROCM_PATH=/opt/rocm -DCMAKE_INSTALL_REFIX=`pwd`/install ..
-        make -j3 install
         cp /opt/cuda-${{matrix.cuda}}/lib64/stubs/libcuda.so `pwd`/install/lib/libcuda.so
         cp /opt/cuda-${{matrix.cuda}}/lib64/stubs/libcuda.so `pwd`/install/lib/libcuda.so.1
+        export LIBRARY_PATH=$LIBRARY_PATH:`pwd`/install/lib
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/install/lib
+        cmake -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.clang_version}} -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.clang_version}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.clang_version}}/cmake -DWITH_CUDA_BACKEND=ON -DWITH_ROCM_BACKEND=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install -DCUDA_TOOLKIT_ROOT_DIR=/opt/cuda-${{matrix.cuda}} -DROCM_PATH=/opt/rocm -DCMAKE_INSTALL_REFIX=`pwd`/install ..
+        make -j3 install
     - name: build generic SSCP tests
       if: matrix.clang_version >= 14
       run: |

--- a/.github/workflows/linux-self-hosted.yml
+++ b/.github/workflows/linux-self-hosted.yml
@@ -17,12 +17,6 @@ jobs:
         cmake -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.clang_version}} -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.clang_version}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.clang_version}}/cmake -DWITH_CUDA_BACKEND=ON -DWITH_ROCM_BACKEND=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install -DCUDA_TOOLKIT_ROOT_DIR=/opt/cuda-${{matrix.cuda}} -DROCM_PATH=/opt/rocm -DCMAKE_INSTALL_REFIX=`pwd`/install ..
         make -j16 install
         cp /.singularity.d/libs/libcuda.* `pwd`/install/lib/
-    - name: build CPU tests
-      run: |
-        mkdir ${GITHUB_WORKSPACE}/build/tests-cpu
-        cd ${GITHUB_WORKSPACE}/build/tests-cpu
-        cmake -DOPENSYCL_TARGETS="omp" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
-        make -j16
     - name: build generic SSCP tests
       if: matrix.clang_version >= 14
       run: |
@@ -41,6 +35,27 @@ jobs:
         echo "Running tests on CUDA..."
         cd ${GITHUB_WORKSPACE}/build/tests-cuda
         ./sycl_tests
+  test-cpu:
+    name: Host with clang ${{ matrix.clang_version }}
+    runs-on: [self-hosted, cpu]
+    strategy:
+      matrix:
+        clang_version: ['15']
+        cuda: ['11.0']
+    steps:
+    - uses: actions/checkout@v2
+    - name: build
+      run : |
+        mkdir build && cd build
+        cmake -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.clang_version}} -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.clang_version}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.clang_version}}/cmake -DWITH_CUDA_BACKEND=ON -DWITH_ROCM_BACKEND=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install -DCUDA_TOOLKIT_ROOT_DIR=/opt/cuda-${{matrix.cuda}} -DROCM_PATH=/opt/rocm -DCMAKE_INSTALL_REFIX=`pwd`/install ..
+        make -j16 install
+        cp /.singularity.d/libs/libcuda.* `pwd`/install/lib/
+    - name: build CPU tests
+      run: |
+        mkdir ${GITHUB_WORKSPACE}/build/tests-cpu
+        cd ${GITHUB_WORKSPACE}/build/tests-cpu
+        cmake -DOPENSYCL_TARGETS="omp" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
+        make -j16
     - name: run CPU tests
       run: |
         cd ${GITHUB_WORKSPACE}/build/tests-cpu

--- a/.github/workflows/linux-self-hosted.yml
+++ b/.github/workflows/linux-self-hosted.yml
@@ -89,13 +89,6 @@ jobs:
         cd ${GITHUB_WORKSPACE}/build/tests-sscp
         cmake -DOPENSYCL_TARGETS="generic" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
         make -j3
-    - name: build generic SSCP tests
-      if: matrix.clang_version >= 14
-      run: |
-        mkdir ${GITHUB_WORKSPACE}/build/tests-sscp
-        cd ${GITHUB_WORKSPACE}/build/tests-sscp
-        cmake -DOPENSYCL_TARGETS="generic" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
-        make -j3
     - name: build ROCm tests (integrated multipass)
       run: |
         mkdir ${GITHUB_WORKSPACE}/build/tests-rocm

--- a/.github/workflows/linux-self-hosted.yml
+++ b/.github/workflows/linux-self-hosted.yml
@@ -1,4 +1,4 @@
-name: Linux GPU build and test
+name: Self-hosted CI
 
 on: [push, pull_request]
 jobs:
@@ -80,8 +80,9 @@ jobs:
       run : |
         mkdir build && cd build
         cmake -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.clang_version}} -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.clang_version}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.clang_version}}/cmake -DWITH_CUDA_BACKEND=ON -DWITH_ROCM_BACKEND=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install -DCUDA_TOOLKIT_ROOT_DIR=/opt/cuda-${{matrix.cuda}} -DROCM_PATH=/opt/rocm -DCMAKE_INSTALL_REFIX=`pwd`/install ..
-        make -j16 install
-        cp /.singularity.d/libs/libcuda.* `pwd`/install/lib/
+        make -j3 install
+        cp /opt/cuda-${{matrix.cuda}}/lib64/stubs/libcuda.so `pwd`/install/lib/libcuda.so
+        cp /opt/cuda-${{matrix.cuda}}/lib64/stubs/libcuda.so `pwd`/install/lib/libcuda.so.1
     - name: build generic SSCP tests
       if: matrix.clang_version >= 14
       run: |

--- a/.github/workflows/linux-self-hosted.yml
+++ b/.github/workflows/linux-self-hosted.yml
@@ -74,15 +74,12 @@ jobs:
     strategy:
       matrix:
         clang_version: ['15']
+        cuda: ['11.0'] # Just to be able to build the backend for explicit multipass
     steps:
     - uses: actions/checkout@v2
     - name: build
       run : |
         mkdir build && cd build
-        cp /opt/cuda-${{matrix.cuda}}/lib64/stubs/libcuda.so `pwd`/install/lib/libcuda.so
-        cp /opt/cuda-${{matrix.cuda}}/lib64/stubs/libcuda.so `pwd`/install/lib/libcuda.so.1
-        export LIBRARY_PATH=$LIBRARY_PATH:`pwd`/install/lib
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/install/lib
         cmake -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.clang_version}} -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.clang_version}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.clang_version}}/cmake -DWITH_CUDA_BACKEND=ON -DWITH_ROCM_BACKEND=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install -DCUDA_TOOLKIT_ROOT_DIR=/opt/cuda-${{matrix.cuda}} -DROCM_PATH=/opt/rocm -DCMAKE_INSTALL_REFIX=`pwd`/install ..
         make -j3 install
     - name: build generic SSCP tests

--- a/.github/workflows/linux-self-hosted.yml
+++ b/.github/workflows/linux-self-hosted.yml
@@ -31,13 +31,13 @@ jobs:
         cd ${GITHUB_WORKSPACE}/build/tests-cuda
         cmake -DOPENSYCL_TARGETS="omp;cuda:sm_61" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
         make -j16
-    - name build CUDA tests (explicit multipass)
+    - name: build CUDA tests (explicit multipass)
       run: |
         mkdir ${GITHUB_WORKSPACE}/build/tests-cuda-emp
         cd ${GITHUB_WORKSPACE}/build/tests-cuda-emp
         cmake -DOPENSYCL_TARGETS="omp;cuda.explicit-multipass:sm_61;hip:gfx906" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
         make -j16
-    - name build CUDA tests (nvc++)
+    - name: build CUDA tests (nvc++)
       run: |
         mkdir ${GITHUB_WORKSPACE}/build/tests-cuda-nvcxx
         cd ${GITHUB_WORKSPACE}/build/tests-cuda-nvcxx

--- a/.github/workflows/linux-self-hosted.yml
+++ b/.github/workflows/linux-self-hosted.yml
@@ -22,20 +22,20 @@ jobs:
         mkdir ${GITHUB_WORKSPACE}/build/tests-cpu
         cd ${GITHUB_WORKSPACE}/build/tests-cpu
         cmake -DOPENSYCL_TARGETS="omp" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
-        make -j2
+        make -j16
     - name: build generic SSCP tests
       if: matrix.clang_version >= 14
       run: |
         mkdir ${GITHUB_WORKSPACE}/build/tests-sscp
         cd ${GITHUB_WORKSPACE}/build/tests-sscp
         cmake -DOPENSYCL_TARGETS="generic" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
-        make -j2
+        make -j16
     - name: build CUDA tests
       run: |
         mkdir ${GITHUB_WORKSPACE}/build/tests-cuda
         cd ${GITHUB_WORKSPACE}/build/tests-cuda
         cmake -DOPENSYCL_TARGETS="cuda:sm_61" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
-        make -j2
+        make -j16
     - name: run CUDA tests
       run: |
         echo "Running tests on CUDA..."

--- a/.github/workflows/linux-self-hosted.yml
+++ b/.github/workflows/linux-self-hosted.yml
@@ -37,14 +37,18 @@ jobs:
         cd ${GITHUB_WORKSPACE}/build/tests-cuda-emp
         cmake -DOPENSYCL_TARGETS="omp;cuda.explicit-multipass:sm_61;hip:gfx906" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
         make -j16
-    - name: build CUDA tests (nvc++)
-      run: |
-        mkdir ${GITHUB_WORKSPACE}/build/tests-cuda-nvcxx
-        cd ${GITHUB_WORKSPACE}/build/tests-cuda-nvcxx
-        export NV_HPC_SDK_ROOT=/opt/nvidia/hpc_sdk/Linux_x86_64/${{matrix.nvhpc_version}}
-        export OPENSYCL_NVCXX=${NV_HPC_SDK_ROOT}/compilers/bin/nvc++ 
-        cmake -DOPENSYCL_TARGETS="cuda-nvcxx" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
-        make -j16
+    # NVC++ is commented out for now, because the build takes ages
+    # and it seems that nvc++ currently miscompiles some tests
+    # (e.g. group algorithms) that would need fixing first.
+    #
+    #- name: build CUDA tests (nvc++)
+    #  run: |
+    #    mkdir ${GITHUB_WORKSPACE}/build/tests-cuda-nvcxx
+    #    cd ${GITHUB_WORKSPACE}/build/tests-cuda-nvcxx
+    #    export NV_HPC_SDK_ROOT=/opt/nvidia/hpc_sdk/Linux_x86_64/${{matrix.nvhpc_version}}
+    #    export OPENSYCL_NVCXX=${NV_HPC_SDK_ROOT}/compilers/bin/nvc++ 
+    #    cmake -DOPENSYCL_TARGETS="cuda-nvcxx" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
+    #    make -j16
     - name: run CUDA tests (integrated multipass)
       run: |
         echo "Running tests on CUDA..."
@@ -55,12 +59,62 @@ jobs:
         echo "Running tests on CUDA..."
         cd ${GITHUB_WORKSPACE}/build/tests-cuda-emp
         ./sycl_tests
-    - name: run CUDA tests (nvcxx)
-      run: |
-        echo "Running tests on CUDA..."
-        cd ${GITHUB_WORKSPACE}/build/tests-cuda-nvcxx
-        ./sycl_tests
+    #- name: run CUDA tests (nvc++)
+    #  run: |
+    #    echo "Running tests on CUDA..."
+    #    cd ${GITHUB_WORKSPACE}/build/tests-cuda-nvcxx
+    #    ./sycl_tests
     - name: run CPU tests
       run: |
         cd ${GITHUB_WORKSPACE}/build/tests-cuda
         HIPSYCL_VISIBILITY_MASK=omp LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ./sycl_tests
+  test-gpu-amd:
+    name: AMD with clang ${{ matrix.clang_version }}
+    runs-on: [self-hosted, gpu-amd]
+    strategy:
+      matrix:
+        clang_version: ['15']
+    steps:
+    - uses: actions/checkout@v2
+    - name: build
+      run : |
+        mkdir build && cd build
+        cmake -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.clang_version}} -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.clang_version}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.clang_version}}/cmake -DWITH_CUDA_BACKEND=ON -DWITH_ROCM_BACKEND=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install -DCUDA_TOOLKIT_ROOT_DIR=/opt/cuda-${{matrix.cuda}} -DROCM_PATH=/opt/rocm -DCMAKE_INSTALL_REFIX=`pwd`/install ..
+        make -j16 install
+        cp /.singularity.d/libs/libcuda.* `pwd`/install/lib/
+    - name: build generic SSCP tests
+      if: matrix.clang_version >= 14
+      run: |
+        mkdir ${GITHUB_WORKSPACE}/build/tests-sscp
+        cd ${GITHUB_WORKSPACE}/build/tests-sscp
+        cmake -DOPENSYCL_TARGETS="generic" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
+        make -j3
+    - name: build generic SSCP tests
+      if: matrix.clang_version >= 14
+      run: |
+        mkdir ${GITHUB_WORKSPACE}/build/tests-sscp
+        cd ${GITHUB_WORKSPACE}/build/tests-sscp
+        cmake -DOPENSYCL_TARGETS="generic" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
+        make -j3
+    - name: build ROCm tests (integrated multipass)
+      run: |
+        mkdir ${GITHUB_WORKSPACE}/build/tests-rocm
+        cd ${GITHUB_WORKSPACE}/build/tests-rocm
+        cmake -DOPENSYCL_TARGETS="omp;hip:gfx906" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
+        make -j3
+    - name: build ROCm tests (explicit multipass)
+      run: |
+        mkdir ${GITHUB_WORKSPACE}/build/tests-rocm-emp
+        cd ${GITHUB_WORKSPACE}/build/tests-rocm-emp
+        cmake -DOPENSYCL_TARGETS="omp;hip.explicit-multipass:gfx906;cuda:sm_61" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
+        make -j3
+    - name: run ROCm tests (integrated multipass)
+      run: |
+        echo "Running tests on AMD..."
+        cd ${GITHUB_WORKSPACE}/build/tests-rocm
+        ./sycl_tests
+    - name: run ROCm tests (explicit multipass)
+      run: |
+        echo "Running tests on AMD..."
+        cd ${GITHUB_WORKSPACE}/build/tests-rocm-emp
+        ./sycl_tests

--- a/.github/workflows/linux-self-hosted.yml
+++ b/.github/workflows/linux-self-hosted.yml
@@ -28,37 +28,14 @@ jobs:
       run: |
         mkdir ${GITHUB_WORKSPACE}/build/tests-cuda
         cd ${GITHUB_WORKSPACE}/build/tests-cuda
-        cmake -DOPENSYCL_TARGETS="cuda:sm_61" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
+        cmake -DOPENSYCL_TARGETS="omp;cuda:sm_61" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
         make -j16
     - name: run CUDA tests
       run: |
         echo "Running tests on CUDA..."
         cd ${GITHUB_WORKSPACE}/build/tests-cuda
         ./sycl_tests
-  test-cpu:
-    name: Host with clang ${{ matrix.clang_version }}
-    runs-on: [self-hosted, cpu]
-    strategy:
-      matrix:
-        clang_version: ['15']
-        cuda: ['11.0']
-    steps:
-    - uses: actions/checkout@v2
-    - name: build
-      run : |
-        mkdir build && cd build
-        cmake -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.clang_version}} -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.clang_version}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.clang_version}}/cmake -DWITH_CUDA_BACKEND=ON -DWITH_ROCM_BACKEND=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install -DCUDA_TOOLKIT_ROOT_DIR=/opt/cuda-${{matrix.cuda}} -DROCM_PATH=/opt/rocm -DCMAKE_INSTALL_REFIX=`pwd`/install ..
-        make -j16 install
-        cp /.singularity.d/libs/libcuda.* `pwd`/install/lib/
-    - name: build CPU tests
-      run: |
-        mkdir ${GITHUB_WORKSPACE}/build/tests-cpu
-        cd ${GITHUB_WORKSPACE}/build/tests-cpu
-        cmake -DOPENSYCL_TARGETS="omp" -DOpenSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/OpenSYCL ${GITHUB_WORKSPACE}/tests
-        make -j16
     - name: run CPU tests
       run: |
-        cd ${GITHUB_WORKSPACE}/build/tests-cpu
-        LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ./sycl_tests
-    
-
+        cd ${GITHUB_WORKSPACE}/build/tests-cuda
+        HIPSYCL_VISIBILITY_MASK=omp LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ./sycl_tests

--- a/.github/workflows/runner.def
+++ b/.github/workflows/runner.def
@@ -1,0 +1,32 @@
+BootStrap: docker
+From: ubuntu:22.04
+
+%post
+export DEBIAN_FRONTEND=noninteractive
+export ROCM_VERSION="5.4.3"
+
+export NVHPC_MAJOR_VERSION="22"
+export NVHPC_MINOR_VERSION="11"
+
+apt-get update
+apt-get install -y libboost-all-dev wget git libnuma-dev cmake curl unzip apt-transport-https ca-certificates software-properties-common sudo build-essential gettext libcurl4-openssl-dev openssh-client libnuma-dev jq
+
+mkdir -p /opt/cuda-11.0
+wget -q -O cuda-11.0.sh http://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_450.51.05_linux.run
+sh ./cuda-11.0.sh --override --silent --toolkit --no-man-page --no-drm --no-opengl-libs --installpath=/opt/cuda-11.0 && rm ./cuda-11.0.sh
+echo "CUDA Version 11.0.0" | tee /opt/cuda-11.0/version.txt
+
+wget https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64/nvhpc-${NVHPC_MAJOR_VERSION}-${NVHPC_MINOR_VERSION}_${NVHPC_MAJOR_VERSION}.${NVHPC_MINOR_VERSION}_amd64.deb
+wget https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64/nvhpc-20${NVHPC_MAJOR_VERSION}_${NVHPC_MAJOR_VERSION}.${NVHPC_MINOR_VERSION}_amd64.deb
+apt-get install -y ./nvhpc-*
+
+wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
+echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/${ROCM_VERSION} focal main" | sudo tee /etc/apt/sources.list.d/rocm.list
+printf 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
+apt-get update
+apt-get install -y rocm-dev
+
+wget https://apt.llvm.org/llvm.sh
+chmod +x llvm.sh
+./llvm.sh 15
+apt-get install -y libclang-15-dev clang-tools-15 libomp-15-dev

--- a/tests/sycl/info_queries.cpp
+++ b/tests/sycl/info_queries.cpp
@@ -24,7 +24,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
+#include <iostream>
 
 #include "sycl_test_suite.hpp"
 using namespace cl;
@@ -38,6 +38,8 @@ BOOST_AUTO_TEST_CASE(device_queries) {
 
   std::string device = d.get_info<sycl::info::device::name>();
   BOOST_TEST(device.length() > 0);
+  std::cout << "Default-selected queue runs on device: " << device << std::endl;
+  
   // TODO Add tests for more queries
 }
 BOOST_AUTO_TEST_CASE(kernel_specific_queries) {


### PR DESCRIPTION
This PR adds (or rather, resurrects) GPU-based testing in CI using our own self-host infrastructure at Uni Heidelberg. We had some infrastructure for this in the past, but it turned out to be unstable -- hopefully this new approach remedies the issues.

GPU testing in CI has now become even more important than earlier, because our SSCP flow relies heavily on runtime code compilation - which means we don't even stress the full compiler stack unless we actually run SSCP binaries on a GPU.
While the unit tests are not yet in a shape to allow for SSCP testing, this PR is the first step towards this goal.

## Backend software infrastructure

The backend infrastructure to deploy and manage the github runners in a containerized manner is contained in the `OpenSYCL/ci` repository, which is currently only accessible for members of the OpenSYCL organization.

## Container for test environment

The PR here contains the workflow as well as the definition of the singularity container image that is used on our infrastructure.

Currently, when the container definition changes, the container needs to be rebuilt and deployed manually. 

This is a bit cumbersome, so ideally we could have some additional mechanism that automatically rebuilds the image when the file is change and maybe stores it on dockerhub or similar... The runners could then just pull that image (although they'd still need to be restarted somehow..).
In the best case, we could then even share the images between the self-hosted flows and the github flows to remove redundancy. If somebody has experience with these kinds of things and wants to look into this, please let me know :-)

## Hardware

Currently testing is enabled on a dedicated node with 32 cores and 4 NVIDIA 1080 Ti `sm_61` GPUs with the `omp` and SMCP `cuda` compilation flow.  Each GPU is used exclusively by one GitHub runner.
I also have AMD and Intel hardware available which I plan to hook up into CI as part of this PR soon.

## Security

**Important:** GitHub very prominently warns that adding self-hosted CI runners to public repositories like ours can pose a security risk, because if someone with malicious intent opens a PR, arbitrary code from that PR will be executed on our own machines.
Because of this, and even though I have taken some safeguards on our machines, I have changed the repository setting such that **all PRs from non-members of the organization will require approval from a member before workflows will be run**.

I'd appreciate if @OpenSYCL members could help me approve workflows where necessary :-) But please have a quick glance at the code before approving just to check if there is no bogus stuff in there that could be a security hazard. Whoever approves, vouches for the code ;)

Membership in the OpenSYCL organization is not intended to be exclusive; if you want in please let me know. I'm open to adding people as long as we have some idea who that person is, in order to have accountability regarding the security aspect. And bonus points for people who have contributed/we have collaborated with in the past :-)


## Workflow todos

The current workflow is pretty bare bones. There are more things we should test:

- [x] Explicit multipass testing
- [x] AMD hardware testing
- [ ] nvc++ testing?

Probably in a separate PR:
- [ ] SSCP testing
- [ ] Intel testing (depends on SSCP testing)