### PR TITLE
[SSCP] Fix excessive global pruning introduced in #1166

### DIFF
--- a/src/compiler/sscp/KernelOutliningPass.cpp
+++ b/src/compiler/sscp/KernelOutliningPass.cpp
@@ -34,6 +34,10 @@ namespace {
 bool isUsedInFunctions(llvm::SmallPtrSet<llvm::User*, 16>& VisitedUsers, llvm::User* User) {
   if(llvm::isa<llvm::Function>(User))
       return true;
+  if(llvm::Instruction* I = llvm::dyn_cast<llvm::Instruction>(User)){
+    if(I->getFunction())
+      return true;
+  }
   
   if(VisitedUsers.contains(User))
     return false;


### PR DESCRIPTION
Fixes a regression introduced in #1166. #1166 was supposed to remove all globals that were not used in functions, however, the check was incorrect so that it removed globals even if they were used.
This PR fixes this.