### PR TITLE
Fix error when compiling with `-std=c++20`

### DIFF
--- a/include/hipSYCL/compiler/cbs/IRUtils.hpp
+++ b/include/hipSYCL/compiler/cbs/IRUtils.hpp
@@ -67,6 +67,7 @@ template <class PtrSet> struct PtrSetWrapper {
   template <class IT, class ValueT> IT insert(IT, const ValueT &Value) {
     return Set.insert(Value).first;
   }
+  auto begin() -> decltype(Set.begin()) { return Set.begin(); }
 };
 
 llvm::Loop *updateDtAndLi(llvm::LoopInfo &LI, llvm::DominatorTree &DT, const llvm::BasicBlock *B,


### PR DESCRIPTION
While trying to fix the `constexpr half` problems I tried compiling the project with `-std=c++20`. Almost everything compiled expect for a function call to `std::inserter` in the cbs part: In C++20 the [signature of `std::inserter` changed](https://en.cppreference.com/w/cpp/iterator/inserter) and the container that is used with `std::inserter` now requires a `begin` method (because the second argument of `std::inserter` now is of type [std::ranges::iterator_t](https://en.cppreference.com/w/cpp/ranges/iterator_t) which is essentially defined as the type of `ranges::begin(Container)`). So I just added a begin function to the type it complains about (and since this type is just a wrapper for `llvm::SmallPtrSet`, I can just call `begin` of `llvm::SmallPtrSet`).