### PR TITLE
Add missing prefixes when checking if function is in `std` namespace

### DIFF
--- a/src/compiler/stdpar/MallocToUSM.cpp
+++ b/src/compiler/stdpar/MallocToUSM.cpp
@@ -100,7 +100,7 @@ bool isRestrictedToRegularMalloc(llvm::Function* F) {
 }
 
 bool isStdFunction(llvm::Function* F) {
-  static const std::string StdPrefixes[21] =
+  static const std::string StdPrefixes[] =
     {
       "_ZSt", "_ZNSt", "_ZNKSt",
       "_ZSa", "_ZNSa", "_ZNKSa",

--- a/src/compiler/stdpar/MallocToUSM.cpp
+++ b/src/compiler/stdpar/MallocToUSM.cpp
@@ -100,9 +100,21 @@ bool isRestrictedToRegularMalloc(llvm::Function* F) {
 }
 
 bool isStdFunction(llvm::Function* F) {
+  static const std::string StdPrefixes[21] =
+    {
+      "_ZSt", "_ZNSt", "_ZNKSt",
+      "_ZSa", "_ZNSa", "_ZNKSa",
+      "_ZSb", "_ZNSb", "_ZNKSb",
+      "_ZSs", "_ZNSs", "_ZNKSs",
+      "_ZSi", "_ZNSi", "_ZNKSi",
+      "_ZSo", "_ZNSo", "_ZNKSo",
+      "_ZSd", "_ZNSd", "_ZNKSd"
+    };
+
   llvm::StringRef Name = F->getName();
-  if(Name.startswith("_ZNSt") || Name.startswith("_ZSt"))
-    return true;
+  for (const auto &Prefix : StdPrefixes)
+    if(Name.startswith(Prefix))
+      return true;
   return false;
 }
 


### PR DESCRIPTION
According to [the Itanium ABI spec](https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling-compression) certain classes in the `std` namespace have their own abbreviations and do not start with `St` so the current check would not mark them as `std` functions. However, I am not sure if these abbreviations are actually used by the LLVM Itanium mangler. I haven't looked at the source code yet but I looked at the symbols of some test applications using `nm` and all mangled names of `std::` functions started with `_ZSt`, `_ZNSt` or `_ZNKSt` (this last one is for `const` member functions and was missing previously), so maybe it is enough to just check for these three. 

Opening this as a draft for now until I'm sure which is the correct approach (hoping that  someone who knows more about this sees this and can comment on it).