### PR TITLE
Make malloc(0) always return nullptr

### DIFF
--- a/include/hipSYCL/sycl/usm.hpp
+++ b/include/hipSYCL/sycl/usm.hpp
@@ -52,6 +52,8 @@ namespace sycl {
 
 inline void *malloc_device(size_t num_bytes, const device &dev,
                            const context &ctx) {
+  if(num_bytes == 0)
+    return nullptr;
   return detail::select_device_allocator(dev)->allocate(0, num_bytes);
 }
 
@@ -72,6 +74,8 @@ T* malloc_device(std::size_t count, const queue &q) {
 
 inline void *aligned_alloc_device(std::size_t alignment, std::size_t num_bytes,
                                   const device &dev, const context &ctx) {
+  if(num_bytes == 0)
+    return nullptr;
   return detail::select_device_allocator(dev)->allocate(alignment, num_bytes);
 }
 
@@ -96,6 +100,9 @@ T *aligned_alloc_device(std::size_t alignment, std::size_t count,
 // Restricted USM
 
 inline void *malloc_host(std::size_t num_bytes, const context &ctx) {
+  if(num_bytes == 0)
+    return nullptr;
+
   return detail::select_usm_allocator(ctx)->allocate_optimized_host(0, num_bytes);
 }
 
@@ -113,6 +120,9 @@ template <typename T> T *malloc_host(std::size_t count, const queue &q) {
 
 inline void *malloc_shared(std::size_t num_bytes, const device &dev,
                            const context &ctx) {
+  if(num_bytes == 0)
+    return nullptr;
+
   return detail::select_usm_allocator(ctx, dev)->allocate_usm(num_bytes);
 }
 
@@ -131,6 +141,9 @@ template <typename T> T *malloc_shared(std::size_t count, const queue &q) {
 
 inline void *aligned_alloc_host(std::size_t alignment, std::size_t num_bytes,
                                 const context &ctx) {
+  if(num_bytes == 0)
+    return nullptr;
+
   return detail::select_usm_allocator(ctx)->allocate_optimized_host(alignment,
                                                                     num_bytes);
 }
@@ -154,6 +167,9 @@ T *aligned_alloc_host(std::size_t alignment, std::size_t count,
 
 inline void *aligned_alloc_shared(std::size_t alignment, std::size_t num_bytes,
                                   const device &dev, const context &ctx) {
+  if(num_bytes == 0)
+    return nullptr;
+
   return detail::select_usm_allocator(ctx, dev)->allocate_usm(num_bytes);
 }
 
@@ -241,7 +257,8 @@ T *aligned_alloc(std::size_t alignment, std::size_t count, const sycl::queue &q,
 }
 
 inline void free(void *ptr, const sycl::context &ctx) {
-  return detail::select_usm_allocator(ctx)->free(ptr);
+  if(ptr)
+    detail::select_usm_allocator(ctx)->free(ptr);
 }
 
 inline void free(void *ptr, const sycl::queue &q) {


### PR DESCRIPTION
This should make `sycl::malloc_*(0)` behavior consistent across backends by returning nullptr.

See https://github.com/OpenSYCL/OpenSYCL/discussions/1047

CC @ravil-mobile

The open question is what the other USM functions should do with such a nullptr. E.g. the USM pointer property query.