### PR TITLE
[OpenCL] Fix accessing build log

### DIFF
--- a/src/runtime/ocl/ocl_code_object.cpp
+++ b/src/runtime/ocl/ocl_code_object.cpp
@@ -76,7 +76,7 @@ ocl_executable_object::ocl_executable_object(const cl::Context& ctx, cl::Device&
         _program.getBuildInfo(_dev, CL_PROGRAM_BUILD_LOG, &build_log);
 
     std::string msg = "ocl_code_object: Building CL program failed.";
-    if(access_build_log_err != CL_SUCCESS)
+    if(access_build_log_err == CL_SUCCESS)
       msg += " Build log: " + build_log;
     
     _build_status = register_error(


### PR DESCRIPTION
According to the [specification](https://man.opencl.org/clGetProgramBuildInfo.html), if return value of `_program.getBuildInfo(_dev, CL_PROGRAM_BUILD_LOG, &build_log);` is `CL_SUCCESS`, build log is available in `build_log`.