### PR TITLE
[CI] Fix failing OpenCL install in Linux LIT tests

### DIFF
--- a/.github/workflows/linux-lit.yml
+++ b/.github/workflows/linux-lit.yml
@@ -101,7 +101,7 @@ jobs:
           wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
           echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
           sudo apt update
-          sudo apt install intel-oneapi-runtime-opencl intel-oneapi-runtime-compilers ocl-icd-libopencl1 ocl-icd-opencl-dev
+          sudo apt install intel-oneapi-runtime-opencl-2024 intel-oneapi-runtime-compilers-2024 ocl-icd-libopencl1 ocl-icd-opencl-dev
       - name: build AdaptiveCpp
         run: |
           mkdir build && cd build


### PR DESCRIPTION
Installation of OpenCL from the oneAPI repos was broken, I found [this](https://community.intel.com/t5/oneAPI-Registration-Download/Cannot-install-package-quot-intel-oneapi-runtime-compilers-quot/m-p/1546419#M6471) bug report with the solution to use the `-2024` versions of the packages. Maybe this will break again if packages are renamed or so, but I guess for now this is fine. 