### PR TITLE
Add test case for #1276

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -88,7 +88,7 @@ jobs:
       run: |
         mkdir ${GITHUB_WORKSPACE}/build/tests-cpu
         cd ${GITHUB_WORKSPACE}/build/tests-cpu
-        cmake -DACPP_TARGETS="omp" -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp ${GITHUB_WORKSPACE}/tests
+        cmake -DACPP_TARGETS="omp" -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp ${GITHUB_WORKSPACE}/tests -DWITH_COMPILER_LAUNCHER_TEST=On
         make -j2
     - name: build generic SSCP tests
       if: matrix.clang >= 14
@@ -119,6 +119,12 @@ jobs:
       run: |
         cd ${GITHUB_WORKSPACE}/build/tests-cpu
         LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ./sycl_tests
+    - name: run compiler launcher test
+      run: |
+        cd ${GITHUB_WORKSPACE}/build/tests-cpu
+        make clean
+        make compiler_launcher_test > output.txt
+        grep "Hello from compiler launcher" output.txt
   test-nvcxx-based:
     name: nvcxx ${{matrix.nvhpc}}, ${{matrix.os}}, CUDA ${{matrix.cuda}}
     runs-on: ${{ matrix.os }}

--- a/bin/acpp
+++ b/bin/acpp
@@ -2036,7 +2036,7 @@ if __name__ == '__main__':
       if not config.has_optimization_flag():
         print_warning("No optimization flag was given, optimizations are "
               "disabled by default. Performance may be degraded. Compile with e.g. -O2/-O3 to "
-              "enable optimizations.")
+              "enable optimizations.", file=sys.stderr)
     
     c = compiler(config)
     sys.exit(c.run())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -143,3 +143,7 @@ if(WITH_PSTL_TESTS)
 endif()
 
 add_subdirectory(compiler)
+
+if (WITH_COMPILER_LAUNCHER_TEST)
+  add_subdirectory(compiler_launcher)
+endif()

--- a/tests/compiler_launcher/CMakeLists.txt
+++ b/tests/compiler_launcher/CMakeLists.txt
@@ -1,0 +1,9 @@
+# First build our custom compiler launcher
+execute_process(COMMAND ${CMAKE_CXX_COMPILER} 
+                        ${CMAKE_CURRENT_SOURCE_DIR}/compiler_launcher.cc 
+                        -o ${CMAKE_BINARY_DIR}/compiler_launcher/compiler_launcher)
+
+set(CMAKE_CXX_COMPILER_LAUNCHER ${CMAKE_BINARY_DIR}/compiler_launcher/compiler_launcher)
+
+add_executable(compiler_launcher_test main.cc)
+add_sycl_to_target(TARGET compiler_launcher_test)

--- a/tests/compiler_launcher/compiler_launcher.cc
+++ b/tests/compiler_launcher/compiler_launcher.cc
@@ -1,0 +1,14 @@
+#include <cstdlib>
+#include <iostream>
+
+int main(int argc, char* argv[]) {
+  std::cout << "Hello from compiler launcher\n";
+
+  std::string command;
+  for (int i=1; i < argc; ++i) {
+    command += argv[i];
+    command += " ";
+  }
+
+  std::system(command.c_str());
+}

--- a/tests/compiler_launcher/main.cc
+++ b/tests/compiler_launcher/main.cc
@@ -1,0 +1,6 @@
+#include <iostream>
+#include <sycl/sycl.hpp>
+
+int main() {
+  std::cout << "Hello from SYCL program\n";
+}


### PR DESCRIPTION
This adds a test case for a compiler launcher as suggested [here](https://github.com/AdaptiveCpp/AdaptiveCpp/pull/1276#issuecomment-1929125743). I couldn't push to the base branch of the PR directly, so this depends on #1276. 