### PR TITLE
Use `FindCUDAToolkit` for cmake versions >= 3.17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,4 @@
-cmake_minimum_required (VERSION 3.5)
-if(NOT CMAKE_VERSION VERSION_LESS 3.12)
-  cmake_policy(SET CMP0074 NEW) # Don't complain about using BOOST_ROOT...
-endif()
+cmake_minimum_required (VERSION 3.17)
 
 set(HIPSYCL_VERSION_MAJOR 0)
 set(HIPSYCL_VERSION_MINOR 9)
@@ -39,7 +36,7 @@ if(NOT Boost_FOUND)
 endif()
 
 # Check for CUDA/ROCm and clang
-find_package(CUDA QUIET)
+find_package(CUDAToolkit QUIET)
 find_package(HIP QUIET HINTS ${ROCM_PATH} ${ROCM_PATH}/lib/cmake)
 # Check for OpenCL
 find_package(OpenCL QUIET)
@@ -60,9 +57,23 @@ else()
 endif()
 
 if(WITH_CUDA_BACKEND)
-  if(NOT CUDA_FOUND)
+  if(NOT CUDAToolkit_FOUND)
     message(SEND_ERROR "CUDA was not found")
+  else()
+    # CMake version < 3.18 does not define CUDAToolkit_LIBRARY_ROOT, and in some
+    # cases CMake does not define this variable even for CMake version >= 3.18.
+    # In these cases we define it ourselves by taking the parent directory of
+    # the CUDAToolkit_LIBRARY_DIR directory and check if this is the right directory.
+    if (CMAKE_VERSION VERSION_LESS 3.18 OR NOT CUDAToolkit_LIBRARY_ROOT)
+      get_filename_component(CUDAToolkit_LIBRARY_ROOT ${CUDAToolkit_LIBRARY_DIR} DIRECTORY)
+
+      if (NOT EXISTS "${CUDAToolkit_LIBRARY_ROOT}/nvvm")
+        message(SEND_ERROR "CUDAToolkit_LIBRARY_ROOT does not point to the correct directory")
+      endif()
+    endif()
   endif()
+
+  message(STATUS "Found CUDA version ${CUDAToolkit_VERSION} in ${CUDAToolkit_LIBRARY_ROOT}")
 endif()
 if(WITH_ROCM_BACKEND)
   if(NOT ROCM_FOUND)
@@ -102,8 +113,6 @@ set(WITH_CPU_BACKEND true)
 
 if(WITH_CUDA_BACKEND)
   set(DEFAULT_PLATFORM "cuda")
-  find_library(CUDA_DRIVER_LIBRARY cuda HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib64/stubs ${CUDA_TOOLKIT_ROOT_DIR}/lib/x64 REQUIRED)
-  message(STATUS "Found CUDA driver library: ${CUDA_DRIVER_LIBRARY}")
 
   find_program(NVCXX_COMPILER NAMES nvc++)
 elseif(WITH_ROCM_BACKEND)
@@ -382,7 +391,7 @@ set(SYCLCC_CONFIG_FILE "{
   \"default-clang\"     : \"${CLANG_EXECUTABLE_PATH}\",
   \"default-nvcxx\"     : \"${NVCXX_COMPILER}\",
   \"default-platform\"  : \"${DEFAULT_PLATFORM}\",
-  \"default-cuda-path\" : \"${CUDA_TOOLKIT_ROOT_DIR}\",
+  \"default-cuda-path\" : \"${CUDAToolkit_LIBRARY_ROOT}\",
   \"default-gpu-arch\"  : \"${DEFAULT_GPU_ARCH}\",
   \"default-cpu-cxx\"   : \"${CMAKE_CXX_COMPILER}\",
   \"default-rocm-path\" : \"${ROCM_PATH}\",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
-cmake_minimum_required (VERSION 3.17)
+cmake_minimum_required (VERSION 3.5)
+if(NOT CMAKE_VERSION VERSION_LESS 3.12)
+  cmake_policy(SET CMP0074 NEW) # Don't complain about using BOOST_ROOT...
+endif()
 
 set(HIPSYCL_VERSION_MAJOR 0)
 set(HIPSYCL_VERSION_MINOR 9)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,8 @@ if(NOT Boost_FOUND)
 endif()
 
 # Check for CUDA/ROCm and clang
-find_package(CUDAToolkit QUIET)
+list(INSERT CMAKE_MODULE_PATH 0 "${PROJECT_SOURCE_DIR}/cmake/")
+find_package(CUDA QUIET)
 find_package(HIP QUIET HINTS ${ROCM_PATH} ${ROCM_PATH}/lib/cmake)
 # Check for OpenCL
 find_package(OpenCL QUIET)
@@ -57,23 +58,9 @@ else()
 endif()
 
 if(WITH_CUDA_BACKEND)
-  if(NOT CUDAToolkit_FOUND)
+  if(NOT CUDA_FOUND)
     message(SEND_ERROR "CUDA was not found")
-  else()
-    # CMake version < 3.18 does not define CUDAToolkit_LIBRARY_ROOT, and in some
-    # cases CMake does not define this variable even for CMake version >= 3.18.
-    # In these cases we define it ourselves by taking the parent directory of
-    # the CUDAToolkit_LIBRARY_DIR directory and check if this is the right directory.
-    if (CMAKE_VERSION VERSION_LESS 3.18 OR NOT CUDAToolkit_LIBRARY_ROOT)
-      get_filename_component(CUDAToolkit_LIBRARY_ROOT ${CUDAToolkit_LIBRARY_DIR} DIRECTORY)
-
-      if (NOT EXISTS "${CUDAToolkit_LIBRARY_ROOT}/nvvm")
-        message(SEND_ERROR "CUDAToolkit_LIBRARY_ROOT does not point to the correct directory")
-      endif()
-    endif()
   endif()
-
-  message(STATUS "Found CUDA version ${CUDAToolkit_VERSION} in ${CUDAToolkit_LIBRARY_ROOT}")
 endif()
 if(WITH_ROCM_BACKEND)
   if(NOT ROCM_FOUND)
@@ -391,7 +378,7 @@ set(SYCLCC_CONFIG_FILE "{
   \"default-clang\"     : \"${CLANG_EXECUTABLE_PATH}\",
   \"default-nvcxx\"     : \"${NVCXX_COMPILER}\",
   \"default-platform\"  : \"${DEFAULT_PLATFORM}\",
-  \"default-cuda-path\" : \"${CUDAToolkit_LIBRARY_ROOT}\",
+  \"default-cuda-path\" : \"${CUDA_TOOLKIT_ROOT_DIR}\",
   \"default-gpu-arch\"  : \"${DEFAULT_GPU_ARCH}\",
   \"default-cpu-cxx\"   : \"${CMAKE_CXX_COMPILER}\",
   \"default-rocm-path\" : \"${ROCM_PATH}\",

--- a/cmake/FindCUDA.cmake
+++ b/cmake/FindCUDA.cmake
@@ -22,6 +22,10 @@ if (CMAKE_VERSION VERSION_LESS 3.17)
       set(CUDA_LIBS "${CUDA_LIBRARIES} ${CUDA_DRIVER_LIBRARY}")
    endif()
 else()
+   if (DEFINED CUDA_TOOLKIT_ROOT_DIR AND NOT DEFINED CUDAToolkit_ROOT)
+      set(CUDAToolkit_ROOT ${CUDA_TOOLKIT_ROOT_DIR})
+   endif()
+
    find_package(CUDAToolkit QUIET)
 
    if (CUDAToolkit_FOUND)

--- a/cmake/FindCUDA.cmake
+++ b/cmake/FindCUDA.cmake
@@ -16,8 +16,8 @@ if (CMAKE_VERSION VERSION_LESS 3.17)
                    HINTS
                    ${CUDA_TOOLKIT_ROOT_DIR}/lib64/stubs
                    ${CUDA_TOOLKIT_ROOT_DIR}/lib/x64 REQUIRED)
-      message(STATUS "Found CUDA driver library: ${CUDA_DRIVER_LIBRARY}")
 
+      message(STATUS "Found CUDA version ${CUDA_VERSION} in ${CUDA_TOOLKIT_ROOT_DIR}")
 
       set(CUDA_LIBS "${CUDA_LIBRARIES} ${CUDA_DRIVER_LIBRARY}")
    endif()
@@ -40,6 +40,8 @@ else()
             message(SEND_ERROR "CUDAToolkit_LIBRARY_ROOT does not point to the correct directory, try setting it manually")
          endif()
       endif()
+
+      message(STATUS "Found CUDA version ${CUDAToolkit_VERSION} in ${CUDAToolkit_LIBRARY_ROOT}")
 
       set(CUDA_FOUND TRUE)
       set(CUDA_TOOLKIT_ROOT_DIR ${CUDAToolkit_LIBRARY_ROOT})

--- a/cmake/FindCUDA.cmake
+++ b/cmake/FindCUDA.cmake
@@ -1,0 +1,47 @@
+# This module serves as a compatibility layer to support cmake versions < 3.17
+# (which do not support the replacement for the deprecated FindCUDA,
+# FindCUDAToolkit) and cmake versions >= 3.17 (which do have FindCUDAToolkit).
+
+# Remove our own modules from cmake's module search path to prevent
+# it from recursively calling this module when using find_package(CUDA) below.
+set(OLD_CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH})
+list(REMOVE_ITEM CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/")
+
+if (CMAKE_VERSION VERSION_LESS 3.17)
+   find_package(CUDA QUIET)
+
+   if (CUDA_FOUND)
+      find_library(CUDA_DRIVER_LIBRARY
+                   cuda
+                   HINTS
+                   ${CUDA_TOOLKIT_ROOT_DIR}/lib64/stubs
+                   ${CUDA_TOOLKIT_ROOT_DIR}/lib/x64 REQUIRED)
+      message(STATUS "Found CUDA driver library: ${CUDA_DRIVER_LIBRARY}")
+
+
+      set(CUDA_LIBS "${CUDA_LIBRARIES} ${CUDA_DRIVER_LIBRARY}")
+   endif()
+else()
+   find_package(CUDAToolkit QUIET)
+
+   if (CUDAToolkit_FOUND)
+      # CMake version < 3.18 does not define CUDAToolkit_LIBRARY_ROOT, and in some
+      # cases CMake does not define this variable even for CMake version >= 3.18.
+      # In these cases we define it ourselves by taking the parent directory of
+      # the CUDAToolkit_LIBRARY_DIR directory and check if this is the right directory.
+      if (CMAKE_VERSION VERSION_LESS 3.18 OR NOT CUDAToolkit_LIBRARY_ROOT)
+         get_filename_component(CUDAToolkit_LIBRARY_ROOT ${CUDAToolkit_LIBRARY_DIR} DIRECTORY)
+
+         if (NOT EXISTS "${CUDAToolkit_LIBRARY_ROOT}/nvvm")
+            message(SEND_ERROR "CUDAToolkit_LIBRARY_ROOT does not point to the correct directory, try setting it manually")
+         endif()
+      endif()
+
+      set(CUDA_FOUND TRUE)
+      set(CUDA_TOOLKIT_ROOT_DIR ${CUDAToolkit_LIBRARY_ROOT})
+      set(CUDA_LIBS CUDA::cudart CUDA::cuda_driver)
+   endif()
+endif()
+
+# Restore the cmake module path that contains our modules
+set(CMAKE_MODULE_PATH OLD_CMAKE_MODULE_PATH)

--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -146,7 +146,7 @@ if(WITH_SSCP_COMPILER)
 
     target_compile_definitions(llvm-to-ptx PRIVATE
       -DHIPSYCL_CLANG_PATH="${CLANG_EXECUTABLE_PATH}" 
-      -DHIPSYCL_CUDA_PATH="${CUDA_TOOLKIT_ROOT_DIR}")
+      -DHIPSYCL_CUDA_PATH="${CUDAToolkit_LIBRARY_ROOT}")
   endif()
 
   if(WITH_LLVM_TO_AMDGPU_AMDHSA)

--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -146,7 +146,7 @@ if(WITH_SSCP_COMPILER)
 
     target_compile_definitions(llvm-to-ptx PRIVATE
       -DHIPSYCL_CLANG_PATH="${CLANG_EXECUTABLE_PATH}" 
-      -DHIPSYCL_CUDA_PATH="${CUDAToolkit_LIBRARY_ROOT}")
+      -DHIPSYCL_CUDA_PATH="${CUDA_TOOLKIT_ROOT_DIR}")
   endif()
 
   if(WITH_LLVM_TO_AMDGPU_AMDHSA)

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -103,9 +103,9 @@ if(WITH_CUDA_BACKEND)
 
   target_include_directories(rt-backend-cuda PRIVATE
     ${HIPSYCL_SOURCE_DIR}/include
-    ${CUDA_TOOLKIT_ROOT_DIR}/include)
+    ${CUDAToolkit_INCLUDE_DIRS})
   
-  target_link_libraries(rt-backend-cuda PRIVATE hipSYCL-rt ${CUDA_LIBRARIES} ${CUDA_DRIVER_LIBRARY})
+  target_link_libraries(rt-backend-cuda PRIVATE hipSYCL-rt CUDA::cudart CUDA::cuda_driver)
 
   target_compile_options(rt-backend-cuda PRIVATE ${HIPSYCL_RT_EXTRA_CXX_FLAGS})
   target_link_libraries(rt-backend-cuda PRIVATE ${HIPSYCL_RT_EXTRA_LINKER_FLAGS})

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -103,9 +103,9 @@ if(WITH_CUDA_BACKEND)
 
   target_include_directories(rt-backend-cuda PRIVATE
     ${HIPSYCL_SOURCE_DIR}/include
-    ${CUDAToolkit_INCLUDE_DIRS})
+    ${CUDA_TOOLKIT_ROOT_DIR}/include)
   
-  target_link_libraries(rt-backend-cuda PRIVATE hipSYCL-rt CUDA::cudart CUDA::cuda_driver)
+  target_link_libraries(rt-backend-cuda PRIVATE hipSYCL-rt ${CUDA_LIBS})
 
   target_compile_options(rt-backend-cuda PRIVATE ${HIPSYCL_RT_EXTRA_CXX_FLAGS})
   target_link_libraries(rt-backend-cuda PRIVATE ${HIPSYCL_RT_EXTRA_LINKER_FLAGS})


### PR DESCRIPTION
As reported in #1119, `FindCUDA` is deprecated in recent cmake versions.
This PR adds our own `FindCUDA` that falls back to cmake's `FindCUDA` for cmake versions < 3.17. For cmake versions >= 3.17 it uses the replacement for `FindCUDA`, `FindCUDAToolkit`.

Fixes #1119