### PR TITLE
[stdpar] Reimplement synchronization elision using CFG analysis

### DIFF
--- a/.github/workflows/linux-lit.yml
+++ b/.github/workflows/linux-lit.yml
@@ -71,7 +71,7 @@ jobs:
           cd ${GITHUB_WORKSPACE}/build/tests-cpu
           LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ./sycl_tests
   sscp:
-    name: SSCP/Reflection, clang ${{ matrix.clang }}, ${{ matrix.os }}
+    name: SSCP/Reflection/stdpar, clang ${{ matrix.clang }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -122,3 +122,9 @@ jobs:
           cd ${GITHUB_WORKSPACE}/build/tests-reflection  
           cmake -DACPP_TARGETS=generic -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp  ${GITHUB_WORKSPACE}/tests
           LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib make check-reflection
+      - name: run stdpar LIT tests
+        run: |
+          mkdir ${GITHUB_WORKSPACE}/build/tests-stdpar
+          cd ${GITHUB_WORKSPACE}/build/tests-stdpar
+          cmake -DACPP_TARGETS=generic -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp  ${GITHUB_WORKSPACE}/tests
+          LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib make check-stdpar

--- a/include/hipSYCL/compiler/stdpar/SyncElision.hpp
+++ b/include/hipSYCL/compiler/stdpar/SyncElision.hpp
@@ -35,23 +35,68 @@
 
 namespace hipsycl {
 namespace compiler {
-// Detects stdpar calls, replaces noinline with always_inline attribute
-// and ensure __hipsycl_stdpar_consume_sync() is right at the start of the function.
-class SyncElisionEntrypointPreparationPass
-    : public llvm::PassInfoMixin<SyncElisionEntrypointPreparationPass> {
+
+/// Implements the main synchronization elision logic. The idea is as follows:
+/// 1.) Detect stdpar functions using "hipsycl_stdpar_entrypoint" annotation attribute.
+/// 2.) Detect calls to __hipsycl_stdpar_optional_barrier() inside stdpar functions.
+/// 3.) Remove __hipsycl_stdpar_optional_barrier() calls, and reinsert them after the call
+/// instruction to the stdpar function (i.e. move them out of the stdpar function, and to the
+/// callsite) 4.) Move calls to __hipsycl_stdpar_optional_barrier() down the instruction flow,
+/// taking all routes through the control flow graph until a place is encountered where barriers
+/// must be present for correctness:
+///  - memory accesses such as loads/stores
+///  - calls to other functions that are not stdpar calls, since we cannot know what these functions
+///    do and our control flow analysis currently cannot continue in other functions
+///  - exit of control flow from the current function
+///
+/// If a barrier is already present at one of the determined insertion points, no additional
+/// barrier is inserted.
+/// If a position where synchronization is needed is found, or a present barrier, that path in the
+/// control flow graph is considered finished, and the other paths are investigated.
+///
+/// This algorithm effectively causes synchronization to be as delayed as possible, potentially
+/// even removing synchronization entirely between two stdpar calls.
+///
+/// In order to properly function, __hipsycl_stdpar_optional_barrier() should have an internal
+/// counter of enqueued operations, and only synchronize if that counter is > 0. This is because
+/// in some control flow graphs it can happen that there is a path that crosses multiple
+/// synchronization points.
+///
+/// Additional logic is applied when hitting store instructions: These are commonly inserted
+/// by clang before stdpar calls to assemble function arguments, such as lambda objects passed
+/// to the stdpar algorithm. This is problematic, because hitting these stores can prevent barriers
+/// from moving beyond them, and ultimately prevent this optimization from becoming relevant in
+/// most cases. Thus, a way is needed to distinguish stores that purely relate to assembling stdpar
+/// arguments from stores to memory locations that might actually be used inside kernels.
+///
+/// In theory, we know that stores to addresses that are then exclusively used for by-value
+/// arguments to stdpar calls can be considered to be part of stdpar argument handling, and can thus
+/// be skipped. In practice, we cannot easily determine this due to opaque pointers and clang/LLVM's
+/// inconsistent use of the byval(T) attribute. Currently, we use the following heuristic:
+/// - Consider instructions stores to memory locations originate from an alloca
+/// - The original alloca memory location and all its derived uses must only be in getelementptr
+///   instructions, stores, and the stdpar call.
+/// - The store must occur in the same block as the stdpar call, and precede it in the instruction
+///   order.
+///
+/// It is possible that pathological cases can be constructed where this returns false positives,
+/// especially in the presence of system USM where stack memory might be used inside kernels too.
+/// In practice, for cases where this becomes relevant we should not offload anyway because the problem
+/// size would be way too small to be an efficient offload use case.
+class SyncElisionPass : public llvm::PassInfoMixin<SyncElisionPass> {
 public:
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
 };
 
+/// This pass causes callers of stdpar algorithms to be inlined. This is a simplistic heuristic
+/// to combine more stdpar calls in one function, assuming that often stdpar usage happens from only
+/// a few root functions. Having as many of the stdpar calls as possible in one function is important
+/// because the main SyncElision algorithm currently does not work beyond a single function.
 class SyncElisionInliningPass : public llvm::PassInfoMixin<SyncElisionInliningPass> {
 public:
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
 };
 
-class SyncElisionPass : public llvm::PassInfoMixin<SyncElisionPass> {
-public:
-  llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
-};
 
 }
 }

--- a/include/hipSYCL/compiler/stdpar/SyncElision.hpp
+++ b/include/hipSYCL/compiler/stdpar/SyncElision.hpp
@@ -35,6 +35,13 @@
 
 namespace hipsycl {
 namespace compiler {
+// Detects stdpar calls, replaces noinline with always_inline attribute
+// and ensure __hipsycl_stdpar_consume_sync() is right at the start of the function.
+class SyncElisionEntrypointPreparationPass
+    : public llvm::PassInfoMixin<SyncElisionEntrypointPreparationPass> {
+public:
+  llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
+};
 
 class SyncElisionInliningPass : public llvm::PassInfoMixin<SyncElisionInliningPass> {
 public:

--- a/include/hipSYCL/std/stdpar/detail/offload.hpp
+++ b/include/hipSYCL/std/stdpar/detail/offload.hpp
@@ -302,10 +302,12 @@ bool should_offload(AlgorithmType type, Size n, const Args &...args) {
       algorithm_type_object, problem_size, __VA_ARGS__);                       \
   if (is_offloaded) {                                                          \
     offload_invoker(q);                                                        \
+    hipsycl::stdpar::detail::stdpar_tls_runtime::get()                         \
+        .increment_num_outstanding_operations();                               \
   } else {                                                                     \
     fallback_invoker();                                                        \
   }                                                                            \
-  __hipsycl_stdpar_optimizable_sync(q, is_offloaded);
+  __hipsycl_stdpar_optional_barrier(); /*Compiler might move/elide this call*/
 
 #define HIPSYCL_STDPAR_OFFLOAD(algorithm_type_object, problem_size,            \
                                return_type, offload_invoker, fallback_invoker, \
@@ -314,7 +316,10 @@ bool should_offload(AlgorithmType type, Size n, const Args &...args) {
   bool is_offloaded = hipsycl::stdpar::should_offload(                         \
       algorithm_type_object, problem_size, __VA_ARGS__);                       \
   return_type ret = is_offloaded ? offload_invoker(q) : fallback_invoker();    \
-  __hipsycl_stdpar_optimizable_sync(q, is_offloaded);                          \
+  if (is_offloaded)                                                            \
+    hipsycl::stdpar::detail::stdpar_tls_runtime::get()                         \
+        .increment_num_outstanding_operations();                               \
+  __hipsycl_stdpar_optional_barrier(); /*Compiler might move/elide this call*/ \
   return ret;
 
 #define HIPSYCL_STDPAR_BLOCKING_OFFLOAD(algorithm_type_object, problem_size,   \
@@ -329,6 +334,17 @@ bool should_offload(AlgorithmType type, Size n, const Args &...args) {
   };                                                                           \
   return_type ret =                                                            \
       is_offloaded ? offload_invoker(q) : blocking_fallback_invoker();         \
+  if (is_offloaded) {                                                          \
+    int num_ops = hipsycl::stdpar::detail::stdpar_tls_runtime::get()           \
+                      .get_num_outstanding_operations();                       \
+    HIPSYCL_DEBUG_INFO                                                         \
+        << "[stdpar] Considering " << num_ops                                  \
+        << " outstanding operations as completed due to call to "              \
+           "blocking stdpar algorithm."                                        \
+        << std::endl;                                                          \
+    hipsycl::stdpar::detail::stdpar_tls_runtime::get()                         \
+        .reset_num_outstanding_operations();                                   \
+  }                                                                            \
   return ret;
 } // namespace hipsycl::stdpar
 

--- a/include/hipSYCL/std/stdpar/detail/offload.hpp
+++ b/include/hipSYCL/std/stdpar/detail/offload.hpp
@@ -297,7 +297,6 @@ bool should_offload(AlgorithmType type, Size n, const Args &...args) {
 
 #define HIPSYCL_STDPAR_OFFLOAD_NORET(algorithm_type_object, problem_size,      \
                                      offload_invoker, fallback_invoker, ...)   \
-  __hipsycl_stdpar_consume_sync();                                             \
   auto &q = hipsycl::stdpar::detail::single_device_dispatch::get_queue();      \
   bool is_offloaded = hipsycl::stdpar::should_offload(                         \
       algorithm_type_object, problem_size, __VA_ARGS__);                       \
@@ -311,7 +310,6 @@ bool should_offload(AlgorithmType type, Size n, const Args &...args) {
 #define HIPSYCL_STDPAR_OFFLOAD(algorithm_type_object, problem_size,            \
                                return_type, offload_invoker, fallback_invoker, \
                                ...)                                            \
-  __hipsycl_stdpar_consume_sync();                                             \
   auto &q = hipsycl::stdpar::detail::single_device_dispatch::get_queue();      \
   bool is_offloaded = hipsycl::stdpar::should_offload(                         \
       algorithm_type_object, problem_size, __VA_ARGS__);                       \
@@ -322,7 +320,6 @@ bool should_offload(AlgorithmType type, Size n, const Args &...args) {
 #define HIPSYCL_STDPAR_BLOCKING_OFFLOAD(algorithm_type_object, problem_size,   \
                                         return_type, offload_invoker,          \
                                         fallback_invoker, ...)                 \
-  __hipsycl_stdpar_consume_sync();                                             \
   auto &q = hipsycl::stdpar::detail::single_device_dispatch::get_queue();      \
   bool is_offloaded = hipsycl::stdpar::should_offload(                         \
       algorithm_type_object, problem_size, __VA_ARGS__);                       \

--- a/include/hipSYCL/std/stdpar/detail/stdpar_builtins.hpp
+++ b/include/hipSYCL/std/stdpar/detail/stdpar_builtins.hpp
@@ -35,17 +35,16 @@
 // these calls, so mark them as noexcept (which should be fine) such
 // that call instructions are generated instead.
 HIPSYCL_STDPAR_NOINLINE
-extern "C" void __hipsycl_stdpar_optimizable_sync(hipsycl::sycl::queue &q,
-                                                  bool is_offloaded) noexcept {
-  if(is_offloaded)
-    q.wait();
+extern "C" void __hipsycl_stdpar_optional_barrier() noexcept {
+  auto& rt = hipsycl::stdpar::detail::stdpar_tls_runtime::get();
+  int num_ops = rt.get_num_outstanding_operations();
+  if(num_ops > 0) {
+    HIPSYCL_DEBUG_INFO << "[stdpar] Initializing wait for " << num_ops
+                       << " operations" << std::endl;
+    rt.get_queue().wait();
+    rt.reset_num_outstanding_operations();
+  }
 }
-
-#ifdef __clang__
-extern "C" void __hipsycl_stdpar_consume_sync() noexcept;
-#else
-inline void __hipsycl_stdpar_consume_sync() noexcept {}
-#endif
 
 
 

--- a/include/hipSYCL/std/stdpar/detail/stdpar_defs.hpp
+++ b/include/hipSYCL/std/stdpar/detail/stdpar_defs.hpp
@@ -30,8 +30,9 @@
 
 #ifdef __clang__
 #define HIPSYCL_STDPAR_INLINE __attribute__((always_inline))
-#define HIPSYCL_STDPAR_ENTRYPOINT HIPSYCL_STDPAR_INLINE
 #define HIPSYCL_STDPAR_NOINLINE __attribute__((noinline))
+#define HIPSYCL_STDPAR_ENTRYPOINT \
+    HIPSYCL_STDPAR_NOINLINE __attribute__((annotate("hipsycl_stdpar_entrypoint")))
 #else
 #define HIPSYCL_STDPAR_INLINE
 #define HIPSYCL_STDPAR_ENTRYPOINT

--- a/include/hipSYCL/std/stdpar/detail/sycl_glue.hpp
+++ b/include/hipSYCL/std/stdpar/detail/sycl_glue.hpp
@@ -71,10 +71,23 @@ private:
   algorithms::util::allocation_cache _device_scratch_cache;
   algorithms::util::allocation_cache _shared_scratch_cache;
   algorithms::util::allocation_cache _host_scratch_cache;
+  int _outstanding_offloaded_operations = 0;
 public:
   
   sycl::queue& get_queue() {
     return _queue;
+  }
+
+  int get_num_outstanding_operations() const {
+    return _outstanding_offloaded_operations;
+  }
+
+  void increment_num_outstanding_operations() {
+    ++_outstanding_offloaded_operations;
+  }
+
+  void reset_num_outstanding_operations() {
+    _outstanding_offloaded_operations = 0;
   }
 
   template<algorithms::util::allocation_type AT>

--- a/src/compiler/AdaptiveCppClangPlugin.cpp
+++ b/src/compiler/AdaptiveCppClangPlugin.cpp
@@ -146,11 +146,14 @@ extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo llvmGetPassPluginIn
 
 #ifdef HIPSYCL_WITH_STDPAR_COMPILER
           if(EnableStdPar) {
-            if(!StdparNoMallocToUSM) {
-              PB.registerPipelineStartEPCallback([&](llvm::ModulePassManager &MPM, OptLevel Level) {
+            PB.registerPipelineStartEPCallback([&](llvm::ModulePassManager &MPM, OptLevel Level) {
+              MPM.addPass(SyncElisionEntrypointPreparationPass{});
+              MPM.addPass(llvm::AlwaysInlinerPass{});
+              if(!StdparNoMallocToUSM) {
                 MPM.addPass(MallocToUSMPass{});
-              });
-            }
+              }
+            });
+          
             PB.registerOptimizerLastEPCallback([&](llvm::ModulePassManager &MPM, OptLevel Level) {
               MPM.addPass(SyncElisionInliningPass{});
               MPM.addPass(llvm::AlwaysInlinerPass{});

--- a/src/compiler/AdaptiveCppClangPlugin.cpp
+++ b/src/compiler/AdaptiveCppClangPlugin.cpp
@@ -147,8 +147,6 @@ extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo llvmGetPassPluginIn
 #ifdef HIPSYCL_WITH_STDPAR_COMPILER
           if(EnableStdPar) {
             PB.registerPipelineStartEPCallback([&](llvm::ModulePassManager &MPM, OptLevel Level) {
-              MPM.addPass(SyncElisionEntrypointPreparationPass{});
-              MPM.addPass(llvm::AlwaysInlinerPass{});
               if(!StdparNoMallocToUSM) {
                 MPM.addPass(MallocToUSMPass{});
               }

--- a/src/compiler/stdpar/SyncElision.cpp
+++ b/src/compiler/stdpar/SyncElision.cpp
@@ -30,6 +30,9 @@
 #include "hipSYCL/compiler/stdpar/SyncElision.hpp"
 #include "hipSYCL/compiler/cbs/IRUtils.hpp"
 
+
+#include <llvm/ADT/SmallPtrSet.h>
+#include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/Attributes.h>
 #include <llvm/Support/Casting.h>
 #include <llvm/IR/Instructions.h>
@@ -45,94 +48,266 @@ namespace compiler {
 
 namespace {
 
-bool accessesMemory(llvm::Instruction* I) {
+template <class Handler>
+bool descendInstructionUseTree(llvm::Instruction *I, Handler &&H,
+                               llvm::Instruction *Parent = nullptr) {
+  if(H(I, Parent)) {
+    for(auto* U : I->users()) {
+      if(auto* UI = llvm::dyn_cast<llvm::Instruction>(U)) {
+        if(!descendInstructionUseTree(UI, H, I))
+          return false;
+      } else {
+        return false;
+      }
+    }
+    return true;
+  } else {
+    return false;
+  }
+}
+
+using InstToInstListMapT =
+    llvm::SmallDenseMap<llvm::Instruction *, llvm::SmallVector<llvm::Instruction *, 16>>;
+
+// Identifies store instructions that might be related for argument handling:
+// We identify these instructions by looking for allocas in the function. If that alloca
+// is only used by getelementptr, stores, and calls to stdpar functions, chances are
+// these instructions are only relevant for constructing stdpar arguments.
+//
+// The result is a map from encountered store instructions to other instructions referencing the same
+// memory.
+void identifyStoresPotentiallyForStdparArgHandling(
+    llvm::Function *F, const llvm::SmallPtrSet<llvm::Function *, 16> &StdparFunctions,
+    InstToInstListMapT &Out) {
+  for(auto& BB : *F) {
+    for(auto& I : BB) {
+      if(llvm::isa<llvm::AllocaInst>(&I)) {
+        llvm::SmallVector<llvm::Instruction*, 16> Users;
+
+        bool onlyUsedInAllowedInstructions = descendInstructionUseTree(
+            &I, [&](llvm::Instruction *Current, llvm::Instruction *Parent) {
+              if (llvm::isa<llvm::AllocaInst>(Current) ||
+                  llvm::isa<llvm::GetElementPtrInst>(Current)) {
+                Users.push_back(Current);
+                return true;
+              } else if(auto *SI = llvm::dyn_cast<llvm::StoreInst>(Current)) {
+                // For store instructions, we enforce that the previous instruction in
+                // the use chain must be the pointer operand, not the value operand.
+                if(SI->getValueOperand() != Parent) {
+                  Users.push_back(Current);
+                  return true;
+                }
+              } else if (auto *CB = llvm::dyn_cast<llvm::CallBase>(Current)) {
+                if (StdparFunctions.contains(CB->getCalledFunction())) {
+                  Users.push_back(Current);
+                  return true;
+                } else if(CB->getCalledFunction()->getName().startswith("llvm.lifetime")) {
+                  return true;
+                }
+              }
+
+              return false;
+            });
+
+        if(onlyUsedInAllowedInstructions) {
+          for(auto* U: Users) {
+            if(auto* SI = llvm::dyn_cast<llvm::StoreInst>(U)) {
+              for(auto* U : Users) {
+                Out[SI].push_back(U);
+              }  
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+void identifyStoresPotentiallyForStdparArgHandling(
+    const llvm::SmallVector<llvm::Instruction *, 16> &StdparCallPositions,
+    const llvm::SmallPtrSet<llvm::Function *, 16> &StdparFunctions,
+    InstToInstListMapT &Out) {
+  llvm::SmallPtrSet<llvm::Function*, 16> InvolvedFunctions;
+
+  for(auto* I : StdparCallPositions) {
+    if(I) {
+      InvolvedFunctions.insert(I->getParent()->getParent());
+    }
+  }
+
+  for(auto* F: InvolvedFunctions) {
+    identifyStoresPotentiallyForStdparArgHandling(F, StdparFunctions, Out);
+  }
+}
+
+bool instructionAccessesMemory(llvm::Instruction* I) {
   if (llvm::isa<llvm::StoreInst>(I) || llvm::isa<llvm::LoadInst>(I) ||
       llvm::isa<llvm::AtomicRMWInst>(I) || llvm::isa<llvm::AtomicCmpXchgInst>(I) ||
       llvm::isa<llvm::FenceInst>(I))
     return true;
-  
-  if(auto* CB = llvm::dyn_cast<llvm::CallBase>(I)) {
-    if(auto* F = CB->getCalledFunction()) {
-      if(F->isIntrinsic()) {
-        // Currently we assume that all intrinsics apart from llvm.lifetime
-        // may access memory. This is of course not true, but since intrinsics
-        // are backend-specific it might be difficult to get a comprehensive list
-        // of safe intrinsic
-        if(!F->getName().startswith("llvm.lifetime"))
-          return true;
-      }
+
+  return false;
+}
+
+bool isSkippableStoreInstruction(llvm::Instruction* I) {
+  if(!I)
+    return false;
+  if(auto* S = llvm::dyn_cast<llvm::StoreInst>(I)) {
+    
+  }
+  return false;
+}
+
+bool functionDoesNotAccessMemory(llvm::Function* F){
+  if(!F)
+    return true;
+  if(F->isIntrinsic()) {
+    if(F->getName().startswith("llvm.lifetime")){
+      return true;
     }
   }
-
+  // We could improve this logic massively: E.g. a function which does not have ptr arguments,
+  // does not have gobal variable users, contains no inttoptr instructions, and only calls functions
+  // which satisfy these criteria could be assumed to not access memory.
   return false;
 }
 
-bool isBranchingInst(llvm::Instruction* I) {
-  if(auto* CB = llvm::dyn_cast<llvm::CallBase>(I))
-    if(auto * F = CB->getCalledFunction())
-      if(!F->isIntrinsic())
+// returns whether To is in the same BB as From, and succeeds it in the instruction list.
+bool isSucceedingInBB(llvm::Instruction* From, llvm::Instruction* To) {
+  if(From->getParent() == To->getParent()) {
+    for(auto* I = From; I != nullptr; I = I->getNextNonDebugInstruction()) {
+      if(I == To)
         return true;
-
-  return llvm::isa<llvm::BranchInst>(I) || llvm::isa<llvm::CatchReturnInst>(I) ||
-         llvm::isa<llvm::CatchSwitchInst>(I) || llvm::isa<llvm::CleanupReturnInst>(I) ||
-         llvm::isa<llvm::IndirectBrInst>(I) || llvm::isa<llvm::ResumeInst>(I) ||
-         llvm::isa<llvm::ReturnInst>(I) || llvm::isa<llvm::SwitchInst>(I);
-}
-
-bool instructionRequiresSync(llvm::Instruction* I) {
-  assert(I);
-
-  if(accessesMemory(I) || isBranchingInst(I))
-    return true;
-  
+    }
+  } 
   return false;
 }
 
-constexpr const char* ConsumeMarker = "__hipsycl_stdpar_consume_sync";
-constexpr const char* OptimizableMarker = "__hipsycl_stdpar_optimizable_sync";
+template <unsigned N>
+bool allAreSucceedingInBB(llvm::Instruction* From,
+                          const llvm::SmallVector<llvm::Instruction *, N> &To) {
+  for(auto* I : To) {
+    if(!isSucceedingInBB(From, I))
+      return false;
+  }
+  return true;
+}
+
+constexpr const char* BarrierBuiltinName = "__hipsycl_stdpar_optional_barrier";
 constexpr const char* EntrypointMarker = "hipsycl_stdpar_entrypoint";
 
-void beginWithCallToConsumeBuiltin(llvm::Function* F, llvm::Module& M) {
-  llvm::Type* RetType = llvm::Type::getVoidTy(M.getContext());
-  auto ConsumeFunction =
-      M.getOrInsertFunction(ConsumeMarker, llvm::FunctionType::get(RetType, false));
-  
-  if (F->size() > 0) {
-
-    llvm::Instruction *FirstInst = &(*F->getEntryBlock().begin());
-    llvm::CallInst *CI = llvm::CallInst::Create(ConsumeFunction, "", FirstInst);
-    if(auto* CF = CI->getCalledFunction()) {
-      if(!CF->hasFnAttribute(llvm::Attribute::NoUnwind))
-        CF->addFnAttr(llvm::Attribute::NoUnwind);
-    }
-  }
-}
-
-}
-
-llvm::PreservedAnalyses SyncElisionEntrypointPreparationPass::run(llvm::Module &M,
-                                                                  llvm::ModuleAnalysisManager &AM) {
+template<class Handler>
+void forEachStdparFunction(llvm::Module& M, Handler&& H){
   utils::findFunctionsWithStringAnnotations(M,  [&](llvm::Function* F, llvm::StringRef Annotation){
     if(F) {
       if(Annotation.compare(EntrypointMarker) == 0) {
-        HIPSYCL_DEBUG_INFO << "Found stdpar call: " << F->getName() << "\n";
-        if(F->hasFnAttribute(llvm::Attribute::NoInline)) {
-          F->removeFnAttr(llvm::Attribute::NoInline);
-        }
-        if(!F->hasFnAttribute(llvm::Attribute::AlwaysInline)) {
-          F->addFnAttr(llvm::Attribute::AlwaysInline);
-        }
-        beginWithCallToConsumeBuiltin(F, M);
+        H(F);
       }
-    }  
+    }
   });
-
-  return llvm::PreservedAnalyses::none();
 }
+
+template <class Handler>
+void forEachReachableInstructionRequiringSync(
+    llvm::Instruction *Start, const llvm::SmallPtrSet<llvm::Function *, 16> &StdparFunctions,
+    const InstToInstListMapT& PotentialStoresForStdparArgs,
+    llvm::SmallPtrSet<llvm::BasicBlock*, 16> &CompletelyVisitedBlocks,
+    Handler &&H) {
+
+  if(!Start)
+    return;
+
+  llvm::Instruction* Current = Start;
+  if(CompletelyVisitedBlocks.contains(Current->getParent())) {
+    return;
+  }
+
+  llvm::Instruction* FirstInst = &(*Current->getParent()->getFirstInsertionPt());
+  if(Current == FirstInst) {
+    CompletelyVisitedBlocks.insert(Current->getParent());
+  }
+
+  while(Current) {
+    if(auto* CB = llvm::dyn_cast<llvm::CallBase>(Current)) {
+      llvm::Function* CalledF = CB->getCalledFunction();
+      if(CalledF->getName().equals(BarrierBuiltinName)) {
+        // basic block already contains barrier; nothing to do
+        return;
+      }
+
+      // If we have found a call to an stdpar function, we can skip it --
+      // after all, the whole point is to not sync after every stdpar call.
+      // For all other calls, we need a sync because we currently
+      // do not take control flow beyond our own function into account.
+      // We can also safely ignore functions for which we know that they
+      // do not access memory
+      bool CanSkipFunctionCall =
+          StdparFunctions.contains(CalledF) || functionDoesNotAccessMemory(CalledF);
+
+      if(!CanSkipFunctionCall) {
+        H(Current);
+        return;
+      }
+    } else if(instructionAccessesMemory(Current)) {
+      bool isSkippableStore = false;
+      if(llvm::isa<llvm::StoreInst>(Current)) {
+        // Check if the store is perhaps only used to setup arguments of stdpar calls
+        // (e.g. to assemble kernel lambdas)
+        auto It = PotentialStoresForStdparArgs.find(Current);
+        if(It != PotentialStoresForStdparArgs.end()) {
+          // Store is skippable, if the referenced memory is used by stdpar function calls
+          // which succeed the store in the control flow.
+          llvm::SmallVector<llvm::Instruction*, 16> StdparCallsUsingMemory;
+          for(auto* I : It->getSecond()) {
+            if(auto *CB = llvm::dyn_cast<llvm::CallBase>(I)){
+              if(StdparFunctions.contains(CB->getCalledFunction())) {
+                StdparCallsUsingMemory.push_back(CB);
+              }
+            }
+          }
+          if(allAreSucceedingInBB(Current, StdparCallsUsingMemory)) {
+            isSkippableStore = true;
+          }
+        }
+      }
+
+      if(!isSkippableStore) {
+        H(Current);
+        return;
+      } else {
+        HIPSYCL_DEBUG_INFO
+            << "[stdpar] SyncElision: Detected store that does not block barrier movement\n";
+      }
+    } else if(Current->isTerminator()){
+      // If this terminator causes control flow to exit from this function, we need
+      // to insert synchronization.
+      // TODO: Look again at exception handling instructions in more detail
+      if (llvm::isa<llvm::ReturnInst>(Current) || llvm::isa<llvm::InvokeInst>(Current) ||
+          llvm::isa<llvm::CallBrInst>(Current) || llvm::isa<llvm::ResumeInst>(Current)) {
+        H(Current);
+        return;
+      }
+    }
+    Current = Current->getNextNonDebugInstruction();
+  }
+  // We have reached the end of this BB - so we need to look
+  // at all its successors in the CFG
+  llvm::BasicBlock* BB = Start->getParent();
+  for(int i = 0; i < BB->getTerminator()->getNumSuccessors(); ++i) {
+    llvm::BasicBlock* Successor = BB->getTerminator()->getSuccessor(i);
+    if(Successor->size() > 0) {
+      llvm::Instruction* FirstI = &(*Successor->getFirstInsertionPt());
+      forEachReachableInstructionRequiringSync(
+          FirstI, StdparFunctions, PotentialStoresForStdparArgs, CompletelyVisitedBlocks, H);
+    }
+  }
+}
+}
+
 
 llvm::PreservedAnalyses SyncElisionInliningPass::run(llvm::Module& M, llvm::ModuleAnalysisManager& AM) {
 
-  auto InlineEachCaller = [&](llvm::Function *F) {
+  auto InlineEachCaller = [](llvm::Function *F) {
     if(!F)
       return;
     for (auto *U : F->users()) {
@@ -148,82 +323,100 @@ llvm::PreservedAnalyses SyncElisionInliningPass::run(llvm::Module& M, llvm::Modu
     }
   };
 
-  InlineEachCaller(M.getFunction(ConsumeMarker));
-  InlineEachCaller(M.getFunction(OptimizableMarker));
+  forEachStdparFunction(M, [&](llvm::Function* F){
+    InlineEachCaller(F);
+  });
 
   return llvm::PreservedAnalyses::all();
 }
 
 llvm::PreservedAnalyses SyncElisionPass::run(llvm::Module &M, llvm::ModuleAnalysisManager &AM) {
 
-  if(auto* F = M.getFunction(ConsumeMarker)) {
-    F->setLinkage(llvm::GlobalValue::LinkOnceODRLinkage);
-  }
-  if(auto* F = M.getFunction(OptimizableMarker)) {
-    F->setLinkage(llvm::GlobalValue::LinkOnceODRLinkage);
-  }
+  llvm::SmallPtrSet<llvm::Function*, 16> StdparFunctions;
+  forEachStdparFunction(M, [&](llvm::Function *F) {
+    HIPSYCL_DEBUG_INFO << "[stdpar] SyncElision: Found stdpar call: " << F->getName() << "\n";
+    if (F->hasFnAttribute(llvm::Attribute::NoInline)) {
+      F->removeFnAttr(llvm::Attribute::NoInline);
+    }
+    StdparFunctions.insert(F);
+  });
 
-  llvm::SmallVector<llvm::CallInst*, 16> RemovableSyncCalls;
-  std::size_t TotalNumSyncCalls = 0;
+  if(auto* SyncF = M.getFunction(BarrierBuiltinName)) {
+    SyncF->setLinkage(llvm::GlobalValue::LinkOnceODRLinkage);
+    if (SyncF->hasFnAttribute(llvm::Attribute::NoInline)) {
+      SyncF->removeFnAttr(llvm::Attribute::NoInline);
+    }
 
-  for(auto& F : M) {
-    for(auto& BB: F) {
-      llvm::CallInst* PreviousOptimizableSyncInst = nullptr;
-      for(auto& I: BB) {
-        // We currently only support call instructions for consume and sync builtins, as
-        // those are easier to handle (particularly regarding BB terminators)
-        llvm::CallInst* CI = llvm::dyn_cast<llvm::CallInst>(&I);
-
-        // If we have encountered any other instruction,
-        // we may have to reset whether PreviousOptimizableSyncInst was set.
-        bool NeedsReset = true;
-
-        if(CI){
-          if(auto* CalledF = CI->getCalledFunction()){
-            if(CalledF->getName().compare(OptimizableMarker) == 0) {
-              ++TotalNumSyncCalls;
-              PreviousOptimizableSyncInst = CI;
-              NeedsReset = false;
-            } else if(CalledF->getName().compare(ConsumeMarker) == 0) {
-              if(PreviousOptimizableSyncInst) {
-                RemovableSyncCalls.push_back(PreviousOptimizableSyncInst);
-                HIPSYCL_DEBUG_INFO << "[stdpar] SyncElision: Eliding synchronization in function "
-                                   << F.getName().str() << "\n";
-              }
-            } else {
-              if(!instructionRequiresSync(&I))
-                NeedsReset = false;
+    llvm::SmallPtrSet<llvm::Instruction*, 16> SyncCallsToRemove;
+    llvm::SmallVector<llvm::Instruction*, 16> StdparCallPositions;
+    
+    for(auto* U : SyncF->users()) {
+      if(auto* I = llvm::dyn_cast<llvm::CallBase>(U)){
+        
+        llvm::Function* Caller = I->getParent()->getParent();
+        if(StdparFunctions.contains(Caller)) {
+          
+          for(auto* CallerU : Caller->users()) {
+            if(auto* CB = llvm::dyn_cast<llvm::CallBase>(CallerU)) {
+              HIPSYCL_DEBUG_INFO << "[stdpar] SyncElision: Found stdpar call in potential need of "
+                                    "synchronization: Call to "
+                                 << Caller->getName() << " in function "
+                                 << CB->getParent()->getParent()->getName() << "\n";
+              SyncCallsToRemove.insert(I);
+              StdparCallPositions.push_back(CB);
             }
           }
+        } else {
+          HIPSYCL_DEBUG_WARNING << "[stdpar] SyncElision: Encountered call to " << BarrierBuiltinName
+                                << " in function that is not stdpar entrypoint\n";
         }
+      }
+    }
+    
+    // Remove synchronization calls present in stdpar function definitions
+    for(auto* I : SyncCallsToRemove) {
+      I->eraseFromParent();
+    }
 
-        if(NeedsReset)
-          PreviousOptimizableSyncInst = nullptr;
+    // It can frequently happen that we have store instructions between two stdpar calls.
+    // These store instructions can prevent synchronization elision, even if they are just
+    // used to set up stdpar arguments (e.g., construct lambda objects).
+    // To counter this, we try to identify instructions that are purely used for argument handling,
+    // and do not interact with the stdpar kernel itself.
+    InstToInstListMapT InstructionsPotentiallyForStdparArgHandling;
+    identifyStoresPotentiallyForStdparArgHandling(
+        StdparCallPositions, StdparFunctions, InstructionsPotentiallyForStdparArgHandling);
+
+    for(auto* I : StdparCallPositions) {
+      // For the start of our search, we need be move to the next instruction following
+      // the stdpar call.
+      // If the stdpar call is mapped to an InvokeInst (which is tpyically the case),
+      // it does not have a next instruction.
+      //
+      // It is important to have this logic here, and not e.g. when collecting StdparCallPositions,
+      // because the appropriate start position might be altered by other barrier insertions
+      // in earlier iterations!
+      llvm::SmallVector<llvm::Instruction*, 8> StartPositions;
+      if(I->isTerminator()) {
+        for(int i = 0; i < I->getNumSuccessors(); ++i) {
+          StartPositions.push_back(&*(I->getSuccessor(i)->getFirstInsertionPt()));
+        }
+      } else {
+        StartPositions.push_back(I->getNextNonDebugInstruction());
+      }
+      for(auto* Start : StartPositions) {
+
+        llvm::SmallPtrSet<llvm::BasicBlock*, 16> VisitedBlocks;
+        forEachReachableInstructionRequiringSync(
+            Start, StdparFunctions, InstructionsPotentiallyForStdparArgHandling, VisitedBlocks,
+            [&](llvm::Instruction *InsertSyncBefore) {
+              HIPSYCL_DEBUG_INFO << "[stdpar] SyncElision: Inserting synchronization in function "
+                                << InsertSyncBefore->getParent()->getParent()->getName() << "\n";
+              llvm::CallInst::Create(SyncF->getFunctionType(), SyncF, "", InsertSyncBefore);
+            });
       }
     }
   }
-
-  auto* ConsumeFunction = M.getFunction(ConsumeMarker);
-  if(ConsumeFunction) {
-    llvm::SmallVector<llvm::CallInst*, 16> Calls;
-    for(auto* U : ConsumeFunction->users()) {
-      llvm::CallInst* CI = llvm::dyn_cast<llvm::CallInst>(U);
-      if(CI) {
-        Calls.push_back(CI);
-      }
-    }
-    for(auto* CI : Calls)
-      CI->eraseFromParent();
-    ConsumeFunction->replaceAllUsesWith(llvm::UndefValue::get(ConsumeFunction->getType()));
-    ConsumeFunction->eraseFromParent();
-  }
-
-
-  for(auto* Call : RemovableSyncCalls)
-    Call->eraseFromParent();
-  HIPSYCL_DEBUG_INFO << "[stdpar] SyncElision: Removed " << RemovableSyncCalls.size()
-                     << " kernel wait() calls out of " << TotalNumSyncCalls << " total calls"
-                     << "\n";
 
   return llvm::PreservedAnalyses::none();
 }

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -5,6 +5,8 @@ add_custom_target(check-sscp
         COMMAND lit "${CMAKE_CURRENT_BINARY_DIR}/sscp" -v)
 add_custom_target(check-reflection
         COMMAND lit "${CMAKE_CURRENT_BINARY_DIR}/reflection" -v)
+add_custom_target(check-stdpar
+        COMMAND lit "${CMAKE_CURRENT_BINARY_DIR}/stdpar" -v)
 
 add_custom_target(check)
-add_dependencies(check check-cbs check-sscp check-reflection)
+add_dependencies(check check-cbs check-sscp check-reflection check-stdpar)

--- a/tests/compiler/stdpar/sync-elision/call_sequence.cpp
+++ b/tests/compiler/stdpar/sync-elision/call_sequence.cpp
@@ -1,0 +1,17 @@
+// RUN: %acpp %s -o %t --acpp-targets=generic -O3 --acpp-stdpar --acpp-stdpar-unconditional-offload
+// RUN: %t | FileCheck %s
+
+#include <cstdio>
+#include "common.hpp"
+
+
+int main() {
+  stdpar_call();
+  stdpar_call();
+  
+  // CHECK: 2
+  printf("%d\n", get_num_enqueued_ops());
+  // printf call should have triggered synchronization
+  // CHECK: 0
+  printf("%d\n", get_num_enqueued_ops());
+}

--- a/tests/compiler/stdpar/sync-elision/common.hpp
+++ b/tests/compiler/stdpar/sync-elision/common.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#define STDPAR_ENTRYPOINT \
+    __attribute__((noinline)) __attribute__((annotate("hipsycl_stdpar_entrypoint")))
+
+static int num_outstanding_operations = 0;
+
+__attribute__((noinline))
+extern "C" void __hipsycl_stdpar_optional_barrier() noexcept {
+  num_outstanding_operations = 0;
+}
+
+STDPAR_ENTRYPOINT static void stdpar_call() {
+  ++num_outstanding_operations;
+  __hipsycl_stdpar_optional_barrier();
+};
+
+// This is a hack: If we just directly access num_outstanding_operations for testing,
+// we trigger a load for this global variable, which would cause a barrier to be inserted.
+// As a workaround, we introduce another STDPAR_ENTRYPOINT function to retrieve this value.
+// This works, because the compiler skips calls to stdpar entrypoint functions when determining
+// the next necessary synchronization.
+STDPAR_ENTRYPOINT static int get_num_enqueued_ops() {
+  return num_outstanding_operations;
+};

--- a/tests/compiler/stdpar/sync-elision/control_flow.cpp
+++ b/tests/compiler/stdpar/sync-elision/control_flow.cpp
@@ -1,0 +1,25 @@
+// RUN: %acpp %s -o %t --acpp-targets=generic -O3 --acpp-stdpar --acpp-stdpar-unconditional-offload
+// RUN: %t | FileCheck %s
+
+#include <cstdio>
+#include "common.hpp"
+
+__attribute__((noinline))
+void test(int n = 10 /* to avoid all branches being optimized out*/) {
+  stdpar_call();
+  for(int i=0; i < n; ++i)
+    stdpar_call();
+  if(n > 10) {
+    // Is not executed, and thus should not trigger sync
+    printf("Triggering synchronization\n");
+  }
+  // CHECK: 11
+  printf("%d\n", get_num_enqueued_ops());
+}
+
+int main() {
+  test();
+  // printf() call to external function will trigger synchronization
+  // CHECK: 0
+  printf("%d\n", get_num_enqueued_ops());
+}

--- a/tests/compiler/stdpar/sync-elision/function_exit.cpp
+++ b/tests/compiler/stdpar/sync-elision/function_exit.cpp
@@ -1,0 +1,27 @@
+// RUN: %acpp %s -o %t --acpp-targets=generic --acpp-stdpar --acpp-stdpar-unconditional-offload
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s -o %t --acpp-targets=generic -O3 --acpp-stdpar --acpp-stdpar-unconditional-offload
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s -o %t --acpp-targets=generic -g --acpp-stdpar --acpp-stdpar-unconditional-offload
+// RUN: %t | FileCheck %s
+
+#include <cstdio>
+#include "common.hpp"
+
+__attribute__((noinline))
+void test() {
+  stdpar_call();
+}
+
+// Compiler will currently always inline the first level of calls
+// to stdpar functions, so we need another layer of function calls
+// to actually trigger a function exit in LLVM IR
+__attribute__((noinline)) void test_wrapper() {
+  test();
+}
+
+int main() {
+  test_wrapper();
+  // CHECK: 0
+  printf("%d\n", get_num_enqueued_ops());
+}

--- a/tests/compiler/stdpar/sync-elision/load_store.cpp
+++ b/tests/compiler/stdpar/sync-elision/load_store.cpp
@@ -1,0 +1,38 @@
+// RUN: %acpp %s -o %t --acpp-targets=generic --acpp-stdpar --acpp-stdpar-unconditional-offload
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s -o %t --acpp-targets=generic -O3 --acpp-stdpar --acpp-stdpar-unconditional-offload
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s -o %t --acpp-targets=generic -g --acpp-stdpar --acpp-stdpar-unconditional-offload
+// RUN: %t | FileCheck %s
+
+#include <cstdio>
+#include <vector>
+#include "common.hpp"
+
+
+
+int main() {
+  std::vector<int> data(1024);
+  for(int i = 0; i < data.size(); ++i)
+    data[i] = i;
+
+  stdpar_call();
+  stdpar_call();
+  
+  int pre_load_queue_size = get_num_enqueued_ops();
+  if(data[pre_load_queue_size] < 0) {
+    printf("(output to prevent dead code elimination: %d\n)", data[pre_load_queue_size]);
+  }
+  int post_load_queue_size = get_num_enqueued_ops();
+  // CHECK: 2
+  // CHECK: 0
+  printf("%d\n", pre_load_queue_size);
+  printf("%d\n", post_load_queue_size);
+
+  stdpar_call();
+  data[0] = 10;
+  // CHECK: 0
+  printf("%d\n", get_num_enqueued_ops());
+  // CHECK: 0
+  printf("%d\n", data[0]);
+}


### PR DESCRIPTION
This PR completely reimplements the synchronization elision optimization for stdpar. While it started out by looking into a regression preventing synchronization elision following #1237, this PR introduces a completely new approach that has several benefits.

Previously, there was a builtin call at the beginning and end of stdpar functions. When these two builtins met in the IR without memory accesses, control flow or function calls in between, synchronization was elided. This approach was fairly limited. In particular, it could not elide synchronization between stdpar calls e.g. in a loop:

```
for(int i = 0; i < num_iterations; ++i) {
  std::for_each(....);
}
```

It also failed if the compiler inserts store operations into the lambda struct to assemble the function argument prior to invoking to call. This pattern happens reliably as soon as arguments exceed trivial size.

The new approach addresses both issues:

It works as follows:
1. Detect stdpar functions using the new `hipsycl_stdpar_entrypoint` annotation attribute.
2. Detect calls to `__hipsycl_stdpar_optional_barrier()` inside stdpar functions.
3. Remove `__hipsycl_stdpar_optional_barrier()` calls from within the stdpar function definition, and reinsert them after the call instruction to the stdpar function (i.e. move them out of the stdpar function, and to the callsite)
4. Move calls to `__hipsycl_stdpar_optional_barrier()` down the instruction flow, taking all routes through the control flow graph until a place is encountered where barriers must be present for correctness:
  * memory accesses such as loads/stores
  * calls to other functions that are not stdpar calls, since we cannot know what these functions do and our control flow analysis currently cannot continue in other functions. Stdpar calls are ignored, which is what allows us to avoid synchronization in between them.
  * exit of control flow from the current function
  * If a barrier is already present at one of the determined insertion points, no additional barrier is inserted.
  * If a position where synchronization is needed is found, or a present barrier, that path in the control flow graph is considered finished, and the other paths are investigated.

Even if synchronization could not be elided completely, this algorithm might still yield a speedup because it effectively causes synchronization to be as delayed as possible.

`__hipsycl_stdpar_optional_barrier()` accesses an internal counter of enqueued operations, which is incremented by each stdpar call. `__hipsycl_stdpar_optional_barrier()` only synchronizes if that counter is > 0, and after a synchronization resets it. This is because the exact requirement for synchronization now depend on the precise route through the control flow graph that the program has taken, and in some control flow graphs it can happen that it hits multiple calls to `__hipsycl_stdpar_optional_barrier()` without a new stdpar call in between.

Store instructions are tricky and obey additional logic: Stores are commonly inserted by clang before stdpar calls to assemble function arguments, such as lambda objects passed to the stdpar algorithm. This is problematic, because hitting these stores can prevent barriers from being moved beyond them, and ultimately prevent the SyncElision optimization from becoming beneficial in many cases. Thus, a way is needed to distinguish stores that purely relate to assembling stdpar arguments from stores to memory locations that might actually be used inside kernels.

In theory, we know that stores to addresses that are then exclusively used for by-value
arguments to stdpar calls can be considered to be part of stdpar argument handling, and can thus
be skipped. In practice, we cannot easily determine this due to opaque pointers and clang/LLVM's
inconsistent use of the `byval(T)` attribute. Currently, we use the following heuristic to detect "harmless" stores that do not require synchronization:
* Consider stores to memory locations that originate from an alloca
* The original alloca memory location and all its derived uses must only be in the form of `getelementptr` instructions, stores, and the stdpar call.
* The store must occur in the same block as the stdpar call, and precede it in the instruction order.

I believe that there might be pathological cases where this returns false positives, especially in the presence of system USM where stack memory might be used inside kernels too. In practice, for cases where this becomes relevant we should not offload anyway because the problem size would be way too small to be an efficient offload use case. It's also not yet clear to me whether a meaningful program could be written that triggers such a pathological case.




This PR also introduces a test infrastructure for synchronization elision. This should help us detect issues and regressions better.


With the new approach, we can elide far more synchronization. For example, in the case of Lulesh, we find that we can enqueue up to 14 kernels before a wait is needed:

```
[AdaptiveCpp Info] [stdpar] Initializing wait for 14 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 5 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 14 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 5 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 14 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 5 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 14 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 5 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 14 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 5 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 14 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 5 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 14 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 5 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 14 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 5 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 14 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 5 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 14 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 5 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 14 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 5 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 14 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 5 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 14 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 5 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 14 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 5 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 14 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 5 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 14 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 5 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 14 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 2 operations
[AdaptiveCpp Info] [stdpar] Initializing wait for 1 operations
```

CC @tom91136 - perhaps this might also be relevant for you :)