### PR TITLE
add sycl::popcount support

### DIFF
--- a/include/hipSYCL/sycl/libkernel/builtin_interface.hpp
+++ b/include/hipSYCL/sycl/libkernel/builtin_interface.hpp
@@ -549,6 +549,11 @@ HIPSYCL_BUILTIN T __hipsycl_mul24(T x, T y) noexcept {
   HIPSYCL_RETURN_DISPATCH_BUILTIN(__hipsycl_mul24, x, y);
 }
 
+template<class T>
+HIPSYCL_BUILTIN T __hipsycl_popcount(T x) noexcept {
+  HIPSYCL_RETURN_DISPATCH_BUILTIN(__hipsycl_popcount, x);
+}
+
 // **************** common functions *****************
 
 template<class T, std::enable_if_t<!std::is_integral_v<T>,int> = 0>

--- a/include/hipSYCL/sycl/libkernel/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/builtins.hpp
@@ -841,11 +841,12 @@ HIPSYCL_BUILTIN VecType min(const VecType &a, ScalarType b) {
 // TODO rotate
 // TODO sub_sat
 // TODO upsample
-// TODO popcount
 // TODO mad24
 
 HIPSYCL_DEFINE_BUILTIN(mul24, HIPSYCL_BUILTIN_OVERLOAD_SET_GENINTEGER32BIT,
                         HIPSYCL_BUILTIN_GENERATOR_BINARY_T_T)
+HIPSYCL_DEFINE_BUILTIN(popcount, HIPSYCL_BUILTIN_OVERLOAD_SET_GENINTEGER,
+                        HIPSYCL_BUILTIN_GENERATOR_UNARY_T)
 
 // ********************** common functions *******************
 #define HIPSYCL_BUILTIN_ENABLE_IF_MATCHING_FP_SCALAR(VecType, ScalarType)      \

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp
@@ -457,6 +457,11 @@ HIPSYCL_HIPLIKE_BUILTIN T __hipsycl_mul24(T x, T y) noexcept {
   return __mul24(x, y);
 }
 
+template<class T>
+HIPSYCL_HIPLIKE_BUILTIN T __hipsycl_popcount(T x) noexcept {
+  return __popc(x);
+}
+
 // **************** common functions *****************
 
 template<class T, std::enable_if_t<!std::is_integral_v<T>,int> = 0>

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp
@@ -457,9 +457,23 @@ HIPSYCL_HIPLIKE_BUILTIN T __hipsycl_mul24(T x, T y) noexcept {
   return __mul24(x, y);
 }
 
-template<class T>
+
+template<class T, std::enable_if_t<std::is_integral_v<T> && sizeof(T) < 4, int> = 0>
 HIPSYCL_HIPLIKE_BUILTIN T __hipsycl_popcount(T x) noexcept {
-  return __popc(x);
+  //we convert to the unsigned type to avoid the typecast creating
+  //additional ones in front of the value if x is negative
+  using Usigned = typename std::make_unsigned<T>::type;
+  return __popc(static_cast<__hipsycl_uint32>(static_cast<Usigned>(x)));
+}
+
+template<class T, std::enable_if_t<std::is_integral_v<T> && sizeof(T) == 4, int> = 0>
+HIPSYCL_HIPLIKE_BUILTIN T __hipsycl_popcount(T x) noexcept {
+  return __popc(static_cast<__hipsycl_uint32>(x));
+}
+
+template<class T, std::enable_if_t<std::is_integral_v<T> && sizeof(T) == 8, int> = 0>
+HIPSYCL_HIPLIKE_BUILTIN T __hipsycl_popcount(T x) noexcept {
+  return __popcll(static_cast<__hipsycl_uint64>(x));
 }
 
 // **************** common functions *****************

--- a/include/hipSYCL/sycl/libkernel/host/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/host/builtins.hpp
@@ -612,6 +612,15 @@ HIPSYCL_BUILTIN T __hipsycl_mul24(T x, T y) noexcept {
   return x * y;
 }
 
+template<class T, std::enable_if_t<std::is_integral_v<T>,int> = 0>
+HIPSYCL_BUILTIN T __hipsycl_popcount(T x) noexcept {
+    T count = T(0);
+    for (size_t i = 0; i < sizeof(T) * 8; i++) {
+        count += !!(x & (T(1) << i));
+    }
+    return count;
+}
+
 // **************** common functions *****************
 
 template<class T, std::enable_if_t<!std::is_integral_v<T>,int> = 0>

--- a/include/hipSYCL/sycl/libkernel/spirv/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/spirv/builtins.hpp
@@ -368,7 +368,7 @@ HIPSYCL_BUILTIN T __hipsycl_mul24(T x, T y) noexcept {
 }
 
 template<class T>
-HIPSYCL_BUILTIN T __hipsycl_clz(T x) noexcept {
+HIPSYCL_BUILTIN T __hipsycl_popcount(T x) noexcept {
   return __spirv_ocl_popcount(x);
 }
 

--- a/include/hipSYCL/sycl/libkernel/spirv/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/spirv/builtins.hpp
@@ -367,6 +367,11 @@ HIPSYCL_BUILTIN T __hipsycl_mul24(T x, T y) noexcept {
   return __spirv_ocl_u_mul24(x, y);
 }
 
+template<class T>
+HIPSYCL_BUILTIN T __hipsycl_clz(T x) noexcept {
+  return __spirv_ocl_popcount(x);
+}
+
 // **************** common functions *****************
 
 template<class T, std::enable_if_t<!std::is_integral_v<T>,int> = 0>

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins.hpp
@@ -434,6 +434,22 @@ HIPSYCL_BUILTIN T __hipsycl_mul24(T x, T y) noexcept {
   return __hipsycl_sscp_mul24_u32(x, y);
 }
 
+template <class T,
+          std::enable_if_t<
+              (std::is_integral_v<T> && sizeof(T) <= 4),
+              int> = 0>
+HIPSYCL_BUILTIN T __hipsycl_popcount(T x) noexcept {
+  return __hipsycl_sscp_popcount_u32(static_cast<__hipsycl_uint32>(x));
+}
+
+template <class T,
+          std::enable_if_t<
+              (std::is_integral_v<T> && sizeof(T) == 8),
+              int> = 0>
+HIPSYCL_BUILTIN T __hipsycl_popcount(T x) noexcept {
+  return __hipsycl_sscp_popcount_u64(static_cast<__hipsycl_uint64>(x));
+}
+
 // **************** common functions *****************
 
 template<class T, std::enable_if_t<!std::is_integral_v<T>,int> = 0>

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins.hpp
@@ -436,7 +436,18 @@ HIPSYCL_BUILTIN T __hipsycl_mul24(T x, T y) noexcept {
 
 template <class T,
           std::enable_if_t<
-              (std::is_integral_v<T> && sizeof(T) <= 4),
+              (std::is_integral_v<T> && sizeof(T) < 4),
+              int> = 0>
+HIPSYCL_BUILTIN T __hipsycl_popcount(T x) noexcept {
+  //we convert to the unsigned type to avoid the typecast creating
+  //additional ones in front of the value if x is negative
+  using Usigned = typename std::make_unsigned<T>::type;
+  return __hipsycl_sscp_popcount_u32(static_cast<__hipsycl_uint32>(static_cast<Usigned>(x)));
+}
+
+template <class T,
+          std::enable_if_t<
+              (std::is_integral_v<T> && sizeof(T) == 4),
               int> = 0>
 HIPSYCL_BUILTIN T __hipsycl_popcount(T x) noexcept {
   return __hipsycl_sscp_popcount_u32(static_cast<__hipsycl_uint32>(x));

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/interger.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/interger.hpp
@@ -38,4 +38,6 @@ HIPSYCL_SSCP_BUILTIN __hipsycl_uint16 __hipsycl_sscp_clz_u16(__hipsycl_uint16);
 HIPSYCL_SSCP_BUILTIN __hipsycl_uint32 __hipsycl_sscp_clz_u32(__hipsycl_uint32); 	
 HIPSYCL_SSCP_BUILTIN __hipsycl_uint64 __hipsycl_sscp_clz_u64(__hipsycl_uint64); 	
 
+HIPSYCL_SSCP_BUILTIN __hipsycl_uint32 __hipsycl_sscp_popcount_u32(__hipsycl_uint32);
+HIPSYCL_SSCP_BUILTIN __hipsycl_uint64 __hipsycl_sscp_popcount_u64(__hipsycl_uint64);
 #endif

--- a/src/libkernel/sscp/amdgpu/integer.cpp
+++ b/src/libkernel/sscp/amdgpu/integer.cpp
@@ -50,3 +50,9 @@ HIPSYCL_SSCP_BUILTIN __hipsycl_uint32 __hipsycl_sscp_clz_u32(__hipsycl_uint32 a)
 HIPSYCL_SSCP_BUILTIN __hipsycl_uint64 __hipsycl_sscp_clz_u64(__hipsycl_uint64 a){
   return __ockl_clz_u64(a);
 }
+HIPSYCL_SSCP_BUILTIN __hipsycl_uint32 __hipsycl_sscp_popcount_u32(__hipsycl_uint32 a){
+  return __ockl_popcount_u32(a);
+}
+HIPSYCL_SSCP_BUILTIN __hipsycl_uint64 __hipsycl_sscp_popcount_u64(__hipsycl_uint64 a){
+  return __ockl_popcount_u64(a);
+}

--- a/src/libkernel/sscp/ptx/integer.cpp
+++ b/src/libkernel/sscp/ptx/integer.cpp
@@ -54,3 +54,10 @@ HIPSYCL_SSCP_BUILTIN __hipsycl_uint8 __hipsycl_sscp_clz_u8(__hipsycl_uint8 a){
 HIPSYCL_SSCP_BUILTIN __hipsycl_uint16 __hipsycl_sscp_clz_u16(__hipsycl_uint16 a){
   return __hipsycl_sscp_clz_u32(a)-16;
 }
+
+HIPSYCL_SSCP_BUILTIN __hipsycl_uint32 __hipsycl_sscp_popcount_u32(__hipsycl_uint32 a){
+  return __nv_popc(a);
+}
+HIPSYCL_SSCP_BUILTIN __hipsycl_uint64 __hipsycl_sscp_popcount_u64(__hipsycl_uint64 a){
+  return __nv_popcll(a);
+}

--- a/src/libkernel/sscp/spirv/integer.cpp
+++ b/src/libkernel/sscp/spirv/integer.cpp
@@ -58,3 +58,13 @@ HIPSYCL_SSCP_BUILTIN __hipsycl_uint8 __hipsycl_sscp_clz_u8(__hipsycl_uint8 a){
 HIPSYCL_SSCP_BUILTIN __hipsycl_uint16 __hipsycl_sscp_clz_u16(__hipsycl_uint16 a){
   return __hipsycl_sscp_clz_u32(a)-16;
 }
+
+__hipsycl_uint32 __spirv_ocl_popcount(__hipsycl_uint32 a);
+__hipsycl_uint64 __spirv_ocl_popcount(__hipsycl_uint64 a);
+
+HIPSYCL_SSCP_BUILTIN __hipsycl_uint32 __hipsycl_sscp_popcount_u32(__hipsycl_uint32 a){
+  return __spirv_ocl_popcount(a);
+}
+HIPSYCL_SSCP_BUILTIN __hipsycl_uint64 __hipsycl_sscp_popcount_u64(__hipsycl_uint64 a){
+  return __spirv_ocl_popcount(a);
+}

--- a/tests/sycl/math.cpp
+++ b/tests/sycl/math.cpp
@@ -224,6 +224,12 @@ namespace {
     while(!bset[sizeof(T)*CHAR_BIT - idx -1]){idx++;}
     return idx;
   }
+
+  template<class T, std::enable_if_t<std::is_integral_v<T>,int> = 0>
+  inline T ref_popcount(T x) noexcept {
+    std::bitset<sizeof(T)*CHAR_BIT> bset(x);
+    return bset.count();
+  }
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_binary, T,
@@ -396,7 +402,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(builtin_int_basic, T, math_test_genints::type) {
 
   namespace s = cl::sycl;
 
-  constexpr int FUN_COUNT = 4;
+  constexpr int FUN_COUNT = 5;
 
   // build inputs
 
@@ -421,6 +427,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(builtin_int_basic, T, math_test_genints::type) {
       acc[i++] = s::min(acc[0], acc[1]);
       acc[i++] = s::max(acc[0], acc[1]);
       acc[i++] = s::clz(acc[0]);
+      acc[i++] = s::popcount(acc[0]);
     });
   });
 
@@ -438,6 +445,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(builtin_int_basic, T, math_test_genints::type) {
       BOOST_TEST(comp(acc[i++], c) == std::min(comp(acc[0], c), comp(acc[1], c)));
       BOOST_TEST(comp(acc[i++], c) == std::max(comp(acc[0], c), comp(acc[1], c)));
       BOOST_TEST(comp(acc[i++], c) == ref_clz(comp(acc[0], c)));
+      BOOST_TEST(comp(acc[i++], c) == ref_popcount(comp(acc[0], c)));
     }
   }
 }


### PR DESCRIPTION
Only tested on OpenMP and CUDA backend, could someone help me verify that the __hipsycl_popcount works in the other backends too?