### PR TITLE
Add aliases for `marray`

### DIFF
--- a/include/hipSYCL/sycl/libkernel/marray.hpp
+++ b/include/hipSYCL/sycl/libkernel/marray.hpp
@@ -29,9 +29,11 @@
 #define HIPSYCL_MARRAY_HPP
 
 #include <cstddef>
+#include <cstdint>
 #include <type_traits>
 
 #include "detail/device_array.hpp"
+#include "half.hpp"
 
 namespace hipsycl {
 namespace sycl {
@@ -488,7 +490,28 @@ template <class T, class... U,
           class = std::enable_if_t<(std::is_same<T, U>::value && ...)>>
 marray(T, U...) -> marray<T, sizeof...(U) + 1>;
 
+#define MARRAY_TYPE_ALIASES(type, storage_type, elements)   \
+  using m##type##elements = marray<storage_type, elements>;
 
+#define MARRAY_TYPE_ALIASES_ALL(type, storage_type)   \
+  MARRAY_TYPE_ALIASES(type, storage_type, 2);         \
+  MARRAY_TYPE_ALIASES(type, storage_type, 3);         \
+  MARRAY_TYPE_ALIASES(type, storage_type, 4);         \
+  MARRAY_TYPE_ALIASES(type, storage_type, 8);         \
+  MARRAY_TYPE_ALIASES(type, storage_type, 16);
+
+  MARRAY_TYPE_ALIASES_ALL(char, int8_t);
+  MARRAY_TYPE_ALIASES_ALL(uchar, uint8_t);
+  MARRAY_TYPE_ALIASES_ALL(short, int16_t);
+  MARRAY_TYPE_ALIASES_ALL(ushort, uint16_t);
+  MARRAY_TYPE_ALIASES_ALL(int, int32_t);
+  MARRAY_TYPE_ALIASES_ALL(uint, uint32_t);
+  MARRAY_TYPE_ALIASES_ALL(long, int64_t);
+  MARRAY_TYPE_ALIASES_ALL(ulong, uint64_t);
+  MARRAY_TYPE_ALIASES_ALL(half, half);
+  MARRAY_TYPE_ALIASES_ALL(float, float);
+  MARRAY_TYPE_ALIASES_ALL(double, double);
+  MARRAY_TYPE_ALIASES_ALL(bool, bool);
 }
 }
 

--- a/tests/sycl/marray.cpp
+++ b/tests/sycl/marray.cpp
@@ -111,4 +111,28 @@ BOOST_AUTO_TEST_CASE(marray_constructor) {
   BOOST_TEST(verify_marray_content(v5, {1, 1, 1, 3, 0, 1, 1, 1}));
 }
 
+#define MARRAY_ALIAS_SAME(type, storage_type, elements)                 \
+  (std::is_same_v<sycl::m##type##elements, sycl::marray<storage_type, elements>>)
+
+#define MARRAY_ALIAS_CHECK(type, storage_type)        \
+  MARRAY_ALIAS_SAME(type, storage_type, 2) &&         \
+  MARRAY_ALIAS_SAME(type, storage_type, 3) &&         \
+  MARRAY_ALIAS_SAME(type, storage_type, 4) &&         \
+  MARRAY_ALIAS_SAME(type, storage_type, 8) &&         \
+  MARRAY_ALIAS_SAME(type, storage_type, 16)
+
+BOOST_AUTO_TEST_CASE(marray_aliases) {
+  BOOST_CHECK(MARRAY_ALIAS_CHECK(char, int8_t));
+  BOOST_CHECK(MARRAY_ALIAS_CHECK(uchar, uint8_t));
+  BOOST_CHECK(MARRAY_ALIAS_CHECK(short, int16_t));
+  BOOST_CHECK(MARRAY_ALIAS_CHECK(ushort, uint16_t));
+  BOOST_CHECK(MARRAY_ALIAS_CHECK(int, int32_t));
+  BOOST_CHECK(MARRAY_ALIAS_CHECK(uint, uint32_t));
+  BOOST_CHECK(MARRAY_ALIAS_CHECK(long, int64_t));
+  BOOST_CHECK(MARRAY_ALIAS_CHECK(ulong, uint64_t));
+  BOOST_CHECK(MARRAY_ALIAS_CHECK(half, sycl::half));
+  BOOST_CHECK(MARRAY_ALIAS_CHECK(float, float));
+  BOOST_CHECK(MARRAY_ALIAS_CHECK(double, double));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
 As required by §4.14.3.2. of the spec