### PR TITLE
CMake: Check availability of libLLVM when building SSCP

### DIFF
--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -29,7 +29,7 @@ function(create_llvm_based_library)
   target_compile_definitions(${target} PRIVATE ${LLVM_DEFINITIONS} -DHIPSYCL_COMPILER_COMPONENT)
   find_library(LLVM_LIBRARY NAMES LLVM HINTS ${LLVM_LIBRARY_DIRS})
   if(NOT LLVM_LIBRARY)
-    message(FATAL_ERROR "LLVM at ${LLVM_DIR} does not have libLLVM.so. Please disable SSCP and OpenCL (-DWITH_SSCP_COMPILER=OFF -DWITH_OPENCL_BACKEND=OFF) or choose another LLVM installation")
+    message(FATAL_ERROR "LLVM at ${LLVM_DIR} does not have libLLVM.so. Please disable SSCP and related backends (-DWITH_SSCP_COMPILER=OFF -DWITH_OPENCL_BACKEND=OFF -DWITH_LEVEL_ZERO_BACKEND=OFF) or choose another LLVM installation")
   endif()
   llvm_config(${target} USE_SHARED core support irreader passes)
   # We need symbolic functions for stdpar

--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -27,6 +27,10 @@ function(create_llvm_based_library)
     ${LLVM_TO_BACKEND_INCLUDE_DIRS})
   
   target_compile_definitions(${target} PRIVATE ${LLVM_DEFINITIONS} -DHIPSYCL_COMPILER_COMPONENT)
+  find_library(LLVM_LIBRARY NAMES LLVM HINTS ${LLVM_LIBRARY_DIRS})
+  if(NOT LLVM_LIBRARY)
+    message(FATAL_ERROR "LLVM at ${LLVM_DIR} does not have libLLVM.so. Please disable SSCP and OpenCL (-DWITH_SSCP_COMPILER=OFF -DWITH_OPENCL_BACKEND=OFF) or choose another LLVM installation")
+  endif()
   llvm_config(${target} USE_SHARED core support irreader passes)
   # We need symbolic functions for stdpar
   target_link_libraries(${target} PRIVATE ${HIPSYCL_STDPAR_RT_LINKER_FLAGS})


### PR DESCRIPTION
Error if it cannot be found. Theoretically, in this case static linking might work, but it did not for me and LLVM from ROCm 5.7.0.

More elegant solutions are welcome, but I haven't found a way to robustly implement heuristics for automatically disabling SSCP in top-level CMakeLists.txt. But hey, at least it's not a weird linking error anymore.

Inspired by https://github.com/secure-software-engineering/phasar/blob/de6d50500f4958fbbafec3daba95f3d4a15ea85d/Config.cmake.in#L45C7-L52

Linking to libLLVM: https://github.com/llvm/llvm-project/blob/7f677fe3100131214386f9ce1fa308c235a595e9/llvm/cmake/modules/LLVM-Config.cmake#L95