### PR TITLE
`mangleTypeName` was renamed to `mangleCanonicalTypeName` in LLVM 18

### DIFF
--- a/include/hipSYCL/compiler/Frontend.hpp
+++ b/include/hipSYCL/compiler/Frontend.hpp
@@ -159,7 +159,7 @@ class CompleteCallSet : public clang::RecursiveASTVisitor<CompleteCallSet> {
 inline std::string buildKernelNameFromRecordType(const clang::QualType &RecordType, clang::MangleContext *Mangler) {
   std::string KernelName;
   llvm::raw_string_ostream SS(KernelName);
-  Mangler->mangleTypeName(RecordType, SS);
+  Mangler->mangleCanonicalTypeName(RecordType, SS);
 
   return KernelName;
 }

--- a/include/hipSYCL/compiler/Frontend.hpp
+++ b/include/hipSYCL/compiler/Frontend.hpp
@@ -159,7 +159,11 @@ class CompleteCallSet : public clang::RecursiveASTVisitor<CompleteCallSet> {
 inline std::string buildKernelNameFromRecordType(const clang::QualType &RecordType, clang::MangleContext *Mangler) {
   std::string KernelName;
   llvm::raw_string_ostream SS(KernelName);
+#if LLVM_VERSION_MAJOR >= 18
   Mangler->mangleCanonicalTypeName(RecordType, SS);
+#else
+  Mangler->mangleTypeName(RecordType, SS);
+#endif
 
   return KernelName;
 }


### PR DESCRIPTION
See [here](https://github.com/llvm/llvm-project/commit/9c89b29555a7ccfc3942340f558c3bbea8d10532).

Fixes #1334 