### PR TITLE
[SSCP][llvm-to-spirv] Also strip debug information for SPIR-V JIT

### DIFF
--- a/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
+++ b/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
@@ -42,6 +42,7 @@
 #include <llvm/IR/CallingConv.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
+#include <llvm/IR/DebugInfo.h>
 #include <llvm/Passes/PassBuilder.h>
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/MemoryBuffer.h>
@@ -212,6 +213,10 @@ bool LLVMToSpirvTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
 
   AddressSpaceInferencePass ASIPass{ASMap};
   ASIPass.run(M, *PH.ModuleAnalysisManager);
+
+  // It seems there is an issue with debug info in llvm-spirv, so strip it for now
+  // TODO: We should attempt to find out what exactly is causing the problem
+  llvm::StripDebugInfo(M);
 
   return true;
 }


### PR DESCRIPTION
Same as #1168. Turns out llvm-spirv translator sometimes trips over debug information too.