### PR TITLE
[HipLike] add header noinline workaround for gcc-13

### DIFF
--- a/include/hipSYCL/std/hiplike/bits/basic_string.h
+++ b/include/hipSYCL/std/hiplike/bits/basic_string.h
@@ -1,0 +1,12 @@
+// Modified from https://reviews.llvm.org/D149364
+
+// CUDA headers define __noinline__ which interferes with libstdc++'s use of
+// `__attribute((__noinline__))`. In order to avoid compilation error,
+// temporarily unset __noinline__ when we include affected libstdc++ header.
+// this is an additional issue when using gcc13 headers
+
+#pragma push_macro("__noinline__")
+#undef __noinline__
+#include_next "bits/basic_string.h"
+
+#pragma pop_macro("__noinline__")

--- a/include/hipSYCL/std/hiplike/bits/basic_string.tcc
+++ b/include/hipSYCL/std/hiplike/bits/basic_string.tcc
@@ -1,0 +1,12 @@
+// Taken from https://reviews.llvm.org/D149364
+
+// CUDA headers define __noinline__ which interferes with libstdc++'s use of
+// `__attribute((__noinline__))`. In order to avoid compilation error,
+// temporarily unset __noinline__ when we include affected libstdc++ header.
+// this is an additional issue when using gcc13 headers
+
+#pragma push_macro("__noinline__")
+#undef __noinline__
+#include_next "bits/basic_string.tcc"
+
+#pragma pop_macro("__noinline__")


### PR DESCRIPTION
After checking with gcc-13 new issues appears, but they can be solved with a similar workaround as in PR #1161

Before the fix on up to date Arch linux:
```
clang-16: warning: CUDA version is newer than the latest partially supported version 11.8 [-Wunknown-cuda-version]
In file included from /media/nvme/sycl_include.cpp:1:
In file included from /media/nvme/acpp/bin/../include/sycl/sycl.hpp:31:
In file included from /media/nvme/acpp/include/sycl/../hipSYCL/sycl/sycl.hpp:50:
In file included from /media/nvme/acpp/bin/../include/hipSYCL/glue/persistent_runtime.hpp:32:
In file included from /media/nvme/acpp/bin/../include/hipSYCL/runtime/application.hpp:33:
In file included from /media/nvme/acpp/bin/../include/hipSYCL/runtime/backend.hpp:32:
In file included from /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/string:54:
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/basic_string.h:2532:22: error: use of undeclared identifier 'noinline'; did you mean 'inline'?
      __attribute__((__noinline__, __noclone__, __cold__)) void
                     ^
/opt/cuda/include/crt/host_defines.h:83:24: note: expanded from macro '__noinline__'
        __attribute__((noinline))
                       ^
In file included from /media/nvme/sycl_include.cpp:1:
In file included from /media/nvme/acpp/bin/../include/sycl/sycl.hpp:31:
In file included from /media/nvme/acpp/include/sycl/../hipSYCL/sycl/sycl.hpp:50:
In file included from /media/nvme/acpp/bin/../include/hipSYCL/glue/persistent_runtime.hpp:32:
In file included from /media/nvme/acpp/bin/../include/hipSYCL/runtime/application.hpp:33:
In file included from /media/nvme/acpp/bin/../include/hipSYCL/runtime/backend.hpp:32:
In file included from /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/string:54:
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/basic_string.h:2532:22: error: type name does not allow function specifier to be specified
/opt/cuda/include/crt/host_defines.h:83:24: note: expanded from macro '__noinline__'
        __attribute__((noinline))
                       ^
In file included from /media/nvme/cmake/feature_test/sycl_include.cpp:1:
In file included from /media/nvme/acpp/bin/../include/sycl/sycl.hpp:31:
In file included from /media/nvme/acpp/include/sycl/../hipSYCL/sycl/sycl.hpp:50:
In file included from /media/nvme/acpp/bin/../include/hipSYCL/glue/persistent_runtime.hpp:32:
In file included from /media/nvme/acpp/bin/../include/hipSYCL/runtime/application.hpp:33:
In file included from /media/nvme/acpp/bin/../include/hipSYCL/runtime/backend.hpp:32:
In file included from /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/string:54:
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/basic_string.h:2532:22: error: expected expression
/opt/cuda/include/crt/host_defines.h:83:33: note: expanded from macro '__noinline__'
        __attribute__((noinline))
                                ^
In file included from /media/nvme/sycl_include.cpp:1:
In file included from /media/nvme/acpp/bin/../include/sycl/sycl.hpp:31:
In file included from /media/nvme/acpp/include/sycl/../hipSYCL/sycl/sycl.hpp:50:
In file included from /media/nvme/acpp/bin/../include/hipSYCL/glue/persistent_runtime.hpp:32:
In file included from /media/nvme/acpp/bin/../include/hipSYCL/runtime/application.hpp:33:
In file included from /media/nvme/acpp/bin/../include/hipSYCL/runtime/backend.hpp:32:
In file included from /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/string:55:
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/basic_string.tcc:473:20: error: use of undeclared identifier 'noinline'; did you mean 'inline'?
    __attribute__((__noinline__, __noclone__, __cold__)) void
                   ^
/opt/cuda/include/crt/host_defines.h:83:24: note: expanded from macro '__noinline__'
        __attribute__((noinline))
                       ^
In file included from /media/nvme/sycl_include.cpp:1:
In file included from /media/nvme/acpp/bin/../include/sycl/sycl.hpp:31:
In file included from /media/nvme/acpp/include/sycl/../hipSYCL/sycl/sycl.hpp:50:
In file included from /media/nvme/acpp/bin/../include/hipSYCL/glue/persistent_runtime.hpp:32:
In file included from /media/nvme/acpp/bin/../include/hipSYCL/runtime/application.hpp:33:
In file included from /media/nvme/acpp/bin/../include/hipSYCL/runtime/backend.hpp:32:
In file included from /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/string:55:
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/basic_string.tcc:473:20: error: type name does not allow function specifier to be specified
/opt/cuda/include/crt/host_defines.h:83:24: note: expanded from macro '__noinline__'
        __attribute__((noinline))
                       ^
In file included from /media/nvme/feature_test/sycl_include.cpp:1:
In file included from /media/nvme/acpp/bin/../include/sycl/sycl.hpp:31:
In file included from /media/nvme/acpp/include/sycl/../hipSYCL/sycl/sycl.hpp:50:
In file included from /media/nvme/acpp/bin/../include/hipSYCL/glue/persistent_runtime.hpp:32:
In file included from /media/nvme/acpp/bin/../include/hipSYCL/runtime/application.hpp:33:
In file included from /media/nvme/acpp/bin/../include/hipSYCL/runtime/backend.hpp:32:
In file included from /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/string:55:
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/basic_string.tcc:473:20: error: expected expression
/opt/cuda/include/crt/host_defines.h:83:33: note: expanded from macro '__noinline__'
        __attribute__((noinline))
                                ^
6 errors generated when compiling for sm_70.
```

sycl_include.cpp : 
```c++
#include <sycl/sycl.hpp>

int main(void){}
```

just adding `basic_string.tcc`, `basic_string.h` like in PR #1161 works