### PR TITLE
buffer allocation: Avoid requesting alignments not supported by backends

### DIFF
--- a/src/runtime/dag_direct_scheduler.cpp
+++ b/src/runtime/dag_direct_scheduler.cpp
@@ -98,12 +98,14 @@ result ensure_allocation_exists(runtime *rt,
     const std::size_t num_bytes =
         bmem_req->get_data_region()->get_num_elements().size() *
         bmem_req->get_data_region()->get_element_size();
-    const std::size_t min_align = // max requested alignment the size of a sycl::vec<double, 16>
-        std::min(bmem_req->get_data_region()->get_element_size(), sizeof(double) * 16);
 
     backend_allocator *allocator =
         rt->backends().get(target_dev.get_backend())->get_allocator(target_dev);
-    void *ptr = allocator->allocate(min_align, num_bytes);
+    // Currently we just pass 0 for the alignment which should
+    // cause backends to align to the largest supported type.
+    // TODO: A better solution might be to select a custom alignment
+    // best on sizeof(T). This requires querying backend alignment capabilities.
+    void *ptr = allocator->allocate(0, num_bytes);
 
     if(!ptr)
       return register_error(

--- a/src/runtime/ocl/ocl_allocator.cpp
+++ b/src/runtime/ocl/ocl_allocator.cpp
@@ -44,6 +44,7 @@ void* ocl_allocator::allocate(size_t min_alignment, size_t size_bytes) {
                               error_type::memory_allocation_error});
     return nullptr;
   }
+  
   cl_int err;
   void* ptr = _usm->malloc_device(size_bytes, min_alignment, err);
   if(err != CL_SUCCESS) {

--- a/src/runtime/omp/omp_allocator.cpp
+++ b/src/runtime/omp/omp_allocator.cpp
@@ -38,10 +38,13 @@ omp_allocator::omp_allocator(const device_id &my_device)
     : _my_device{my_device} {}
 
 void *omp_allocator::allocate(size_t min_alignment, size_t size_bytes) {
+  if(min_alignment == 0)
+    return std::malloc(size_bytes);
+
 #ifndef _WIN32
   // posix requires alignment to be a multiple of sizeof(void*)
   if (min_alignment < sizeof(void*))
-    return malloc(size_bytes);
+    return std::malloc(size_bytes);
 #else
   min_alignment = std::max(min_alignment, 1ULL);
 #endif


### PR DESCRIPTION
Previously we have just passed in the size of the data type as desired alignment for `buffer` data storage. This might fail on some backends if the data type is not power-of-two, or too large to be aligned etc.

This PR causes buffer memory allocation requests to require alignment 0 instead, which should be universally compatible.