### PR TITLE
Fix UB in test cases

### DIFF
--- a/include/hipSYCL/sycl/libkernel/marray.hpp
+++ b/include/hipSYCL/sycl/libkernel/marray.hpp
@@ -55,8 +55,8 @@ private:
     if constexpr(std::is_scalar_v<T>) {
       _data[offset] = x;
     } else {
-      for(std::size_t i = 0; i < _data.size(); ++i)
-      _data[offset + i] = x[i];  
+      for(std::size_t i = 0; i < x.size(); ++i)
+        _data[offset + i] = x[i];  
     }
   }
 

--- a/tests/sycl/accessor.cpp
+++ b/tests/sycl/accessor.cpp
@@ -749,8 +749,9 @@ BOOST_AUTO_TEST_CASE(offset_1d) {
   {
     s::buffer<int> buf(data.data(), N);
     s::queue{}.submit([&](s::handler &cgh) {
-      s::range range{N};
       s::id offset{2};
+      s::range range{N-offset};
+      
       auto acc = s::accessor(buf, cgh, range, offset);
 
       cgh.parallel_for(s::range{N - offset},
@@ -779,8 +780,10 @@ BOOST_AUTO_TEST_CASE(offset_2d) {
     s::buffer<int, 2> buf(data.data(), {N,N});
 
     s::queue{}.submit([&](s::handler &cgh) {
-      s::range range{N, N};
-      s::id offset{2, 2};
+      std::size_t offset_1d = 2;
+      s::range range{N - offset_1d, N - offset_1d};
+      s::id offset{offset_1d, offset_1d};
+      
       auto acc = s::accessor(buf, cgh, range, offset);
 
       cgh.parallel_for(s::range{N - offset.get(0), N - offset.get(1)},
@@ -817,8 +820,10 @@ BOOST_AUTO_TEST_CASE(offset_nested_subscript) {
   {
     s::buffer<int, 2> buf(data.data(), {N,N});
     s::queue{}.submit([&](s::handler &cgh) {
-      s::range range{N, N};
-      s::id offset{2, 2};
+      std::size_t offset_1d = 2;
+      s::range range{N - offset_1d, N - offset_1d};
+      s::id offset{offset_1d, offset_1d};
+      
       auto acc = s::accessor(buf, cgh, range, offset);
 
       cgh.parallel_for(s::range{N - offset.get(0), N - offset.get(1)},


### PR DESCRIPTION
This fixes two UB cases that currently affect our test cases:
- out-of-bounds access in accessor tests
- marray constructor out-of-bounds access

This hopefully resolves the spurious CI failures that we have occasionally seen.

With this PR, running the tests is clean of asan issues.