### PR TITLE
[stdpar] Remove names of unused parameters to avoid warnings

### DIFF
--- a/include/hipSYCL/std/stdpar/detail/sycl_glue.hpp
+++ b/include/hipSYCL/std/stdpar/detail/sycl_glue.hpp
@@ -313,56 +313,56 @@ void operator delete[]( void* ptr ) noexcept {
 }
 
 HIPSYCL_STDPAR_FREE
-void operator delete  ( void* ptr, std::align_val_t al ) noexcept {
+void operator delete  ( void* ptr, std::align_val_t ) noexcept {
   hipsycl::stdpar::unified_shared_memory::free(ptr);
 }
 
 HIPSYCL_STDPAR_FREE
-void operator delete[]( void* ptr, std::align_val_t al ) noexcept {
+void operator delete[]( void* ptr, std::align_val_t ) noexcept {
   hipsycl::stdpar::unified_shared_memory::free(ptr);
 }
 
 HIPSYCL_STDPAR_FREE
-void operator delete  ( void* ptr, std::size_t sz ) noexcept {
+void operator delete  ( void* ptr, std::size_t ) noexcept {
   hipsycl::stdpar::unified_shared_memory::free(ptr);
 }
 
 HIPSYCL_STDPAR_FREE
-void operator delete[]( void* ptr, std::size_t sz ) noexcept {
+void operator delete[]( void* ptr, std::size_t ) noexcept {
   hipsycl::stdpar::unified_shared_memory::free(ptr);
 }
 
 HIPSYCL_STDPAR_FREE
-void operator delete  ( void* ptr, std::size_t sz,
-                        std::align_val_t al ) noexcept {
+void operator delete  ( void* ptr, std::size_t,
+                        std::align_val_t ) noexcept {
   hipsycl::stdpar::unified_shared_memory::free(ptr);
 }
 
 HIPSYCL_STDPAR_FREE
-void operator delete[]( void* ptr, std::size_t sz,
-                        std::align_val_t al ) noexcept {
+void operator delete[]( void* ptr, std::size_t,
+                        std::align_val_t ) noexcept {
   hipsycl::stdpar::unified_shared_memory::free(ptr);
 }
 
 HIPSYCL_STDPAR_FREE
-void operator delete  ( void* ptr, const std::nothrow_t& tag ) noexcept {
+void operator delete  ( void* ptr, const std::nothrow_t& ) noexcept {
   hipsycl::stdpar::unified_shared_memory::free(ptr);
 }
 
 HIPSYCL_STDPAR_FREE
-void operator delete[]( void* ptr, const std::nothrow_t& tag ) noexcept {
+void operator delete[]( void* ptr, const std::nothrow_t& ) noexcept {
   hipsycl::stdpar::unified_shared_memory::free(ptr);
 }
 
 HIPSYCL_STDPAR_FREE
-void operator delete  ( void* ptr, std::align_val_t al,
-                        const std::nothrow_t& tag ) noexcept {
+void operator delete  ( void* ptr, std::align_val_t,
+                        const std::nothrow_t& ) noexcept {
   hipsycl::stdpar::unified_shared_memory::free(ptr);
 }
 
 HIPSYCL_STDPAR_FREE
-void operator delete[]( void* ptr, std::align_val_t al,
-                        const std::nothrow_t& tag ) noexcept {
+void operator delete[]( void* ptr, std::align_val_t,
+                        const std::nothrow_t& ) noexcept {
   hipsycl::stdpar::unified_shared_memory::free(ptr);
 }
 


### PR DESCRIPTION
When compiling anything with `--acpp-stdpar` and enabling `-Wextra`, warnings were generated for some unused parameters 