### PR TITLE
Add <string> include to debug.hpp for std::stoi

### DIFF
--- a/include/hipSYCL/common/debug.hpp
+++ b/include/hipSYCL/common/debug.hpp
@@ -40,6 +40,7 @@
 
 #include <iostream>
 #include <cstdlib>
+#include <string>
 
 #ifndef HIPSYCL_COMPILER_COMPONENT
 #include "hipSYCL/runtime/application.hpp"


### PR DESCRIPTION
## Overview
This pull request adds an `#include <string>` directive to `debug.hpp` in AdaptiveCpp. This change addresses a compilation issue on Windows where `std::stoi` is used but not declared due to the absence of the `<string>` header.

## Problem Description
The file `debug.hpp` uses `std::stoi`, which requires the `<string>` header. While this compiles on Linux (likely due to indirect inclusion through `<cstdlib>`), it fails on Windows where such indirect inclusions are not guaranteed.

## Proposed Change
- Added `#include <string>` to `debug.hpp`.

## Rationale
Explicitly including `<string>` ensures that the declaration of `std::stoi` is always available, regardless of the platform or differences in standard library implementations. This change improves the portability and robustness of the code.

## Testing
The change has been tested on Windows, ensuring that code using `std::stoi` in `debug.hpp` now compiles without issues. It should not affect other platforms as `<string>` is a standard header.

Thank you for considering this pull request.