### PR TITLE
Fix build with ROCm Clang 5.5.0

### DIFF
--- a/src/compiler/cbs/PipelineBuilder.cpp
+++ b/src/compiler/cbs/PipelineBuilder.cpp
@@ -70,7 +70,7 @@ void registerCBSPipelineLegacy(llvm::legacy::PassManagerBase &PM) {
 }
 #endif // LLVM_VERSION_MAJOR < 16
 
-#if defined(ROCM_CLANG_VERSION_MAJOR) && ROCM_CLANG_VERSION_MAJOR == 5 && ROCM_CLANG_VERSION_MINOR == 5 && ROCM_CLANG_VERSION_PATCH == 0
+#if defined(ROCM_CLANG_VERSION_MAJOR) && ROCM_CLANG_VERSION_MAJOR == 5 && ROCM_CLANG_VERSION_MINOR == 5
 #define IS_ROCM_CLANG_VERSION_5_5_0
 #endif
 

--- a/src/compiler/cbs/PipelineBuilder.cpp
+++ b/src/compiler/cbs/PipelineBuilder.cpp
@@ -70,6 +70,10 @@ void registerCBSPipelineLegacy(llvm::legacy::PassManagerBase &PM) {
 }
 #endif // LLVM_VERSION_MAJOR < 16
 
+#if defined(ROCM_CLANG_VERSION_MAJOR) && ROCM_CLANG_VERSION_MAJOR == 5 && ROCM_CLANG_VERSION_MINOR == 5 && ROCM_CLANG_VERSION_PATCH == 0
+#define IS_ROCM_CLANG_VERSION_5_5_0
+#endif
+
 void registerCBSPipeline(llvm::ModulePassManager &MPM, OptLevel Opt) {
   MPM.addPass(SplitterAnnotationAnalysisCacher{});
 
@@ -85,7 +89,7 @@ void registerCBSPipeline(llvm::ModulePassManager &MPM, OptLevel Opt) {
     FPM.addPass(llvm::InstCombinePass{});
 #if LLVM_VERSION_MAJOR <= 13
     FPM.addPass(llvm::SROA{});
-#elif LLVM_VERSION_MAJOR < 16
+#elif (LLVM_VERSION_MAJOR < 16) || defined(IS_ROCM_CLANG_VERSION_5_5_0)
     FPM.addPass(llvm::SROAPass{});
 #else
     FPM.addPass(llvm::SROAPass{llvm::SROAOptions::ModifyCFG});


### PR DESCRIPTION
It identifies as Clang 16, but lacks one new enum.