### PR TITLE
Fix various warnings when building AdaptiveCpp with `-Wall -Wextra -Wpedantic -pedantic`

### DIFF
--- a/include/hipSYCL/compiler/llvm-to-backend/Utils.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/Utils.hpp
@@ -287,6 +287,7 @@ public:
         assert(CallArgs[i]->getType() == F->getFunctionType()->getParamType(i));
       }
 
+      llvm::CallInst::Create(llvm::FunctionCallee(F), CallArgs, "", BB);
       llvm::ReturnInst::Create(M.getContext(), BB);
 
       if(!F->hasFnAttribute(llvm::Attribute::AlwaysInline))

--- a/include/hipSYCL/compiler/llvm-to-backend/Utils.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/Utils.hpp
@@ -156,8 +156,6 @@ public:
     auto* OldFType = F->getFunctionType();
     std::string FunctionName = F->getName().str();
     F->setName(FunctionName+"_PreKernelParameterRewriting");
-    // Make sure old function can be inlined
-    auto OldLinkage = F->getLinkage();
     F->setLinkage(llvm::GlobalValue::InternalLinkage);
 
     llvm::SmallVector<llvm::Type*, 8> Params;
@@ -289,8 +287,6 @@ public:
         assert(CallArgs[i]->getType() == F->getFunctionType()->getParamType(i));
       }
 
-      auto *Call = llvm::CallInst::Create(llvm::FunctionCallee(F), CallArgs,
-                                            "", BB);
       llvm::ReturnInst::Create(M.getContext(), BB);
 
       if(!F->hasFnAttribute(llvm::Attribute::AlwaysInline))

--- a/include/hipSYCL/compiler/utils/LLVMUtils.hpp
+++ b/include/hipSYCL/compiler/utils/LLVMUtils.hpp
@@ -29,13 +29,13 @@
 #define HIPSYCL_LLVMUTILS_HPP
 
 #if LLVM_VERSION_MAJOR < 13 || (LLVM_VERSION_MAJOR == 13 && defined(ROCM_CLANG_VERSION_MAJOR) && ROCM_CLANG_VERSION_MAJOR < 5)
-#define IS_OPAQUE(pointer) constexpr(false)
+#define IS_OPAQUE(pointer) constexpr(false && pointer)
 #define HAS_TYPED_PTR 1
 #elif LLVM_VERSION_MAJOR < 16
 #define IS_OPAQUE(pointer) (pointer->isOpaquePointerTy())
 #define HAS_TYPED_PTR 1
 #else
-#define IS_OPAQUE(pointer) constexpr(true)
+#define IS_OPAQUE(pointer) constexpr(true || pointer)
 #define HAS_TYPED_PTR 0
 #endif
 

--- a/include/hipSYCL/compiler/utils/LLVMUtils.hpp
+++ b/include/hipSYCL/compiler/utils/LLVMUtils.hpp
@@ -29,13 +29,13 @@
 #define HIPSYCL_LLVMUTILS_HPP
 
 #if LLVM_VERSION_MAJOR < 13 || (LLVM_VERSION_MAJOR == 13 && defined(ROCM_CLANG_VERSION_MAJOR) && ROCM_CLANG_VERSION_MAJOR < 5)
-#define IS_OPAQUE(pointer) constexpr(false && pointer)
+#define IS_OPAQUE(pointer) constexpr(false && pointer) /* Use `pointer` to silence warnings */
 #define HAS_TYPED_PTR 1
 #elif LLVM_VERSION_MAJOR < 16
 #define IS_OPAQUE(pointer) (pointer->isOpaquePointerTy())
 #define HAS_TYPED_PTR 1
 #else
-#define IS_OPAQUE(pointer) constexpr(true || pointer)
+#define IS_OPAQUE(pointer) constexpr(true || pointer) /* Use `pointer` to silence warnings */
 #define HAS_TYPED_PTR 0
 #endif
 

--- a/include/hipSYCL/runtime/dag_manager.hpp
+++ b/include/hipSYCL/runtime/dag_manager.hpp
@@ -77,7 +77,8 @@ private:
   // Should only be used for flush_async()
   std::mutex _flush_mutex;
 
-  runtime* _rt;
+  // TODO: This is not used anywhere
+  [[maybe_unused]] runtime* _rt;
 };
 
 class dag_build_guard

--- a/include/hipSYCL/runtime/data.hpp
+++ b/include/hipSYCL/runtime/data.hpp
@@ -556,7 +556,7 @@ public:
     range<3> num_pages = pr.second;
 
     // Find outdated regions among pages
-    bool was_found = _allocations.select_and_handle(
+    [[maybe_unused]] bool was_found = _allocations.select_and_handle(
         default_allocation_selector{d}, [&](auto &alloc) {
           alloc.invalid_pages.intersections_with(
               std::make_pair(first_page, num_pages), out);
@@ -625,12 +625,14 @@ public:
     assert(has_allocation(dev));
 
     Memory_descriptor mem{};
-    bool was_found = _allocations.select_and_handle(
+
+    [[maybe_unused]] bool was_found = _allocations.select_and_handle(
         default_allocation_selector{dev}, [&](const auto &alloc) {
           mem = alloc.memory;
     });
 
     assert(was_found);
+
     return mem;
   }
 
@@ -638,12 +640,14 @@ public:
     assert(has_allocation(dev));
 
     data_allocation<Memory_descriptor> found_alloc;
-    bool was_found = _allocations.select_and_handle(
+
+    [[maybe_unused]] bool was_found = _allocations.select_and_handle(
         default_allocation_selector{dev}, [&](const auto &alloc) {
           found_alloc = alloc;
     });
 
     assert(was_found);
+
     return found_alloc;
   }
 
@@ -714,7 +718,7 @@ private:
       new_alloc.invalid_pages.remove(std::make_pair(id<3>{0, 0, 0}, _num_pages));
     }
 
-    bool was_inserted = _allocations.add_if_unique(
+    [[maybe_unused]] bool was_inserted = _allocations.add_if_unique(
         default_allocation_comparator{}, std::move(new_alloc));
 
     // If another thread has added an allocation for this device in the meantime

--- a/include/hipSYCL/runtime/device_id.hpp
+++ b/include/hipSYCL/runtime/device_id.hpp
@@ -98,7 +98,6 @@ class device_id
 {
 public:
   device_id() = default;
-  device_id(const device_id&) = default;
   device_id(backend_descriptor b, int id);
   
   bool is_host() const;

--- a/include/hipSYCL/runtime/multi_queue_executor.hpp
+++ b/include/hipSYCL/runtime/multi_queue_executor.hpp
@@ -172,7 +172,6 @@ private:
   };
 
   std::vector<per_device_data> _device_data;
-  std::size_t _num_submitted_operations;
   std::vector<inorder_queue*> _managed_queues;
   backend_id _backend;
 };
@@ -182,7 +181,7 @@ class lazily_constructed_executor {
 public:
   template<class Factory>
   lazily_constructed_executor(Factory&& F)
-  : _factory{std::forward<Factory>(F)}, _is_initialized{false} {}
+  : _is_initialized{false}, _factory{std::forward<Factory>(F)} {}
 
   Executor* get() {
     if(_is_initialized.load(std::memory_order_acquire))

--- a/include/hipSYCL/runtime/util.hpp
+++ b/include/hipSYCL/runtime/util.hpp
@@ -59,10 +59,7 @@ U* cast(T* val)
 
 template <int Dim> class static_array {
 public:
-
   static_array() = default;
-  static_array(const static_array &other) : _data{other._data} {}
-
 
   static_array(std::size_t dim0) {
     for (int i = 0; i < Dim; ++i)

--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -79,9 +79,9 @@ add_library(acpp-clang SHARED
 
 target_include_directories(acpp-clang PRIVATE
   ../../include
-  ${LLVM_INCLUDE_DIRS}
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_BINARY_DIR}/include)
+target_include_directories(acpp-clang SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS})
 
 target_compile_definitions(acpp-clang PRIVATE
   ${LLVM_DEFINITIONS} -DHIPSYCL_COMPILER_COMPONENT)

--- a/src/compiler/cbs/IRUtils.cpp
+++ b/src/compiler/cbs/IRUtils.cpp
@@ -371,7 +371,7 @@ void arrayifyAllocas(llvm::BasicBlock *EntryBlock, llvm::Loop &L, llvm::Value *I
   llvm::SmallVector<llvm::AllocaInst *, 8> WL;
   for (auto &I : *EntryBlock) {
     if (auto *Alloca = llvm::dyn_cast<llvm::AllocaInst>(&I)) {
-      if (llvm::MDNode *MD = Alloca->getMetadata(hipsycl::compiler::MDKind::Arrayified))
+      if (Alloca->getMetadata(hipsycl::compiler::MDKind::Arrayified))
         continue; // already arrayificated
       if (!std::all_of(Alloca->user_begin(), Alloca->user_end(), [&LoopBlocks](llvm::User *User) {
             auto *Inst = llvm::dyn_cast<llvm::Instruction>(User);

--- a/src/compiler/cbs/SubCfgFormation.cpp
+++ b/src/compiler/cbs/SubCfgFormation.cpp
@@ -404,9 +404,10 @@ SubCFG::createExitWithID(llvm::detail::DenseMapPair<llvm::BasicBlock *, size_t> 
 SubCFG::SubCFG(llvm::BasicBlock *EntryBarrier, llvm::AllocaInst *LastBarrierIdStorage,
                const llvm::DenseMap<llvm::BasicBlock *, size_t> &BarrierIds,
                const SplitterAnnotationInfo &SAA, llvm::Value *IndVar, size_t Dim)
-    : LastBarrierIdStorage_(LastBarrierIdStorage), EntryId_(BarrierIds.lookup(EntryBarrier)),
-      EntryBarrier_(EntryBarrier), EntryBB_(EntryBarrier->getSingleSuccessor()), LoadBB_(nullptr),
-      ContIdx_(IndVar), PreHeader_(nullptr), Dim(Dim) {
+    : EntryId_(BarrierIds.lookup(EntryBarrier)), EntryBarrier_(EntryBarrier),
+      LastBarrierIdStorage_(LastBarrierIdStorage),
+      ContIdx_(IndVar), EntryBB_(EntryBarrier->getSingleSuccessor()),
+      LoadBB_(nullptr), PreHeader_(nullptr), Dim(Dim) {
   assert(ContIdx_ && "Must have found __hipsycl_local_id_{x,y,z}");
 
   llvm::SmallVector<llvm::BasicBlock *, 4> WL{EntryBarrier};
@@ -612,7 +613,7 @@ void SubCFG::arrayifyMultiSubCfgValues(
       if (InstAllocaMap.lookup(&I))
         continue;
       // if any use is in another subcfg
-      if (utils::anyOfUsers<llvm::Instruction>(&I, [&OtherCFGBlocks, this, &I](auto *UI) {
+      if (utils::anyOfUsers<llvm::Instruction>(&I, [&OtherCFGBlocks, &I](auto *UI) {
             return UI->getParent() != I.getParent() && OtherCFGBlocks.contains(UI->getParent());
           })) {
         // load from an alloca, just widen alloca

--- a/src/compiler/cbs/UniformityAnalysis.cpp
+++ b/src/compiler/cbs/UniformityAnalysis.cpp
@@ -377,20 +377,20 @@ void VectorizationAnalysis::analyze() {
   }
 }
 
-static bool AllUniformOrUndefCall(const VectorizationInfo &VecInfo, const Instruction &I) {
-  const auto *C = dyn_cast<CallInst>(&I);
-  if (!C)
-    return false;
-  for (const llvm::Value *Op : C->args()) {
-    if (!VecInfo.hasKnownShape(*Op))
-      continue;
-    auto OpShape = VecInfo.getVectorShape(*Op);
-    if (OpShape.isUniform() || !OpShape.isDefined())
-      continue;
-    return false;
-  }
-  return true;
-}
+// static bool AllUniformOrUndefCall(const VectorizationInfo &VecInfo, const Instruction &I) {
+//   const auto *C = dyn_cast<CallInst>(&I);
+//   if (!C)
+//     return false;
+//   for (const llvm::Value *Op : C->args()) {
+//     if (!VecInfo.hasKnownShape(*Op))
+//       continue;
+//     auto OpShape = VecInfo.getVectorShape(*Op);
+//     if (OpShape.isUniform() || !OpShape.isDefined())
+//       continue;
+//     return false;
+//   }
+//   return true;
+// }
 
 void VectorizationAnalysis::promoteUndefShapesToUniform(const Function &F) {
   // Walk through the program and query recursive resolvers for all completly

--- a/src/compiler/cbs/VectorShapeTransformer.cpp
+++ b/src/compiler/cbs/VectorShapeTransformer.cpp
@@ -56,7 +56,7 @@ VectorShape VectorShapeTransformer::getObservedShape(const BasicBlock &observerB
   return vecInfo.getObservedShape(LI, observerBlock, val);
 }
 
-static Type *getElementType(Type *Ty) {
+[[maybe_unused]] static Type *getElementType(Type *Ty) {
   if (auto VecTy = dyn_cast<VectorType>(Ty)) {
     return VecTy->getElementType();
   }

--- a/src/compiler/cbs/VectorizationInfo.cpp
+++ b/src/compiler/cbs/VectorizationInfo.cpp
@@ -143,7 +143,7 @@ void VectorizationInfo::print(llvm::raw_ostream &out) const {
 }
 
 VectorizationInfo::VectorizationInfo(llvm::Function &scalarFn, Region &_region)
-    : scalarFn(scalarFn), DL(scalarFn.getParent()->getDataLayout()), region(_region) {
+    : DL(scalarFn.getParent()->getDataLayout()), region(_region), scalarFn(scalarFn) {
   for (auto &arg : scalarFn.args()) {
     //    RV_UNUSED(arg);
     setPinned(arg);

--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 set(LLVM_TO_BACKEND_INCLUDE_DIRS 
   ../../../include
-  ${LLVM_INCLUDE_DIRS}
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_BINARY_DIR}/include)
 
@@ -25,6 +24,7 @@ function(create_llvm_based_library)
 
   target_include_directories(${target} PRIVATE
     ${LLVM_TO_BACKEND_INCLUDE_DIRS})
+  target_include_directories(${target} SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS})
   
   target_compile_definitions(${target} PRIVATE ${LLVM_DEFINITIONS} -DHIPSYCL_COMPILER_COMPONENT)
   find_library(LLVM_LIBRARY NAMES LLVM HINTS ${LLVM_LIBRARY_DIRS})
@@ -74,6 +74,7 @@ function(create_llvm_to_backend_tool)
 
   target_include_directories(${target}-tool PRIVATE
     ${LLVM_TO_BACKEND_INCLUDE_DIRS})
+  target_include_directories(${target}-tool SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS})
   
   target_compile_definitions(${target}-tool PRIVATE ${LLVM_DEFINITIONS} -DHIPSYCL_TOOL_COMPONENT)
   target_link_libraries(${target}-tool PRIVATE ${target})

--- a/src/compiler/reflection/IntrospectStructPass.cpp
+++ b/src/compiler/reflection/IntrospectStructPass.cpp
@@ -224,7 +224,7 @@ llvm::PreservedAnalyses IntrospectStructPass::run(llvm::Module& M, llvm::ModuleA
                   << " is invalid; argument is not a pointer type. Ingoring call.\n";
               return;
             }
-            llvm::StoreInst *S =
+            [[maybe_unused]] llvm::StoreInst *S =
                 new llvm::StoreInst(GV, CI->getArgOperand(ArgIndex), CI);
           };
 

--- a/src/compiler/sscp/AggregateArgumentExpansionPass.cpp
+++ b/src/compiler/sscp/AggregateArgumentExpansionPass.cpp
@@ -159,13 +159,8 @@ void ExpandAggregateArguments(llvm::Module &M, llvm::Function &F,
 
           llvm::ArrayRef<llvm::Value *> GEPIndicesRef{GEPIndices};
 
-          auto *GEPInst = llvm::GetElementPtrInst::CreateInBounds(
-              EI.OriginalByValType, Alloca, llvm::ArrayRef<llvm::Value *>{GEPIndicesRef}, "", BB);
           // Store expanded argument into allocated space
           assert(CurrentNewIndex + j < NewF->getFunctionType()->getNumParams());
-          
-          auto *StoredVal = NewF->getArg(CurrentNewIndex + j);
-          auto *StoreInst = new llvm::StoreInst(StoredVal, GEPInst, BB);
 
           // Store the indexed offset - runtimes can use this information later
           // when invoking the function.

--- a/src/compiler/sscp/AggregateArgumentExpansionPass.cpp
+++ b/src/compiler/sscp/AggregateArgumentExpansionPass.cpp
@@ -159,8 +159,13 @@ void ExpandAggregateArguments(llvm::Module &M, llvm::Function &F,
 
           llvm::ArrayRef<llvm::Value *> GEPIndicesRef{GEPIndices};
 
+          auto *GEPInst = llvm::GetElementPtrInst::CreateInBounds(
+              EI.OriginalByValType, Alloca, llvm::ArrayRef<llvm::Value *>{GEPIndicesRef}, "", BB);
           // Store expanded argument into allocated space
           assert(CurrentNewIndex + j < NewF->getFunctionType()->getNumParams());
+
+          auto *StoredVal = NewF->getArg(CurrentNewIndex + j);
+          auto *StoreInst = new llvm::StoreInst(StoredVal, GEPInst, BB);
 
           // Store the indexed offset - runtimes can use this information later
           // when invoking the function.

--- a/src/compiler/sscp/AggregateArgumentExpansionPass.cpp
+++ b/src/compiler/sscp/AggregateArgumentExpansionPass.cpp
@@ -165,7 +165,7 @@ void ExpandAggregateArguments(llvm::Module &M, llvm::Function &F,
           assert(CurrentNewIndex + j < NewF->getFunctionType()->getNumParams());
 
           auto *StoredVal = NewF->getArg(CurrentNewIndex + j);
-          auto *StoreInst = new llvm::StoreInst(StoredVal, GEPInst, BB);
+          [[maybe_unused]] auto *StoreInst = new llvm::StoreInst(StoredVal, GEPInst, BB);
 
           // Store the indexed offset - runtimes can use this information later
           // when invoking the function.

--- a/src/compiler/sscp/KernelOutliningPass.cpp
+++ b/src/compiler/sscp/KernelOutliningPass.cpp
@@ -97,7 +97,7 @@ public:
   llvm::Type* run(llvm::Function* F, int ArgNo) {
     VisitedUsers.clear();
     if(llvm::Value* Arg = F->getArg(ArgNo)) {
-      if(llvm::PointerType* PT = llvm::dyn_cast<llvm::PointerType>(Arg->getType())) {
+      if(llvm::dyn_cast<llvm::PointerType>(Arg->getType())) {
 
         // If either byval or byref attributes are present, we can just look up
         // the pointee type directly.
@@ -157,7 +157,7 @@ private:
         Scores[GEPI->getSourceElementType()] = CurrentScore - 1;
       } else if (auto EEI = llvm::dyn_cast<llvm::ExtractElementInst>(Current)) {
         Scores[EEI->getVectorOperand()->getType()] = CurrentScore - 2;
-      } else if (auto ACI = llvm::dyn_cast<llvm::AddrSpaceCastInst>(Current)) {
+      } else if (llvm::dyn_cast<llvm::AddrSpaceCastInst>(Current)) {
         // Follow address space casts, we don't care about pointer address spaces
         rankUsers(Current, Scores, CurrentScore);
       } else if(auto CI = llvm::dyn_cast<llvm::CallBase>(Current)) {

--- a/src/compiler/sscp/TargetSeparationPass.cpp
+++ b/src/compiler/sscp/TargetSeparationPass.cpp
@@ -60,7 +60,7 @@ namespace compiler {
 class Timer {
 public:
   Timer(llvm::StringRef Name, bool PrintAtDestruction = false, llvm::StringRef Description = "")
-  : Name{Name}, Print{PrintAtDestruction}, Description{Description} {
+  : Print{PrintAtDestruction}, Name{Name}, Description{Description} {
     Start = std::chrono::high_resolution_clock::now();;
     IsRunning = true;
   }

--- a/src/runtime/backend_loader.cpp
+++ b/src/runtime/backend_loader.cpp
@@ -47,7 +47,7 @@ namespace {
 
 void close_plugin(void *handle) {
 #ifndef _WIN32
-  if (int err = dlclose(handle)) {
+  if (dlclose(handle)) {
     HIPSYCL_DEBUG_ERROR << "backend_loader: dlclose() failed" << std::endl;
   }
 #else

--- a/src/runtime/cuda/cuda_code_object.cpp
+++ b/src/runtime/cuda/cuda_code_object.cpp
@@ -236,7 +236,7 @@ cuda_sscp_executable_object::cuda_sscp_executable_object(
     hcf_object_id hcf_source, const std::vector<std::string> &kernel_names,
     int device, const glue::kernel_configuration &config)
     : _target_arch{target_arch}, _hcf{hcf_source}, _kernel_names{kernel_names},
-      _device{device}, _id{config.generate_id()}, _module{nullptr} {
+      _id{config.generate_id()}, _device{device}, _module{nullptr} {
   _build_result = build(ptx_source);
 }
 

--- a/src/runtime/cuda/cuda_queue.cpp
+++ b/src/runtime/cuda/cuda_queue.cpp
@@ -182,8 +182,9 @@ void cuda_queue::activate_device() const {
 }
 
 cuda_queue::cuda_queue(cuda_backend *be, device_id dev, int priority)
-    : _dev{dev}, _multipass_code_object_invoker{this},
-      _sscp_code_object_invoker{this}, _stream{nullptr}, _backend{be},
+    : _dev{dev}, _stream{nullptr},
+      _multipass_code_object_invoker{this},
+      _sscp_code_object_invoker{this}, _backend{be},
       _kernel_cache{kernel_cache::get()} {
   this->activate_device();
 
@@ -322,7 +323,7 @@ result cuda_queue::submit_memcpy(memcpy_operation & op, dag_node_ptr node) {
     
   } else {
     
-    cudaMemcpy3DParms params = {0};
+    cudaMemcpy3DParms params {};
     params.srcPtr = make_cudaPitchedPtr(op.source().get_access_ptr(),
                                         op.source().get_allocation_shape()[2] *
                                             op.source().get_element_size(),

--- a/src/runtime/data.cpp
+++ b/src/runtime/data.cpp
@@ -78,7 +78,7 @@ void data_user_tracker::release_dead_users()
 {
   std::lock_guard<std::mutex> lock{_lock};
   _users.erase(std::remove_if(_users.begin(), _users.end(),
-                              [this](const data_user &user) -> bool {
+                              [](const data_user &user) -> bool {
                                 auto u = user.user.lock();
                                 if (!u)
                                   return true;
@@ -93,20 +93,18 @@ range_store::range_store(range<3> size)
 
 void range_store::add(const rect& r)
 {
-  this->for_each_element_in_range(r, 
-    [this](id<3>, data_state& s){
-      
-    s = data_state::available;
-  });
+  this->for_each_element_in_range(r,
+    [](id<3>, data_state& s){
+      s = data_state::available;
+    });
 }
 
 void range_store::remove(const rect& r)
 {
   this->for_each_element_in_range(r, 
-    [this](id<3>, data_state& s){
-
-    s = data_state::empty;
-  });
+    [](id<3>, data_state& s){
+      s = data_state::empty;
+    });
 }
 
 range<3> range_store::get_size() const

--- a/src/runtime/multi_queue_executor.cpp
+++ b/src/runtime/multi_queue_executor.cpp
@@ -115,7 +115,7 @@ std::size_t determine_target_lane(dag_node_ptr node,
 
 multi_queue_executor::multi_queue_executor(
     const backend &b, queue_factory_function queue_factory)
-    : _num_submitted_operations{0}, _backend{b.get_unique_backend_id()} {
+    : _backend{b.get_unique_backend_id()} {
   std::size_t num_devices = b.get_hardware_manager()->get_num_devices();
 
 

--- a/src/runtime/omp/omp_backend.cpp
+++ b/src/runtime/omp/omp_backend.cpp
@@ -61,7 +61,7 @@ std::unique_ptr<inorder_queue> make_omp_queue(device_id dev) {
 
 std::unique_ptr<multi_queue_executor>
 create_multi_queue_executor(omp_backend *b) {
-  return std::make_unique<multi_queue_executor>(*b, [b](device_id dev) {
+  return std::make_unique<multi_queue_executor>(*b, [](device_id dev) {
     return make_omp_queue(dev);
   });
 }


### PR DESCRIPTION
When building AdaptiveCpp with `-Wall -Wextra -Wpedantic -pedantic`, a lot of warnings are emitted (such as: order of initialisation in constructor initialisier lists, unused lambda captures, unused variables, not defining assignment operators even though a copy constructor was explicitly defined etc.).
This PR introduces some changes that silence _some_ warnings. There are still a lot of warnings concerning comparison of integers of different signs and unused parameters. Most of the unused parameters are in methods that override some virtual method of a base class and thus need to have certain arguments. We could consider adding `[[maybe_unused]]` or removing the parameter's name for them. Regarding the sign-compare warnings: I think they should also be fixed at some point but there are quite a lot of them (~200), so I didn't feel like going through and fixing them all yet. 

Now, compiling with `-Wall -Wextra -Wpedantic -pedantic -Wno-sign-compare -Wno-unused-parameter` compiles ~_almost_~ without warnings.~, there is one warning left about an unused variable where I'm not sure if it can just be removed or if there's some additional logic missing. 
The unused variable is [here](https://github.com/AdaptiveCpp/AdaptiveCpp/blob/5a466f115446888b7265e9c4ed977a9f16547c58/src/compiler/reflection/IntrospectStructPass.cpp#L227), and I think it can be removed (actually the whole branch starting [here](https://github.com/AdaptiveCpp/AdaptiveCpp/blob/5a466f115446888b7265e9c4ed977a9f16547c58/src/compiler/reflection/IntrospectStructPass.cpp#L215)).~

Just ignore this :D I guess the variable can be removed, but the constructor will already insert the created instruction  somewhere so that no additional `instructions->AddInst()` or something similar has to be called?

