### PR TITLE
[stdpar] Add check for `const` std member functions

### DIFF
--- a/src/compiler/stdpar/MallocToUSM.cpp
+++ b/src/compiler/stdpar/MallocToUSM.cpp
@@ -101,7 +101,7 @@ bool isRestrictedToRegularMalloc(llvm::Function* F) {
 
 bool isStdFunction(llvm::Function* F) {
   llvm::StringRef Name = F->getName();
-  if(Name.startswith("_ZNSt") || Name.startswith("_ZSt"))
+  if(Name.startswith("_ZNSt") || Name.startswith("_ZSt") || Name.startswith("_ZNKSt"))
     return true;
   return false;
 }


### PR DESCRIPTION
In the function that checks whether a method is in the `std::` namespace, a check for `const` member functions was missing.

In #1222 a few more checks are included but this one added here is the only one where I'm sure that it's really missing. So I think this one can safely go into the 23.10 release.