### PR TITLE
[SSCP][llvm-to-ptx] Strip debug information to avoid JIT failures when using -g

### DIFF
--- a/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
+++ b/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
@@ -41,6 +41,7 @@
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Metadata.h>
 #include <llvm/IR/Module.h>
+#include <llvm/IR/DebugInfo.h>
 #include <llvm/Passes/PassBuilder.h>
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/MemoryBuffer.h>
@@ -157,6 +158,11 @@ bool LLVMToPtxTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
 
   AddressSpaceInferencePass ASIPass {ASMap};
   ASIPass.run(M, *PH.ModuleAnalysisManager);
+
+  // It seems there is an issue with debug info in PTX, so strip it for now
+  // TODO: We should attempt to find out what exactly is causing the problem
+  // so that code still can be debugged on NVIDIA GPUs.
+  llvm::StripDebugInfo(M);
 
   if(!this->linkBitcodeFile(M, BuiltinBitcodeFile))
     return false;


### PR DESCRIPTION
CUDA does not seem to like some debug information generated by clang when using `-g`. Because of this, PTX JIT currently fails in that case even for very simple code.

This PR avoids the problem by stripping debug information from device code until a more localized solution is found.

Fixes #1062 