### PR TITLE
Introduce separate acpp JSON config files for backends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,14 +303,14 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_subdirectory(src)
 
-set(SYCLCC_CONFIG_FILE_PATH "${PROJECT_BINARY_DIR}/syclcc.json")
-set(SYCLCC_CONFIG_FILE_GLOBAL_INSTALLATION false CACHE BOOL 
-  "Whether to install the syclcc configuration file into a global directory (typically, /etc/hipSYCL). This is generally not recommended.")
+set(ACPP_CONFIG_FILE_PATH "${PROJECT_BINARY_DIR}")
+set(ACPP_CONFIG_FILE_GLOBAL_INSTALLATION false CACHE BOOL 
+  "Whether to install the AdaptiveCpp configuration files into a global directory (typically, /etc/AdaptiveCpp). This is generally not recommended.")
 
-if(SYCLCC_CONFIG_FILE_GLOBAL_INSTALLATION)
-  set(SYCLCC_CONFIG_FILE_INSTALL_DIR /etc/hipSYCL/)
+if(ACPP_CONFIG_FILE_GLOBAL_INSTALLATION)
+  set(ACPP_CONFIG_FILE_INSTALL_DIR /etc/AdaptiveCpp/)
 else()
-  set(SYCLCC_CONFIG_FILE_INSTALL_DIR etc/hipSYCL)
+  set(ACPP_CONFIG_FILE_INSTALL_DIR etc/AdaptiveCpp)
 endif()
 
 if(Boost_FIBER_LIBRARY_DEBUG)
@@ -434,7 +434,7 @@ else()
   set(PLUGIN_LLVM_VERSION_MAJOR 0)
 endif()
 
-set(SYCLCC_CONFIG_FILE "{
+set(ACPP_CORE_CONFIG_FILE "{
   \"version-major\" : \"${ACPP_VERSION_MAJOR}\",
   \"version-minor\" : \"${ACPP_VERSION_MINOR}\",
   \"version-patch\" : \"${ACPP_VERSION_PATCH}\",
@@ -442,9 +442,7 @@ set(SYCLCC_CONFIG_FILE "{
   \"plugin-llvm-version-major\" : \"${PLUGIN_LLVM_VERSION_MAJOR}\",
   \"plugin-with-cpu-acceleration\" : \"${WITH_ACCELERATED_CPU}\",
   \"default-clang\"     : \"${CLANG_EXECUTABLE_PATH}\",
-  \"default-nvcxx\"     : \"${NVCXX_COMPILER}\",
   \"default-platform\"  : \"${DEFAULT_PLATFORM}\",
-  \"default-cuda-path\" : \"${CUDA_TOOLKIT_ROOT_DIR}\",
   \"default-gpu-arch\"  : \"${DEFAULT_GPU_ARCH}\",
   \"default-cpu-cxx\"   : \"${CMAKE_CXX_COMPILER}\",
   \"default-rocm-path\" : \"${ROCM_PATH}\",
@@ -465,8 +463,30 @@ set(SYCLCC_CONFIG_FILE "{
 }
 ")
 
-file(WRITE ${SYCLCC_CONFIG_FILE_PATH} ${SYCLCC_CONFIG_FILE})
 
+set(ACPP_CUDA_CONFIG_FILE "{
+  \"default-nvcxx\"     : \"${NVCXX_COMPILER}\",
+  \"default-cuda-path\" : \"${CUDA_TOOLKIT_ROOT_DIR}\",
+  \"default-cuda-link-line\" : \"${CUDA_LINK_LINE}\",
+  \"default-cuda-cxx-flags\" : \"${CUDA_CXX_FLAGS}\"
+}
+")
+
+
+set(ACPP_ROCM_CONFIG_FILE "{
+  \"default-rocm-path\" : \"${ROCM_PATH}\",
+  \"default-rocm-link-line\" : \"${ROCM_LINK_LINE}\",
+  \"default-rocm-cxx-flags\" : \"${ROCM_CXX_FLAGS}\"
+}
+")
+
+file(WRITE ${ACPP_CONFIG_FILE_PATH}/acpp-core.json ${ACPP_CORE_CONFIG_FILE})
+if(WITH_CUDA_BACKEND)
+  file(WRITE ${ACPP_CONFIG_FILE_PATH}/acpp-cuda.json ${ACPP_CUDA_CONFIG_FILE})
+endif()
+if(WITH_ROCM_BACKEND)
+  file(WRITE ${ACPP_CONFIG_FILE_PATH}/acpp-rocm.json ${ACPP_ROCM_CONFIG_FILE})
+endif()
 
 
 # must stay after add_subdirectory(src) as HIPSYCL_COMMON_LIBRARY_OUTPUT_NAME is declared there
@@ -491,7 +511,13 @@ install(PROGRAMS bin/acpp DESTINATION bin RENAME syclcc)
 install(PROGRAMS bin/acpp DESTINATION bin RENAME syclcc-clang)
 
 
-install(FILES ${SYCLCC_CONFIG_FILE_PATH} DESTINATION ${SYCLCC_CONFIG_FILE_INSTALL_DIR})
+install(FILES ${ACPP_CONFIG_FILE_PATH}/acpp-core.json DESTINATION ${ACPP_CONFIG_FILE_INSTALL_DIR})
+if(WITH_CUDA_BACKEND)
+  install(FILES ${ACPP_CONFIG_FILE_PATH}/acpp-cuda.json DESTINATION ${ACPP_CONFIG_FILE_INSTALL_DIR})
+endif()
+if(WITH_ROCM_BACKEND)
+  install(FILES ${ACPP_CONFIG_FILE_PATH}/acpp-rocm.json DESTINATION ${ACPP_CONFIG_FILE_INSTALL_DIR})
+endif()
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,10 +454,6 @@ set(ACPP_CORE_CONFIG_FILE "{
   \"default-sequential-cxx-flags\" : \"${SEQUENTIAL_CXX_FLAGS}\",
   \"default-omp-link-line\" : \"${OMP_LINK_LINE}\",
   \"default-omp-cxx-flags\" : \"${OMP_CXX_FLAGS}\",
-  \"default-rocm-link-line\" : \"${ROCM_LINK_LINE}\",
-  \"default-rocm-cxx-flags\" : \"${ROCM_CXX_FLAGS}\",
-  \"default-cuda-link-line\" : \"${CUDA_LINK_LINE}\",
-  \"default-cuda-cxx-flags\" : \"${CUDA_CXX_FLAGS}\",
   \"default-is-explicit-multipass\" : \"false\",
   \"default-save-temps\" : \"false\"
 }

--- a/bin/acpp
+++ b/bin/acpp
@@ -165,24 +165,29 @@ HIPSYCL_STATIC_HCF_REGISTRATION({hcf_object_id}ull, __hipsycl_hcf_object_{hcf_ob
       f.write(str(self))
 
 class config_file:
-  def __init__(self, filepath):
-    self._location = filepath
-    try:
-      with open(filepath, 'r') as config_file:
-        self._data = json.load(config_file)
-        self._is_loaded = True
-    except:
-      print("Could not open config",filepath)
-      self._data = {}
-      self._is_loaded = False
+  # Scans the provided directory for json files
+  def __init__(self, config_file_dir):
+    
+    self._data = {}
+    self._locations = {}
+    self._config_dir = config_file_dir
+
+    files = os.listdir(config_file_dir)
+    for f in files:
+      if os.path.basename(f).endswith(".json"):
+        with open(f, 'r') as config_file:
+          data = json.load(config_file)
+          for d in data:
+            self._data[d] = data[d]
+          self._is_loaded = True
 
   @property
   def is_loaded(self):
     return self._is_loaded
 
   @property
-  def location(self):
-    return self._location
+  def config_dir(self):
+    return self._config_dir
 
   @property
   def keys(self):
@@ -199,7 +204,7 @@ class config_file:
 
   def get(self, key):
     if not self.contains_key(key):
-      raise RuntimeError("Accessed missing key in config file: "+key)
+      raise RuntimeError("Accessed missing key in config files: "+key)
 
     return self._data[key]
 
@@ -235,13 +240,13 @@ class acpp_config:
   def __init__(self, args):
     config_file_path = os.path.abspath(
       os.path.join(self.acpp_installation_path,
-                  "etc/hipSYCL/syclcc.json"))
+                  "etc/AdaptiveCpp"))
     
     self._config_file = None
-    # First check silently if we can open the default config file.
+    # First check silently if we can open the default config path.
     # If that fails, we try later on after argument parsing if a
     # custom location for the config file has been supplied.
-    # (This happens when compiling hipSYCL)
+    # (This happens when compiling AdaptiveCpp)
     if os.path.exists(config_file_path):
       self._config_file = config_file(config_file_path)
       
@@ -308,8 +313,8 @@ class acpp_config:
       'cuda-cxx-flags' : option("--acpp-cuda-cxx-flags", "ACPP_CUDA_CXX_FLAGS", "default-cuda-cxx-flags",
 """ The arguments passed to the compiler to compile for the CUDA backend"""),
 
-      'config-file' : option("--acpp-config-file", "ACPP_CONFIG_FILE", "default-config-file",
-"""  Select an alternative path for the config file containing the default hipSYCL settings.
+      'config-file-dir' : option("--acpp-config-file-dir", "ACPP_CONFIG_FILE_DIR", "default-config-file-dir",
+"""  Select an alternative path for the config files containing the default AdaptiveCpp settings.
     It is normally not necessary for the user to change this setting. """),
     
       'targets': option("--acpp-targets", "ACPP_TARGETS", "default-targets",
@@ -404,20 +409,21 @@ class acpp_config:
         self._acpp_environment_args[envvar] = os.environ[envvar]
       elif self._is_acpp_envvar(self._upgrade_legacy_environ_var(envvar)):
         self._acpp_environment_args[self._upgrade_legacy_environ_var(envvar)] = os.environ[envvar]
-        
-    if self._is_option_set_to_non_default_value("config-file"):
-      self._config_file = config_file(self._retrieve_option("config-file"))
+    
+    config_file_dir = None
+    if self._is_option_set_to_non_default_value("config-file-dir"):
+      config_file_dir = config_file(self._retrieve_option("config-file-dir"))
       
-    if self._config_file == None:
-      # If the config file is still None at this point, probably no alternative
-      # config file was supplied and the default one doesn't exist.
-      # As a last resort, we check if there is a global config file
+    if config_file_dir == None:
+      # If the config dir is still None at this point, probably no alternative
+      # config dir was supplied and the default one doesn't exist.
+      # As a last resort, we check if there is a global dir file
       # TODO try using some more portable path here
-      global_config_file = '/etc/hipSYCL/syclcc.json'
-      if os.path.exists(global_config_file):
-        self._config_file = config_file(global_config_file)
+      global_config_dir = '/etc/AdaptiveCpp'
+      if os.path.exists(global_config_dir):
+        self._config_file = config_file(global_config_dir)
       else:
-        # The main purpose of opening the default config file explicitly 
+        # The main purpose of opening the default config file dir explicitly 
         # here is that it will print a warning for the user
         # if it doesn't exist and set the config file content to {}.
         self._config_file = config_file(config_file_path)
@@ -459,7 +465,7 @@ class acpp_config:
       opt = self._options[option_name]
       print(opt.commandline + "=<value>")
       print("  [can also be set with environment variable: {}=<value>]".format(opt.environment))
-      print("  [default value provided by field '{}' in {}.]".format(opt.configfile, self._config_file.location))
+      print("  [default value provided by field '{}' in JSON files in {}.]".format(opt.configfile, self._config_file.config_dir))
       try:
         print("  [current value: {}]".format(self._retrieve_option(option_name)))
       except OptionNotSet:
@@ -474,7 +480,7 @@ class acpp_config:
       print("  [can also be set by setting environment variable {} to any value other than false|off|0 ]".format(
         flag.environment
       ))
-      print("  [default value provided by field '{}' in {}.]".format(flag.configfile, self._config_file.location))
+      print("  [default value provided by field '{}' in JSON files in {}.]".format(flag.configfile, self._config_file.config_dir))
       try:
         print("  [current value: {}]".format(self._is_flag_set(flag_name)))
       except OptionNotSet:
@@ -2041,5 +2047,6 @@ if __name__ == '__main__':
     c = compiler(config)
     sys.exit(c.run())
   except Exception as e:
+    raise e
     print("acpp fatal error: "+str(e))
     sys.exit(-1)

--- a/bin/acpp
+++ b/bin/acpp
@@ -175,8 +175,8 @@ class config_file:
     for current_dir in config_file_dirs:
       files = os.listdir(current_dir)
       for f in files:
-        if os.path.basename(f).endswith(".json"):
-          with open(f, 'r') as config_file:
+        if f.lower().endswith(".json"):
+          with open(os.path.join(current_dir, f), 'r') as config_file:
             data = json.load(config_file)
             for d in data:
               self._data[d] = data[d]

--- a/bin/acpp
+++ b/bin/acpp
@@ -164,7 +164,7 @@ HIPSYCL_STATIC_HCF_REGISTRATION({hcf_object_id}ull, __hipsycl_hcf_object_{hcf_ob
     with open(filename, 'w') as f:
       f.write(str(self))
 
-class config_file:
+class config_db:
   # Scans the provided directory for json files
   def __init__(self, config_file_dirs):
     
@@ -215,10 +215,10 @@ class config_file:
     return default_value
 
 class option:
-  def __init__(self, commandline, environment, configfile, description):
+  def __init__(self, commandline, environment, config_db, description):
     self._commandline = commandline
     self._environment = environment
-    self._configfile = configfile
+    self._config_db = config_db
     self._description = description
 
   @property
@@ -230,8 +230,8 @@ class option:
     return self._environment
 
   @property
-  def configfile(self):
-    return self._configfile
+  def config_db(self):
+    return self._config_db
 
   @property
   def description(self):
@@ -416,7 +416,7 @@ class acpp_config:
       config_file_directories.append(install_config_dir)
     elif os.path.exists(global_config_dir):
       config_file_directories.append(global_config_dir)
-    self._config_file = config_file(config_file_directories)
+    self._config_db = config_db(config_file_directories)
 
     
     self._common_compiler_args = self._get_std_compiler_args()
@@ -456,7 +456,7 @@ class acpp_config:
       opt = self._options[option_name]
       print(opt.commandline + "=<value>")
       print("  [can also be set with environment variable: {}=<value>]".format(opt.environment))
-      print("  [default value provided by field '{}' in JSON files from directories: {}.]".format(opt.configfile, self._config_file.config_dirs))
+      print("  [default value provided by field '{}' in JSON files from directories: {}.]".format(opt.config_db, self._config_db.config_dirs))
       try:
         print("  [current value: {}]".format(self._retrieve_option(option_name)))
       except OptionNotSet:
@@ -471,7 +471,7 @@ class acpp_config:
       print("  [can also be set by setting environment variable {} to any value other than false|off|0 ]".format(
         flag.environment
       ))
-      print("  [default value provided by field '{}' in JSON files from directories: {}.]".format(flag.configfile, self._config_file.config_dirs))
+      print("  [default value provided by field '{}' in JSON files from directories: {}.]".format(flag.config_db, self._config_db.config_dirs))
       try:
         print("  [current value: {}]".format(self._is_flag_set(flag_name)))
       except OptionNotSet:
@@ -500,8 +500,8 @@ class acpp_config:
       env_value = self._acpp_environment_args[flag.environment]
       return self._interpret_flag(env_value)
 
-    if self._config_file.contains_key(flag.configfile):
-      return self._interpret_flag(self._config_file.get(flag.configfile))
+    if self._config_db.contains_key(flag.config_db):
+      return self._interpret_flag(self._config_db.get(flag.config_db))
 
     raise OptionNotSet(
       "Could not infer value of required flag from command line argument {}, "
@@ -581,9 +581,9 @@ class acpp_config:
     if opt.environment in self._acpp_environment_args:
       return self._acpp_environment_args[opt.environment]
 
-    # Try config file
-    if self._config_file.contains_key(opt.configfile):
-      return self._config_file.get(opt.configfile)
+    # Try config db
+    if self._config_db.contains_key(opt.config_db):
+      return self._config_db.get(opt.config_db)
   
     if not allow_unset:
       raise OptionNotSet("Required command line argument {} or environment variable {} not specified".format(
@@ -640,29 +640,29 @@ class acpp_config:
   @property
   def version(self):
   
-    if not self._config_file.contains_key("version-major"):
+    if not self._config_db.contains_key("version-major"):
       raise OptionNotSet("Could not retrieve major version from config file")
-    if not self._config_file.contains_key("version-minor"):
+    if not self._config_db.contains_key("version-minor"):
       raise OptionNotSet("Could not retrieve major version from config file")
-    if not self._config_file.contains_key("version-patch"):
+    if not self._config_db.contains_key("version-patch"):
       raise OptionNotSet("Could not retrieve major version from config file")
     
     # version suffix may be empty if git queries fail
     suffix = ""
-    if self._config_file.contains_key("version-suffix"):
-      suffix = self._config_file.get("version-suffix")
+    if self._config_db.contains_key("version-suffix"):
+      suffix = self._config_db.get("version-suffix")
 
     return (
-      self._config_file.get("version-major"), 
-      self._config_file.get("version-minor"),
-      self._config_file.get("version-patch"),
+      self._config_db.get("version-major"), 
+      self._config_db.get("version-minor"),
+      self._config_db.get("version-patch"),
       suffix)
 
   @property
   def plugin_llvm_version(self):
-    if not self._config_file.contains_key("plugin-llvm-version-major"):
+    if not self._config_db.contains_key("plugin-llvm-version-major"):
       raise OptionNotSet("Could not retrieve plugin LLVM version from config file")
-    return int(self._config_file.get("plugin-llvm-version-major"))
+    return int(self._config_db.get("plugin-llvm-version-major"))
 
   @property
   def has_plugin(self):
@@ -670,9 +670,9 @@ class acpp_config:
 
   @property
   def has_plugin_cpu_acceleration(self):
-    if not self._config_file.contains_key("plugin-with-cpu-acceleration"):
+    if not self._config_db.contains_key("plugin-with-cpu-acceleration"):
       raise OptionNotSet("Could not retrieve plugin cpu acceleration capability from config file")
-    return self._interpret_flag(self._config_file.get("plugin-with-cpu-acceleration"))
+    return self._interpret_flag(self._config_db.get("plugin-with-cpu-acceleration"))
 
   @property
   def runtime_backends(self):
@@ -892,8 +892,8 @@ class acpp_config:
     return source_files
 
   @property
-  def configfile(self):
-    return self._config_file
+  def config_db(self):
+    return self._config_db
 
   def is_pure_linking_stage(self):
     return len(self.source_file_arguments) == 0
@@ -1968,12 +1968,12 @@ class compiler:
       return self._run(temp_dir)
 
 def print_config(config):
-  config_file = config.configfile
+  config_db = config.config_db
   print("\n\nFull configuration [can be overriden using environment variables or command line arguments]:")
-  for k in config_file.keys:
+  for k in config_db.keys:
     v = "(unconfigured)"
     try:
-      v = config_file.get(k)
+      v = config_db.get(k)
     except Exception as e:
       pass
     print("    {}: {}".format(k, v))

--- a/bin/acpp
+++ b/bin/acpp
@@ -166,28 +166,29 @@ HIPSYCL_STATIC_HCF_REGISTRATION({hcf_object_id}ull, __hipsycl_hcf_object_{hcf_ob
 
 class config_file:
   # Scans the provided directory for json files
-  def __init__(self, config_file_dir):
+  def __init__(self, config_file_dirs):
     
     self._data = {}
     self._locations = {}
-    self._config_dir = config_file_dir
+    self._config_dirs = config_file_dirs
 
-    files = os.listdir(config_file_dir)
-    for f in files:
-      if os.path.basename(f).endswith(".json"):
-        with open(f, 'r') as config_file:
-          data = json.load(config_file)
-          for d in data:
-            self._data[d] = data[d]
-          self._is_loaded = True
+    for current_dir in config_file_dirs:
+      files = os.listdir(current_dir)
+      for f in files:
+        if os.path.basename(f).endswith(".json"):
+          with open(f, 'r') as config_file:
+            data = json.load(config_file)
+            for d in data:
+              self._data[d] = data[d]
+            self._is_loaded = True
 
   @property
   def is_loaded(self):
     return self._is_loaded
 
   @property
-  def config_dir(self):
-    return self._config_dir
+  def config_dirs(self):
+    return self._config_dirs
 
   @property
   def keys(self):
@@ -238,19 +239,6 @@ class option:
 
 class acpp_config:
   def __init__(self, args):
-    config_file_path = os.path.abspath(
-      os.path.join(self.acpp_installation_path,
-                  "etc/AdaptiveCpp"))
-    
-    self._config_file = None
-    # First check silently if we can open the default config path.
-    # If that fails, we try later on after argument parsing if a
-    # custom location for the config file has been supplied.
-    # (This happens when compiling AdaptiveCpp)
-    if os.path.exists(config_file_path):
-      self._config_file = config_file(config_file_path)
-      
-    self._args = args
 
     # Describes different representations of options:
     # 1.) the corresponding command line argument
@@ -388,6 +376,9 @@ class acpp_config:
   This particularly affects small problem sizes. If this flag is set, supported parallel STL
   algorithms will be offloaded unconditionally.""")
     }
+
+
+    self._args = args
     self._insufficient_cpp_standards = ['98', '03', '11', '14', '0x']
     self._acpp_args = []
     self._acpp_environment_args = {}
@@ -410,23 +401,23 @@ class acpp_config:
       elif self._is_acpp_envvar(self._upgrade_legacy_environ_var(envvar)):
         self._acpp_environment_args[self._upgrade_legacy_environ_var(envvar)] = os.environ[envvar]
     
-    config_file_dir = None
+    config_file_directories = []
+
+    install_config_dir = os.path.abspath(
+      os.path.join(self.acpp_installation_path,
+                  "etc/AdaptiveCpp"))
+    
+    # TODO try using some more portable path here
+    global_config_dir = '/etc/AdaptiveCpp'
+    
     if self._is_option_set_to_non_default_value("config-file-dir"):
-      config_file_dir = config_file(self._retrieve_option("config-file-dir"))
-      
-    if config_file_dir == None:
-      # If the config dir is still None at this point, probably no alternative
-      # config dir was supplied and the default one doesn't exist.
-      # As a last resort, we check if there is a global dir file
-      # TODO try using some more portable path here
-      global_config_dir = '/etc/AdaptiveCpp'
-      if os.path.exists(global_config_dir):
-        self._config_file = config_file(global_config_dir)
-      else:
-        # The main purpose of opening the default config file dir explicitly 
-        # here is that it will print a warning for the user
-        # if it doesn't exist and set the config file content to {}.
-        self._config_file = config_file(config_file_path)
+      config_file_directories.append(self._retrieve_option("config-file-dir"))
+    elif os.path.exists(install_config_dir):
+      config_file_directories.append(install_config_dir)
+    elif os.path.exists(global_config_dir):
+      config_file_directories.append(global_config_dir)
+    self._config_file = config_file(config_file_directories)
+
     
     self._common_compiler_args = self._get_std_compiler_args()
 
@@ -465,7 +456,7 @@ class acpp_config:
       opt = self._options[option_name]
       print(opt.commandline + "=<value>")
       print("  [can also be set with environment variable: {}=<value>]".format(opt.environment))
-      print("  [default value provided by field '{}' in JSON files in {}.]".format(opt.configfile, self._config_file.config_dir))
+      print("  [default value provided by field '{}' in JSON files from directories: {}.]".format(opt.configfile, self._config_file.config_dirs))
       try:
         print("  [current value: {}]".format(self._retrieve_option(option_name)))
       except OptionNotSet:
@@ -480,7 +471,7 @@ class acpp_config:
       print("  [can also be set by setting environment variable {} to any value other than false|off|0 ]".format(
         flag.environment
       ))
-      print("  [default value provided by field '{}' in JSON files in {}.]".format(flag.configfile, self._config_file.config_dir))
+      print("  [default value provided by field '{}' in JSON files from directories: {}.]".format(flag.configfile, self._config_file.config_dirs))
       try:
         print("  [current value: {}]".format(self._is_flag_set(flag_name)))
       except OptionNotSet:
@@ -2047,6 +2038,5 @@ if __name__ == '__main__':
     c = compiler(config)
     sys.exit(c.run())
   except Exception as e:
-    raise e
     print("acpp fatal error: "+str(e))
     sys.exit(-1)

--- a/doc/using-hipsycl.md
+++ b/doc/using-hipsycl.md
@@ -66,7 +66,7 @@ See [here](stdpar.md) for details on how to offload C++ standard STL algorithms 
 After installing AdaptiveCpp, it can be used as a standalone tool to manually build source files similarly to regular compilers, or it can be integrated in build systems other than CMake.
 For example, compiling a SYCL source `example.cpp` to an executable, while targeting CPU and CUDA backends, is possible using `acpp -o example example.cpp -O3 --acpp-targets="omp;cuda:sm_61"`.
 
-The full excerpt from `acpp --help` follows below. Note the options can also be set via environment variables or corresponding CMake options. Default values can be set in `/acpp/install/path/etc/hipSYCL/syclcc.json`.
+The full excerpt from `acpp --help` follows below. Note the options can also be set via environment variables or corresponding CMake options. Default values can be set in the `/acpp/install/path/etc/AdaptiveCpp/*.json` files.
 ```
 acpp [hipSYCL compilation driver], Copyright (C) 2018-2022 Aksel Alpay and the hipSYCL project
   hipSYCL version: 0.9.2


### PR DESCRIPTION
Previously, we had a single `syclcc.json` that stores information for all backends.

This PR changes `acpp` to take into account all JSON files that it finds in a directory. This allows us to have separate JSON files for different backends or components. This can be helpful e.g. for packaging.

Additionally,
* This PR changes the JSON directory to `etc/AdaptiveCpp` from `etc/hipSYCL`
* Changes naming from `syclcc.json` to `acpp-*.json`
* Renames cmake argument `SYCLCC_CONFIG_FILE_GLOBAL_INSTALLATION` to `ACPP_CONFIG_FILE_GLOBAL_INSTALLATION`. It is probably fine to just rename it directly as this flag was not widely known and is primarily interesting only for packages.
