### PR TITLE
[CI][CBS] Enable LLVM 17 in CI

### DIFF
--- a/.github/workflows/linux-cbs.yml
+++ b/.github/workflows/linux-cbs.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        clang: [13, 14, 15, 16]
+        clang: [13, 14, 15, 16, 17]
         os: [ubuntu-22.04]
         include:
           - clang: 11

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -57,7 +57,7 @@ jobs:
     - name: install ROCm
       run: |
         [[ ${{matrix.os}} == ubuntu-20.04 ]] && CODENAME=xenial
-        [[ ${{matrix.os}} == ubuntu-22.04 ]] && CODENAME=focal
+        [[ ${{matrix.os}} == ubuntu-22.04 ]] && CODENAME=jammy
         sudo apt install libnuma-dev cmake unzip
         wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
         echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/${{matrix.rocm}} $CODENAME main" | sudo tee /etc/apt/sources.list.d/rocm.list

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        clang: [15, 16, 17]
+        clang: [15, 16]
         os: [ubuntu-22.04]
         cuda: [11.0.2]
         rocm: [5.4.3]
@@ -29,6 +29,10 @@ jobs:
             os: ubuntu-20.04
             cuda: 11.0.2
             rocm: 4.0.1
+          - clang: 17
+            os: ubuntu-22.04
+            cuda: 11.0.2
+            rocm: 5.6.1
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        clang: [15, 16]
+        clang: [15, 16, 17]
         os: [ubuntu-22.04]
         cuda: [11.0.2]
         rocm: [5.4.3]

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -56,8 +56,8 @@ jobs:
         echo "CUDA Version ${{matrix.cuda}}" | sudo tee /opt/AdaptiveCpp/cuda/version.txt
     - name: install ROCm
       run: |
-        [[ ${{matrix.rocm}} == 4.0.1 ]] && CODENAME=xenial
-        [[ ${{matrix.rocm}} == 5.4.3 ]] && CODENAME=focal
+        [[ ${{matrix.os}} == ubuntu-20.04 ]] && CODENAME=xenial
+        [[ ${{matrix.os}} == ubuntu-22.04 ]] && CODENAME=focal
         sudo apt install libnuma-dev cmake unzip
         wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
         echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/${{matrix.rocm}} $CODENAME main" | sudo tee /etc/apt/sources.list.d/rocm.list

--- a/src/compiler/AdaptiveCppClangPlugin.cpp
+++ b/src/compiler/AdaptiveCppClangPlugin.cpp
@@ -161,7 +161,8 @@ extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo llvmGetPassPluginIn
 
 #ifdef HIPSYCL_WITH_ACCELERATED_CPU
           PB.registerAnalysisRegistrationCallback([](llvm::ModuleAnalysisManager &MAM) {
-            MAM.registerPass([] { return SplitterAnnotationAnalysis{}; });
+            if(!CompilationStateManager::getASTPassState().isDeviceCompilation())
+              MAM.registerPass([] { return SplitterAnnotationAnalysis{}; });
           });
 #if LLVM_VERSION_MAJOR < 12
           PB.registerPipelineStartEPCallback([](llvm::ModulePassManager &MPM) {
@@ -169,12 +170,14 @@ extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo llvmGetPassPluginIn
 #else
           PB.registerPipelineStartEPCallback([](llvm::ModulePassManager &MPM, OptLevel Opt) {
 #endif
-            registerCBSPipeline(MPM, Opt);
+            if(!CompilationStateManager::getASTPassState().isDeviceCompilation())
+              registerCBSPipeline(MPM, Opt);
           });
           // SROA adds loads / stores without adopting the llvm.access.group MD, need to re-add.
           // todo: check back with LLVM 13, might be fixed with https://reviews.llvm.org/D103254
           PB.registerVectorizerStartEPCallback([](llvm::FunctionPassManager &FPM, OptLevel) {
-            FPM.addPass(LoopsParallelMarkerPass{});
+            if(!CompilationStateManager::getASTPassState().isDeviceCompilation())
+              FPM.addPass(LoopsParallelMarkerPass{});
           });
 #endif
         }


### PR DESCRIPTION
This enables LLVM 17 to CI.

HIP SMCP needed a bit of a workaround to fully disable any extra passes landing in the device pipeline from CBS.
(InstCombine triggers some invalid addrspace cast issue)