### PR TITLE
Workaround for Clang/MSVC Compatibility in CUDA Mode with C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,7 +287,7 @@ if(BUILD_CLANG_PLUGIN)
   
 # Check if building on Windows and LLVM_LIBS is set, if not, use LLVM_AVAILABLE_LIBS 
   if(WIN32 AND NOT LLVM_LIBS AND LLVM_AVAILABLE_LIBS)
-    set(LLVM_LIBS ${LLVM_AVAILABLE_LIBS})
+    llvm_map_components_to_libnames(LLVM_LIBS analysis core support passes)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,11 @@ if(BUILD_CLANG_PLUGIN)
     set(WITH_REFLECTION_BUILTINS OFF)
   endif()
   message(STATUS "Using clang include directory: ${CLANG_INCLUDE_PATH}")
+  
+# Check if building on Windows and LLVM_LIBS is set, if not, use LLVM_AVAILABLE_LIBS 
+  if(WIN32 AND NOT LLVM_LIBS AND LLVM_AVAILABLE_LIBS)
+    set(LLVM_LIBS ${LLVM_AVAILABLE_LIBS})
+  endif()
 endif()
 
 #add_compile_definitions(HIPSYCL_DEBUG_LEVEL="${HIPSYCL_DEBUG_LEVEL}")

--- a/include/hipSYCL/std/hiplike/cmath
+++ b/include/hipSYCL/std/hiplike/cmath
@@ -1,0 +1,10 @@
+#if defined(__clang__) && (defined(__CUDACC__) || defined(__HIP__))
+#if defined(_WIN32)
+namespace std {
+  __attribute__((device))
+  long double fma(long double, long double, long double);
+}
+#endif
+#endif
+
+#include_next <cmath>


### PR DESCRIPTION
### Problem
When compiling CUDA code with Clang on Windows using MSVC's standard library and C++20 standard, an ambiguity error arises due to the lack of a `long double` overload for `std::fma`. This issue affects all programs compiled in this environment, indicating a broader compatibility issue between Clang and MSVC.

### Solution
This PR introduces a workaround for this compatibility issue. It adds a conditional declaration for `std::fma` in a custom `cmath` header, specifically for the affected environment (Windows with HIP or CUDA enabled). This approach resolves the ambiguity error and allows successful compilation.

### Considerations
Ideally, detection of MSVC's standard library version (`_MSVC_STL_VERSION`) would be a more precise approach than checking the operating system. However, this macro is not defined at the point of processing headers included via `-isystem`, as the standard library is included after these paths. Therefore, the current workaround checks for the Windows environment as a proxy.

## Future Work
This workaround is effective until a more permanent solution is implemented in Clang. As was [noted](https://github.com/AdaptiveCpp/AdaptiveCpp/issues/1256#issuecomment-1830287219) by @nilsfriess, it may also be worthwhile to report this issue to the LLVM project, as it's fundamentally a Clang/MSVC compatibility issue.

## Testing
This solution has been tested on a Windows environment, ensuring seamless compilation when targeting the CUDA backend with C++20 standard enabled. Tests were focused on verifying that the introduction of the custom std::fma declaration effectively resolves the previously encountered ambiguity errors. Additionally, the conditional nature of the changes ensures that they are only applied in the relevant context (Windows with CUDA or HIP enabled), thereby minimizing the risk of unintended side-effects on other platforms.

Thank you for considering this pull request.