### PR TITLE
Allow for non-default-constructible iterators in `std::for_each_n`

### DIFF
--- a/include/hipSYCL/std/stdpar/detail/offload.hpp
+++ b/include/hipSYCL/std/stdpar/detail/offload.hpp
@@ -234,7 +234,12 @@ bool should_offload(AlgorithmType type, Size n, const Args &...args) {
   auto &q = hipsycl::stdpar::detail::single_device_dispatch::get_queue();      \
   bool is_offloaded = hipsycl::stdpar::should_offload(                         \
       algorithm_type_object, problem_size, __VA_ARGS__);                       \
-  return_type ret = is_offloaded ? offload_invoker(q) : fallback_invoker();    \
+  const auto blocking_fallback_invoker = [&]() {                               \
+    q.wait();                                                                  \
+    return fallback_invoker();                                                 \
+  };                                                                           \
+  return_type ret =                                                            \
+      is_offloaded ? offload_invoker(q) : blocking_fallback_invoker();         \
   return ret;
 } // namespace hipsycl::stdpar
 

--- a/include/hipSYCL/std/stdpar/detail/offload.hpp
+++ b/include/hipSYCL/std/stdpar/detail/offload.hpp
@@ -223,12 +223,7 @@ bool should_offload(AlgorithmType type, Size n, const Args &...args) {
   auto &q = hipsycl::stdpar::detail::single_device_dispatch::get_queue();      \
   bool is_offloaded = hipsycl::stdpar::should_offload(                         \
       algorithm_type_object, problem_size, __VA_ARGS__);                       \
-  return_type ret;                                                             \
-  if (is_offloaded) {                                                          \
-    ret = offload_invoker(q);                                                  \
-  } else {                                                                     \
-    ret = fallback_invoker();                                                  \
-  }                                                                            \
+  return_type ret = is_offloaded ? offload_invoker(q) : fallback_invoker();    \
   __hipsycl_stdpar_optimizable_sync(q, is_offloaded);                          \
   return ret;
 
@@ -239,13 +234,7 @@ bool should_offload(AlgorithmType type, Size n, const Args &...args) {
   auto &q = hipsycl::stdpar::detail::single_device_dispatch::get_queue();      \
   bool is_offloaded = hipsycl::stdpar::should_offload(                         \
       algorithm_type_object, problem_size, __VA_ARGS__);                       \
-  return_type ret;                                                             \
-  if (is_offloaded) {                                                          \
-    ret = offload_invoker(q);                                                  \
-  } else {                                                                     \
-    q.wait();                                                                  \
-    ret = fallback_invoker();                                                  \
-  }                                                                            \
+  return_type ret = is_offloaded ? offload_invoker(q) : fallback_invoker();    \
   return ret;
 } // namespace hipsycl::stdpar
 


### PR DESCRIPTION
When the macro `HIPSYCL_STDPAR_OFFLOAD` is used in `std::for_each_n`, the type `return_type` is `ForwardIt` (in the C++ standard it is called `InputIt`) and this iterator only has to meet the requirements of a `LegacyInputIterator` which does not include default-constructibility. By replacing the if/else with a ternary operator, the declaration that causes a call to the (possibly non-existent) default constructor can be removed.

Edit: ~I just realised that I accidentally removed a call to `q.wait()` in the second macro; ill fix that asap.~ Fixed it.