### PR TITLE
Emmit error in find_package() if no targets specified

### DIFF
--- a/cmake/adaptivecpp-config.cmake.in
+++ b/cmake/adaptivecpp-config.cmake.in
@@ -24,6 +24,8 @@ if(NOT ACPP_TARGETS)
 endif()
 if(ACPP_TARGETS)
   set(ACPP_EXTRA_ARGS "${ACPP_EXTRA_ARGS} --acpp-targets=\"${ACPP_TARGETS}\"")
+else()
+  message(FATAL_ERROR "ACPP targets were not specified")
 endif()
 
 set(ACPP_CLANG "" CACHE STRING "Clang compiler executable used for compilation.")


### PR DESCRIPTION
According to the [documentation](https://github.com/AdaptiveCpp/AdaptiveCpp/blob/develop/doc/using-hipsycl.md#using-the-cmake-integration) 

> A typical configure command line looks like this: `cmake .. -DAdaptiveCpp_DIR=/acpp/install/dir/lib/cmake/AdaptiveCpp -DACPP_TARGETS="<targets>"`.
> `ACPP_TARGETS` has to be set either as environment variable or on the command line for the `find_package` call to succeed. See the documentation of this flag above.

This PR emits a Fatal error from the CMake integration in case no targets have been found. Prior to this change, the configuration succeeded even though there were no targets specified.

To consider: Maybe emitting a warning and setting the package not found would be more elegant in this case?