### PR TITLE
fix HIPSYCL_LIBKERNEL_COMPILER_SUPPORTS_{CUDA,HIP} variables

### DIFF
--- a/include/hipSYCL/sycl/libkernel/cuda/cuda_backend.hpp
+++ b/include/hipSYCL/sycl/libkernel/cuda/cuda_backend.hpp
@@ -30,10 +30,10 @@
 #define HIPSYCL_LIBKERNEL_CUDA_BACKEND_HPP
 
 #if defined(__CUDACC__)
- #define HIPSYCL_LIBKERNEL_COMPILER_SUPPORTS_CUDA 1
+ #define HIPSYCL_LIBKERNEL_COMPILER_SUPPORTS_CUDA
  #if defined(__NVCOMPILER)
   #define HIPSYCL_LIBKERNEL_CUDA_NVCXX
- #else 
+ #else
   #define HIPSYCL_LIBKERNEL_CUDA_CLANG
  #endif
 
@@ -45,8 +45,6 @@
  #ifdef HIPSYCL_LIBKERNEL_CUDA_NVCXX
   #include <nv/target>
  #endif
-#else
- #define HIPSYCL_LIBKERNEL_COMPILER_SUPPORTS_CUDA 0
 #endif
 
 #if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ != 0 \

--- a/include/hipSYCL/sycl/libkernel/hip/hip_backend.hpp
+++ b/include/hipSYCL/sycl/libkernel/hip/hip_backend.hpp
@@ -31,7 +31,7 @@
 
 
 #if defined(__HIP__) || defined(__HCC__)
- #define HIPSYCL_LIBKERNEL_COMPILER_SUPPORTS_HIP 1
+ #define HIPSYCL_LIBKERNEL_COMPILER_SUPPORTS_HIP
 // We need to include HIP headers always to have __HIP_DEVICE_COMPILE__
 // available below
  #ifdef __HIPSYCL_ENABLE_HIP_TARGET__
@@ -40,8 +40,6 @@
   #include <hip/hip_runtime.h>
   #pragma clang diagnostic pop
  #endif
-#else
- #define HIPSYCL_LIBKERNEL_COMPILER_SUPPORTS_HIP 0
 #endif
 
 #if defined(__HIP_DEVICE_COMPILE__)


### PR DESCRIPTION
They were being set to 0 or 1 but being checked to see if they
were defined. Instead just define them rather than setting them to 1
and do not do anything rather than set them to 0.
