### PR TITLE
[stdpar][Reflection] Make struct introspection more robust

### DIFF
--- a/.github/workflows/linux-lit.yml
+++ b/.github/workflows/linux-lit.yml
@@ -87,6 +87,8 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh ${{matrix.clang}}
           sudo apt install libclang-${{matrix.clang}}-dev clang-tools-${{matrix.clang}} libomp-${{matrix.clang}}-dev llvm-${{matrix.clang}}-dev
+          # install with --force-override since this tries to override some clang README
+          sudo apt install -o DPkg::options::="--force-overwrite" libclang-rt-${{matrix.clang}}-dev
           sudo python -m pip install lit
           sudo ln -s /usr/bin/FileCheck-${{matrix.clang}} /usr/bin/FileCheck
           if [[ "${{matrix.clang}}" == "16" ]]; then

--- a/.github/workflows/linux-lit.yml
+++ b/.github/workflows/linux-lit.yml
@@ -87,7 +87,7 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh ${{matrix.clang}}
           sudo apt install libclang-${{matrix.clang}}-dev clang-tools-${{matrix.clang}} libomp-${{matrix.clang}}-dev llvm-${{matrix.clang}}-dev
-          # install with --force-override since this tries to override some clang README
+          # install with --force-overwrite since this tries to overwrite some clang README
           sudo apt install -o DPkg::options::="--force-overwrite" libclang-rt-${{matrix.clang}}-dev
           sudo python -m pip install lit
           sudo ln -s /usr/bin/FileCheck-${{matrix.clang}} /usr/bin/FileCheck

--- a/include/hipSYCL/glue/reflection.hpp
+++ b/include/hipSYCL/glue/reflection.hpp
@@ -29,9 +29,11 @@
 #define HIPSYCL_REFLECTION_HPP
 
 template<class StructT>
-void __hipsycl_introspect_flattened_struct(int **num_flattened_members,
-                                      int **member_offsets, int **member_sizes,
-                                      int **member_kinds);
+void __hipsycl_introspect_flattened_struct(StructT *s,
+                                           int **num_flattened_members,
+                                           int **member_offsets,
+                                           int **member_sizes,
+                                           int **member_kinds) {}
 
 namespace hipsycl::glue::reflection {
 
@@ -44,12 +46,12 @@ public:
   : _num_members{nullptr} {
     // Compiler needs this copy to figure out
     // the struct type in the presence of opaque pointers.
-    // Currently it looks for alloca instructions preceding the
-    // builtin call for this purpose.
+    // Currently it checks if the first operand of the call
+    // to the builtin comes from an alloca instruction.
     StructT s_copy = s;
-    __hipsycl_introspect_flattened_struct<StructT>(
-        &_num_members, &_member_offsets, &_member_sizes,
-        reinterpret_cast<int **>(&_member_kinds));
+    __hipsycl_introspect_flattened_struct(&s_copy, &_num_members,
+                                          &_member_offsets, &_member_sizes,
+                                          reinterpret_cast<int **>(&_member_kinds));
   }
 
   int get_num_members() const {

--- a/include/hipSYCL/glue/reflection.hpp
+++ b/include/hipSYCL/glue/reflection.hpp
@@ -29,11 +29,11 @@
 #define HIPSYCL_REFLECTION_HPP
 
 template<class StructT>
-void __hipsycl_introspect_flattened_struct(StructT *s,
+void __hipsycl_introspect_flattened_struct(void *s,
                                            int **num_flattened_members,
                                            int **member_offsets,
                                            int **member_sizes,
-                                           int **member_kinds) {}
+                                           int **member_kinds);
 
 namespace hipsycl::glue::reflection {
 
@@ -49,9 +49,9 @@ public:
     // Currently it checks if the first operand of the call
     // to the builtin comes from an alloca instruction.
     StructT s_copy = s;
-    __hipsycl_introspect_flattened_struct(&s_copy, &_num_members,
-                                          &_member_offsets, &_member_sizes,
-                                          reinterpret_cast<int **>(&_member_kinds));
+    __hipsycl_introspect_flattened_struct<StructT>(&s_copy, &_num_members,
+                                                   &_member_offsets, &_member_sizes,
+                                                   reinterpret_cast<int **>(&_member_kinds));
   }
 
   int get_num_members() const {

--- a/src/compiler/reflection/IntrospectStructPass.cpp
+++ b/src/compiler/reflection/IntrospectStructPass.cpp
@@ -182,61 +182,92 @@ llvm::PreservedAnalyses IntrospectStructPass::run(llvm::Module& M, llvm::ModuleA
     }
   }
 
-  
   llvm::SmallDenseMap<llvm::Function*, TypeInformation> StructTypeInfoForBuiltin;
   llvm::SmallVector<llvm::CallInst*, 16> Calls;
   for(auto* F: BuiltinInstantiations) {
-    for(auto* U : F->users()) {
-      if(llvm::CallInst* CI = llvm::dyn_cast<llvm::CallInst>(U)) {
+    for (auto *U : F->users()) {
+      if (llvm::CallInst *CI = llvm::dyn_cast<llvm::CallInst>(U)) {
         Calls.push_back(CI);
+
         // Obtain type referenced by builtin calls. To workaround opaque pointers, this
         // assumes that an alloca instruction with the type is present in the preceding code.
-        auto* AI = getPrevAllocaInst(CI);
-        if(AI) {
-          llvm::Type* T = AI->getAllocatedType();
+        auto *AI = getPrevAllocaInst(CI);
+        if (AI == nullptr) {
+          /* In some cases it might happen that the alloca instruction is in a
+           * different BasicBlock (e.g., when compiling with -fsanitize=undefined).
+           * We therefore traverse all the BasicBlocks in the function and check
+           * if there is exactly one BasicBlock containing
+           * alloca instructions. Within this block, we take the last alloca
+           * instruction. */
+          llvm::BasicBlock *AllocaBlock;
+          std::size_t NumAllocaBlocks = 0;
+
+          // Instruction::getParent() gives the parent BasicBlock,
+          // BasicBlock::getParent the parent Function
+          for (auto &Block : *CI->getParent()->getParent()) {
+            for (auto &Inst : Block) {
+              if (const auto *NewAI = llvm::dyn_cast<llvm::AllocaInst>(&Inst)) {
+                AllocaBlock = &Block;
+                NumAllocaBlocks++;
+                break;
+              }
+            }
+          }
+
+          if (NumAllocaBlocks == 1) {
+            for (auto &Inst : *AllocaBlock) {
+              if (auto *NextAI = llvm::dyn_cast<llvm::AllocaInst>(&Inst)) {
+                AI = NextAI;
+              }
+            }
+          }
+        }
+
+        if (AI) {
+          llvm::Type *T = AI->getAllocatedType();
           auto TI = getTypeInformation(T, M);
           StructTypeInfoForBuiltin[F] = TI;
         } else {
           HIPSYCL_DEBUG_WARNING
-            << "IntrospectStructPass: " << F->getName().str()
-            << " instantiation could not be connected to type information, ignoring.\n";
+              << "IntrospectStructPass: " << F->getName().str()
+              << " instantiation could not be connected to type information, ignoring.\n";
         }
       }
     }
   }
 
-  for(auto* CI : Calls) {
-    llvm::Function* F = CI->getCalledFunction();
-    if(F) {
-      auto It = StructTypeInfoForBuiltin.find(F);
+  if (StructTypeInfoForBuiltin.size() > 0)
+    for(auto* CI : Calls) {
+      llvm::Function* F = CI->getCalledFunction();
+      if(F) {
+        auto It = StructTypeInfoForBuiltin.find(F);
 
-      auto GVs = storeTypeInformationAsGlobals(F, M, It->getSecond());
+        auto GVs = storeTypeInformationAsGlobals(F, M, It->getSecond());
 
-      if(It != StructTypeInfoForBuiltin.end()) {
-        if(F->getFunctionType()->getNumParams() != 4) {
-          HIPSYCL_DEBUG_WARNING << "IntrospectStructPass: Call to " << F->getName().str()
-                                << " has the wrong number of parameters, ignoring call\n";
-        } else {
-          auto createStoreOp = [&](int ArgIndex, llvm::GlobalVariable* GV) {
-            if(!CI->getArgOperand(ArgIndex)->getType()->isPointerTy()) {
-              HIPSYCL_DEBUG_WARNING
-                  << "IntrospectStructPass: Call to " << F->getName().str()
-                  << " is invalid; argument is not a pointer type. Ingoring call.\n";
-              return;
-            }
-            [[maybe_unused]] llvm::StoreInst *S =
+        if(It != StructTypeInfoForBuiltin.end()) {
+          if(F->getFunctionType()->getNumParams() != 4) {
+            HIPSYCL_DEBUG_WARNING << "IntrospectStructPass: Call to " << F->getName().str()
+            << " has the wrong number of parameters, ignoring call\n";
+          } else {
+            auto createStoreOp = [&](int ArgIndex, llvm::GlobalVariable* GV) {
+              if(!CI->getArgOperand(ArgIndex)->getType()->isPointerTy()) {
+                HIPSYCL_DEBUG_WARNING
+                << "IntrospectStructPass: Call to " << F->getName().str()
+                << " is invalid; argument is not a pointer type. Ingoring call.\n";
+                return;
+              }
+              [[maybe_unused]] llvm::StoreInst *S =
                 new llvm::StoreInst(GV, CI->getArgOperand(ArgIndex), CI);
-          };
+            };
 
-          createStoreOp(0, GVs.FlattenedNumMembers);
-          createStoreOp(1, GVs.MemberOffsets);
-          createStoreOp(2, GVs.MemberSizes);
-          createStoreOp(3, GVs.MemberKind);
-
+            createStoreOp(0, GVs.FlattenedNumMembers);
+            createStoreOp(1, GVs.MemberOffsets);
+            createStoreOp(2, GVs.MemberSizes);
+            createStoreOp(3, GVs.MemberKind);
+          }
         }
       }
     }
-  }
 
   // Lastly, remove calls and builtin declarations from IR
   for(auto* CI : Calls)

--- a/src/compiler/reflection/IntrospectStructPass.cpp
+++ b/src/compiler/reflection/IntrospectStructPass.cpp
@@ -192,6 +192,9 @@ llvm::PreservedAnalyses IntrospectStructPass::run(llvm::Module& M, llvm::ModuleA
         if (auto *AI = llvm::dyn_cast<llvm::AllocaInst>(CI->getOperand(0))) {
           llvm::Type *T = AI->getAllocatedType();
           StructTypeInfoForBuiltin[F] = getTypeInformation(T, M);
+        } else if (auto *BI = llvm::dyn_cast<llvm::BitCastInst>(CI->getOperand(0))) {
+          llvm::Type *T = BI->getSrcTy()->getNonOpaquePointerElementType();
+          StructTypeInfoForBuiltin[F] = getTypeInformation(T, M);
         } else {
           HIPSYCL_DEBUG_WARNING
               << "IntrospectStructPass: " << F->getName().str()

--- a/src/compiler/reflection/IntrospectStructPass.cpp
+++ b/src/compiler/reflection/IntrospectStructPass.cpp
@@ -49,17 +49,6 @@ namespace compiler {
 namespace {
 constexpr const char* builtin_name = "__hipsycl_introspect_flattened_struct";
 
-llvm::AllocaInst *getPrevAllocaInst(llvm::Instruction *I) {
-  llvm::Instruction *CurrentInst = I;
-  while (CurrentInst) {
-    if (auto *AI = llvm::dyn_cast<llvm::AllocaInst>(CurrentInst)) {
-      return AI;
-    }
-    CurrentInst = CurrentInst->getPrevNonDebugInstruction();
-  }
-  return nullptr;
-}
-
 struct TypeInformation {
   int FlattenedNumMembers;
   llvm::SmallVector<int, 8> MemberOffsets;

--- a/tests/compiler/reflection/introspect_struct.cpp
+++ b/tests/compiler/reflection/introspect_struct.cpp
@@ -4,6 +4,10 @@
 // RUN: %t | FileCheck %s
 // RUN: %acpp %s -o %t --acpp-targets=generic -g
 // RUN: %t | FileCheck %s
+// RUN: %acpp %s -o %t --acpp-targets=generic -fsanitize=undefined
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s -o %t --acpp-targets=generic -fsanitize=address
+// RUN: %t | FileCheck %s
 
 #include <iostream>
 #include "hipSYCL/glue/reflection.hpp"


### PR DESCRIPTION
In #1282 it was reported that the compiler segfaults when trying to compile with `--acpp-stdpar -fsanitize=undefined`.

The problem was that the `IntrospectStructPass` assumed that calls to the builtin `__hipsycl_introspect_flattened_struct` are always preceded by a alloca instruction in LLVM IR. However, it seems that when compiling with `-fsanitize=undefined`, the compiler adds some `__ubsan...` calls after [this line](https://github.com/AdaptiveCpp/AdaptiveCpp/blob/4e6608fe7ad9cc0a045d56de43705ff37d8c62e0/include/hipSYCL/glue/reflection.hpp#L49). Even worse, in LLVM IR this then ends up as a separate block, so that just traversing the instructions before the call to `__hipsycl_introspect_flattened_struct` does not work anymore.

This PR makes the introspect pass a bit more robust by checking the other blocks in the function for the alloca instruction (in case it wasn't found by the first approach). This is done, however, only if there is exactly one BasicBlock containing alloca instructions; within this block it takes the last alloca instruction.

Fixes #1282 