### PR TITLE
HIP: Support hipPointerAttribute_t from ROCm 6

### DIFF
--- a/src/runtime/hip/hip_allocator.cpp
+++ b/src/runtime/hip/hip_allocator.cpp
@@ -146,7 +146,7 @@ result hip_allocator::query_pointer(const void *ptr, pointer_info &out) const
 
   out.dev = rt::device_id{_backend_descriptor, attribs.device};
   out.is_from_host_backend = false;
-  out.is_optimized_host = memoryType == hipMemoryTypeHost;
+  out.is_optimized_host = (memoryType == hipMemoryTypeHost);
 #ifndef HIPSYCL_RT_NO_HIP_MANAGED_MEMORY
   out.is_usm = attribs.isManaged;
 #else
@@ -154,7 +154,7 @@ result hip_allocator::query_pointer(const void *ptr, pointer_info &out) const
   // correct as HIP versions that do not support attribs.isManaged
   // have no way of querying whether something was malloc'd with
   // hipMallocManaged().
-  out.is_usm = memoryType == hipMemoryTypeUnified;
+  out.is_usm = (memoryType == hipMemoryTypeUnified);
 #endif
   
   return make_success();

--- a/src/runtime/hip/hip_allocator.cpp
+++ b/src/runtime/hip/hip_allocator.cpp
@@ -138,10 +138,15 @@ result hip_allocator::query_pointer(const void *ptr, pointer_info &out) const
           error_info{"hip_allocator: query_pointer(): query failed",
                      error_code{"HIP", err}});
   }
+#if HIP_VERSION_MAJOR > 5
+  const auto memoryType = attribs.type;
+#else
+  const auto memoryType = attribs.memoryType;
+#endif
 
   out.dev = rt::device_id{_backend_descriptor, attribs.device};
   out.is_from_host_backend = false;
-  out.is_optimized_host = attribs.memoryType == hipMemoryTypeHost;
+  out.is_optimized_host = memoryType == hipMemoryTypeHost;
 #ifndef HIPSYCL_RT_NO_HIP_MANAGED_MEMORY
   out.is_usm = attribs.isManaged;
 #else
@@ -149,7 +154,7 @@ result hip_allocator::query_pointer(const void *ptr, pointer_info &out) const
   // correct as HIP versions that do not support attribs.isManaged
   // have no way of querying whether something was malloc'd with
   // hipMallocManaged().
-  out.is_usm = attribs.memoryType == hipMemoryTypeUnified;
+  out.is_usm = memoryType == hipMemoryTypeUnified;
 #endif
   
   return make_success();


### PR DESCRIPTION
In ROCm 5.5, `hipPointerAttribute_t::memoryType` was deprecated in favor of `hipPointerAttribute_t::type`.

The old version will be removed in ROCm 6: https://rocm.docs.amd.com/en/docs-5.7.0/release.html#upcoming-changes-for-hip-in-rocm-6-0-release

Haven't actually tested ROCm 6, so there might be other issues.