### PR TITLE
[stdpar] Use new allocation_map::get_entry_of_root_address() in free()

### DIFF
--- a/include/hipSYCL/std/stdpar/detail/offload.hpp
+++ b/include/hipSYCL/std/stdpar/detail/offload.hpp
@@ -298,11 +298,12 @@ void prepare_offloading(AlgorithmType type, Size problem_size, const Args&... ar
             std::size_t *most_recent_offload_batch =
                 &(lookup_result.info->most_recent_offload_batch);
 
+            std::size_t prefetch_size = lookup_result.info->allocation_size;
+
             // Need to use atomic builtins until we can use C++ 20 atomic_ref :(
             if (__atomic_load_n(most_recent_offload_batch, __ATOMIC_ACQUIRE) <
-                current_batch_id) {
-              q.prefetch(lookup_result.root_address,
-                         lookup_result.info->allocation_size);
+                    current_batch_id) {
+              q.prefetch(lookup_result.root_address, prefetch_size);
               __atomic_store_n(most_recent_offload_batch, current_batch_id,
                                __ATOMIC_RELEASE);
             }

--- a/include/hipSYCL/std/stdpar/detail/sycl_glue.hpp
+++ b/include/hipSYCL/std/stdpar/detail/sycl_glue.hpp
@@ -246,7 +246,8 @@ public:
 
       push_disabled();
       uint64_t root_address = 0;
-      if (!get()._allocation_map.get_entry(reinterpret_cast<uint64_t>(ptr), root_address)) {
+      if (!get()._allocation_map.get_entry_of_root_address(
+              reinterpret_cast<uint64_t>(ptr), root_address)) {
         __libc_free(ptr);
       } else {
         get()._allocation_map.erase(reinterpret_cast<uint64_t>(ptr));
@@ -271,7 +272,6 @@ public:
 
     result.root_address = reinterpret_cast<void*>(root_address);
     result.info = ret;
-   
     return true;
   }
 private:


### PR DESCRIPTION
In stdpar's `free()` implementation, we need to check whether a given pointer is a USM pointer or a host pointer. Previously, we have been using `allocation_map::get_entry` for this purpose. This function is however a little overkill, since it contains additional logic to find the base pointer for a pointer that is offset w.r.t the base of the allocation.

This PR adds a new function `allocation_map::get_entry_of_root_address()`, which cannot work work with offset pointers, but can retrieve entries for base pointers more effectively. The PR then updates `free()` to use this function, since we know that `free()` will always be given the base pointer.