### PR TITLE
HIP: Update platform macros for ROCm 6

### DIFF
--- a/include/hipSYCL/runtime/hip/hip_target.hpp
+++ b/include/hipSYCL/runtime/hip/hip_target.hpp
@@ -37,11 +37,17 @@
 #endif
 
 #ifdef HIPSYCL_RT_HIP_TARGET_CUDA
-#define __HIP_PLATFORM_NVCC__
+#define __HIP_PLATFORM_NVCC__ // Only needed for ROCm <6.0
+#define __HIP_PLATFORM_NVIDIA__
 #include <hip/hip_runtime.h>
 #elif defined(HIPSYCL_RT_HIP_TARGET_ROCM)
-#ifndef __HIP_PLATFORM_HCC__
+#ifndef __HIP_PLATFORM_HCC__ // Only needed for ROCm <6.0
 #define __HIP_PLATFORM_HCC__
+#endif
+#ifndef __HIP_PLATFORM_AMD__
+#define __HIP_PLATFORM_AMD__
+#endif
+#ifndef __HIP_ROCclr__
 #define __HIP_ROCclr__ (1)
 #endif
 #include <hip/hip_runtime.h>


### PR DESCRIPTION
Old `__HIP_PLATFORM_NVCC__` and `__HIP_PLATFORM_HCC__` no longer work.
Now `__HIP_PLATFORM_AMD__` and `__HIP_PLATFORM_NVIDIA__` are used.

See https://github.com/ROCm/clr/commit/8fe1d9dda109e31acb7600e92f1697366c35590b