### PR TITLE
[SSCP][llvm-to-spirv] Don't error if requested local memory is unused

### DIFF
--- a/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
+++ b/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
@@ -181,8 +181,9 @@ bool LLVMToSpirvTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
     HIPSYCL_DEBUG_INFO << "LLVMToSpirv: Configuring kernel for " << DynamicLocalMemSize
                        << " bytes of local memory\n";
     if(!setDynamicLocalMemoryCapacity(M, DynamicLocalMemSize)) {
-      this->registerError("Could not set dynamic local memory size");
-      return false;
+      HIPSYCL_DEBUG_WARNING
+          << "Could not set dynamic local memory size; this could imply that local memory "
+             "requested by the application is not actually used inside kernels\n";
     }
   } else {
     HIPSYCL_DEBUG_INFO << "LLVMToSpirv: Removing dynamic local memory support from module\n";


### PR DESCRIPTION
If local memory requested (e.g. with a local accessor) is not actually used inside kernels, then llvm-to-spirv's mechanism to set local memory might fail because the local memory placeholder array might likely be optimized away.
Currently we error in this case which triggers a JIT failure. Since this can happen with perfectly legal programs that just don't use their requested local memory, this can be an issue.

This PR changes the behavior to emit a warning in this case instead.