### PR TITLE
[SSCP] Fix incorrect signature being used in calls to llvm.lifetime intrinsics

### DIFF
--- a/src/compiler/llvm-to-backend/AddressSpaceInferencePass.cpp
+++ b/src/compiler/llvm-to-backend/AddressSpaceInferencePass.cpp
@@ -159,7 +159,7 @@ llvm::PreservedAnalyses AddressSpaceInferencePass::run(llvm::Module &M,
                   llvm::SmallVector<llvm::Type*> IntrinsicType {NewAI->getType()};
                   llvm::Function *LifetimeIntrinsic =
                       llvm::Intrinsic::getDeclaration(&M, Id, IntrinsicType);
-                  llvm::SmallVector<llvm::Value*> CallArgs{NewAI};
+                  llvm::SmallVector<llvm::Value*> CallArgs{CB->getArgOperand(0), NewAI};
                   llvm::CallInst::Create(llvm::FunctionCallee(LifetimeIntrinsic), CallArgs, "", CB);
                 }
               }


### PR DESCRIPTION
Urgent hotfix due to regression from #1349 