### PR TITLE
[L0] Take EUs into account when calculating compute units

### DIFF
--- a/src/runtime/ze/ze_hardware_manager.cpp
+++ b/src/runtime/ze/ze_hardware_manager.cpp
@@ -313,7 +313,7 @@ bool ze_hardware_context::has(device_support_aspect aspect) const {
 std::size_t ze_hardware_context::get_property(device_uint_property prop) const {
   switch (prop) {
   case device_uint_property::max_compute_units:
-    return _props.numSlices * _props.numSubslicesPerSlice;
+    return _props.numSlices * _props.numSubslicesPerSlice * _props.numEUsPerSubslice;
     break;
   case device_uint_property::max_global_size0:
     return _compute_props.maxGroupSizeX * _compute_props.maxGroupCountX;


### PR DESCRIPTION
This change aligns us with what DPC++ returns in this case: https://github.com/intel/llvm/blob/6e524e25c422b616d37f13fe3e9fef218f1ac235/sycl/plugins/unified_runtime/ur/adapters/level_zero/device.cpp#L205