### PR TITLE
Declare project before cmake_minimum_required in tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(adaptivecpp-tests)
 cmake_minimum_required(VERSION 3.12)
+project(adaptivecpp-tests)
 
 set(Boost_USE_STATIC_LIBS off)
 set(BUILD_SHARED_LIBS on)


### PR DESCRIPTION
Newer cmake versions (tested with 3.28) complain about calling the top-level project call before `cmake_minimum_required`. This PR fixes that.