### PR TITLE
[stdpar] Don't attempt to prefetch with system USM

### DIFF
--- a/include/hipSYCL/std/stdpar/detail/offload.hpp
+++ b/include/hipSYCL/std/stdpar/detail/offload.hpp
@@ -319,7 +319,9 @@ void prepare_offloading(AlgorithmType type, Size problem_size, const Args&... ar
   std::size_t current_batch_id = stdpar::detail::stdpar_tls_runtime::get()
                                      .get_current_offloading_batch_id();
 
-  
+  // In system USM mode, we don't track allocations and thus also cannot
+  // issue automatic prefetches.
+#ifndef __HIPSYCL_STDPAR_ASSUME_SYSTEM_USM__
   // Use "first" mode in case of automatic prefetch decision for now
   const auto prefetch_mode =
       (get_prefetch_mode() == prefetch_mode::automatic) ? prefetch_mode::first
@@ -376,6 +378,7 @@ void prepare_offloading(AlgorithmType type, Size problem_size, const Args&... ar
   } else if (prefetch_mode == prefetch_mode::never) {
     /* nothing to do */
   }
+#endif
 }
 
 template <class AlgorithmType, class Size, typename... Args>


### PR DESCRIPTION
In system USM mode, the memory tracking interfaces are unavailable. The current code still attempts to use them for prefetches, which causes compilation issues. This PR guards the prefetch code with macros such that it is only active in the non-system-USM case.