### PR TITLE
Allow non-default-construbtible types for `buffer(Container)` and `buffer(Iterator, Iterator)` constructors 

### DIFF
--- a/include/hipSYCL/sycl/buffer.hpp
+++ b/include/hipSYCL/sycl/buffer.hpp
@@ -608,13 +608,8 @@ public:
       copy_host_content(reinterpret_cast<T*>(contiguous_buffer.data()));
     } else {
       std::vector<T> contiguous_buffer;
-      if constexpr (std::is_default_constructible_v<T>) {
-        contiguous_buffer.reserve(num_elements);
-        std::copy(first, last, contiguous_buffer.begin());
-      } else {
-        for(auto it = first; it != last; ++it)
-          contiguous_buffer.emplace_back(*it);
-      }
+      contiguous_buffer.reserve(num_elements);
+      std::copy(first, last, contiguous_buffer.begin());
       copy_host_content(contiguous_buffer.data());
     }
   }

--- a/include/hipSYCL/sycl/buffer.hpp
+++ b/include/hipSYCL/sycl/buffer.hpp
@@ -310,21 +310,21 @@ template <typename, typename = void>
 struct has_data : std::false_type {};
 
 template <typename Container>
-struct has_data<Container, std::void_t<decltype(std::data(Container{}))>>
+struct has_data<Container, std::void_t<decltype(std::data(std::declval<Container>()))>>
   : std::true_type {};
 
 template <typename, typename = void>
 struct has_size : std::false_type {};
 
 template <typename Container>
-struct has_size<Container, std::void_t<decltype(std::size(Container{}))>>
+struct has_size<Container, std::void_t<decltype(std::size(std::declval<Container>()))>>
   : std::true_type {};
 
 template <typename Container, typename T>
 using enable_if_contiguous = std::void_t<std::enable_if_t<
   has_data<Container>::value &&
   has_size<Container>::value &&
-  std::is_convertible_v<decltype(std::data(Container{})),
+  std::is_convertible_v<decltype(std::data(std::declval<Container>())),
                         const T*>>>;
 }
 

--- a/include/hipSYCL/sycl/buffer.hpp
+++ b/include/hipSYCL/sycl/buffer.hpp
@@ -607,8 +607,14 @@ public:
       std::copy(first, last, reinterpret_cast<T*>(&(contiguous_buffer[0])));
       copy_host_content(reinterpret_cast<T*>(contiguous_buffer.data()));
     } else {
-      std::vector<T> contiguous_buffer(num_elements);
-      std::copy(first, last, contiguous_buffer.begin());
+      std::vector<T> contiguous_buffer;
+      if constexpr (std::is_default_constructible_v<T>) {
+        contiguous_buffer.reserve(num_elements);
+        std::copy(first, last, contiguous_buffer.begin());
+      } else {
+        for(auto it = first; it != last; ++it)
+          contiguous_buffer.emplace_back(*it);
+      }
       copy_host_content(contiguous_buffer.data());
     }
   }

--- a/tests/sycl/buffer.cpp
+++ b/tests/sycl/buffer.cpp
@@ -252,23 +252,30 @@ BOOST_AUTO_TEST_CASE(buffer_container_constructor_no_def_constr) {
   };
 
   A testVal = A{42};
-  std::array<A, 2> data = {A{1}, A{2}};
+  std::array<A, 2> data1 = {A{1}, A{2}};
+  std::array<A, 2> data2 = {A{1}, A{2}};
   {
-    cl::sycl::buffer<A> buff{data};
+    cl::sycl::buffer<A> buff1{data1};
+    cl::sycl::buffer<A> buff2{data2.begin(), data2.end()};
+    buff2.set_final_data(data2.data());
 
     q.submit([&](cl::sycl::handler &cgh) {
-      auto acc =
-        buff.get_access<cl::sycl::access::mode::write>(cgh);
+      auto acc1 =
+        buff1.get_access<cl::sycl::access::mode::write>(cgh);
+      auto acc2 =
+        buff2.get_access<cl::sycl::access::mode::write>(cgh);
 
       cgh.parallel_for(cl::sycl::range{2}, [=](auto idx) {
-        acc[idx] = testVal;
+        acc1[idx] = testVal;
+        acc2[idx] = testVal;
       });
     });
   }
 
-  for(int i = 0; i < data.size(); ++i) {
-    BOOST_CHECK(data[i].val == testVal.val);
-  }
+  for(int i = 0; i < data1.size(); ++i)
+    BOOST_CHECK(data1[i].val == testVal.val);
+  for(int i = 0; i < data2.size(); ++i)
+    BOOST_CHECK(data2[i].val == testVal.val);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The previous implementations required the `Container` or `T` to be default-constructible. Now it also works for non-default-constructible. 