### PR TITLE
Lazily construct multi-queue executors on all backends

### DIFF
--- a/include/hipSYCL/runtime/cuda/cuda_backend.hpp
+++ b/include/hipSYCL/runtime/cuda/cuda_backend.hpp
@@ -64,7 +64,7 @@ public:
   create_inorder_executor(device_id dev, int priority) override;
 private:
   mutable cuda_hardware_manager _hw_manager;
-  mutable multi_queue_executor _executor;
+  mutable lazily_constructed_executor<multi_queue_executor> _executor;
 };
 
 }

--- a/include/hipSYCL/runtime/hip/hip_backend.hpp
+++ b/include/hipSYCL/runtime/hip/hip_backend.hpp
@@ -64,7 +64,7 @@ public:
   hip_event_pool* get_event_pool(device_id dev) const;
 private:
   mutable hip_hardware_manager _hw_manager;
-  mutable multi_queue_executor _executor;
+  mutable lazily_constructed_executor<multi_queue_executor> _executor;
 };
 
 }

--- a/include/hipSYCL/runtime/multi_queue_executor.hpp
+++ b/include/hipSYCL/runtime/multi_queue_executor.hpp
@@ -189,8 +189,10 @@ public:
       return _ptr.get();
     else {
       std::lock_guard<std::mutex> lock{_mutex};
-      _ptr = _factory();
-      _is_initialized.store(true, std::memory_order_release);
+      if(!_is_initialized.load(std::memory_order_acquire)) {
+        _ptr = _factory();
+        _is_initialized.store(true, std::memory_order_release);
+      }
       return _ptr.get();
     }
   }

--- a/include/hipSYCL/runtime/multi_queue_executor.hpp
+++ b/include/hipSYCL/runtime/multi_queue_executor.hpp
@@ -182,7 +182,7 @@ class lazily_constructed_executor {
 public:
   template<class Factory>
   lazily_constructed_executor(Factory&& F)
-  : _factory{F}, _is_initialized{false} {}
+  : _factory{std::forward<Factory>(F)}, _is_initialized{false} {}
 
   Executor* get() {
     if(_is_initialized.load(std::memory_order_acquire))

--- a/include/hipSYCL/runtime/multi_queue_executor.hpp
+++ b/include/hipSYCL/runtime/multi_queue_executor.hpp
@@ -31,6 +31,8 @@
 #include <cmath>
 #include <cassert>
 #include <functional>
+#include <atomic>
+#include <mutex>
 
 #include "backend.hpp"
 #include "device_id.hpp"
@@ -173,6 +175,31 @@ private:
   std::size_t _num_submitted_operations;
   std::vector<inorder_queue*> _managed_queues;
   backend_id _backend;
+};
+
+template<class Executor>
+class lazily_constructed_executor {
+public:
+  template<class Factory>
+  lazily_constructed_executor(Factory&& F)
+  : _factory{F}, _is_initialized{false} {}
+
+  Executor* get() {
+    if(_is_initialized.load(std::memory_order_acquire))
+      return _ptr.get();
+    else {
+      std::lock_guard<std::mutex> lock{_mutex};
+      _ptr = _factory();
+      _is_initialized.store(true, std::memory_order_release);
+      return _ptr.get();
+    }
+  }
+
+private:
+  std::atomic<bool> _is_initialized;
+  std::mutex _mutex;
+  std::function<std::unique_ptr<Executor>()> _factory;
+  std::unique_ptr<Executor> _ptr = nullptr;
 };
 
 }

--- a/include/hipSYCL/runtime/ocl/ocl_backend.hpp
+++ b/include/hipSYCL/runtime/ocl/ocl_backend.hpp
@@ -61,7 +61,7 @@ public:
   create_inorder_executor(device_id dev, int priority) override;
 private:
   mutable ocl_hardware_manager _hw_manager;
-  mutable multi_queue_executor _executor;
+  mutable lazily_constructed_executor<multi_queue_executor> _executor;
 };
 
 }

--- a/include/hipSYCL/runtime/omp/omp_backend.hpp
+++ b/include/hipSYCL/runtime/omp/omp_backend.hpp
@@ -59,7 +59,7 @@ public:
 private:
   mutable omp_allocator _allocator;
   mutable omp_hardware_manager _hw;
-  mutable multi_queue_executor _executor;
+  mutable lazily_constructed_executor<multi_queue_executor> _executor;
 }; 
 
 }

--- a/include/hipSYCL/runtime/ze/ze_backend.hpp
+++ b/include/hipSYCL/runtime/ze/ze_backend.hpp
@@ -64,7 +64,7 @@ public:
 
 private:
   std::unique_ptr<ze_hardware_manager> _hardware_manager;
-  std::unique_ptr<multi_queue_executor> _executor;
+  std::unique_ptr<lazily_constructed_executor<multi_queue_executor>> _executor;
   mutable std::vector<ze_allocator> _allocators;
 };
 

--- a/src/runtime/omp/omp_backend.cpp
+++ b/src/runtime/omp/omp_backend.cpp
@@ -59,14 +59,21 @@ std::unique_ptr<inorder_queue> make_omp_queue(device_id dev) {
   return std::make_unique<omp_queue>(dev.get_backend());
 }
 
+std::unique_ptr<multi_queue_executor>
+create_multi_queue_executor(omp_backend *b) {
+  return std::make_unique<multi_queue_executor>(*b, [b](device_id dev) {
+    return make_omp_queue(dev);
+  });
+}
+
 }
 
 omp_backend::omp_backend()
     : _allocator{device_id{
           backend_descriptor{omp_backend::get_hardware_platform(), omp_backend::get_api_platform()}, 0}},
       _hw{},
-      _executor(*this, [](device_id dev) -> std::unique_ptr<inorder_queue> {
-        return make_omp_queue(dev);
+      _executor([this](){
+        return create_multi_queue_executor(this);
       }) {}
 
 api_platform omp_backend::get_api_platform() const {
@@ -93,7 +100,7 @@ backend_executor* omp_backend::get_executor(device_id dev) const {
     return nullptr;
   }
 
-  return &_executor;
+  return _executor.get();
 }
 
 backend_allocator* omp_backend::get_allocator(device_id dev) const {

--- a/src/runtime/ze/ze_backend.cpp
+++ b/src/runtime/ze/ze_backend.cpp
@@ -28,6 +28,7 @@
 #include <level_zero/ze_api.h>
 
 
+#include "hipSYCL/runtime/multi_queue_executor.hpp"
 #include "hipSYCL/runtime/ze/ze_backend.hpp"
 #include "hipSYCL/runtime/ze/ze_allocator.hpp"
 #include "hipSYCL/runtime/ze/ze_hardware_manager.hpp"
@@ -50,6 +51,19 @@ const char *hipsycl_backend_plugin_get_name() {
 namespace hipsycl {
 namespace rt {
 
+
+namespace {
+
+std::unique_ptr<multi_queue_executor>
+create_multi_queue_executor(ze_backend *b, ze_hardware_manager *mgr) {
+  return std::make_unique<multi_queue_executor>(*b, [b, mgr](device_id dev) {
+    return std::make_unique<ze_queue>(mgr,
+                                      static_cast<std::size_t>(dev.get_id()));
+  });
+}
+}
+
+
 ze_backend::ze_backend() {
   ze_result_t err = zeInit(0);
 
@@ -66,11 +80,8 @@ ze_backend::ze_backend() {
         _hardware_manager.get()});
   }
 
-  _executor = std::make_unique<multi_queue_executor>(
-      *this, [this](device_id dev) {
-        return std::make_unique<ze_queue>(this->_hardware_manager.get(),
-                                          dev.get_id());
-      });
+  _executor = std::make_unique<lazily_constructed_executor<multi_queue_executor>>(
+      create_multi_queue_executor(this, _hardware_manager.get()));
 }
 
 api_platform ze_backend::get_api_platform() const {
@@ -90,7 +101,7 @@ backend_hardware_manager* ze_backend::get_hardware_manager() const {
 }
 
 backend_executor* ze_backend::get_executor(device_id dev) const {
-  return _executor.get();
+  return _executor->get();
 }
 
 backend_allocator *ze_backend::get_allocator(device_id dev) const {

--- a/src/runtime/ze/ze_backend.cpp
+++ b/src/runtime/ze/ze_backend.cpp
@@ -80,8 +80,11 @@ ze_backend::ze_backend() {
         _hardware_manager.get()});
   }
 
-  _executor = std::make_unique<lazily_constructed_executor<multi_queue_executor>>(
-      create_multi_queue_executor(this, _hardware_manager.get()));
+  _executor =
+      std::make_unique<lazily_constructed_executor<multi_queue_executor>>(
+          [this, hw_mgr = _hardware_manager.get()]() {
+            return create_multi_queue_executor(this, hw_mgr);
+          });
 }
 
 api_platform ze_backend::get_api_platform() const {


### PR DESCRIPTION
Hopefully fixes #1246 

This PR causes multi-queue executors to only be constructed once they are actually needed. This should solve the issue for apps which only use in-order queues. However it does not solve the issue when out-of-order queues only use a subset of devices. That would require lazy construction inside `multi_queue_executor`. I suspect this might be more difficult.

CC @al42and 