### PR TITLE
[SSCP] Strip module level inline assembly from device code

### DIFF
--- a/src/compiler/sscp/TargetSeparationPass.cpp
+++ b/src/compiler/sscp/TargetSeparationPass.cpp
@@ -214,6 +214,16 @@ std::unique_ptr<llvm::Module> generateDeviceIR(llvm::Module &M,
   PB.registerLoopAnalyses(LAM);
   PB.crossRegisterProxies(LAM, FAM, CGAM, DeviceMAM);
 
+  // Strip module-level inline assembly. Module-level inline assembly is used
+  // by some libstdc++ versions (>13?) in their headers. This causes problems
+  // because we cannot infer whether global assembly code not contained in functions
+  // is part of device or host code. Thus, such inline assembly can cause JIT
+  // failures.
+  // Because global inline assembly does not make sense in device code (there are
+  // multiple JIT targets, each with their own inline assembly syntax), such code
+  // cannot be relevant to device code and we can safely strip it from device code.
+  DeviceModule->setModuleInlineAsm("");
+
   // Fix std:: math function calls to point to our builtins.
   // This is required such that e.g. std::sin() can be called in kernels.
   // This should be done prior to kernel outlining, such that the now defunct


### PR DESCRIPTION
It seems some libstdc++ header versions use module-level inline assembly. This can cause SSCP JIT failures, as host inline assembly can enter device code through that path. Because module-level inline assembly does not make sense in device code, we can just assume that it can only relate to host code and thus safely remove it from device code.

This PR causes the SSCP `TargetSeparationPass` to also strip module-level inline assembly during stage 1 compilation.

Hopefully fixes the issue reported in #1118.