### PR TITLE
Enable CPack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -732,6 +732,8 @@ mark_as_advanced(
 )
 
 # New module
+set(CPACK_PACKAGE_CONTACT aksel.alpay@uni-heidelberg.de)
+include(CPack)
 
 
 set(ADAPTIVECPP_INSTALL_CMAKE_DIR
@@ -775,7 +777,11 @@ install(EXPORT install_exports
   DESTINATION ${ADAPTIVECPP_INSTALL_CMAKE_DIR}
 )
 
+if(UNIX AND ACPP_INSTALL_LDCONF)
+  file(WRITE ${PROJECT_BINARY_DIR}/30-adaptivecpp.conf "${CMAKE_INSTALL_PREFIX}/lib/hipSYCL\n")
+  install(FILES ${PROJECT_BINARY_DIR}/30-adaptivecpp.conf COMPONENT ACPP DESTINATION /etc/ld.so.conf.d)
+endif()
+
 mark_as_advanced(
   ADAPTIVECPP_INSTALL_CMAKE_DIR
 )
-

--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -28,7 +28,7 @@ function(create_llvm_based_library)
   target_include_directories(${target} SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS})
   
   target_compile_definitions(${target} PRIVATE ${LLVM_DEFINITIONS} -DHIPSYCL_COMPILER_COMPONENT)
-  find_library(LLVM_LIBRARY NAMES LLVM HINTS ${LLVM_LIBRARY_DIRS} NO_DEFAULT_PATH)
+  find_library(LLVM_LIBRARY NAMES LLVM LLVMCore HINTS ${LLVM_LIBRARY_DIRS} NO_DEFAULT_PATH)
   if(NOT LLVM_LIBRARY)
     message(FATAL_ERROR "LLVM at ${LLVM_DIR} does not have libLLVM.so. Please disable SSCP and related backends (-DWITH_SSCP_COMPILER=OFF -DWITH_OPENCL_BACKEND=OFF -DWITH_LEVEL_ZERO_BACKEND=OFF) or choose another LLVM installation")
   endif()
@@ -142,11 +142,16 @@ if(WITH_SSCP_COMPILER)
     if(NOT LLVMSpirvTranslator_POPULATED)
       FetchContent_Populate(LLVMSpirvTranslator)
       execute_process(COMMAND patch -N -p0 -c --fuzz=4 --ignore-whitespace -i llvm-spirv.patch ${llvmspirvtranslator_SOURCE_DIR}/lib/SPIRV/SPIRVInternal.h ${CMAKE_CURRENT_SOURCE_DIR}/spirv/llvm-spirv.patch)
-      execute_process(COMMAND ${CMAKE_COMMAND} -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DLLVM_SPIRV_BUILD_EXTERNAL=ON -DLLVM_DIR=${LLVM_DIR} -DCMAKE_INSTALL_PREFIX=${LLVMSPIRV_INSTALLDIR} -DCMAKE_BUILD_TYPE=Release -S ${llvmspirvtranslator_SOURCE_DIR} -B ${llvmspirvtranslator_BINARY_DIR})
+      execute_process(COMMAND patch -d ${llvmspirvtranslator_SOURCE_DIR} --ignore-whitespace -i ${CMAKE_CURRENT_SOURCE_DIR}/spirv/llvm-spirv-cpack.patch)
     endif()
     
-    add_custom_target(llvm-spirv-translator ALL COMMAND ${CMAKE_COMMAND} --build ${llvmspirvtranslator_BINARY_DIR} --config Release)
-    install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} --install ${llvmspirvtranslator_BINARY_DIR})")
+    set(LLVM_SPIRV_BUILD_EXTERNAL ON)
+    set(llvm-spirv_TOOLS_INSTALL_DIR {LLVMSPIRV_RELATIVE_INSTALLDIR}/bin)
+    add_subdirectory(${llvmspirvtranslator_SOURCE_DIR} ${llvmspirvtranslator_BINARY_DIR})
+
+    # Install them to the desired relative path
+    install(TARGETS LLVMSPIRVLib COMPONENT ACPP DESTINATION ${LLVMSPIRV_RELATIVE_INSTALLDIR}/lib)
+    install(TARGETS llvm-spirv COMPONENT ACPP DESTINATION ${LLVMSPIRV_RELATIVE_INSTALLDIR}/bin)
 
     target_compile_definitions(llvm-to-spirv PRIVATE
       -DHIPSYCL_RELATIVE_LLVMSPIRV_PATH="${LLVMSPIRV_RELATIVE_PATH}")

--- a/src/compiler/llvm-to-backend/spirv/llvm-spirv-cpack.patch
+++ b/src/compiler/llvm-to-backend/spirv/llvm-spirv-cpack.patch
@@ -1,0 +1,32 @@
+--- CMakeLists.org.txt  2024-07-30 19:44:18.612183498 +0200
++++ CMakeLists.txt      2024-07-30 19:45:17.636893678 +0200
+--- CMakeLists.org.txt  2024-07-30 23:20:34.157373087 +0200
++++ CMakeLists.txt      2024-07-30 23:20:13.249091262 +0200
+@@ -22,6 +22,9 @@
+ if(LLVM_SPIRV_BUILD_EXTERNAL)
+   # Make sure llvm-spirv gets built when building outside the llvm tree.
+   set(LLVM_BUILD_TOOLS ON)
++  # Prevent the LLVM.cmake scripts from issueing an install command
++  # https://github.com/llvm/llvm-project/blob/main/llvm/cmake/modules/AddLLVM.cmake#L928
++  set(LLVM_INSTALL_TOOLCHAIN_ONLY ON)
+ endif(LLVM_SPIRV_BUILD_EXTERNAL)
+
+ # Download spirv.hpp from the official SPIRV-Headers repository.
+@@ -154,7 +154,8 @@
+     ${LLVM_SPIRV_INCLUDE_DIRS}/LLVMSPIRVOpts.h
+     ${LLVM_SPIRV_INCLUDE_DIRS}/LLVMSPIRVExtensions.inc
+   DESTINATION
+-    ${CMAKE_INSTALL_PREFIX}/include/LLVMSPIRVLib
++    ${LLVMSPIRV_RELATIVE_INSTALLDIR}/include/LLVMSPIRVLib
++  COMPONENT ACPP
+ )
+
+ configure_file(LLVMSPIRVLib.pc.in ${CMAKE_BINARY_DIR}/LLVMSPIRVLib.pc @ONLY)
+@@ -162,5 +163,6 @@
+   FILES
+     ${CMAKE_BINARY_DIR}/LLVMSPIRVLib.pc
+   DESTINATION
+-    ${CMAKE_INSTALL_PREFIX}/lib${LLVM_LIBDIR_SUFFIX}/pkgconfig
++    ${LLVMSPIRV_RELATIVE_INSTALLDIR}/lib${LLVM_LIBDIR_SUFFIX}/pkgconfig
++  COMPONENT ACPP
+ )


### PR DESCRIPTION
The current build scripts require root access, since LLVM's SPIRV is installed during the build.
This PR enables CPACK, and allows everything to build without root access.

Having packages instead of an install-during-build, helps me keeping my system clean.

Is this something that's acceptable as a change?