### PR TITLE
[SSCP][llvm-to-amdgpu] Work around hipRTC no longer correctly linking device libs for newer ROCm versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ find_package(OpenCL QUIET)
 # In case HIP is not found via the cmake pkgs we fall back to the legacy rocm discovery:
 if (NOT HIP_FOUND)
   message(STATUS "Could not find HIP cmake integration, falling back to finding hipcc")
-  find_program(HIPCC_COMPILER NAMES hipcc HINTS ${ROCM_PATH})
+  find_program(HIPCC_COMPILER NAMES hipcc HINTS ${ROCM_PATH} ${ROCM_PATH}/bin)
   set(ROCM_PATH /opt/rocm CACHE PATH "Path to ROCm installation")
   if(HIPCC_COMPILER MATCHES "-NOTFOUND")
     message(STATUS "Could not find ROCm installation by looking for hipcc. ROCm support unavailable.")

--- a/include/hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp
@@ -180,10 +180,12 @@ protected:
   
   bool linkBitcodeFile(llvm::Module &M, const std::string &BitcodeFile,
                        const std::string &ForcedTriple = "",
-                       const std::string &ForcedDataLayout = "");
+                       const std::string &ForcedDataLayout = "",
+                       bool LinkOnlyNeeded = true);
   bool linkBitcodeString(llvm::Module &M, const std::string &Bitcode,
                          const std::string &ForcedTriple = "",
-                         const std::string &ForcedDataLayout = "");
+                         const std::string &ForcedDataLayout = "",
+                         bool LinkOnlyNeeded = true);
   // If backend needs to set IR constants, it should do so here.
   virtual bool prepareBackendFlavor(llvm::Module& M) = 0;
   // Transform LLVM IR as much as required to backend-specific flavor

--- a/include/hipSYCL/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.hpp
@@ -54,6 +54,7 @@ protected:
 private:
   std::vector<std::string> KernelNames;
   std::string RocmDeviceLibsPath;
+  std::string RocmPath = ACPP_ROCM_PATH;
   std::string TargetDevice = "gfx900";
   bool OnlyGenerateAssembly = false;
 

--- a/include/hipSYCL/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.hpp
@@ -56,9 +56,9 @@ private:
   std::string RocmDeviceLibsPath;
   std::string RocmPath = ACPP_ROCM_PATH;
   std::string TargetDevice = "gfx900";
-  bool OnlyGenerateAssembly = false;
 
   bool hiprtcJitLink(const std::string& Bitcode, std::string& Output);
+  bool clangJitLink(llvm::Module& FlavoredModule, std::string& Output);
 };
 
 }

--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -164,22 +164,23 @@ if(WITH_SSCP_COMPILER)
 
     target_compile_definitions(llvm-to-amdgpu PRIVATE
       -DACPP_ROCM_PATH="${ROCM_PATH}")
-
-    find_library(HIPRTC_LIBRARY hiprtc HINTS ${ROCM_PATH}/lib REQUIRED)
+    
     find_program(HIPCC_PATH hipcc HINTS ${ROCM_PATH}/bin)
+    if(HIPCC_PATH)
+      target_compile_definitions(llvm-to-amdgpu PRIVATE
+        -DACPP_HIPCC_PATH="${HIPCC_PATH}")
+    endif()
+    target_compile_definitions(llvm-to-amdgpu PRIVATE
+        -DACPP_CLANG_PATH="${CLANG_EXECUTABLE_PATH}")
+
+    find_library(HIPRTC_LIBRARY hiprtc HINTS ${ROCM_PATH}/lib)
+   
     if(HIPRTC_LIBRARY)
       message(STATUS "Found hipRTC: ${HIPRTC_LIBRARY}")
 
-      target_compile_definitions(llvm-to-amdgpu PRIVATE
-          -DACPP_CLANG_PATH="${CLANG_EXECUTABLE_PATH}")
-      
-      if(HIPCC_PATH)
-        target_compile_definitions(llvm-to-amdgpu PRIVATE
-          -DACPP_HIPCC_PATH="${HIPCC_PATH}")
-      endif()
-
       target_include_directories(llvm-to-amdgpu PRIVATE ${ROCM_PATH}/include)
       target_link_libraries(llvm-to-amdgpu PRIVATE ${HIPRTC_LIBRARY})
+      target_compile_definitions(llvm-to-amdgpu PRIVATE -DACPP_HIPRTC_LINK)
     endif()
 
   endif()

--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -163,27 +163,24 @@ if(WITH_SSCP_COMPILER)
       TOOL amdgpu/LLVMToAmdgpuTool.cpp)
 
     target_compile_definitions(llvm-to-amdgpu PRIVATE
-      -DHIPSYCL_ROCM_PATH="${ROCM_PATH}")
+      -DACPP_ROCM_PATH="${ROCM_PATH}")
 
-    find_library(HIPRTC_LIBRARY hiprtc HINTS ${ROCM_PATH}/lib)
+    find_library(HIPRTC_LIBRARY hiprtc HINTS ${ROCM_PATH}/lib REQUIRED)
+    find_program(HIPCC_PATH hipcc HINTS ${ROCM_PATH}/bin)
     if(HIPRTC_LIBRARY)
       message(STATUS "Found hipRTC: ${HIPRTC_LIBRARY}")
-      target_compile_definitions(llvm-to-amdgpu PRIVATE -DHIPSYCL_SSCP_AMDGPU_USE_HIPRTC)
+
+      target_compile_definitions(llvm-to-amdgpu PRIVATE
+          -DACPP_CLANG_PATH="${CLANG_EXECUTABLE_PATH}")
+      
+      if(HIPCC_PATH)
+        target_compile_definitions(llvm-to-amdgpu PRIVATE
+          -DACPP_HIPCC_PATH="${HIPCC_PATH}")
+      endif()
+
       target_include_directories(llvm-to-amdgpu PRIVATE ${ROCM_PATH}/include)
       target_link_libraries(llvm-to-amdgpu PRIVATE ${HIPRTC_LIBRARY})
     endif()
 
-    if(HIPSYCL_SSCP_AMDGPU_USE_ROCM_CLANG)
-      find_program(ROCM_CLANG_PATH NAMES clang++ HINTS ${ROCM_PATH}/llvm/bin)
-      target_compile_definitions(llvm-to-amdgpu PRIVATE
-        -DHIPSYCL_CLANG_PATH="${ROCM_CLANG_PATH}")
-    else()
-      target_compile_definitions(llvm-to-amdgpu PRIVATE
-        -DHIPSYCL_CLANG_PATH="${CLANG_EXECUTABLE_PATH}")
-    endif()
-    if(HIPSYCL_SSCP_AMDGPU_FORCE_OCLC_ABI_VERSION)
-      target_compile_definitions(llvm-to-amdgpu PRIVATE
-        -DHIPSYCL_SSCP_AMDGPU_FORCE_OCLC_ABI_VERSION)
-    endif()
   endif()
 endif()


### PR DESCRIPTION
ROCm versions starting at least with 5.7 no longer correctly link the ROCm AMD device bitcode libraries when we give our SSCP bitcode libraries to hipRTC. This causes a JIT failure, since builtins remain undefined.

To me it looks like the issue is that hipRTC *first* links the AMD device bitcode libraries, and only afterwards links our user-provided bitcode. Because at the point when the device libraries are linked none of their symbols are actually required yet, nothing happens.

More worryingly, it looks like the underlying action in comgr, which powers hipRTC, is deprecated and supposed to be removed (was?) in ROCm 6.0: https://github.com/ROCm/llvm-project/blob/197f5bc2fccbeac4a6386fe93329358ef45ed630/amd/comgr/include/amd_comgr.h.in#L1585
It seems that device bitcode library linking is now supposed to happen only when the clang driver processes source code, instead of the IR level where we are.

As a hotfix, this PR introduces manually linking the required bitcode libraries. The logic to determine which bitcode libraries are exactly needed depends on the target device, compiler flags, and ROCm/LLVM version. It is thus non-trivial. For this reason, we invoke `hipcc -###` and parse the output to find the list of device libraries that `hipcc` would link against.

This is a bit unfortunate, because it might impact the deployment process of SSCP binaries: Previously the only direct dependency was `hipRTC`, but now we need to have ROCm compilers and bitcode libraries available when a program is executed. I don't see a way around that at the moment. And of course since this issue is critical as it blocks using more recent ROCm versions with SSCP altogether, a quick fix is desirable, even if we might perhaps find a better solution with more effort.

This PR also removes a fallback codepath for ROCm version prior to ROCm 5.2 that did not have hipRTC. However, this code path was broken and we nowadays say in our documentation that SSCP requires ROCm 5.3+.

@Calandracas606 @breyerml This might fix your problem with `generic` target on at least ROCm 5.7. Please let me know if that is the case, and if it also helps on ROCm 6.0 if you have a ROCm 6.0 installation.