### PR TITLE
Fix warnings when compiling with `-acpp-stdpar -Wall -Wextra`

### DIFF
--- a/include/hipSYCL/std/stdpar/detail/allocation_map.hpp
+++ b/include/hipSYCL/std/stdpar/detail/allocation_map.hpp
@@ -121,7 +121,7 @@ public:
 
   // Access entry of allocation that has the given address. Unlike get_entry(),
   // this does not succeed if the address does not point to the base of the allocation.
-  value_type* get_entry_of_root_address(uint64_t address, uint64_t& root_address) noexcept {
+  value_type* get_entry_of_root_address(uint64_t address) noexcept {
     insert_or_get_entry_lock lock{_num_in_progress_operations};
     return get_entry_of_root_address(_root, address);
   }
@@ -202,7 +202,7 @@ private:
   };
 
   value_type *get_entry(leaf_node &current_node, uint64_t address,
-                        int &num_leaf_attempts,
+                        int &/*num_leaf_attempts*/,
                         uint64_t &root_address) noexcept {
     int start_address = 0;
 
@@ -634,7 +634,7 @@ private:
   }
 
   int find_lowest_level_with_free_blocks(int min_level) {
-    for(int i = min_level; i < _sorted_free_blocks_in_level.size(); ++i) {
+    for(std::size_t i = min_level; i < _sorted_free_blocks_in_level.size(); ++i) {
       if(!_sorted_free_blocks_in_level[i].empty())
         return i;
     }

--- a/include/hipSYCL/std/stdpar/detail/offload.hpp
+++ b/include/hipSYCL/std/stdpar/detail/offload.hpp
@@ -424,7 +424,7 @@ bool should_offload(AlgorithmType type, Size n, const Args &...args) {
       state.get_configuration().get_min_ops_per_offload_decision();
 
   int num_predicted_ops = 0;
-  uint64_t op_hash = get_operation_hash(type, args...);
+  uint64_t op_hash = get_operation_hash(type, n, args...);
   // Identify ops using a combination of hash and problem size
   using op_id = offload_heuristic_state::op_id;
 
@@ -585,7 +585,7 @@ private:
 template<class AlgorithmType, class Size, class F, typename... Args>
 auto host_instrumentation(F&& f, AlgorithmType t, Size n, Args... args) {
 #ifndef __HIPSYCL_STDPAR_UNCONDITIONAL_OFFLOAD__
-  uint64_t hash = get_operation_hash(t, args...);
+  uint64_t hash = get_operation_hash(t, n, args...);
   host_invocation_measurement m{hash, n};
   return m(f);
 #else
@@ -596,7 +596,7 @@ auto host_instrumentation(F&& f, AlgorithmType t, Size n, Args... args) {
 template<class AlgorithmType, class Size, class F, typename... Args>
 auto device_instrumentation(F&& f, AlgorithmType t, Size n, Args... args) {
 #ifndef __HIPSYCL_STDPAR_UNCONDITIONAL_OFFLOAD__
-  uint64_t hash = get_operation_hash(t, args...);
+  uint64_t hash = get_operation_hash(t, n, args...);
   device_invocation_measurement m{hash, n};
   return m(f);
 #else

--- a/include/hipSYCL/std/stdpar/detail/offload.hpp
+++ b/include/hipSYCL/std/stdpar/detail/offload.hpp
@@ -424,7 +424,7 @@ bool should_offload(AlgorithmType type, Size n, const Args &...args) {
       state.get_configuration().get_min_ops_per_offload_decision();
 
   int num_predicted_ops = 0;
-  uint64_t op_hash = get_operation_hash(type, n, args...);
+  uint64_t op_hash = get_operation_hash(type, args...);
   // Identify ops using a combination of hash and problem size
   using op_id = offload_heuristic_state::op_id;
 
@@ -585,7 +585,7 @@ private:
 template<class AlgorithmType, class Size, class F, typename... Args>
 auto host_instrumentation(F&& f, AlgorithmType t, Size n, Args... args) {
 #ifndef __HIPSYCL_STDPAR_UNCONDITIONAL_OFFLOAD__
-  uint64_t hash = get_operation_hash(t, n, args...);
+  uint64_t hash = get_operation_hash(t, args...);
   host_invocation_measurement m{hash, n};
   return m(f);
 #else
@@ -596,7 +596,7 @@ auto host_instrumentation(F&& f, AlgorithmType t, Size n, Args... args) {
 template<class AlgorithmType, class Size, class F, typename... Args>
 auto device_instrumentation(F&& f, AlgorithmType t, Size n, Args... args) {
 #ifndef __HIPSYCL_STDPAR_UNCONDITIONAL_OFFLOAD__
-  uint64_t hash = get_operation_hash(t, n, args...);
+  uint64_t hash = get_operation_hash(t, args...);
   device_invocation_measurement m{hash, n};
   return m(f);
 #else

--- a/include/hipSYCL/std/stdpar/detail/offload_heuristic_db.hpp
+++ b/include/hipSYCL/std/stdpar/detail/offload_heuristic_db.hpp
@@ -356,15 +356,14 @@ private:
 };
 
 
-template <class AlgorithmType, class Size, typename... Args>
-inline uint64_t get_operation_hash(AlgorithmType /*arg*/, Size n, Args...) {
+template <class AlgorithmType, typename... Args>
+inline uint64_t get_operation_hash(AlgorithmType /*arg*/, Args...) {
   common::stable_running_hash hash;
 
   auto add_to_hash = [&](const auto& x){
     hash(&x, sizeof(x));
   };
   add_to_hash(typeid(AlgorithmType).hash_code());
-  add_to_hash(n);
   (add_to_hash(typeid(Args).hash_code()), ...);
   return hash.get_current_hash();
 }

--- a/include/hipSYCL/std/stdpar/detail/offload_heuristic_db.hpp
+++ b/include/hipSYCL/std/stdpar/detail/offload_heuristic_db.hpp
@@ -356,8 +356,8 @@ private:
 };
 
 
-template <class AlgorithmType, typename... Args>
-inline uint64_t get_operation_hash(AlgorithmType /*arg*/, Args...) {
+template <class AlgorithmType, class Size, typename... Args>
+inline uint64_t get_operation_hash(AlgorithmType /*arg*/, Size /*n*/, Args...) {
   common::stable_running_hash hash;
 
   auto add_to_hash = [&](const auto& x){

--- a/include/hipSYCL/std/stdpar/detail/offload_heuristic_db.hpp
+++ b/include/hipSYCL/std/stdpar/detail/offload_heuristic_db.hpp
@@ -191,8 +191,8 @@ public:
     void write(std::ostream& ostr) const {
       
       ostr << entries.size() << " ";
-      for(int i = 0; i < entries.size(); ++i)
-        ostr << entries[i] << " ";
+      for(const auto &entry : entries)
+        ostr << entry << " ";
     }
   };
 
@@ -357,13 +357,14 @@ private:
 
 
 template <class AlgorithmType, class Size, typename... Args>
-inline uint64_t get_operation_hash(AlgorithmType arg, Size n, Args...) {
+inline uint64_t get_operation_hash(AlgorithmType /*arg*/, Size n, Args...) {
   common::stable_running_hash hash;
 
   auto add_to_hash = [&](const auto& x){
     hash(&x, sizeof(x));
   };
   add_to_hash(typeid(AlgorithmType).hash_code());
+  add_to_hash(n);
   (add_to_hash(typeid(Args).hash_code()), ...);
   return hash.get_current_hash();
 }

--- a/include/hipSYCL/std/stdpar/detail/sycl_glue.hpp
+++ b/include/hipSYCL/std/stdpar/detail/sycl_glue.hpp
@@ -147,7 +147,7 @@ public:
     assert(_instrumented_ops_in_batch.size() ==
            _instrumented_op_problem_sizes_in_batch.size());
     
-    for(int i = 0; i < _instrumented_ops_in_batch.size(); ++i) {
+    for(std::size_t i = 0; i < _instrumented_ops_in_batch.size(); ++i) {
       std::size_t problem_size = _instrumented_op_problem_sizes_in_batch[i];
       _offload_db.update_entry(_instrumented_ops_in_batch[i], problem_size,
                                offload_heuristic_db::offload_device_id,
@@ -235,8 +235,9 @@ private:
   }
 public:
   memory_pool(std::size_t size)
-      : _pool_size{size}, _free_space_map{size > 0 ? size : 1024},
-        _pool{nullptr}, _page_size{static_cast<int>(sysconf(_SC_PAGESIZE))} {
+      : _pool_size{size}, _pool{nullptr},
+        _free_space_map{size > 0 ? size : 1024},
+        _page_size{static_cast<std::size_t>(sysconf(_SC_PAGESIZE))} {
     init();
   }
 
@@ -304,7 +305,7 @@ private:
   void* _pool;
   void* _base_address;
   free_space_map _free_space_map;
-  int _page_size;
+  std::size_t _page_size;
 };
 
 class unified_shared_memory {
@@ -400,9 +401,8 @@ public:
         return;
 
       push_disabled();
-      uint64_t root_address = 0;
       auto* map_entry = get()._allocation_map.get_entry_of_root_address(
-              reinterpret_cast<uint64_t>(ptr), root_address);
+              reinterpret_cast<uint64_t>(ptr));
       if (!map_entry) {
         __libc_free(ptr);
       } else {


### PR DESCRIPTION
When compiling stdpar applications with `-Wall -Wextra` users will get a few warnings (specifically: comparison of int and size_t, unused parameters and constructor initialisier list order being different from member declaration order). This fixes those warnings.

The only one I wasn't sure about is `n` being unused in `get_operation_hash(AlgorithmType arg, Size n, Args...)`. I've now just removed it from the function arguments, maybe the first idea was to include the problem size in the hash? But I think the problem size is handled in offload.hpp separately, so I guess it can be removed here.

