### PR TITLE
Use `size_t` in decl and def of `createExitWithID`

### DIFF
--- a/src/compiler/cbs/SubCfgFormation.cpp
+++ b/src/compiler/cbs/SubCfgFormation.cpp
@@ -305,7 +305,7 @@ class SubCFG {
   size_t Dim;
 
   llvm::BasicBlock *
-  createExitWithID(llvm::detail::DenseMapPair<llvm::BasicBlock *, unsigned long> BarrierPair,
+  createExitWithID(llvm::detail::DenseMapPair<llvm::BasicBlock *, size_t> BarrierPair,
                    llvm::BasicBlock *After, llvm::BasicBlock *TargetBB);
 
   void loadMultiSubCfgValues(


### PR DESCRIPTION
Fixes #1060 