### PR TITLE
Return device architecture in info::device::version

### DIFF
--- a/include/hipSYCL/sycl/device.hpp
+++ b/include/hipSYCL/sycl/device.hpp
@@ -665,7 +665,7 @@ HIPSYCL_SPECIALIZE_GET_INFO(device, profile)
 { return get_rt_device()->get_profile(); }
 
 HIPSYCL_SPECIALIZE_GET_INFO(device, version) {
-  return "1.2 "+detail::version_string();
+  return get_rt_device()->get_device_arch();
 }
 
 HIPSYCL_SPECIALIZE_GET_INFO(device, opencl_c_version)


### PR DESCRIPTION
[Per spec](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_device_information_descriptors), `sycl::device::get_info<sycl::info::device::version>` "Returns a backend-defined [device](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#device) version."

Currently, it returns "1.2 {info::platform::version}", which is redundant and (IMO) not particularly useful. Returning device architecture version seems spec-compliant and could have some uses.