### PR TITLE
[stdpar] Make automatic prefetch mode configurable, and improve prefetch performance

### DIFF
--- a/bin/acpp
+++ b/bin/acpp
@@ -340,7 +340,17 @@ class acpp_config:
                - hip.integrated-multipass: Force HIP backend to operate in integrated
                                            multipass mode.
       * spirv - use clang SYCL driver to generate spirv
-      * generic - use generic LLVM SSCP compilation flow, and JIT at runtime to target device""")
+      * generic - use generic LLVM SSCP compilation flow, and JIT at runtime to target device"""),
+
+      'stdpar-prefetch-mode' : option("--acpp-stdpar-prefetch-mode", "ACPP_STDPAR_PREFETCH_MODE", "default-stdpar-prefetch-mode", 
+"""  AdaptiveCpp supports issuing automati USM prefetch operations for allocations used inside offloaded C++ PSTL
+    algorithms. This flags determines the strategy for submitting such prefetches.
+    Supported values are:
+      * always - Prefetches every allocation
+      * never  - Disables prefetching
+      * first  - Prefetch only allocations for the first kernel submitted after a synchronization point.
+                 (Prefetches running on non-idling queues can be expensive!)
+      * auto   - Let AdaptiveCpp decide (default)""")
     }
     self._flags = {
       'use-accelerated-cpu': option("--acpp-use-accelerated-cpu", "ACPP_USE_ACCELERATED_CPU",
@@ -835,6 +845,15 @@ class acpp_config:
       return self._is_flag_set("stdpar-unconditional-offload")
     except OptionNotSet:
       return False
+  
+  @property
+  def stdpar_prefetch_mode(self):
+    mode = "auto"
+    try:
+      mode = self._retrieve_option("stdpar-prefetch-mode")
+    except OptionNotSet:
+      pass
+    return mode
 
   @property
   def save_temps(self):
@@ -1621,6 +1640,7 @@ class compiler:
     self._is_stdpar = config.is_stdpar
     self._is_stdpar_system_usm = config.is_stdpar_system_usm
     self._is_stdpar_unconditional_offload = config.is_stdpar_unconditional_offload
+    self._stdpar_prefetch_mode = config.stdpar_prefetch_mode
 
     if "hip" in self._targets and "cuda" in self._targets:
         if not self._is_explicit_multipass:
@@ -1802,6 +1822,7 @@ class compiler:
       "-isystem", self._acpp_include_path,
       "-D__OPENSYCL__","-D__HIPSYCL__", "-D__ADAPTIVECPP__", "-D__ACPP__"
     ]
+
     if self._is_stdpar:
       stdpar_include_path = os.path.join(self._acpp_include_path,"hipSYCL","std","stdpar")
       args += [
@@ -1816,6 +1837,20 @@ class compiler:
         args += ["-mllvm", "-hipsycl-stdpar-no-malloc-to-usm", "-D__HIPSYCL_STDPAR_ASSUME_SYSTEM_USM__"]
       if self._is_stdpar_unconditional_offload:
         args += ["-D__HIPSYCL_STDPAR_UNCONDITIONAL_OFFLOAD__"]
+      prefetch_mode_string = self._stdpar_prefetch_mode
+      prefetch_mode_id = 0
+      if prefetch_mode_string == "auto":
+        prefetch_mode_id = 0
+      elif prefetch_mode_string == "always":
+        prefetch_mode_id = 1
+      elif prefetch_mode_string == "never":
+        prefetch_mode_id = 2
+      elif prefetch_mode_string == "first":
+        prefetch_mode_id = 3
+      else:
+        raise RuntimeError("Invalid value for stdpar-prefetch-mode: "+prefetch_mode_string)
+      args += ["-D__HIPSYCL_STDPAR_PREFETCH_MODE__="+str(prefetch_mode_id)]
+
     return args + self._common_compiler_args
 
   @property

--- a/bin/acpp
+++ b/bin/acpp
@@ -346,11 +346,12 @@ class acpp_config:
 """  AdaptiveCpp supports issuing automati USM prefetch operations for allocations used inside offloaded C++ PSTL
     algorithms. This flags determines the strategy for submitting such prefetches.
     Supported values are:
-      * always - Prefetches every allocation
-      * never  - Disables prefetching
-      * first  - Prefetch only allocations for the first kernel submitted after a synchronization point.
-                 (Prefetches running on non-idling queues can be expensive!)
-      * auto   - Let AdaptiveCpp decide (default)""")
+      * always      - Prefetches every allocation used by every stdpar kernel
+      * never       - Disables prefetching
+      * after-sync  - Prefetch all allocations used by the first kernel submitted after each synchronization point.
+                      (Prefetches running on non-idling queues can be expensive!)
+      * first       - Prefetch allocations only the very first time they are used in a kernel
+      * auto        - Let AdaptiveCpp decide (default)""")
     }
     self._flags = {
       'use-accelerated-cpu': option("--acpp-use-accelerated-cpu", "ACPP_USE_ACCELERATED_CPU",
@@ -1833,10 +1834,12 @@ class compiler:
         "-mllvm", "-hipsycl-stdpar",
         "-include", os.path.join(stdpar_include_path, "detail", "sycl_glue.hpp")
       ]
+      
       if self._is_stdpar_system_usm:
         args += ["-mllvm", "-hipsycl-stdpar-no-malloc-to-usm", "-D__HIPSYCL_STDPAR_ASSUME_SYSTEM_USM__"]
       if self._is_stdpar_unconditional_offload:
         args += ["-D__HIPSYCL_STDPAR_UNCONDITIONAL_OFFLOAD__"]
+      
       prefetch_mode_string = self._stdpar_prefetch_mode
       prefetch_mode_id = 0
       if prefetch_mode_string == "auto":
@@ -1845,8 +1848,10 @@ class compiler:
         prefetch_mode_id = 1
       elif prefetch_mode_string == "never":
         prefetch_mode_id = 2
-      elif prefetch_mode_string == "first":
+      elif prefetch_mode_string == "after-sync":
         prefetch_mode_id = 3
+      elif prefetch_mode_string == "first":
+        prefetch_mode_id = 4
       else:
         raise RuntimeError("Invalid value for stdpar-prefetch-mode: "+prefetch_mode_string)
       args += ["-D__HIPSYCL_STDPAR_PREFETCH_MODE__="+str(prefetch_mode_id)]

--- a/include/hipSYCL/runtime/ocl/ocl_usm.hpp
+++ b/include/hipSYCL/runtime/ocl/ocl_usm.hpp
@@ -65,6 +65,12 @@ public:
                               const std::vector<cl::Event> &wait_events,
                               cl::Event *out) = 0;
 
+  virtual cl_int enqueue_prefetch(cl::CommandQueue &queue, const void *ptr,
+                                  std::size_t bytes,
+                                  cl_mem_migration_flags flags,
+                                  const std::vector<cl::Event> &wait_events,
+                                  cl::Event *out) = 0;
+
   virtual cl_int enable_indirect_usm_access(cl::Kernel&) = 0;
 
   static std::unique_ptr<ocl_usm> from_intel_extension(ocl_hardware_manager* hw_mgr, int device_index);

--- a/include/hipSYCL/std/stdpar/detail/sycl_glue.hpp
+++ b/include/hipSYCL/std/stdpar/detail/sycl_glue.hpp
@@ -175,7 +175,10 @@ namespace hipsycl::stdpar {
 class unified_shared_memory {
   
   struct allocation_map_payload {
-    std::size_t most_recent_offload_batch;
+    // Note: This gets updated when logic, such as the prefetch
+    // heuristic, touches this value - so it may not be up to date
+    // if there is no prefetch!
+    int64_t most_recent_offload_batch;
   };
 
   using allocation_map_t = allocation_map<allocation_map_payload>;
@@ -210,7 +213,7 @@ public:
       if(ptr) {
         allocation_map_t::value_type v;
         v.allocation_size = n;
-        v.most_recent_offload_batch = 0;
+        v.most_recent_offload_batch = -1;
         get()._allocation_map.insert(reinterpret_cast<uint64_t>(ptr), v);
       }
 

--- a/src/runtime/cuda/cuda_queue.cpp
+++ b/src/runtime/cuda/cuda_queue.cpp
@@ -89,7 +89,9 @@ public:
                              operation &op, dag_node_ptr node) 
                              : _queue{q}, _operation{&op}, _node{node} {
     assert(q);
-    assert(_node);
+    
+    if(!_node)
+      return;
 
     if (_node->get_execution_hints()
             .has_hint<
@@ -113,6 +115,9 @@ public:
   }
 
   ~cuda_instrumentation_guard() {
+    if(!_node)
+      return;
+    
     if (_node->get_execution_hints()
             .has_hint<rt::hints::request_instrumentation_finish_timestamp>()) {
       std::shared_ptr<dag_node_event> task_finish = _queue->insert_event();

--- a/src/runtime/hip/hip_queue.cpp
+++ b/src/runtime/hip/hip_queue.cpp
@@ -79,7 +79,9 @@ public:
                              operation &op, dag_node_ptr node) 
                              : _queue{q}, _operation{&op}, _node{node} {
     assert(q);
-    assert(_node);
+    
+    if(!_node)
+      return;
 
     if (_node->get_execution_hints()
             .has_hint<
@@ -103,6 +105,9 @@ public:
   }
 
   ~hip_instrumentation_guard() {
+    if(!_node)
+      return;
+
     if (_node->get_execution_hints()
             .has_hint<rt::hints::request_instrumentation_finish_timestamp>()) {
       std::shared_ptr<dag_node_event> task_finish = _queue->insert_event();

--- a/src/runtime/ocl/ocl_queue.cpp
+++ b/src/runtime/ocl/ocl_queue.cpp
@@ -263,8 +263,29 @@ result ocl_queue::submit_kernel(kernel_operation &op, dag_node_ptr node) {
   return make_success();
 }
 
-result ocl_queue::submit_prefetch(prefetch_operation &, dag_node_ptr) {
-  // TODO, prefetch is just a hint
+result ocl_queue::submit_prefetch(prefetch_operation &op, dag_node_ptr) {
+  ocl_hardware_context *ocl_ctx = static_cast<ocl_hardware_context *>(
+        _hw_manager->get_device(_device_index));
+  ocl_usm* usm = ocl_ctx->get_usm_provider();
+
+  cl::Event evt;
+  cl_int err = 0;
+  if(op.get_target().is_host()) {
+    err = usm->enqueue_prefetch(_queue, op.get_pointer(), op.get_num_bytes(),
+                                CL_MIGRATE_MEM_OBJECT_HOST, {}, &evt);
+  } else {
+    err = usm->enqueue_prefetch(_queue, op.get_pointer(), op.get_num_bytes(),
+                                0, {}, &evt);
+  }
+
+  if(err != CL_SUCCESS) {
+    return make_error(
+          __hipsycl_here(),
+          error_info{"ocl_queue: enqueuing prefetch failed",
+                     error_code{"CL", static_cast<int>(err)}});
+  }
+
+  register_submitted_op(evt);
   return make_success();
 }
 

--- a/src/runtime/omp/omp_queue.cpp
+++ b/src/runtime/omp/omp_queue.cpp
@@ -129,6 +129,9 @@ private:
 class omp_instrumentation_setup {
 public:
   omp_instrumentation_setup(operation &op, dag_node_ptr node) {
+    if(!node)
+      return;
+
     if (node->get_execution_hints()
             .has_hint<
                 rt::hints::request_instrumentation_submission_timestamp>()) {


### PR DESCRIPTION
* Adds new flag `--acpp-stdpar-prefetch-mode` which can be set to enforce different prefetch modes. Depending on the application, different prefetch modes can result in wildly different performance! Prefetch mode can be
   *  `always` (prefetches every allocation for every single kernel launch), 
   * `never` (disables automatic prefetch`), 
   * `after-sync` (only submits prefetches when the queue is idle after a synchronization point, i.e. prefetches allocations used by the first kernel after a synchronization point),
   * `first` (prefetches every allocation only once: when it is first used in a kernel),
   *  `auto`. `auto` is the default and currently implemented as synonymous with `first`. In the future, more sophisticated rules could be applied there.
* Since in general multiple prefetches can be submitted for every kernel, prefetch submission latency can become a performance issue, especially for `--acpp-stdpar-prefetch-mode=always`. To mitigate, the code tries to directly extract the underlying `rt::inorder_queue` object and bypass all of the SYCL layers. Thus there should not be a substantial overhead compared to calling `cudaMemPrefetchAsync` directly.
* Adds prefetch support to the OpenCL backend, which was previously unimplemented.


CC @tom91136 