### PR TITLE
Align compilation flows by using -ffp-contract=fast by default

### DIFF
--- a/bin/acpp
+++ b/bin/acpp
@@ -865,6 +865,31 @@ class acpp_config:
   def common_compiler_args(self):
     return self._common_compiler_args
 
+
+  @property
+  def default_clang_optimization_args(self):
+    has_ffp_contract = False
+    opt_level = 0
+    opt_args = []
+
+    for arg in self._args:
+      if arg.startswith("-ffp-contract="):
+        has_ffp_contract = True
+      if arg.startswith("-O"):
+        ending = arg.replace("-O", "", 1)
+        if ending.isnumeric():
+          opt_level = int(ending)
+        elif ending == "fast":
+          opt_level = 3
+        else:
+          opt_level = 1
+
+    if opt_level > 1:
+      if not has_ffp_contract:
+        opt_args.append("-ffp-contract=fast")
+
+    return opt_args
+
   @property
   def acpp_include_path(self):
     return os.path.join(self.acpp_installation_path, "include", "AdaptiveCpp")
@@ -1639,6 +1664,9 @@ class compiler:
     self._is_stdpar = config.is_stdpar
     self._is_stdpar_system_usm = config.is_stdpar_system_usm
     self._is_stdpar_unconditional_offload = config.is_stdpar_unconditional_offload
+    self._clang_opt_args = config.default_clang_optimization_args
+    self._clang_path = config.clang_path
+
     try:
       self._stdpar_prefetch_mode = config.stdpar_prefetch_mode
     except OptionNotSet:
@@ -1941,6 +1969,9 @@ class compiler:
     cxx_flags = self.common_cxx_flags
     ld_flags = self.common_linker_flags
     compiler_executable = self._host_compiler
+
+    if compiler_executable == self._clang_path:
+      cxx_flags += self._clang_opt_args
 
     for backend_args in self._backends:
       cxx_flags += backend_args.get_cxx_flags()

--- a/bin/acpp
+++ b/bin/acpp
@@ -1665,7 +1665,10 @@ class compiler:
     self._is_stdpar_system_usm = config.is_stdpar_system_usm
     self._is_stdpar_unconditional_offload = config.is_stdpar_unconditional_offload
     self._clang_opt_args = config.default_clang_optimization_args
-    self._clang_path = config.clang_path
+    try:
+      self._clang_path = config.clang_path
+    except OptionNotSet:
+      self._clang_path = None
 
     try:
       self._stdpar_prefetch_mode = config.stdpar_prefetch_mode

--- a/bin/acpp
+++ b/bin/acpp
@@ -869,13 +869,16 @@ class acpp_config:
   @property
   def default_clang_optimization_args(self):
     has_ffp_contract = False
+    has_fast_math = False
     opt_level = 0
     opt_args = []
 
     for arg in self._args:
-      if arg.startswith("-ffp-contract="):
+      if arg == "-ffast-math":
+        has_fast_math = True
+      elif arg.startswith("-ffp-contract="):
         has_ffp_contract = True
-      if arg.startswith("-O"):
+      elif arg.startswith("-O"):
         ending = arg.replace("-O", "", 1)
         if ending.isnumeric():
           opt_level = int(ending)
@@ -885,7 +888,7 @@ class acpp_config:
           opt_level = 1
 
     if opt_level > 1:
-      if not has_ffp_contract:
+      if not has_fast_math and not has_ffp_contract:
         opt_args.append("-ffp-contract=fast")
 
     return opt_args


### PR DESCRIPTION
The clang CUDA/HIP toolchains, and by extension, our CUDA and HIP targets, by default compile with `-ffp-contract=fast`. This allows clang to emit FMA operations even for operations that are not part of the same statement.

`omp.accelerated` and `generic` however currently just do what clang does by default, which is `-ffp-contract=on`, which only allows FMA operations within the same statement.

These different defaults can cause noticable performance deltas for compute-intensive code. For the average user, it is very intransparent that this is just due to different defaults, and they might wrongly conclude e.g. that `--acpp-targets=generic` is slower than `--acpp-targets=cuda`, even when that is not necessarily the case.

This PR thus proposes to universally adopt `-ffp-contract=fast` if
* optimization level (via `-O`) is greater than 1
* We are compiling with clang. Other compilers may have different compiler flags, and different conventions about what is in included in `-O` flags. We could consider to also special-casing gcc and enabling it there too.

In other words, this PR aligns the default behavior of all clang-based compilation flows.
**Note that currently, with omp.library-only whether the flag is used depends on whether the host compiler is clang or gcc/some other compiler!**

Alternatively, we could also consider going the other route and disabling `-ffp-contract=fast` on CUDA/HIP to align them with the other flows. However, I believe that users might be surprised by a sudden performance drop when they upgrade AdaptiveCpp, or misinterpret AdaptiveCpp performance numbers when comparing to clang CUDA or clang HIP. So I believe it is better to have `-ffp-contract=fast` everywhere.

In an ideal world, none of this would be necessary as all of clang's toolchains would ideally just use the regular clang defaults and thus avoid surprises. Alas, clang CUDA and HIP have decided that they want to be different, so we have to deal with it.

Note that a similar discussion could also be had about `-ffast-math`, which the oneAPI SYCL compiler enables by default (and we don't, like every other sane compiler). I hate having `-ffast-math` enabled by default, but I'm also pretty certain that this is the explanation behind many cases where oneAPI leads AdaptiveCpp in benchmarks. Generally, these differences in default optimization flags are not widely known and rarely taken into account in my experience.

**For `omp.accelerated` and `generic` users, this PR might lead to substantial performance improvements as well as changes in the default rounding behavior.**

**For users of `hip` and `cuda` targets, this PR does not change anything compared to the current defaults.**
