### PR TITLE
[stdpar] Use allocation_map to query pointer type in free()

### DIFF
--- a/include/hipSYCL/std/stdpar/detail/sycl_glue.hpp
+++ b/include/hipSYCL/std/stdpar/detail/sycl_glue.hpp
@@ -213,7 +213,7 @@ public:
         v.most_recent_offload_batch = 0;
         get()._allocation_map.insert(reinterpret_cast<uint64_t>(ptr), v);
       }
-      
+
       return ptr;
 
     } else {
@@ -245,8 +245,8 @@ public:
         return;
 
       push_disabled();
-      if (hipsycl::sycl::get_pointer_type(ptr, ctx.get()) ==
-          hipsycl::sycl::usm::alloc::unknown) {
+      uint64_t root_address = 0;
+      if (!get()._allocation_map.get_entry(reinterpret_cast<uint64_t>(ptr), root_address)) {
         __libc_free(ptr);
       } else {
         get()._allocation_map.erase(reinterpret_cast<uint64_t>(ptr));


### PR DESCRIPTION
Previously, we have used backend functionality to query whether a pointer needs to be freed with USM free, or regular system free. This can cause deadlocks on some backends, if backends internally call e.g. hijacked `operator delete` in their implementation of USM free, since hijacked memory free will again try to ask backends about pointer information.

This PR avoids this issue by using the new `allocation_map` to determine whether a pointer is a known USM pointer and thus needs USM free, or whether system free is sufficient.

I've also noticed a substantial but surprising performance increase with this PR (e.g. Lulesh with default small problem size went from ~51s to ~38s).