### PR TITLE
[SSCP][llvm-to-spirv] Use pown(double, i32) since IGC does not support pown(double, i64)

### DIFF
--- a/src/libkernel/sscp/spirv/math.cpp
+++ b/src/libkernel/sscp/spirv/math.cpp
@@ -163,10 +163,11 @@ HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN2(nextafter)
 HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN2(powr)
 
 float __spirv_ocl_pown(float, __hipsycl_int32);
-double __spirv_ocl_pown(double, __hipsycl_int64);
+double __spirv_ocl_pown(double, __hipsycl_int32);
 
 HIPSYCL_SSCP_BUILTIN float __hipsycl_sscp_pown_f32(float x, __hipsycl_int32 y) { return __spirv_ocl_pown(x, y); }
-HIPSYCL_SSCP_BUILTIN double __hipsycl_sscp_pown_f64(double x, __hipsycl_int64 y) {return __spirv_ocl_pown(x, y); }
+HIPSYCL_SSCP_BUILTIN double __hipsycl_sscp_pown_f64(double x, __hipsycl_int64 y)
+{return __spirv_ocl_pown(x, static_cast<__hipsycl_int32>(y)); }
 
 HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN2(remainder)
 HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN(rint)


### PR DESCRIPTION
It seems the Intel Graphics Compiler/Level Zero implementation does not support `__spirv_ocl_pown(f64, i64)` as we use it, only `__spirv_ocl_pown(f64, i32)`. This currently causes `pown(double)` to trigger a JIT failure on Intel.
This PR fixes the issue by using `__spirv_ocl_pown(f64, i32)` instead.

Fixes #1089 