### PR TITLE
[stdpar] Track allocations using dedicated map and enable automatic USM prefetch

### DIFF
--- a/doc/stdpar.md
+++ b/doc/stdpar.md
@@ -101,6 +101,7 @@ Such issues are not present for the functions defined in the SYCL headers, becau
 
 Of course, if you wish to have greater control over memory, USM device pointers from user-controlled USM memory management function calls can also be used, as in any regular SYCL kernel. The buffer-accessor model is not supported; memory stored in `sycl::buffer` objects can only be used when converting it to a USM pointer using our buffer-USM interoperability extension.
 Note that you may need to invoke SYCL functions to explicitly copy memory to device and back if you use explicit SYCL device USM allocations.
+It is not recommended to use USM shared allocations from direct calls to `sycl::malloc_shared` in C++ standard algorithms. Such allocations will not be tracked by the stdpar runtime, and as such might not benefit from optimizations such as automatic prefetching.
 
 ### Systems with system-level USM support
 

--- a/include/hipSYCL/std/stdpar/detail/allocation_map.hpp
+++ b/include/hipSYCL/std/stdpar/detail/allocation_map.hpp
@@ -49,7 +49,7 @@ public:
   static_assert(std::is_trivial_v<UserPayload>, "UserPayload must be trivial type");
 
   allocation_map()
-  : _num_in_progress_operations{0}, _num_empty_leaves{0} {}
+  : _num_in_progress_operations{0} {}
 
   struct value_type : public UserPayload {
     std::size_t allocation_size;
@@ -58,33 +58,24 @@ public:
   // Access entry of allocation that address belongs to, or nullptr if the address
   // does not belong to a known allocation.
   value_type* get_entry(uint64_t address, uint64_t& root_address) noexcept {
-    operation_lock lock{_num_in_progress_operations};
+    insert_or_get_entry_lock lock{_num_in_progress_operations};
     root_address = 0;
-    return get_entry(_root, address, root_address);
+    int num_leaf_attempts = 0;
+    return get_entry(_root, address, num_leaf_attempts, root_address);
   }
 
+  // Insert new element. Element's allocation range must be
+  // non-overlapping w.r.t existing entries.
+  // ~0ull is unsupported, because then non-zero allocation
+  // ranges cannot be expressed.
   bool insert(uint64_t address, const value_type& v) {
-    operation_lock lock{_num_in_progress_operations};
-    int unused_leaves_delta = 0;
-    return insert(_root, address, v, unused_leaves_delta);
+    insert_or_get_entry_lock lock{_num_in_progress_operations};
+    return insert(_root, address, v);
   }
 
   bool erase(uint64_t address) {
-    bool result = false;
-    {
-      operation_lock lock{_num_in_progress_operations};
-      int unused_leaves_delta = 0;
-      result = erase(_root, address, unused_leaves_delta);
-    }
-    if(result) {
-      if(needs_garbage_collection()) {
-        gc_lock lock{_num_in_progress_operations};
-        if(needs_garbage_collection()) {
-          garbage_collect();
-        }
-      }
-    }
-    return result;
+    erase_lock lock{_num_in_progress_operations};
+    return erase(_root, address);
   }
 
   ~allocation_map() {
@@ -96,6 +87,27 @@ public:
   }
     
 private:
+  // Useful for debugging/printing
+  template<class F>
+  void with_decomposed_address(uint64_t address, int current_level, F&& handler) {
+    for(int i = root_level_idx; i >= current_level; --i) {
+      handler(get_index_in_level(address, i));
+    }
+    for(int i = current_level - 1; i >= 0; --i) {
+      handler(-1);
+    }
+  }
+
+  template<class Ostream>
+  void print(Ostream& ostr, uint64_t address, int level) {
+    with_decomposed_address(address, level, [&](int x){
+      if(x >= 0)
+        ostr << x << ".";
+      else
+        ostr << "x";
+    });
+    ostr << "\n";
+  }
 
   static constexpr int num_levels = 16;
   static constexpr int root_level_idx = num_levels - 1;
@@ -104,7 +116,7 @@ private:
   static constexpr int empty_leaves_gc_trigger = 10000;
 
   static constexpr int get_num_entries_in_level(int level) {
-    return (1ull << (bitsizes[level] + 1)) - 1;
+    return 1ull << bitsizes[level];
   }
 
   static constexpr int get_bitoffset_in_level(int level) {
@@ -116,12 +128,19 @@ private:
   }
 
   static constexpr int get_index_in_level(uint64_t address, int level) {
-    uint64_t bitmask = (1ull << (bitsizes[level] + 1)) - 1;
+    uint64_t bitmask = get_n_low_bits_set(bitsizes[level]);
     return (address >> get_bitoffset_in_level(level)) & bitmask;
   }
 
+  static constexpr uint64_t get_n_low_bits_set(int n) {
+    if(n == 64)
+      return ~0ull;
+    return (1ull << n) - 1;
+  }
+
   struct leaf_node {
-    leaf_node() {
+    leaf_node()
+    : num_entries {} {
       for(int i = 0; i < get_num_entries_in_level(0); ++i) {
         entries[i].allocation_size = 0;
       }
@@ -141,12 +160,12 @@ private:
     }
   public:
     intermediate_node()
-    : children{}, num_empty_leaves{} {}
+    : children{}, num_entries{} {}
 
     using child_type = decltype(make_child());
 
     std::atomic<child_type*> children [get_num_entries_in_level(Level)];
-    std::atomic<int> num_empty_leaves [get_num_entries_in_level(Level)];
+    std::atomic<int> num_entries;
   };
 
   template<class T>
@@ -158,15 +177,35 @@ private:
     __libc_free(ptr);
   }
 
-  value_type *get_entry(leaf_node &current_node,
-                        uint64_t address, uint64_t &root_address) noexcept {
-    for (int local_address = get_index_in_level(address, 0); local_address >= 0;
+  value_type *get_entry(leaf_node &current_node, uint64_t address,
+                        int &num_leaf_attempts,
+                        uint64_t &root_address) noexcept {
+    int start_address = 0;
+
+    uint64_t max_local_address =
+        root_address | (get_num_entries_in_level(0) - 1);
+    
+    if(max_local_address <= address)
+      start_address = get_num_entries_in_level(0) - 1;
+    else
+      start_address = get_index_in_level(address, 0);
+
+    for (int local_address = start_address; local_address >= 0;
          --local_address) {
+      
       auto& element = current_node.entries[local_address];
-      if(element.allocation_size > 0) {
-        root_address |= static_cast<uint64_t>(local_address)
-                        << get_bitoffset_in_level(0);
-        if(address >= root_address) {
+
+      std::size_t allocation_size =
+          __atomic_load_n(&(element.allocation_size), __ATOMIC_ACQUIRE);
+      if(allocation_size > 0) {
+
+        uint64_t root_address_candidate =
+            root_address |
+            (static_cast<uint64_t>(local_address) << get_bitoffset_in_level(0));
+
+        uint64_t allocation_end = root_address_candidate + allocation_size;
+        if(address >= root_address_candidate && address < allocation_end) {
+          root_address = root_address_candidate;
           return &element;
         } else {
           return nullptr;
@@ -179,41 +218,91 @@ private:
 
   template <int Level>
   value_type *get_entry(intermediate_node<Level> &current_node,
-                        uint64_t address, uint64_t &root_address) noexcept {
-    for (int local_address = get_index_in_level(address, Level);
+                        uint64_t address,
+                        int& num_leaf_attempts,
+                        uint64_t& root_address) noexcept {
+    // If the queried address is too close to the next allocation,
+    // it can happen that the search converges on the next allocation.
+    // Therefore, to exclude that case, if a search fails, we also
+    // need to try again with the next allocation before that.
+    // This variable counts how many leaves we have accessed. If it
+    // reaches two, we can abort.
+    if constexpr(Level == root_level_idx) {
+      num_leaf_attempts = 0;
+    }
+
+    uint64_t max_local_address =
+        root_address |
+        get_n_low_bits_set(get_bitoffset_in_level(Level) + bitsizes[Level]);
+
+    // We are always looking for the next allocation preceding the
+    // current address. If the maximum local address in this node
+    // cannot reach the search address, (e.g. if we are looking in
+    // a preceding node at the same level), we need to start from 
+    // the maximum address. Otherwise, we need to look at the bits
+    // set in this address.
+    int start_address = 0;
+    if(max_local_address <= address)
+      start_address = get_num_entries_in_level(Level) - 1;
+    else
+      start_address = get_index_in_level(address, Level);
+
+    for (int local_address = start_address;
          local_address >= 0; --local_address) {
       
       auto *ptr = current_node.children[local_address].load(
           std::memory_order::memory_order_acquire);
       
       if(ptr) {
-        root_address |= static_cast<uint64_t>(local_address)
-                        << get_bitoffset_in_level(Level);
-        return get_entry(*ptr, address, root_address);
+        uint64_t root_address_candidate =
+            root_address | (static_cast<uint64_t>(local_address)
+                            << get_bitoffset_in_level(Level));
+
+        auto* ret = get_entry(*ptr, address, num_leaf_attempts,
+                              root_address_candidate);
+        // If we are in level 1, ret refers to a leaf node
+        if constexpr(Level == 1) {
+          ++num_leaf_attempts;
+        }
+
+        if(ret) {
+          root_address = root_address_candidate;
+          return ret;
+        } else if(num_leaf_attempts >= 2) {
+          // We can abort if we have looked at the first hit leaf node,
+          // and the one before that.
+          return nullptr;
+        }
       }
     }
     return nullptr;
   }
 
-  bool insert(leaf_node &current_node, uint64_t address, const value_type &v,
-              int &unused_leaves_delta) {
-    unused_leaves_delta = 0;
+  bool insert(leaf_node &current_node, uint64_t address, const value_type &v) {
 
     int local_address = get_index_in_level(address, 0);
-    current_node.entries[local_address] = v;
+
+    std::size_t *allocation_size_ptr =
+        &(current_node.entries[local_address].allocation_size);
+
+    std::size_t allocation_size = __atomic_load_n(allocation_size_ptr, __ATOMIC_ACQUIRE);
+    if(allocation_size > 0) {
+      // Entry is already occupied
+      return false;
+    }
+    
+    __atomic_store_n(allocation_size_ptr, v.allocation_size, __ATOMIC_RELEASE);
+    current_node.entries[local_address].UserPayload::operator=(v);
     
     auto val = current_node.num_entries.fetch_add(
         1, std::memory_order::memory_order_acq_rel);
-    if (val == 0) {
-      _num_empty_leaves.fetch_add(-1, std::memory_order_acq_rel);
-      unused_leaves_delta = -1;
-    }
+
     return true;
   }
 
   template <int Level>
   bool insert(intermediate_node<Level> &current_node, uint64_t address,
-              const value_type &v, int &unused_leaves_delta) {
+              const value_type &v) {
     using child_t = typename intermediate_node<Level>::child_type;
 
     int local_address = get_index_in_level(address, Level);
@@ -226,55 +315,63 @@ private:
       new (new_child) child_t{};
 
       if (!current_node.children[local_address].compare_exchange_strong(
-              ptr, new_child, std::memory_order_acq_rel)) {
-        new_child->~child_t();
-        free(new_child);
+              ptr /* == nullptr*/, new_child, std::memory_order_acq_rel)) {
+        // Assigning new child has failed because child is no longer nullptr
+        // -> free new child again
+        destroy(*new_child);
+        this->free(new_child);
       } else {
+        current_node.num_entries.fetch_add(
+            1, std::memory_order::memory_order_acq_rel);
         ptr = new_child;
       }
     }
 
-    int delta = 0;
-    auto result = insert(*ptr, address, v, delta);
-    if(delta != 0) {
-      current_node.num_empty_leaves[local_address].fetch_add(
-          delta, std::memory_order_acq_rel);
-    }
-    unused_leaves_delta = delta;
-    return result;
+    return insert(*ptr, address, v);
   }
 
-  bool erase(leaf_node& current_node, uint64_t address, int& unused_leaves_delta) {
+  bool erase(leaf_node& current_node, uint64_t address) {
     int local_address = get_index_in_level(address, 0);
-    current_node.entries[local_address].allocation_size = 0;
 
-    int count = current_node.num_entries.fetch_sub(
+    std::size_t *allocation_size_ptr =
+        &(current_node.entries[local_address].allocation_size);
+    // Entry was already deleted or does not exist
+    if(__atomic_load_n(allocation_size_ptr, __ATOMIC_ACQUIRE) == 0)
+      return false;
+
+    __atomic_store_n(allocation_size_ptr, 0, __ATOMIC_RELEASE);
+
+    current_node.num_entries.fetch_sub(
         1, std::memory_order::memory_order_acq_rel);
     
-    unused_leaves_delta = 0;
-    if (count == 1 /* has just become empty */) {
-      _num_empty_leaves.fetch_add(1, std::memory_order::memory_order_acq_rel);
-      unused_leaves_delta = 1;
-    }
     return true;
   }
 
-  template<int Level>
-  bool erase(intermediate_node<Level>& current_node, uint64_t address, int& unused_leaves_delta) {
+  template <int Level>
+  bool erase(intermediate_node<Level> &current_node, uint64_t address) {
+
     int local_address = get_index_in_level(address, Level);
     auto *ptr = current_node.children[local_address].load(
         std::memory_order::memory_order_acquire);
     if(!ptr)
       return false;
     
-    int delta = 0;
-    bool result = erase(*ptr, address, delta);
-    if(delta != 0) {
-      current_node.num_empty_leaves[local_address].fetch_add(
-          delta, std::memory_order_acq_rel);
+    bool result = erase(*ptr, address);
+    if(result) {
+      if(ptr->num_entries.load(std::memory_order::memory_order_acquire) == 0) {
+        auto *current_ptr = current_node.children[local_address].exchange(
+            nullptr, std::memory_order::memory_order_acq_rel);
+        // TODO: We could potentially get erase() lock-free
+        // by counting by how many ops each node is currently used,
+        // and waiting here until the count turns to 0.
+        if(current_ptr) {
+          destroy(*current_ptr);
+          this->free(current_ptr);
+          current_node.num_entries.fetch_sub(
+              1, std::memory_order::memory_order_acq_rel);
+        }
+      }
     }
-    unused_leaves_delta = delta;
-
     return result;
   }
 
@@ -294,10 +391,6 @@ private:
     destroy(current_node);
   }
 
-  bool needs_garbage_collection() const noexcept {
-    return _num_empty_leaves.load(std::memory_order_acquire) >= empty_leaves_gc_trigger;
-  }
-
   void destroy(leaf_node& node) {
     node.~leaf_node();
   }
@@ -307,44 +400,9 @@ private:
     node.~intermediate_node<Level>();
   }
 
-  bool garbage_collect(leaf_node& current_node) {
-    if(current_node.num_entries.load(std::memory_order::memory_order_acquire) == 0) {
-      return true;
-    }
-    return false;
-  }
-
-  template<int Level>
-  bool garbage_collect(intermediate_node<Level>& current_node) {
-    int num_living_children = 0;
-    for(int i = 0; i < get_num_entries_in_level(Level); ++i) {
-      auto* child_ptr = current_node.children[i].load(std::memory_order::memory_order_acquire);
-
-      if(child_ptr) {
-        ++num_living_children;
-
-        if(current_node.num_empty_leaves[i] > 0) {
-          if(garbage_collect(*child_ptr)) {
-            destroy(*child_ptr);
-            free(child_ptr);
-            current_node.children[i].store(nullptr, std::memory_order::memory_order_release);
-            --num_living_children;
-          }
-          // After GC, num empty nodes is always 0
-          current_node.num_empty_leaves[i] = 0; 
-        }
-      }
-    }
-    return num_living_children == 0;
-  }
-
-  void garbage_collect() {
-    garbage_collect(_root);
-  }
-
-  struct gc_lock {
+  struct erase_lock {
   public:
-    gc_lock(std::atomic<int>& op_counter)
+    erase_lock(std::atomic<int>& op_counter)
     : _op_counter{op_counter} {
       int expected = 0;
       while (!_op_counter.compare_exchange_strong(
@@ -354,16 +412,16 @@ private:
       }
     }
 
-    ~gc_lock() {
+    ~erase_lock() {
       _op_counter.store(0, std::memory_order::memory_order_release);
     }
   private:
     std::atomic<int>& _op_counter;
   };
 
-  struct operation_lock {
+  struct insert_or_get_entry_lock {
   public:
-    operation_lock(std::atomic<int>& op_counter)
+    insert_or_get_entry_lock(std::atomic<int>& op_counter)
     : _op_counter{op_counter} {
       int expected = std::max(0, _op_counter.load(std::memory_order_acquire));
       while (!_op_counter.compare_exchange_strong(
@@ -374,7 +432,7 @@ private:
       }
     }
 
-    ~operation_lock() {
+    ~insert_or_get_entry_lock() {
       _op_counter.fetch_sub(1, std::memory_order::memory_order_acq_rel);
     }
   private:
@@ -382,9 +440,7 @@ private:
   };
 
   intermediate_node<root_level_idx> _root;
-  
   std::atomic<int> _num_in_progress_operations;
-  std::atomic<int> _num_empty_leaves;
 };
 
 }

--- a/include/hipSYCL/std/stdpar/detail/allocation_map.hpp
+++ b/include/hipSYCL/std/stdpar/detail/allocation_map.hpp
@@ -57,7 +57,7 @@ public:
 
   // Access entry of allocation that address belongs to, or nullptr if the address
   // does not belong to a known allocation.
-  const value_type* get_entry(uint64_t address, uint64_t& root_address) const noexcept {
+  value_type* get_entry(uint64_t address, uint64_t& root_address) noexcept {
     operation_lock lock{_num_in_progress_operations};
     root_address = 0;
     return get_entry(_root, address, root_address);
@@ -158,11 +158,11 @@ private:
     __libc_free(ptr);
   }
 
-  const value_type *get_entry(const leaf_node &current_node,
-                              uint64_t address, uint64_t &root_address) const noexcept {
+  value_type *get_entry(leaf_node &current_node,
+                        uint64_t address, uint64_t &root_address) noexcept {
     for (int local_address = get_index_in_level(address, 0); local_address >= 0;
          --local_address) {
-      const auto& element = current_node.entries[local_address];
+      auto& element = current_node.entries[local_address];
       if(element.allocation_size > 0) {
         root_address |= static_cast<uint64_t>(local_address)
                         << get_bitoffset_in_level(0);
@@ -178,8 +178,8 @@ private:
   }
 
   template <int Level>
-  const value_type *get_entry(const intermediate_node<Level> &current_node,
-                              uint64_t address, uint64_t &root_address) const noexcept {
+  value_type *get_entry(intermediate_node<Level> &current_node,
+                        uint64_t address, uint64_t &root_address) noexcept {
     for (int local_address = get_index_in_level(address, Level);
          local_address >= 0; --local_address) {
       
@@ -383,7 +383,7 @@ private:
 
   intermediate_node<root_level_idx> _root;
   
-  mutable std::atomic<int> _num_in_progress_operations;
+  std::atomic<int> _num_in_progress_operations;
   std::atomic<int> _num_empty_leaves;
 };
 

--- a/include/hipSYCL/std/stdpar/detail/allocation_map.hpp
+++ b/include/hipSYCL/std/stdpar/detail/allocation_map.hpp
@@ -113,7 +113,6 @@ private:
   static constexpr int root_level_idx = num_levels - 1;
   static constexpr int bitsizes[num_levels] = {4, 4, 4, 4, 4, 4, 4, 4,
                                                4, 4, 4, 4, 4, 4, 4, 4};
-  static constexpr int empty_leaves_gc_trigger = 10000;
 
   static constexpr int get_num_entries_in_level(int level) {
     return 1ull << bitsizes[level];

--- a/include/hipSYCL/std/stdpar/detail/allocation_map.hpp
+++ b/include/hipSYCL/std/stdpar/detail/allocation_map.hpp
@@ -1,0 +1,392 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2023 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HIPSYCL_ALLOCATION_MAP_HPP
+#define HIPSYCL_ALLOCATION_MAP_HPP
+
+
+#include <cstdlib>
+#include <cstdint>
+#include <type_traits>
+#include <atomic>
+#include <algorithm>
+
+extern "C" void *__libc_malloc(size_t);
+extern "C" void __libc_free(void*);
+
+namespace hipsycl::stdpar {
+
+struct default_allocation_map_payload {};
+
+template<class UserPayload = default_allocation_map_payload>
+class allocation_map {
+public:
+  static_assert(sizeof(void*) == 8, "Unsupported pointer size");
+  static_assert(std::is_trivial_v<UserPayload>, "UserPayload must be trivial type");
+
+  allocation_map()
+  : _num_in_progress_operations{0}, _num_empty_leaves{0} {}
+
+  struct value_type : public UserPayload {
+    std::size_t allocation_size;
+  };
+
+  // Access entry of allocation that address belongs to, or nullptr if the address
+  // does not belong to a known allocation.
+  const value_type* get_entry(uint64_t address, uint64_t& root_address) const noexcept {
+    operation_lock lock{_num_in_progress_operations};
+    root_address = 0;
+    return get_entry(_root, address, root_address);
+  }
+
+  bool insert(uint64_t address, const value_type& v) {
+    operation_lock lock{_num_in_progress_operations};
+    int unused_leaves_delta = 0;
+    return insert(_root, address, v, unused_leaves_delta);
+  }
+
+  bool erase(uint64_t address) {
+    bool result = false;
+    {
+      operation_lock lock{_num_in_progress_operations};
+      int unused_leaves_delta = 0;
+      result = erase(_root, address, unused_leaves_delta);
+    }
+    if(result) {
+      if(needs_garbage_collection()) {
+        gc_lock lock{_num_in_progress_operations};
+        if(needs_garbage_collection()) {
+          garbage_collect();
+        }
+      }
+    }
+    return result;
+  }
+
+  ~allocation_map() {
+    for(int i = 0; i < get_num_entries_in_level(root_level_idx); ++i) {
+      auto* ptr = _root.children[i].load(std::memory_order::memory_order_acquire);
+      if(ptr)
+        release(*ptr);
+    }
+  }
+    
+private:
+
+  static constexpr int num_levels = 16;
+  static constexpr int root_level_idx = num_levels - 1;
+  static constexpr int bitsizes[num_levels] = {4, 4, 4, 4, 4, 4, 4, 4,
+                                               4, 4, 4, 4, 4, 4, 4, 4};
+  static constexpr int empty_leaves_gc_trigger = 10000;
+
+  static constexpr int get_num_entries_in_level(int level) {
+    return (1ull << (bitsizes[level] + 1)) - 1;
+  }
+
+  static constexpr int get_bitoffset_in_level(int level) {
+    int result = 0;
+    for(int i = 0; i < level; ++i) {
+      result += bitsizes[i];
+    }
+    return result;
+  }
+
+  static constexpr int get_index_in_level(uint64_t address, int level) {
+    uint64_t bitmask = (1ull << (bitsizes[level] + 1)) - 1;
+    return (address >> get_bitoffset_in_level(level)) & bitmask;
+  }
+
+  struct leaf_node {
+    leaf_node() {
+      for(int i = 0; i < get_num_entries_in_level(0); ++i) {
+        entries[i].allocation_size = 0;
+      }
+    }
+
+    value_type entries [get_num_entries_in_level(0)];
+    std::atomic<int> num_entries;
+  };
+
+  template<int Level>
+  struct intermediate_node {
+  private:
+      static constexpr auto make_child() {
+      if constexpr (Level > 1) return 
+        intermediate_node<Level - 1>{};
+      else return leaf_node{};
+    }
+  public:
+    intermediate_node()
+    : children{}, num_empty_leaves{} {}
+
+    using child_type = decltype(make_child());
+
+    std::atomic<child_type*> children [get_num_entries_in_level(Level)];
+    std::atomic<int> num_empty_leaves [get_num_entries_in_level(Level)];
+  };
+
+  template<class T>
+  static T* alloc(int count) {
+    return static_cast<T*>(__libc_malloc(sizeof(T) * count));
+  }
+
+  static void free(void* ptr) {
+    __libc_free(ptr);
+  }
+
+  const value_type *get_entry(const leaf_node &current_node,
+                              uint64_t address, uint64_t &root_address) const noexcept {
+    for (int local_address = get_index_in_level(address, 0); local_address >= 0;
+         --local_address) {
+      const auto& element = current_node.entries[local_address];
+      if(element.allocation_size > 0) {
+        root_address |= static_cast<uint64_t>(local_address)
+                        << get_bitoffset_in_level(0);
+        if(address >= root_address) {
+          return &element;
+        } else {
+          return nullptr;
+        }
+        
+      }
+    }
+    return nullptr;
+  }
+
+  template <int Level>
+  const value_type *get_entry(const intermediate_node<Level> &current_node,
+                              uint64_t address, uint64_t &root_address) const noexcept {
+    for (int local_address = get_index_in_level(address, Level);
+         local_address >= 0; --local_address) {
+      
+      auto *ptr = current_node.children[local_address].load(
+          std::memory_order::memory_order_acquire);
+      
+      if(ptr) {
+        root_address |= static_cast<uint64_t>(local_address)
+                        << get_bitoffset_in_level(Level);
+        return get_entry(*ptr, address, root_address);
+      }
+    }
+    return nullptr;
+  }
+
+  bool insert(leaf_node &current_node, uint64_t address, const value_type &v,
+              int &unused_leaves_delta) {
+    unused_leaves_delta = 0;
+
+    int local_address = get_index_in_level(address, 0);
+    current_node.entries[local_address] = v;
+    
+    auto val = current_node.num_entries.fetch_add(
+        1, std::memory_order::memory_order_acq_rel);
+    if (val == 0) {
+      _num_empty_leaves.fetch_add(-1, std::memory_order_acq_rel);
+      unused_leaves_delta = -1;
+    }
+    return true;
+  }
+
+  template <int Level>
+  bool insert(intermediate_node<Level> &current_node, uint64_t address,
+              const value_type &v, int &unused_leaves_delta) {
+    using child_t = typename intermediate_node<Level>::child_type;
+
+    int local_address = get_index_in_level(address, Level);
+    
+    auto *ptr = current_node.children[local_address].load(
+        std::memory_order::memory_order_acquire);
+    
+    if(!ptr) {
+      child_t* new_child = alloc<child_t>(1);
+      new (new_child) child_t{};
+
+      if (!current_node.children[local_address].compare_exchange_strong(
+              ptr, new_child, std::memory_order_acq_rel)) {
+        new_child->~child_t();
+        free(new_child);
+      } else {
+        ptr = new_child;
+      }
+    }
+
+    int delta = 0;
+    auto result = insert(*ptr, address, v, delta);
+    if(delta != 0) {
+      current_node.num_empty_leaves[local_address].fetch_add(
+          delta, std::memory_order_acq_rel);
+    }
+    unused_leaves_delta = delta;
+    return result;
+  }
+
+  bool erase(leaf_node& current_node, uint64_t address, int& unused_leaves_delta) {
+    int local_address = get_index_in_level(address, 0);
+    current_node.entries[local_address].allocation_size = 0;
+
+    int count = current_node.num_entries.fetch_sub(
+        1, std::memory_order::memory_order_acq_rel);
+    
+    unused_leaves_delta = 0;
+    if (count == 1 /* has just become empty */) {
+      _num_empty_leaves.fetch_add(1, std::memory_order::memory_order_acq_rel);
+      unused_leaves_delta = 1;
+    }
+    return true;
+  }
+
+  template<int Level>
+  bool erase(intermediate_node<Level>& current_node, uint64_t address, int& unused_leaves_delta) {
+    int local_address = get_index_in_level(address, Level);
+    auto *ptr = current_node.children[local_address].load(
+        std::memory_order::memory_order_acquire);
+    if(!ptr)
+      return false;
+    
+    int delta = 0;
+    bool result = erase(*ptr, address, delta);
+    if(delta != 0) {
+      current_node.num_empty_leaves[local_address].fetch_add(
+          delta, std::memory_order_acq_rel);
+    }
+    unused_leaves_delta = delta;
+
+    return result;
+  }
+
+  void release(leaf_node& current_node) {
+    destroy(current_node);
+  }
+
+  template<int Level>
+  void release(intermediate_node<Level>& current_node) {
+    for(int i = 0; i < get_num_entries_in_level(Level); ++i){
+      if (auto *ptr = current_node.children[i].load(
+              std::memory_order::memory_order_acquire)) {
+        release(*ptr);
+        free(ptr);
+      }
+    }
+    destroy(current_node);
+  }
+
+  bool needs_garbage_collection() const noexcept {
+    return _num_empty_leaves.load(std::memory_order_acquire) >= empty_leaves_gc_trigger;
+  }
+
+  void destroy(leaf_node& node) {
+    node.~leaf_node();
+  }
+
+  template<int Level>
+  void destroy(intermediate_node<Level>& node) {
+    node.~intermediate_node<Level>();
+  }
+
+  bool garbage_collect(leaf_node& current_node) {
+    if(current_node.num_entries.load(std::memory_order::memory_order_acquire) == 0) {
+      return true;
+    }
+    return false;
+  }
+
+  template<int Level>
+  bool garbage_collect(intermediate_node<Level>& current_node) {
+    int num_living_children = 0;
+    for(int i = 0; i < get_num_entries_in_level(Level); ++i) {
+      auto* child_ptr = current_node.children[i].load(std::memory_order::memory_order_acquire);
+
+      if(child_ptr) {
+        ++num_living_children;
+
+        if(current_node.num_empty_leaves[i] > 0) {
+          if(garbage_collect(*child_ptr)) {
+            destroy(*child_ptr);
+            free(child_ptr);
+            current_node.children[i].store(nullptr, std::memory_order::memory_order_release);
+            --num_living_children;
+          }
+          // After GC, num empty nodes is always 0
+          current_node.num_empty_leaves[i] = 0; 
+        }
+      }
+    }
+    return num_living_children == 0;
+  }
+
+  void garbage_collect() {
+    garbage_collect(_root);
+  }
+
+  struct gc_lock {
+  public:
+    gc_lock(std::atomic<int>& op_counter)
+    : _op_counter{op_counter} {
+      int expected = 0;
+      while (!_op_counter.compare_exchange_strong(
+          expected, -1, std::memory_order::memory_order_release,
+          std::memory_order_relaxed)) {
+        expected = 0;
+      }
+    }
+
+    ~gc_lock() {
+      _op_counter.store(0, std::memory_order::memory_order_release);
+    }
+  private:
+    std::atomic<int>& _op_counter;
+  };
+
+  struct operation_lock {
+  public:
+    operation_lock(std::atomic<int>& op_counter)
+    : _op_counter{op_counter} {
+      int expected = std::max(0, _op_counter.load(std::memory_order_acquire));
+      while (!_op_counter.compare_exchange_strong(
+          expected, expected+1, std::memory_order::memory_order_release,
+          std::memory_order_relaxed)) {
+        if(expected < 0)
+          expected = 0;
+      }
+    }
+
+    ~operation_lock() {
+      _op_counter.fetch_sub(1, std::memory_order::memory_order_acq_rel);
+    }
+  private:
+   std::atomic<int>& _op_counter;
+  };
+
+  intermediate_node<root_level_idx> _root;
+  
+  mutable std::atomic<int> _num_in_progress_operations;
+  std::atomic<int> _num_empty_leaves;
+};
+
+}
+
+#endif

--- a/include/hipSYCL/std/stdpar/detail/stdpar_builtins.hpp
+++ b/include/hipSYCL/std/stdpar/detail/stdpar_builtins.hpp
@@ -42,7 +42,7 @@ extern "C" void __hipsycl_stdpar_optional_barrier() noexcept {
     HIPSYCL_DEBUG_INFO << "[stdpar] Initializing wait for " << num_ops
                        << " operations" << std::endl;
     rt.get_queue().wait();
-    rt.reset_num_outstanding_operations();
+    rt.finalize_offloading_batch();
   }
 }
 

--- a/include/hipSYCL/std/stdpar/detail/sycl_glue.hpp
+++ b/include/hipSYCL/std/stdpar/detail/sycl_glue.hpp
@@ -207,11 +207,13 @@ public:
       get()._is_initialized = true;
       pop_disabled();
 
-      allocation_map_t::value_type v;
-      v.allocation_size = n;
-      v.most_recent_offload_batch = 0;
-      get()._allocation_map.insert(reinterpret_cast<uint64_t>(ptr), v);
-
+      if(ptr) {
+        allocation_map_t::value_type v;
+        v.allocation_size = n;
+        v.most_recent_offload_batch = 0;
+        get()._allocation_map.insert(reinterpret_cast<uint64_t>(ptr), v);
+      }
+      
       return ptr;
 
     } else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -130,7 +130,8 @@ if(WITH_PSTL_TESTS)
     pstl/replace_copy_if.cpp
     pstl/transform.cpp
     pstl/transform_reduce.cpp
-    pstl/pointer_validation.cpp)
+    pstl/pointer_validation.cpp
+    pstl/allocation_map.cpp)
 
   target_compile_options(pstl_tests PRIVATE --acpp-stdpar --acpp-stdpar-unconditional-offload)
   # pstl tests cannot run with global memory allocation hijacking, because apparently

--- a/tests/pstl/allocation_map.cpp
+++ b/tests/pstl/allocation_map.cpp
@@ -1,0 +1,261 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2023 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/test/unit_test_suite.hpp>
+
+#include <cstdint>
+#include <random>
+#include <unordered_set>
+#include <thread>
+#include <hipSYCL/std/stdpar/detail/allocation_map.hpp>
+
+
+#include "pstl_test_suite.hpp"
+
+BOOST_AUTO_TEST_SUITE(pstl_allocation_map)
+
+using amap_t = hipsycl::stdpar::allocation_map<>;
+
+template<class F>
+void for_each_test_allocation(std::size_t n, F&& f) {
+  std::mt19937 gen(123);
+  std::uniform_int_distribution<uint64_t> dist;
+
+  for(std::size_t i = 0; i < n; ++i) {
+    f(dist(gen));
+  }
+}
+
+BOOST_AUTO_TEST_CASE(insert) {
+  std::unordered_set<uint64_t> addresses;
+  for_each_test_allocation(50000, [&](uint64_t x){
+    addresses.insert(x);
+  });
+  if(addresses.find(0) == addresses.end())
+    addresses.insert(0);
+  // ~0 is unsupported, due to overflow for non-zero allocation ranges.
+  if(addresses.find(~0ull - 1 ) == addresses.end())
+    addresses.insert(~0ull - 1);
+
+  amap_t amap;
+  for(const auto& x : addresses) {
+    amap_t::value_type v;
+    v.allocation_size = 1;
+    BOOST_CHECK(amap.insert(x, v));
+  }
+
+  for(const auto& x : addresses) {
+    uint64_t root_address = 0;
+    auto* ret = amap.get_entry(x, root_address);
+    BOOST_CHECK(ret != nullptr);
+    if(ret) {
+      BOOST_CHECK(root_address == x);
+      BOOST_CHECK(ret->allocation_size == 1);
+    }
+  }
+
+  std::mt19937 gen(222);
+  std::uniform_int_distribution<uint64_t> dist;
+  
+  for(int num_foreign_addresses_found = 0; num_foreign_addresses_found < 10000;) {
+    uint64_t addr = dist(gen);
+    if(addresses.find(addr) == addresses.end()) {
+      uint64_t root_address = 0;
+      auto* ret = amap.get_entry(addr, root_address);
+      BOOST_CHECK(!ret);
+      ++num_foreign_addresses_found;
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(get_entry) {
+  amap_t amap;
+
+  std::unordered_map<uint64_t, uint64_t> reference_entries;
+
+  uint64_t current_address = 0;
+  for(uint64_t i = 1; i < 1000; ++i) {
+
+    amap_t::value_type v;
+    v.allocation_size = i;
+
+    BOOST_CHECK(amap.insert(current_address, v));
+    reference_entries[current_address] = i;
+
+    current_address += i;
+  }
+
+  for(const auto& entry : reference_entries) {
+    uint64_t root_address = 0;
+    auto* ret = amap.get_entry(entry.first, root_address);
+    BOOST_CHECK(ret);
+    if(ret) {
+      BOOST_CHECK(root_address == entry.first);
+      BOOST_CHECK(ret->allocation_size == entry.second);
+    }
+    root_address = 0;
+    ret = amap.get_entry(entry.first + entry.second / 2, root_address);
+
+    BOOST_CHECK(ret);
+    if(ret) {
+      BOOST_CHECK(root_address == entry.first);
+      BOOST_CHECK(ret->allocation_size == entry.second);
+    }
+
+    root_address = 0;
+    ret = amap.get_entry(entry.first + entry.second - 1, root_address);
+
+    BOOST_CHECK(ret);
+    if(ret) {
+      BOOST_CHECK(root_address == entry.first);
+      BOOST_CHECK(ret->allocation_size == entry.second);
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(erase) {
+  
+  std::unordered_set<uint64_t> addresses;
+  for_each_test_allocation(50000, [&](uint64_t x){
+    addresses.insert(x);
+  });
+  if(addresses.find(0) == addresses.end())
+    addresses.insert(0);
+  // ~0 is unsupported, due to overflow for non-zero allocation ranges.
+  if(addresses.find(~0ull - 1 ) == addresses.end())
+    addresses.insert(~0ull - 1);
+
+  amap_t amap;
+  for(const auto& x : addresses) {
+    amap_t::value_type v;
+    v.allocation_size = 1;
+    BOOST_CHECK(amap.insert(x, v));
+  }
+
+  for(const auto& x : addresses) {
+    uint64_t root_address = 0;
+    BOOST_CHECK(amap.get_entry(x, root_address));
+    BOOST_CHECK(amap.erase(x));
+    BOOST_CHECK(!amap.get_entry(x, root_address));
+  }
+}
+
+BOOST_AUTO_TEST_CASE(multi_threaded) {
+  const std::size_t num_threads = 4;
+  const std::size_t elements_per_thread = 2000;
+  std::vector<std::thread> threads;
+
+  std::vector<std::pair<uint64_t, uint64_t>> reference_entries;
+
+  uint64_t current_address = 0;
+  for(uint64_t i = 1; i < elements_per_thread*num_threads+1; ++i) {
+    reference_entries.push_back(std::make_pair(current_address, i));
+    current_address += i;    
+  }
+
+  amap_t amap;
+  std::vector<int> per_thread_num_successes(num_threads, 0);
+
+  for(int thread_id = 0; thread_id < num_threads; ++thread_id) {
+    threads.push_back(std::thread{
+        [=, &amap, &reference_entries, &per_thread_num_successes]() {
+          int &num_successes = per_thread_num_successes[thread_id];
+          {
+            bool res = true;
+
+            for (int j = 0; j < elements_per_thread; ++j) {
+              int elem = j * num_threads + thread_id;
+              amap_t::value_type v;
+              v.allocation_size = reference_entries[elem].second;
+              if(!amap.insert(reference_entries[elem].first, v)) {
+                res = false;
+              }
+            }
+
+            if (res)
+              num_successes++;
+          }
+          {
+            bool res = true;
+
+            for(int j = 0; j < elements_per_thread/2; ++j) {
+              int elem = j * num_threads + thread_id;
+              if(!amap.erase(reference_entries[elem].first)) {
+                res = false;
+              } else {
+                uint64_t root_address = 0;
+                auto* query_result = amap.get_entry(reference_entries[elem].first, root_address);
+                if(query_result != nullptr) {
+                  res = false;
+                }
+              }
+            }
+
+            if(res)
+              num_successes++;
+          }
+          {
+            bool res = true;
+
+            for(int j = elements_per_thread/2; j < elements_per_thread; ++j) {
+              int elem = j * num_threads + thread_id;
+
+              uint64_t root_address = 0;
+              auto* query_result = amap.get_entry(reference_entries[elem].first, root_address);
+              if(!query_result) {
+                res = false;
+              } else {
+                if(root_address != reference_entries[elem].first) {
+                  res = false;
+                }
+                if(query_result->allocation_size != reference_entries[elem].second) {
+                  res = false;
+                }
+              }
+
+              if(!amap.erase(reference_entries[elem].first))
+                res = false;
+            }
+
+            if(res)
+              num_successes++;
+          }
+        }});
+  }
+
+  for(int i = 0; i < num_threads; ++i)
+    threads[i].join();
+
+  for(int i = 0; i < num_threads; ++i) {
+    BOOST_TEST(per_thread_num_successes[i] == 3);
+  }
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Depends on #1248 

* Adds new semi-lock-free data structure to track information about USM allocations
* Use this data structure to extract allocation sizes when offloading, and automatically enqueuing async prefetch. Each allocation is only prefetched once per offloading batch (code section between barriers).

This can significantly boost performance. Future improvements can be made with the exact heuristics when it is beneficial to prefetch and whether the entire allocation needs to be prefetched.

~~Needs some addtional tests to be added prior to merging, hence a draft PR.~~