### PR TITLE
Make CUDA detection error not fatal

### DIFF
--- a/cmake/FindCUDA.cmake
+++ b/cmake/FindCUDA.cmake
@@ -39,10 +39,13 @@ else()
          get_filename_component(CUDAToolkit_LIBRARY_ROOT ${CUDAToolkit_LIBRARY_DIR} DIRECTORY)
 
          if (NOT EXISTS "${CUDAToolkit_LIBRARY_ROOT}/nvvm")
-            message(SEND_ERROR "CUDAToolkit_LIBRARY_ROOT does not point to the correct directory, try setting it manually")
+            message(WARNING "CUDAToolkit_LIBRARY_ROOT does not point to the correct directory, try setting it manually. Detected CUDA installation cannot be used.")
+            set(CUDAToolkit_FOUND FALSE)
          endif()
       endif()
+   endif()
 
+   if (CUDAToolkit_FOUND)
       message(STATUS "Found CUDA version ${CUDAToolkit_VERSION} in ${CUDAToolkit_LIBRARY_ROOT}")
 
       set(CUDA_FOUND TRUE)


### PR DESCRIPTION
If a broken installation is present, a fatal error CMake error was throws, even if WITH_CUDA_BACKEND=OFF was set. We downgrade it to warning now and mark CUDA as not found.