### PR TITLE
Document release schedule in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,17 +6,26 @@ When in doubt about how to implement something or how to integrate with the over
 
 Please take note of the branch structure of the project. The following are important branches:
 
-* `stable` - contains latest AdaptiveCpp with additional testing. `stable` should always contain a version of AdaptiveCpp that we are confident is stable.
+* `stable` - contains latest AdaptiveCpp release.
 * `develop` - contains latest development version.
 * `sycl/VERSION` - contains AdaptiveCpp code that targets a specific SYCL version.
-   - `sycl/1.2.1` - contains latest AdaptiveCpp targeting SYCL 1.2.1. This branch is now mainly in maintenance mode. If you want to specifically improve AdaptiveCpp SYCL 1.2.1 support, please use this branch.
+   - `sycl/1.2.1` - contains latest AdaptiveCpp targeting SYCL 1.2.1. This branch is now mainly in maintenance mode and not updated anymore.
    - `sycl/2020` - contains latest AdaptiveCpp work targeting SYCL 2020, and any work that is not specific to earlier SYCL versions.
 
 We periodically perform the following merges:
 * `develop` -> `sycl/<latest-version>` -> `stable`
 
 
-Please follow the following guidelines:
-* **File your PR against the `develop` branch, unless you are specifically targeting an earlier SYCL version.**
-* **If you are targeting an earlier SYCL version, target the appropriate `sycl/<version>` branch**
+Please files PRs against the `develop` branch.
+
+# Release schedule
+
+AdaptiveCpp follows a regular release schedule with 4-month cadence:
+
+* `year.02` (released at the end of February)
+* `year.06` (released at the end of June)
+* `year.10` (released at the end of October)
+
+In the last week prior to release, no new features should be added and focus should be on bug fixes.
+In the last two weeks prior to release, new features should only be added for components of the stack that are still under heavy development (e.g. the SSCP compiler or stdpar support).
    


### PR DESCRIPTION
Adds documentation on the planned release schedule (feb, june, oct). Not sure whether `contributing.md` is the right place, but I'm not sure we have something better.