### PR TITLE
Hide incompatible OpenCL devices and platforms

### DIFF
--- a/doc/env_variables.md
+++ b/doc/env_variables.md
@@ -17,5 +17,5 @@
 * `ACPPL_RT_MAX_CACHED_NODES`: Maximum number of nodes that the runtime buffers before flushing work.
 * `ACPP_SSCP_FAILED_IR_DUMP_DIRECTORY`: If non-empty, hipSYCL will dump the IR of code that fails SSCP JIT into this directory.
 * `ACPP_RT_GC_TRIGGER_BATCH_SIZE`: Number of nodes in flight that trigger a garbage collection job to be spawned
-* `ACPP_RT_OCL_NO_SHARED_CONTEXT`: If set to a non-zero value, instructs the OpenCL backend to not attempt to construct a shared context across devices within a platform. This can be necessary on OpenCL implementations that do not support this. Note that if shared contexts are unavailable, support for data transfers between devices might be limited as the devices can no longer directly talk to each other.
-* `ACPP_RT_OCL_SHOW_ALL_DEVICES`: If set to a non-zero value, instructs the OpenCL backend to expose all found devices, even if those might be incompatible with AdaptiveCpp or unable to execute kernels.
+* `ACPP_RT_OCL_NO_SHARED_CONTEXT`: If set to `1`, instructs the OpenCL backend to not attempt to construct a shared context across devices within a platform. This can be necessary on OpenCL implementations that do not support this. Note that if shared contexts are unavailable, support for data transfers between devices might be limited as the devices can no longer directly talk to each other.
+* `ACPP_RT_OCL_SHOW_ALL_DEVICES`: If set to `1`, instructs the OpenCL backend to expose all found devices, even if those might be incompatible with AdaptiveCpp or unable to execute kernels.

--- a/doc/env_variables.md
+++ b/doc/env_variables.md
@@ -18,3 +18,4 @@
 * `ACPP_SSCP_FAILED_IR_DUMP_DIRECTORY`: If non-empty, hipSYCL will dump the IR of code that fails SSCP JIT into this directory.
 * `ACPP_RT_GC_TRIGGER_BATCH_SIZE`: Number of nodes in flight that trigger a garbage collection job to be spawned
 * `ACPP_RT_OCL_NO_SHARED_CONTEXT`: If set to a non-zero value, instructs the OpenCL backend to not attempt to construct a shared context across devices within a platform. This can be necessary on OpenCL implementations that do not support this. Note that if shared contexts are unavailable, support for data transfers between devices might be limited as the devices can no longer directly talk to each other.
+* `ACPP_RT_OCL_SHOW_ALL_DEVICES`: If set to a non-zero value, instructs the OpenCL backend to expose all found devices, even if those might be incompatible with AdaptiveCpp or unable to execute kernels.

--- a/include/hipSYCL/runtime/settings.hpp
+++ b/include/hipSYCL/runtime/settings.hpp
@@ -83,7 +83,8 @@ enum class setting {
   max_cached_nodes,
   sscp_failed_ir_dump_directory,
   gc_trigger_batch_size,
-  ocl_no_shared_context
+  ocl_no_shared_context,
+  ocl_show_all_devices
 };
 
 template <setting S> struct setting_trait {};
@@ -114,6 +115,7 @@ HIPSYCL_RT_MAKE_SETTING_TRAIT(setting::sscp_failed_ir_dump_directory,
                               "sscp_failed_ir_dump_directory", std::string)
 HIPSYCL_RT_MAKE_SETTING_TRAIT(setting::gc_trigger_batch_size, "rt_gc_trigger_batch_size", std::size_t)
 HIPSYCL_RT_MAKE_SETTING_TRAIT(setting::ocl_no_shared_context, "rt_ocl_no_shared_context", bool)
+HIPSYCL_RT_MAKE_SETTING_TRAIT(setting::ocl_show_all_devices, "rt_ocl_show_all_devices", bool)
 
 class settings
 {
@@ -146,6 +148,8 @@ public:
       return _gc_trigger_batch_size;
     } else if constexpr(S == setting::ocl_no_shared_context) {
       return _ocl_no_shared_context;
+    } else if constexpr(S == setting::ocl_show_all_devices) {
+      return _ocl_show_all_devices;
     }
     return typename setting_trait<S>::type{};
   }
@@ -185,6 +189,8 @@ public:
         get_environment_variable_or_default<setting::gc_trigger_batch_size>(128);
     _ocl_no_shared_context =
         get_environment_variable_or_default<setting::ocl_no_shared_context>(false);
+    _ocl_show_all_devices =
+        get_environment_variable_or_default<setting::ocl_show_all_devices>(false);
   }
 
 private:
@@ -237,6 +243,7 @@ private:
   std::size_t _gc_trigger_batch_size;
   visibility_mask_t _visibility_mask;
   bool _ocl_no_shared_context;
+  bool _ocl_show_all_devices;
 };
 
 }

--- a/src/runtime/ocl/ocl_hardware_manager.cpp
+++ b/src/runtime/ocl/ocl_hardware_manager.cpp
@@ -84,6 +84,7 @@ bool should_include_platform(const std::string& platform_name, const cl::Platfor
                              "version for platform " +
                                  platform_name,
                              error_code{"CL", err}});
+    return false;
   } else {
     int ocl_version_major = 0;
     if (!parse_ocl_version_string(ocl_version, ocl_version_major)) {

--- a/src/runtime/ocl/ocl_hardware_manager.cpp
+++ b/src/runtime/ocl/ocl_hardware_manager.cpp
@@ -33,6 +33,7 @@
 #include "hipSYCL/runtime/ocl/ocl_hardware_manager.hpp"
 #include "hipSYCL/runtime/settings.hpp"
 
+#include <CL/cl.h>
 #include <CL/opencl.hpp>
 #include <cstddef>
 #include <optional>
@@ -53,6 +54,96 @@ ResultT info_query(const cl::Device& dev) {
                     error_code{"CL", err}});
   }
   return r;
+}
+
+bool parse_ocl_version_string(const std::string& s, int& major_version_out) {
+  const std::string identifier = "OpenCL ";
+  const auto pos = s.find(identifier);
+  if(pos != 0)
+    return false;
+  std::string version_substring = s.substr(identifier.length());
+  auto dot_pos = version_substring.find(".");
+  if(dot_pos != std::string::npos) {
+    major_version_out = std::stoi(version_substring.substr(0, dot_pos));
+    return true;
+  }
+
+  return false;
+}
+
+bool should_include_platform(const std::string& platform_name, const cl::Platform& p) {
+  const bool show_all_devices = application::get_settings().get<setting::ocl_show_all_devices>();
+  if(show_all_devices)
+    return true;
+
+  std::string ocl_version;
+  cl_int err = p.getInfo(CL_PLATFORM_VERSION, &ocl_version);
+  if (err != CL_SUCCESS) {
+    print_warning(__hipsycl_here(),
+                  error_info{"ocl_hardware_manager: Could not retrieve OpenCL "
+                             "version for platform " +
+                                 platform_name,
+                             error_code{"CL", err}});
+  } else {
+    int ocl_version_major = 0;
+    if (!parse_ocl_version_string(ocl_version, ocl_version_major)) {
+      HIPSYCL_DEBUG_WARNING
+          << "ocl_hardware_manager: Could not parse OpenCL version string "
+              "of platform '"
+          << platform_name
+          << "'; hiding platform. Set ACPP_RT_OCL_SHOW_ALL_DEVICES=1 "
+              "to override. (OpenCL version string was: '"
+          << ocl_version << "')" << std::endl;
+      return false;
+    } else {
+      if (ocl_version_major < 3) {
+        HIPSYCL_DEBUG_WARNING
+            << "ocl_hardware_manager: Platform '"
+            << platform_name
+            << "' does not support OpenCL 3.0; hiding platform. Set "
+               "ACPP_RT_OCL_SHOW_ALL_DEVICES=1 "
+               "to override. (OpenCL version string was: '"
+            << ocl_version << "')" << std::endl;
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+bool should_include_device(const std::string& dev_name, const cl::Device& dev) {
+  const bool show_all_devices = application::get_settings().get<setting::ocl_show_all_devices>();
+  if(show_all_devices)
+    return true;
+
+  if(info_query<CL_DEVICE_IL_VERSION, std::string>(dev).find("SPIR-V") ==
+           std::string::npos) {
+    HIPSYCL_DEBUG_WARNING
+            << "ocl_hardware_manager: OpenCL device '"
+            << dev_name
+            << "' does not support SPIR-V; hiding device. Set "
+               "ACPP_RT_OCL_SHOW_ALL_DEVICES=1 "
+               "to override." << std::endl;
+    return false;
+  }
+
+  cl_device_svm_capabilities cap =
+      info_query<CL_DEVICE_SVM_CAPABILITIES, cl_device_svm_capabilities>(dev);
+
+  bool has_usm_extension = info_query<CL_DEVICE_EXTENSIONS, std::string>(dev).find("cl_intel_unified_shared_memory") != std::string::npos;
+  bool has_system_svm = !(cap & CL_DEVICE_SVM_FINE_GRAIN_SYSTEM);
+
+  if(!has_usm_extension && !has_system_svm) {
+    HIPSYCL_DEBUG_WARNING << "ocl_hardware_manager: OpenCL device '" << dev_name
+                          << "' does not support USM extensions or system SVM. "
+                             "Allocations are not possible; hiding device. Set "
+                             "ACPP_RT_OCL_SHOW_ALL_DEVICES=1 "
+                             "to override."
+                          << std::endl;
+    return false;
+  }
+
+  return true;
 }
 
 }
@@ -441,92 +532,106 @@ ocl_hardware_manager::ocl_hardware_manager()
 
   int global_device_index = 0;
   for(const auto& p : platforms) {
+    
     std::string platform_name;
-    if(p.getInfo(CL_PLATFORM_NAME, &platform_name) == CL_SUCCESS) {
-      HIPSYCL_DEBUG_INFO << "ocl_hardware_manager: Discovered OpenCL platform " << platform_name
-                         << std::endl;
-    }
-    _platforms.push_back(p);
-    int platform_id = _platforms.size() - 1;
-
-    std::vector<cl::Device> devs;
-    // CL param validation layer does not like CL_DEVICE_TYPE_ALL here
-    err = p.getDevices(CL_DEVICE_TYPE_CPU | CL_DEVICE_TYPE_GPU |
-                           CL_DEVICE_TYPE_ACCELERATOR,
-                       &devs);
+    err = p.getInfo(CL_PLATFORM_NAME, &platform_name);
     if(err != CL_SUCCESS) {
       print_warning(
           __hipsycl_here(),
-          error_info{"ocl_hardware_manager: Could not list devices of platform",
+          error_info{"ocl_hardware_manager: Could not retrieve platform name",
                     error_code{"CL", err}});
-    } else {
-      cl_platform_id pid = p.cl::detail::Wrapper<cl_platform_id>::get();
-
-      std::optional<cl::Context> platform_ctx;
-
-      if(!no_shared_contexts) {
-        // First attempt to create shared context
-        cl_context_properties ctx_props[] = {CL_CONTEXT_PLATFORM,
-                                            (cl_context_properties)pid, 0};
-        cl::Context ctx{devs, ctx_props, nullptr, nullptr, &err};
-        if(err == CL_SUCCESS)
-          platform_ctx = ctx;
-        else {
-          print_warning(
-              __hipsycl_here(),
-              error_info{"ocl_hardware_manager: Shared context construction "
-                        "failed. Will attempt to fall back to individual "
-                        "context per device, but this may prevent data "
-                        "transfers between devices from working.",
-                        error_code{"CL", err}});
-        }
-      } else {
-        print_warning(
-            __hipsycl_here(),
-            error_info{"ocl_hardware_manager: Not constructing shared context "
-                       "across devices. Note that this may prevent data "
-                       "transfers between devices from working."});
-      }
-
-      int platform_device_index = 0;
-      for(const auto& dev : devs) {
-        std::optional<cl::Context> chosen_context = platform_ctx;
-
-        if(!chosen_context.has_value()) {
-          // If we don't have a shared context yet, try creating
-          // an individual context for the device.
-          cl::Context ctx{dev, nullptr, nullptr, nullptr, &err};
-          if(err == CL_SUCCESS)
-            chosen_context = ctx;
-          else {
-            print_error(
-                __hipsycl_here(),
-                error_info{
-                    "ocl_hardware_manager: Individual context creation failed",
-                    error_code{"CL", err}});
-          } 
-        }
-        if(chosen_context.has_value()) {
-          ocl_hardware_context hw_ctx{dev, chosen_context.value(),
-                                      static_cast<int>(_devices.size()),
-                                      platform_id};
-
-          if (device_matches(visibility_mask, backend_id::ocl,
-                            global_device_index, platform_device_index,
-                            platform_id, hw_ctx.get_device_name(),
-                            platform_name)) {
-            _devices.push_back(hw_ctx);
-            // Allocator can only be initialized once the hardware context
-            // is in the list, because the allocator may itself attempt to access
-            // it using hardware_manager::get_device()
-            _devices.back().init_allocator(this);
-          }
-        }
-        ++global_device_index;
-        ++platform_device_index;
-      }
     }
 
+    if(should_include_platform(platform_name, p)) {
+      HIPSYCL_DEBUG_INFO << "ocl_hardware_manager: Discovered OpenCL platform "
+                         << platform_name << std::endl;
+
+      _platforms.push_back(p);
+      int platform_id = _platforms.size() - 1;
+
+      std::vector<cl::Device> devs;
+      // CL param validation layer does not like CL_DEVICE_TYPE_ALL here
+      err = p.getDevices(CL_DEVICE_TYPE_CPU | CL_DEVICE_TYPE_GPU |
+                             CL_DEVICE_TYPE_ACCELERATOR,
+                         &devs);
+      if (err != CL_SUCCESS) {
+        print_warning(
+            __hipsycl_here(),
+            error_info{
+                "ocl_hardware_manager: Could not list devices of platform",
+                error_code{"CL", err}});
+      } else {
+        cl_platform_id pid = p.cl::detail::Wrapper<cl_platform_id>::get();
+
+        std::optional<cl::Context> platform_ctx;
+
+        if (!no_shared_contexts) {
+          // First attempt to create shared context
+          cl_context_properties ctx_props[] = {CL_CONTEXT_PLATFORM,
+                                               (cl_context_properties)pid, 0};
+          cl::Context ctx{devs, ctx_props, nullptr, nullptr, &err};
+          if (err == CL_SUCCESS)
+            platform_ctx = ctx;
+          else {
+            print_warning(
+                __hipsycl_here(),
+                error_info{"ocl_hardware_manager: Shared context construction "
+                           "failed. Will attempt to fall back to individual "
+                           "context per device, but this may prevent data "
+                           "transfers between devices from working.",
+                           error_code{"CL", err}});
+          }
+        } else {
+          print_warning(
+              __hipsycl_here(),
+              error_info{
+                  "ocl_hardware_manager: Not constructing shared context "
+                  "across devices. Note that this may prevent data "
+                  "transfers between devices from working."});
+        }
+
+        int platform_device_index = 0;
+        for (const auto &dev : devs) {
+          std::string dev_name = info_query<CL_DEVICE_NAME, std::string>(dev);
+          if(should_include_device(dev_name, dev)) {
+
+            std::optional<cl::Context> chosen_context = platform_ctx;
+
+            if (!chosen_context.has_value()) {
+              // If we don't have a shared context yet, try creating
+              // an individual context for the device.
+              cl::Context ctx{dev, nullptr, nullptr, nullptr, &err};
+              if (err == CL_SUCCESS)
+                chosen_context = ctx;
+              else {
+                print_error(__hipsycl_here(),
+                            error_info{"ocl_hardware_manager: Individual context "
+                                      "creation failed",
+                                      error_code{"CL", err}});
+              }
+            }
+            if (chosen_context.has_value()) {
+              ocl_hardware_context hw_ctx{dev, chosen_context.value(),
+                                          static_cast<int>(_devices.size()),
+                                          platform_id};
+
+              if (device_matches(visibility_mask, backend_id::ocl,
+                                global_device_index, platform_device_index,
+                                platform_id, hw_ctx.get_device_name(),
+                                platform_name)) {
+                _devices.push_back(hw_ctx);
+                // Allocator can only be initialized once the hardware context
+                // is in the list, because the allocator may itself attempt to
+                // access it using hardware_manager::get_device()
+                _devices.back().init_allocator(this);
+              }
+            }
+            ++global_device_index;
+            ++platform_device_index;
+          }
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #1203 

Previously by default OpenCL devices were exposed even if there were potential incompatibilities. This PR hides such platforms and devices by default.

* Entire OpenCL platforms are hidden if the OpenCL version is < 3.0.
* Individual OpenCL devices are hidden if they don't support SPIR-V (makes kernel execution impossible), or support neither USM extensions nor fine-grained system SVM (makes memory allocations impossible).

The environment variable `ACPP_RT_OCL_SHOW_ALL_DEVICES=1` can be set to override this behavior and expose all devices.

This PR should cause AdaptiveCpp to not pick up by default Intel FPGA Emulator, AMD OpenCL and NVIDIA OpenCL.

Incompatible devices or platforms cause a warning to be emitted with further information why they were ignored. This should help in case a user is wondering why these devices don't show up. Possible output:

```
$ ACPP_VISIBILITY_MASK="omp;ocl" install/bin/acpp-info
[AdaptiveCpp Warning] backend_loader: Could not load backend plugin: /home/aksel/src/hipSYCL/master/build/install/lib/hipSYCL/librt-backend-hip.so
[AdaptiveCpp Warning] libamdhip64.so.5: cannot open shared object file: No such file or directory
[AdaptiveCpp Warning] ocl_hardware_manager: Platform 'Intel(R) FPGA Emulation Platform for OpenCL(TM)' does not support OpenCL 3.0; hiding platform. Set ACPP_RT_OCL_SHOW_ALL_DEVICES=1 to override. (OpenCL version string was: 'OpenCL 1.2 Intel(R) FPGA SDK for OpenCL(TM), Version 20.3')
[AdaptiveCpp Warning] ocl_hardware_manager: Platform 'Intel(R) FPGA Emulation Platform for OpenCL(TM)' does not support OpenCL 3.0; hiding platform. Set ACPP_RT_OCL_SHOW_ALL_DEVICES=1 to override. (OpenCL version string was: 'OpenCL 1.2 Intel(R) FPGA SDK for OpenCL(TM), Version 20.3')
[AdaptiveCpp Warning] ocl_hardware_manager: Platform 'Portable Computing Language' does not support OpenCL 3.0; hiding platform. Set ACPP_RT_OCL_SHOW_ALL_DEVICES=1 to override. (OpenCL version string was: 'OpenCL 2.0 pocl 1.8  Linux, None+Asserts, RELOC, LLVM 11.1.0, SLEEF, DISTRO, POCL_DEBUG')
[AdaptiveCpp Warning] ocl_hardware_manager: OpenCL device 'NVIDIA GeForce MX150' does not support SPIR-V; hiding device. Set ACPP_RT_OCL_SHOW_ALL_DEVICES=1 to override.
=================Backend information===================
[...]
```