### PR TITLE
Deprecate syclcc and syclcc-clang

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,7 +25,7 @@ A clear and concise description of what you expected to happen.
    * host compiler
    * CUDA version (if applicable)
    * ROCm version and how ROCm was installed (if applicable)
-* How you have compiled your application and which arguments you have passed to `syclcc`. In particular, which backends and hardware you have compiled for.
+* How you have compiled your application and which arguments you have passed to `acpp`. In particular, which backends and hardware you have compiled for.
 
 
 **Optional additional diagnostic information**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ endif()
 
 project(hipSYCL VERSION ${ACPP_VERSION_MAJOR}.${ACPP_VERSION_MINOR}.${ACPP_VERSION_PATCH})
 
-set(HIPSYCL_DEVICE_COMPILER ${PROJECT_SOURCE_DIR}/bin/syclcc-clang)
+
 set(HIPSYCL_SOURCE_DIR ${PROJECT_SOURCE_DIR})
 
 if(NOT CMAKE_BUILD_TYPE)
@@ -220,7 +220,7 @@ if(BUILD_CLANG_PLUGIN)
   get_filename_component(LLVM_BIN_DIR "${CLANG_EXECUTABLE_PATH}" DIRECTORY)
   get_filename_component(LLVM_PREFIX_DIR "${LLVM_BIN_DIR}" DIRECTORY)
   # The path to the internal clang includes is currently required on ROCm
-  # to let syclcc-clang fix a wrong order of system includes (clang's internal 
+  # to let acpp fix a wrong order of system includes (clang's internal 
   # includes are not of high enough priority in the include path search order).
   # We identify this path as the one containing __clang_cuda_runtime_wrapper.h,
   # which is a clang-specific header file.

--- a/bin/acpp
+++ b/bin/acpp
@@ -2012,9 +2012,9 @@ if __name__ == '__main__':
   
   filename = os.path.basename(os.path.realpath(__file__))
   if filename == "syclcc":
-    print("acpp warning: syclcc is deprecated; please use acpp instead.")
+    print_warning("syclcc is deprecated; please use acpp instead.")
   if filename == "syclcc-clang":
-    print("acpp warning: syclcc-clang is deprecated; please use acpp instead.")
+    print_warning("syclcc-clang is deprecated; please use acpp instead.")
 
   args = sys.argv[1:]
 

--- a/bin/acpp
+++ b/bin/acpp
@@ -2011,9 +2011,9 @@ if __name__ == '__main__':
     sys.exit(-1)
   
   filename = os.path.basename(os.path.realpath(__file__))
-  if os.path.basename(os.path.realpath(__file__)) == "syclcc":
+  if filename == "syclcc":
     print("acpp warning: syclcc is deprecated; please use acpp instead.")
-  if os.path.basename(os.path.realpath(__file__)) == "syclcc-clang":
+  if filename == "syclcc-clang":
     print("acpp warning: syclcc-clang is deprecated; please use acpp instead.")
 
   args = sys.argv[1:]

--- a/bin/acpp
+++ b/bin/acpp
@@ -2010,6 +2010,12 @@ if __name__ == '__main__':
     print_error("acpp requires python 3.")
     sys.exit(-1)
   
+  filename = os.path.basename(os.path.realpath(__file__))
+  if os.path.basename(os.path.realpath(__file__)) == "syclcc":
+    print("acpp warning: syclcc is deprecated; please use acpp instead.")
+  if os.path.basename(os.path.realpath(__file__)) == "syclcc-clang":
+    print("acpp warning: syclcc-clang is deprecated; please use acpp instead.")
+
   args = sys.argv[1:]
 
   try:

--- a/cmake/adaptivecpp-config.cmake.in
+++ b/cmake/adaptivecpp-config.cmake.in
@@ -8,7 +8,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 
 include(adaptivecpp-targets)
 
-set(ACPP_EXTRA_ARGS "${ACPP_EXTRA_ARGS}" CACHE STRING "Arguments to pass through directly to syclcc.")
+set(ACPP_EXTRA_ARGS "${ACPP_EXTRA_ARGS}" CACHE STRING "Arguments to pass through directly to acpp.")
 set(ACPP_EXTRA_COMPILE_OPTIONS "${ACPP_EXTRA_COMPILE_OPTIONS}" CACHE STRING "Additional compile options for source files listed in add_sycl_to_target.")
 
 set(ACPP_TARGETS_DESC "in the format ACPP_TARGETS=<platform1>[:arch1[,arch2][..,archN]][;<platform2>[:arch1][...]][..;<platformN>]. See acpp --help for a list of platforms.")


### PR DESCRIPTION
Adds a warning if `syclcc` and `syclcc-clang` are used, instructing users to use `acpp` instead.