### PR TITLE
[CI] Remove superfluous (and incorrect) cmake install prefix argument

### DIFF
--- a/.github/workflows/linux-self-hosted.yml
+++ b/.github/workflows/linux-self-hosted.yml
@@ -15,7 +15,7 @@ jobs:
     - name: build
       run : |
         mkdir build && cd build
-        cmake -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.clang_version}} -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.clang_version}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.clang_version}}/cmake -DWITH_CUDA_BACKEND=ON -DWITH_ROCM_BACKEND=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install -DCUDA_TOOLKIT_ROOT_DIR=/opt/cuda-${{matrix.cuda}} -DROCM_PATH=/opt/rocm -DCMAKE_INSTALL_REFIX=`pwd`/install ..
+        cmake -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.clang_version}} -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.clang_version}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.clang_version}}/cmake -DWITH_CUDA_BACKEND=ON -DWITH_ROCM_BACKEND=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install -DCUDA_TOOLKIT_ROOT_DIR=/opt/cuda-${{matrix.cuda}} -DROCM_PATH=/opt/rocm ..
         make -j16 install
         cp /.singularity.d/libs/libcuda.* `pwd`/install/lib/
     - name: build generic SSCP tests


### PR DESCRIPTION
* There's already another `-DCMAKE_INSTALL_PREFIX` argument
* The argument that was removed was spelled incorrectly, and so did not have an effect anyway