### PR TITLE
Add runpath $ORIGIN by default for runtime libraries

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,15 +8,13 @@ if(NOT APPLE AND NOT WIN32)
   # parallelism to bleed into code that is executed within the runtime, where
   # USM is a big no-no.
   set(HIPSYCL_STDPAR_RT_LINKER_FLAGS "-Wl,-Bsymbolic-functions")
+  set(base $ORIGIN)
 else()
   set(HIPSYCL_STDPAR_RT_LINKER_FLAGS "")
+  set(base @loader_path)
 endif()
 
 add_subdirectory(common)
-
-list( APPEND CMAKE_INSTALL_RPATH
-  ${CMAKE_INSTALL_PREFIX}/lib
-  ${CMAKE_INSTALL_PREFIX}/lib/hipSYCL/llvm-to-backend)
 
 set(WITH_LLVM_TO_AMDGPU_AMDHSA false)
 set(WITH_LLVM_TO_PTX false)

--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LLVM_TO_BACKEND_INCLUDE_DIRS
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_BINARY_DIR}/include)
 
+set(CMAKE_INSTALL_RPATH ${base} ${base}/../../)
 
 function(create_llvm_based_library)
   set(options)

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -16,6 +16,8 @@ set(HIPSYCL_RT_EXTRA_LINKER_FLAGS ${ACPP_RT_SANITIZE_FLAGS})
 
 set(HIPSYCL_RT_EXTRA_LINKER_FLAGS ${HIPSYCL_RT_EXTRA_LINKER_FLAGS} ${HIPSYCL_STDPAR_RT_LINKER_FLAGS})
 
+set(CMAKE_INSTALL_RPATH ${base} ${base}/hipSYCL)
+
 add_library(acpp-rt SHARED
   application.cpp
   runtime.cpp
@@ -86,6 +88,7 @@ install(TARGETS acpp-rt
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
 
+set(CMAKE_INSTALL_RPATH ${base}/../ ${base}/llvm-to-backend)
 
 if(WITH_CUDA_BACKEND)
   add_library(rt-backend-cuda SHARED
@@ -251,7 +254,7 @@ if(WITH_CPU_BACKEND)
     omp/omp_queue.cpp)
 
     find_package(OpenMP REQUIRED)
-
+    
     target_include_directories(rt-backend-omp PRIVATE ${HIPSYCL_SOURCE_DIR}/include)
     if(APPLE)
       if(CMAKE_VERSION VERSION_LESS "3.16")

--- a/src/tools/acpp-info/CMakeLists.txt
+++ b/src/tools/acpp-info/CMakeLists.txt
@@ -11,5 +11,6 @@ target_link_libraries(acpp-info PRIVATE acpp-rt)
 # Make sure that acpp-info uses compatible sanitizer flags for sanitized runtime builds
 target_link_libraries(acpp-info PRIVATE ${ACPP_RT_SANITIZE_FLAGS})
 target_compile_options(acpp-info PRIVATE ${ACPP_RT_SANITIZE_FLAGS})
+set_target_properties(acpp-info PROPERTIES INSTALL_RPATH ${base}/../lib/)
 
 install(TARGETS acpp-info DESTINATION bin)


### PR DESCRIPTION
Resolve #1331 

Based on this presentation https://crascit.com/wp-content/uploads/2019/09/Deep-CMake-For-Library-Authors-Craig-Scott-CppCon-2019.pdf slide 99-110  this seems to be the canonical way to deal with the issue mentioned above 