### PR TITLE
Let hipSYCL-rt be a non-transitive dependency.

### DIFF
--- a/cmake/hipsycl-config.cmake.in
+++ b/cmake/hipsycl-config.cmake.in
@@ -202,5 +202,5 @@ function(add_sycl_to_target)
   set_target_properties("${ADD_SYCL_TARGET}" PROPERTIES RULE_LAUNCH_COMPILE "${OPENSYCL_SYCLCC_LAUNCH_RULE}")
   set_target_properties("${ADD_SYCL_TARGET}" PROPERTIES RULE_LAUNCH_LINK "${OPENSYCL_SYCLCC_LAUNCH_RULE}")
 
-  target_link_libraries(${ADD_SYCL_TARGET} PUBLIC hipSYCL::hipSYCL-rt)
+  target_link_libraries(${ADD_SYCL_TARGET} PRIVATE hipSYCL::hipSYCL-rt)
 endfunction()

--- a/cmake/opensycl-config.cmake.in
+++ b/cmake/opensycl-config.cmake.in
@@ -122,5 +122,5 @@ function(add_sycl_to_target)
   set_target_properties("${ADD_SYCL_TARGET}" PROPERTIES RULE_LAUNCH_COMPILE "${OPENSYCL_SYCLCC_LAUNCH_RULE}")
   set_target_properties("${ADD_SYCL_TARGET}" PROPERTIES RULE_LAUNCH_LINK "${OPENSYCL_SYCLCC_LAUNCH_RULE}")
 
-  target_link_libraries(${ADD_SYCL_TARGET} PUBLIC OpenSYCL::hipSYCL-rt)
+  target_link_libraries(${ADD_SYCL_TARGET} PRIVATE OpenSYCL::hipSYCL-rt)
 endfunction()


### PR DESCRIPTION
Switch from PUBLIC to PRIVATE in the CMake `target_link_libraries` call at the end of `add_sycl_to_target()`. Clients are assumed to call `add_sycl_to_target()` if they are using hipsycl on their own, and most libraries that are built with `add_sycl_to_target()` do not need to convey their dependence on `hipSYCL-rt` to their clients.

Fixes #1068