### PR TITLE
[SSCP] Add initial sycl::stream support

### DIFF
--- a/include/hipSYCL/sycl/libkernel/sscp/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins.hpp
@@ -25,32 +25,6 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/*
- * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
- *
- * Copyright (c) 2021 Aksel Alpay
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 
 #ifndef HIPSYCL_LIBKERNEL_SSCP_BUILTINS_HPP
 #define HIPSYCL_LIBKERNEL_SSCP_BUILTINS_HPP
@@ -61,6 +35,7 @@
 #include "builtins/native.hpp"
 #include "builtins/interger.hpp"
 #include "builtins/relational.hpp"
+#include "builtins/print.hpp"
 
 #include <cstdlib>
 #include <cmath>

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/print.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/print.hpp
@@ -1,0 +1,35 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018-2022 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HIPSYCL_SSCP_BUILTINS_PRINT_HPP
+#define HIPSYCL_SSCP_BUILTINS_PRINT_HPP
+
+#include "builtin_config.hpp"
+
+HIPSYCL_SSCP_BUILTIN void __hipsycl_sscp_print(const char* msg);
+
+#endif

--- a/include/hipSYCL/sycl/libkernel/stream.hpp
+++ b/include/hipSYCL/sycl/libkernel/stream.hpp
@@ -31,6 +31,9 @@
 #include <cstdio>
 
 #include "hipSYCL/sycl/libkernel/backend.hpp"
+#ifdef HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_SSCP
+#include "hipSYCL/sycl/libkernel/sscp/builtins/print.hpp"
+#endif
 
 #include "id.hpp"
 #include "range.hpp"

--- a/include/hipSYCL/sycl/libkernel/stream.hpp
+++ b/include/hipSYCL/sycl/libkernel/stream.hpp
@@ -44,6 +44,24 @@
 namespace hipsycl {
 namespace sycl {
 
+namespace detail {
+
+template<typename... Args>
+void print(const char* s, Args... args) {
+  __hipsycl_backend_switch(
+    printf(s, args...),
+    if constexpr(sizeof...(args) == 0) {
+      __hipsycl_sscp_print(s);
+    } else {
+      __hipsycl_sscp_print("Type not yet supported for printing with generic target\n");
+    },
+    printf(s, args...),
+    printf(s, args...),
+    printf(s, args...));
+}
+
+}
+
 enum class stream_manipulator {
   flush,
   dec,
@@ -117,91 +135,91 @@ const stream& operator<<(const stream& os, T v) {
 HIPSYCL_KERNEL_TARGET
 inline const stream& operator<<(const stream& os, stream_manipulator manip) {
   if(manip == endl)
-    printf("\n");
+    detail::print("\n");
   // Other stream_manipulators are not yet supported
   return os;
 }
 
 HIPSYCL_KERNEL_TARGET
 inline const stream& operator<<(const stream& os, char v){
-  printf("%c", v); return os;
+  detail::print("%c", v); return os;
 }
 
 HIPSYCL_KERNEL_TARGET
 inline const stream& operator<<(const stream& os, unsigned char v){
-  printf("%hhu", v); return os;
+  detail::print("%hhu", v); return os;
 }
 
 HIPSYCL_KERNEL_TARGET
 inline const stream& operator<<(const stream& os, short v){
-  printf("%hd", v); return os;
+  detail::print("%hd", v); return os;
 }
 
 HIPSYCL_KERNEL_TARGET
 inline const stream& operator<<(const stream& os, unsigned short v){
-  printf("%hu", v); return os;
+  detail::print("%hu", v); return os;
 }
 
 HIPSYCL_KERNEL_TARGET
 inline const stream& operator<<(const stream& os, int v){
-  printf("%d", v); return os;
+  detail::print("%d", v); return os;
 }
 
 HIPSYCL_KERNEL_TARGET
 inline const stream& operator<<(const stream& os, unsigned int v){
-  printf("%u", v); return os;
+  detail::print("%u", v); return os;
 }
 
 HIPSYCL_KERNEL_TARGET
 inline const stream& operator<<(const stream& os, long v){
-  printf("%ld", v); return os;
+  detail::print("%ld", v); return os;
 }
 
 HIPSYCL_KERNEL_TARGET
 inline const stream& operator<<(const stream& os, unsigned long v){
-  printf("%lu", v); return os;
+  detail::print("%lu", v); return os;
 }
 
 HIPSYCL_KERNEL_TARGET
 inline const stream& operator<<(const stream& os, long long v){
-  printf("%lld", v); return os;
+  detail::print("%lld", v); return os;
 }
 
 HIPSYCL_KERNEL_TARGET
 inline const stream& operator<<(const stream& os, unsigned long long v){
-  printf("%llu", v); return os;
+  detail::print("%llu", v); return os;
 }
 
 HIPSYCL_KERNEL_TARGET
 inline const stream& operator<<(const stream& os, char* v) {
-  printf("%s", v); return os;
+  detail::print(v); return os;
 }
 
 HIPSYCL_KERNEL_TARGET
 inline const stream& operator<<(const stream& os, const char* v) {
-  printf("%s", v); return os;
+  detail::print(v); return os;
 }
 
 HIPSYCL_KERNEL_TARGET
 inline const stream& operator<<(const stream& os, float v){
-  printf("%f", v); return os;
+  detail::print("%f", v); return os;
 }
 
 HIPSYCL_KERNEL_TARGET
 inline const stream& operator<<(const stream& os, double v){
-  printf("%f", v); return os;
+  detail::print("%f", v); return os;
 }
 
 template<class T>
 HIPSYCL_KERNEL_TARGET
 const stream& operator<<(const stream& os, T* v) {
-  printf("%p", v); return os;
+  detail::print("%p", v); return os;
 }
 
 template<class T>
 HIPSYCL_KERNEL_TARGET
 const stream& operator<<(const stream& os, const T* v){
-  printf("%p", v); return os;
+  detail::print("%p", v); return os;
 }
 
 template<int Dim>

--- a/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
+++ b/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
@@ -80,7 +80,7 @@ void appendIntelLLVMSpirvOptions(llvm::SmallVector<std::string>& out) {
       "long_constant_composite,+SPV_INTEL_fpga_invocation_pipelining_attributes,+SPV_INTEL_fpga_"
       "dsp_control,+SPV_INTEL_arithmetic_fence,+SPV_INTEL_runtime_aligned,"
       "+SPV_INTEL_optnone,+SPV_INTEL_token_type,+SPV_INTEL_bfloat16_conversion,+SPV_INTEL_joint_"
-      "matrix,+SPV_INTEL_hw_thread_queries,+SPV_INTEL_memory_access_aliasing"
+      "matrix,+SPV_INTEL_hw_thread_queries,+SPV_INTEL_memory_access_aliasing,+SPV_EXT_relaxed_printf_string_address_space"
   };
   for(const auto& S : Args) {
     out.push_back(S);
@@ -252,6 +252,9 @@ bool LLVMToSpirvTranslator::translateToBackendFormat(llvm::Module &FlavoredModul
   };
   if(UseIntelLLVMSpirvArgs)
     appendIntelLLVMSpirvOptions(Args);
+  else {
+    Args.push_back("-spirv-ext=+SPV_EXT_relaxed_printf_string_address_space");
+  }
 
   llvm::SmallVector<llvm::StringRef, 16> Invocation{LLVMSpirVTranslator};
   for(const auto& A : Args)

--- a/src/libkernel/sscp/amdgpu/CMakeLists.txt
+++ b/src/libkernel/sscp/amdgpu/CMakeLists.txt
@@ -2,6 +2,6 @@ if(WITH_LLVM_TO_AMDGPU_AMDHSA)
   libkernel_generate_bitcode_target(
       TARGETNAME amdgpu-amdhsa 
       TRIPLE amdgcn-amd-amdhsa
-      SOURCES atomic.cpp barrier.cpp core.cpp half.cpp integer.cpp math.cpp native.cpp relational.cpp subgroup.cpp localmem.cpp
+      SOURCES atomic.cpp barrier.cpp core.cpp half.cpp integer.cpp math.cpp native.cpp print.cpp relational.cpp subgroup.cpp localmem.cpp
       ADDITIONAL_ARGS -nogpulib)
 endif()

--- a/src/libkernel/sscp/amdgpu/print.cpp
+++ b/src/libkernel/sscp/amdgpu/print.cpp
@@ -1,0 +1,53 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018-2022 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "hipSYCL/sycl/libkernel/sscp/builtins/print.hpp"
+
+extern "C" __hipsycl_uint64 __ockl_fprintf_stdout_begin();
+extern "C" __hipsycl_uint64
+__ockl_fprintf_append_string_n(__hipsycl_uint64 msg_desc, const char *data,
+                               __hipsycl_uint64 length,
+                               __hipsycl_uint32 is_last);
+
+void __hipsycl_sscp_print(const char* msg) {
+  constexpr int max_len = 1 << 16;
+
+  int length = 0;
+  while(length < max_len) {
+    if(msg[length] == '\0') {
+      // string length needs to include the null terminator
+      ++length;
+      break; 
+    } else {
+      ++length;
+    }
+  }
+
+  auto handle = __ockl_fprintf_stdout_begin();
+  __ockl_fprintf_append_string_n(handle, msg, static_cast<__hipsycl_uint64>(length), 1);
+}

--- a/src/libkernel/sscp/ptx/CMakeLists.txt
+++ b/src/libkernel/sscp/ptx/CMakeLists.txt
@@ -3,6 +3,6 @@ if(WITH_LLVM_TO_PTX)
   libkernel_generate_bitcode_target(
       TARGETNAME ptx 
       TRIPLE nvptx64-nvidia-cuda
-      SOURCES atomic.cpp barrier.cpp core.cpp half.cpp integer.cpp relational.cpp math.cpp native.cpp localmem.cpp subgroup.cpp
+      SOURCES atomic.cpp barrier.cpp core.cpp half.cpp integer.cpp print.cpp relational.cpp math.cpp native.cpp localmem.cpp subgroup.cpp
       ADDITIONAL_ARGS -Xclang -target-feature -Xclang +sm_60)
 endif()

--- a/src/libkernel/sscp/ptx/print.cpp
+++ b/src/libkernel/sscp/ptx/print.cpp
@@ -1,0 +1,35 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018-2022 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "hipSYCL/sycl/libkernel/sscp/builtins/print.hpp"
+
+extern "C" int vprintf(const char *, const char *);
+
+void __hipsycl_sscp_print(const char* msg) {
+  vprintf(msg, nullptr);  
+}

--- a/src/libkernel/sscp/spirv/CMakeLists.txt
+++ b/src/libkernel/sscp/spirv/CMakeLists.txt
@@ -3,5 +3,5 @@ if(WITH_LLVM_TO_SPIRV)
   libkernel_generate_bitcode_target(
       TARGETNAME spirv 
       TRIPLE spir64-unknown-unknown
-      SOURCES atomic.cpp barrier.cpp core.cpp half.cpp math.cpp native.cpp integer.cpp relational.cpp localmem.cpp subgroup.cpp)
+      SOURCES atomic.cpp barrier.cpp core.cpp half.cpp math.cpp native.cpp integer.cpp print.cpp relational.cpp localmem.cpp subgroup.cpp)
 endif()

--- a/src/libkernel/sscp/spirv/print.cpp
+++ b/src/libkernel/sscp/spirv/print.cpp
@@ -1,0 +1,36 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2018-2022 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "hipSYCL/sycl/libkernel/sscp/builtins/print.hpp"
+
+template <typename... Args>
+extern int __spirv_ocl_printf(const char *Format, Args... args);
+
+void __hipsycl_sscp_print(const char* msg) {
+  __spirv_ocl_printf(msg);
+}


### PR DESCRIPTION
Currently, using `sycl::stream` inside SSCP causes a JIT failure, because it directly calls `printf` which is not available in SSCP kernels.

This PR
* Adds a new SSCP builtin, `__hipsycl_sscp_print(const char*)`, which prints a charater string to the screen. Implementations for SPIR-V, PTX and amdgcn are also provided.
* Causes `stream` class to call `__hipsycl_sscp_print()` if `operator<<` is invoked with a  string argument. For other arguments, it currently prints that it does not support printing that type.

Of course in the long term, we will need to implement `stream` for other types as well. For this purpose we will have to come up with a device formatting library for ints, floats etc, which might be a larger job.

While this PR thus does not provide a complete implementation as only `char*` and `const char*` arguments are currently supported, it allows us to run the classic "Hello World" (which is also part of the SYCLAcademy curriculum).
And for more complex cases with different types, the user is now actually informed about the problem instead of confronting them with a JIT failure message which might be almost impossible to understand for the average user.
