### PR TITLE
Make `marray` constexpr compatible

### DIFF
--- a/include/hipSYCL/sycl/libkernel/detail/device_array.hpp
+++ b/include/hipSYCL/sycl/libkernel/detail/device_array.hpp
@@ -43,25 +43,25 @@ struct device_array
   using const_iterator = const T*;
 
   HIPSYCL_UNIVERSAL_TARGET
-  T& operator[] (size_t i) noexcept
+  constexpr T& operator[] (size_t i) noexcept
   {
     return _data[i];
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  const T& operator[] (size_t i) const noexcept
+  constexpr const T& operator[] (size_t i) const noexcept
   {
     return _data[i];
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  size_t size() const noexcept
+  constexpr size_t size() const noexcept
   {
     return N;
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  bool operator== (const device_array& other) const noexcept
+  constexpr bool operator== (const device_array& other) const noexcept
   {
     for(size_t i = 0; i < N; ++i)
       if(_data[i] != other._data[i])
@@ -70,7 +70,7 @@ struct device_array
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  bool operator!= (const device_array& other) const noexcept
+  constexpr bool operator!= (const device_array& other) const noexcept
   {
     return !(*this == other);
   }
@@ -85,31 +85,31 @@ struct device_array<T, 0>
   using const_iterator = const T*;
 
   HIPSYCL_UNIVERSAL_TARGET
-  size_t size() const noexcept
+  constexpr size_t size() const noexcept
   {
     return 0;
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  bool operator== (const device_array&) const noexcept
+  constexpr bool operator== (const device_array&) const noexcept
   {
     return true;
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  bool operator!= (const device_array& other) const noexcept
+  constexpr bool operator!= (const device_array& other) const noexcept
   {
     return !(*this == other);
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  T& operator[] (size_t) noexcept
+  constexpr T& operator[] (size_t) noexcept
   {
     return *reinterpret_cast<T*>(0);
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  const T& operator[] (size_t) const noexcept
+  constexpr const T& operator[] (size_t) const noexcept
   {
     return *reinterpret_cast<T*>(0);
   }
@@ -126,31 +126,31 @@ struct device_array<T, 1>
   using const_iterator = const T*;
 
   HIPSYCL_UNIVERSAL_TARGET
-  size_t size() const noexcept
+  constexpr size_t size() const noexcept
   {
     return 1;
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  bool operator== (const device_array& other) const noexcept
+  constexpr bool operator== (const device_array& other) const noexcept
   {
     return _x == other._x;
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  bool operator!= (const device_array& other) const noexcept
+  constexpr bool operator!= (const device_array& other) const noexcept
   {
     return !(*this == other);
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  T& operator[] (size_t) noexcept
+  constexpr T& operator[] (size_t) noexcept
   {
     return _x;
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  const T& operator[] (size_t) const noexcept
+  constexpr const T& operator[] (size_t) const noexcept
   {
     return _x;
   }
@@ -165,25 +165,25 @@ struct device_array<T, 2>
   using const_iterator = const T*;
 
   HIPSYCL_UNIVERSAL_TARGET
-  size_t size() const noexcept
+  constexpr size_t size() const noexcept
   {
     return 2;
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  bool operator== (const device_array& other) const noexcept
+  constexpr bool operator== (const device_array& other) const noexcept
   {
     return _x == other._x && _y == other._y;
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  bool operator!= (const device_array& other) const noexcept
+  constexpr bool operator!= (const device_array& other) const noexcept
   {
     return !(*this == other);
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  T& operator[] (size_t idx) noexcept
+  constexpr T& operator[] (size_t idx) noexcept
   {
     if(idx == 0)
       return _x;
@@ -192,7 +192,7 @@ struct device_array<T, 2>
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  const T& operator[] (size_t idx) const noexcept
+  constexpr const T& operator[] (size_t idx) const noexcept
   {
     if(idx == 0)
       return _x;
@@ -212,25 +212,25 @@ struct device_array<T, 3>
   using const_iterator = const T*;
 
   HIPSYCL_UNIVERSAL_TARGET
-  size_t size() const noexcept
+  constexpr size_t size() const noexcept
   {
     return 3;
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  bool operator== (const device_array& other) const noexcept
+  constexpr bool operator== (const device_array& other) const noexcept
   {
     return _x == other._x && _y == other._y && _z == other._z;
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  bool operator!= (const device_array& other) const noexcept
+  constexpr bool operator!= (const device_array& other) const noexcept
   {
     return !(*this == other);
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  T& operator[] (size_t idx) noexcept
+  constexpr T& operator[] (size_t idx) noexcept
   {
     if(idx == 0)
       return _x;
@@ -241,7 +241,7 @@ struct device_array<T, 3>
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  const T& operator[] (size_t idx) const noexcept
+  constexpr const T& operator[] (size_t idx) const noexcept
   {
     if(idx == 0)
       return _x;
@@ -264,25 +264,25 @@ struct device_array<T, 4>
   using const_iterator = const T*;
 
   HIPSYCL_UNIVERSAL_TARGET
-  size_t size() const noexcept
+  constexpr size_t size() const noexcept
   {
     return 4;
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  bool operator== (const device_array& other) const noexcept
+  constexpr bool operator== (const device_array& other) const noexcept
   {
     return _x == other._x && _y == other._y && _z == other._z && _w == other._w;
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  bool operator!= (const device_array& other) const noexcept
+  constexpr bool operator!= (const device_array& other) const noexcept
   {
     return !(*this == other);
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  T& operator[] (size_t idx) noexcept
+  constexpr T& operator[] (size_t idx) noexcept
   {
     if(idx == 0)
       return _x;
@@ -295,7 +295,7 @@ struct device_array<T, 4>
   }
 
   HIPSYCL_UNIVERSAL_TARGET
-  const T& operator[] (size_t idx) const noexcept
+  constexpr const T& operator[] (size_t idx) const noexcept
   {
     if(idx == 0)
       return _x;


### PR DESCRIPTION
Adding the `constexpr` specifier to methods of the `device_array` class template to make the following compile:

```c++
constexpr sycl::marray<float, 3> v{0.0f, 0.0f, 0.0f};
```

Currently, this fails to compile:

```
constexpr_test.cpp: error: constexpr variable 'v' must be initialized by a constant expression
        constexpr sycl::marray<float, 3> v{0.0f, 0.0f, 0.0f};
                                         ^~~~~~~~~~~~~~~~~~~
/bin/../include/AdaptiveCpp/CL/../hipSYCL/sycl/libkernel/marray.hpp:56:7: note: non-constexpr function 'operator[]' cannot be used in a constant expression
      _data[offset] = x;
      ^
/bin/../include/AdaptiveCpp/CL/../hipSYCL/sycl/libkernel/marray.hpp:65:5: note: in call to '&v->init_offset(0, 0.F)'
    init_offset(current_offset, arg);
    ^
/bin/../include/AdaptiveCpp/CL/../hipSYCL/sycl/libkernel/marray.hpp:100:6: note: in call to '&v->initialize_from_arg(current_offset, 0.F)'
    (initialize_from_arg(current_offset, args), ...);
     ^
constexpr_test.cpp: note: in call to 'marray(0.F, 0.F, 0.F)'
        constexpr sycl::marray<float, 3> v{0.0f, 0.0f, 0.0f};
                                         ^
/bin/../include/AdaptiveCpp/CL/../hipSYCL/sycl/libkernel/detail/device_array.hpp:46:6: note: declared here
  T& operator[] (size_t i) noexcept
```