### PR TITLE
acpp: Warn if deprecated spirv target is used

### DIFF
--- a/bin/acpp
+++ b/bin/acpp
@@ -1679,6 +1679,9 @@ class compiler:
         self._multipass_backends.append(
           hip_multipass_invocation(config, config.targets["hip.explicit-multipass"]))
       elif backend == 'spirv':
+        print("acpp warning: 'spirv' target is deprecated, incomplete and may not work. It should not be "
+              "used outside of experiments and will be removed in a future version. Production "
+              "use cases should use 'generic' target instead to target SPIR-V devices.")
         self._multipass_backends.append(
           spirv_multipass_invocation(config))
       elif backend == 'sscp' or backend == 'generic':


### PR DESCRIPTION
`spirv` target has not really been maintained and has always been incomplete and unstable. This PR causes `acpp` to emit a warning if it is used, and ask users to use `generic` target instead for SPIR-V devices.