### PR TITLE
Warn if using different LLVM then specified by LLVM_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,11 @@ if(WITH_OPENCL_BACKEND OR WITH_LEVEL_ZERO_BACKEND)
 endif()
 
 if(BUILD_CLANG_PLUGIN)
+  set(LLVM_DIR_OLD ${LLVM_DIR})
   find_package(LLVM CONFIG)
+  if(LLVM_DIR_OLD AND NOT ("${LLVM_DIR_OLD}" STREQUAL "${LLVM_DIR}"))
+    message(WARNING "Could not find LLVM in the requested location LLVM_DIR=${LLVM_DIR_OLD}; using ${LLVM_DIR}.")
+  endif()
   message(STATUS "Building hipSYCL against LLVM configured from ${LLVM_DIR}")
   #find_package(Clang REQUIRED)
 


### PR DESCRIPTION
Previously, if `LLVM_DIR` was set incorrectly, ACpp would silently use another LLVM installation when available. Now we issue a warning in this case.

It is easy to set `-DLLVM_DIR=/opt/rocm/llvm/lib/cmake/` instead of `-DLLVM_DIR=/opt/rocm/llvm/lib/cmake/llvm/`, and then miss the "Building hipSYCL against LLVM configured from" message in the long CMake output.