### PR TITLE
[OpenCL] Correctly initialize is_from_host_backend when querying USM pointer info

### DIFF
--- a/src/runtime/ocl/ocl_usm.cpp
+++ b/src/runtime/ocl/ocl_usm.cpp
@@ -177,9 +177,11 @@ public:
                                  sizeof(mem_type), &mem_type, nullptr);
 
     out.is_from_host_backend = false;
+    out.is_optimized_host = false;
+
     if(err != CL_SUCCESS)
       return err;
-    
+
     if(mem_type == CL_MEM_TYPE_HOST_INTEL)
       out.is_optimized_host = true;
     else if(mem_type == CL_MEM_TYPE_SHARED_INTEL)


### PR DESCRIPTION
Previously `is_from_host_backend` was not initialized when the pointer is a device pointer. This can cause issues down the line, such as when USM `memcpy()` tries to figure out what kind of copy this is.