### PR TITLE
[SSCP] Fully leverage -ffast-math

### DIFF
--- a/bin/acpp
+++ b/bin/acpp
@@ -1615,6 +1615,7 @@ class llvm_sscp_invocation:
   def __init__(self, config, targets):
     self._linker_args = []
     self._cxx_flags = []
+    self._config = config
 
     if len(targets) != 0:
       raise RuntimeError("LLVM SSCP backend does not support specifiying target architecture")
@@ -1636,10 +1637,18 @@ class llvm_sscp_invocation:
     flags = ["-D__HIPSYCL_ENABLE_LLVM_SSCP_TARGET__",
             "-Xclang", "-disable-O0-optnone", "-mllvm", "-hipsycl-sscp"]
 
+    sscp_compile_opts = []
+    if ("-Ofast" in self._config.forwarded_compiler_arguments or 
+      "-ffast-math" in self._config.forwarded_compiler_arguments):
+      sscp_compile_opts.append("fast-math")
+
+    if len(sscp_compile_opts) > 0:
+      flags += ["-mllvm", "-hipsycl-sscp-kernel-opts="+ ",".join(sscp_compile_opts)]
+
     if not sys.platform.startswith("win32"):
       flags += [
-        "-fplugin=" + config.acpp_plugin_path
-        , "-fpass-plugin=" + config.acpp_plugin_path
+        "-fplugin=" + self._config.acpp_plugin_path
+        , "-fpass-plugin=" + self._config.acpp_plugin_path
       ]
     flags += self._cxx_flags
 

--- a/include/hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp
@@ -205,6 +205,8 @@ protected:
   int KnownGroupSizeX = 0;
   int KnownGroupSizeY = 0;
   int KnownGroupSizeZ = 0;
+
+  bool IsFastMath = false;
 private:
   bool optimizeForKnownGroupSizes(llvm::Module& M, PassHandler& PH);
 

--- a/include/hipSYCL/compiler/llvm-to-backend/ptx/LLVMToPtx.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/ptx/LLVMToPtx.hpp
@@ -57,9 +57,9 @@ private:
   unsigned PtxVersion = 30;
   unsigned PtxTarget = 30;
 
-  int FlushDenormalsToZero = 0;
-  int PreciseSqrt = 1;
-  int PreciseDiv = 1;
+  int FlushDenormalsToZero = -1;
+  int PreciseSqrt = -1;
+  int PreciseDiv = -1;
 };
 
 }

--- a/include/hipSYCL/compiler/sscp/TargetSeparationPass.hpp
+++ b/include/hipSYCL/compiler/sscp/TargetSeparationPass.hpp
@@ -30,15 +30,20 @@
 #define HIPSYCL_TARGET_SEPARATION_PASS_HPP
 
 #include <llvm/IR/PassManager.h>
+#include <string>
+#include <vector>
 
 namespace hipsycl {
 namespace compiler {
 
 class TargetSeparationPass : public llvm::PassInfoMixin<TargetSeparationPass> {
 public:
+  TargetSeparationPass(const std::string& KernelCompilationOptions);
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
-
+private:
+  std::vector<std::string> CompilationFlags;
+  std::vector<std::pair<std::string, std::string>> CompilationOptions;
 };
 
 }

--- a/include/hipSYCL/runtime/kernel_cache.hpp
+++ b/include/hipSYCL/runtime/kernel_cache.hpp
@@ -114,12 +114,21 @@ public:
 
   const std::vector<std::string> &get_images_containing_kernel() const;
   hcf_object_id get_hcf_object_id() const;
+
+  const std::vector<std::string>& get_compilation_flags() const;
+  const std::vector<std::pair<std::string, std::string>> &
+  get_compilation_options() const;
+
 private:
   std::vector<std::size_t> _arg_offsets;
   std::vector<std::size_t> _arg_sizes;
   std::vector<std::size_t> _original_arg_indices;
   std::vector<argument_type> _arg_types;
   std::vector<std::string> _image_providers;
+  
+  std::vector<std::string> _compilation_flags;
+  std::vector<std::pair<std::string, std::string>> _compilation_options;
+
   hcf_object_id _id;
   bool _parsing_successful = false;
 };

--- a/include/hipSYCL/runtime/ocl/ocl_code_object.hpp
+++ b/include/hipSYCL/runtime/ocl/ocl_code_object.hpp
@@ -64,8 +64,9 @@ private:
 
 class ocl_executable_object : public code_object {
 public:
-  ocl_executable_object(const cl::Context& ctx, cl::Device& dev,
-    hcf_object_id source, const std::string& code_image, const glue::kernel_configuration &config);
+  ocl_executable_object(const cl::Context &ctx, cl::Device &dev,
+                        hcf_object_id source, const std::string &code_image,
+                        const glue::kernel_configuration &config);
   virtual ~ocl_executable_object();
 
   result get_build_result() const;

--- a/src/compiler/AdaptiveCppClangPlugin.cpp
+++ b/src/compiler/AdaptiveCppClangPlugin.cpp
@@ -66,7 +66,12 @@ namespace compiler {
 
 static llvm::cl::opt<bool> EnableLLVMSSCP{
     "hipsycl-sscp", llvm::cl::init(false),
-    llvm::cl::desc{"Enable hipSYCL LLVM SSCP compilation flow"}};
+    llvm::cl::desc{"Enable AdaptiveCpp LLVM SSCP compilation flow"}};
+
+static llvm::cl::opt<std::string> LLVMSSCPKernelOpts{
+    "hipsycl-sscp-kernel-opts", llvm::cl::init(""),
+    llvm::cl::desc{
+        "Specify compilation options to use when JIT-compiling AdaptiveCpp SSCP kernels"}};
 
 static llvm::cl::opt<bool> EnableStdPar{
     "hipsycl-stdpar", llvm::cl::init(false),
@@ -164,7 +169,7 @@ extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo llvmGetPassPluginIn
           if(EnableLLVMSSCP){
             PB.registerPipelineStartEPCallback(
                 [&](llvm::ModulePassManager &MPM, OptLevel Level) {
-                  MPM.addPass(TargetSeparationPass{});
+                  MPM.addPass(TargetSeparationPass{LLVMSSCPKernelOpts});
                 });
           }
 #endif

--- a/src/compiler/llvm-to-backend/LLVMToBackend.cpp
+++ b/src/compiler/llvm-to-backend/LLVMToBackend.cpp
@@ -139,15 +139,23 @@ bool applyKnownGroupSize(llvm::Module &M, PassHandler &PH, int KnownGroupSize,
 }
 
 void setFastMathFunctionAttribs(llvm::Module& M) {
+  auto forceAttr = [&](llvm::Function& F, llvm::StringRef Key, llvm::StringRef Value) {
+    if(F.hasFnAttribute(Key)) {
+      if(!F.getFnAttribute(Key).getValueAsString().equals(Value))
+        F.removeFnAttr(Key);
+    }
+    F.addFnAttr(Key, Value);
+  };
+
   for(auto& F : M) {
     if(!F.isIntrinsic()) {
-      F.addFnAttr("approx-func-fp-math","true");
-      F.addFnAttr("denormal-fp-math","preserve-sign,preserve-sign");
-      F.addFnAttr("no-infs-fp-math","true");
-      F.addFnAttr("no-nans-fp-math","true");
-      F.addFnAttr("no-signed-zeros-fp-math","true");
-      F.addFnAttr("no-trapping-math","true");
-      F.addFnAttr("unsafe-fp-math","true");
+      forceAttr(F, "approx-func-fp-math","true");
+      forceAttr(F, "denormal-fp-math","preserve-sign,preserve-sign");
+      forceAttr(F, "no-infs-fp-math","true");
+      forceAttr(F, "no-nans-fp-math","true");
+      forceAttr(F, "no-signed-zeros-fp-math","true");
+      forceAttr(F, "no-trapping-math","true");
+      forceAttr(F, "unsafe-fp-math","true");
     }
   }
 }

--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -141,7 +141,8 @@ public:
   static bool determineRequiredDeviceLibs(const std::string& RocmPath,
                                           const std::string& DeviceLibsPath,
                                           const std::string& TargetDevice,
-                                          std::vector<std::string>& BitcodeFiles) {
+                                          std::vector<std::string>& BitcodeFiles,
+                                          bool IsFastMath = false) {
     
 
     llvm::SmallVector<std::string> Invocation;
@@ -164,7 +165,8 @@ public:
       "--hip-link",
       "-###"
     };
-    
+    if(IsFastMath)
+      Invocation.push_back("-ffast-math");
     
     std::string Output;
     if(!getCommandOutput(ClangPath, Invocation, Output))
@@ -330,7 +332,7 @@ bool LLVMToAmdgpuTranslator::hiprtcJitLink(const std::string &Bitcode, std::stri
 
   std::vector<std::string> DeviceLibs;
   RocmDeviceLibs::determineRequiredDeviceLibs(RocmPath, RocmDeviceLibsPath, TargetDevice,
-                                              DeviceLibs);
+                                              DeviceLibs, IsFastMath);
   for(const auto& Lib : DeviceLibs) {
     HIPSYCL_DEBUG_INFO << "LLVMToAmdgpu: Linking with bitcode file: " << Lib << "\n";
     addBitcodeFile(Lib);

--- a/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
+++ b/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
@@ -103,40 +103,27 @@ private:
   bool IsFound;
 };
 
-void setFTZMode(llvm::Module& M, int Mode) {
-  
+void setNVVMReflectParameter(llvm::Module& M, llvm::StringRef Name, int Value) {
   llvm::SmallVector<llvm::Metadata*, 4> Metadata;
   Metadata.push_back(llvm::ValueAsMetadata::getConstant(
           llvm::ConstantInt::get(llvm::Type::getInt32Ty(M.getContext()), 4)));
-  Metadata.push_back(llvm::MDString::get(M.getContext(), "nvvm-reflect-ftz"));
+  Metadata.push_back(llvm::MDString::get(M.getContext(), "nvvm-reflect-" + std::string{Name}));
   Metadata.push_back(llvm::ValueAsMetadata::getConstant(
-          llvm::ConstantInt::get(llvm::Type::getInt32Ty(M.getContext()), Mode)));
+          llvm::ConstantInt::get(llvm::Type::getInt32Ty(M.getContext()), Value)));
 
-  M.getModuleFlagsMetadata()->addOperand(llvm::MDTuple::get(M.getContext(), Metadata));
+  M.getModuleFlagsMetadata()->addOperand(llvm::MDTuple::get(M.getContext(), Metadata)); 
+}
+
+void setFTZMode(llvm::Module& M, int Mode) {
+  setNVVMReflectParameter(M, "ftz", Mode);
 }
 
 void setPrecDiv(llvm::Module& M, int Mode) {
-  
-  llvm::SmallVector<llvm::Metadata*, 4> Metadata;
-  Metadata.push_back(llvm::ValueAsMetadata::getConstant(
-          llvm::ConstantInt::get(llvm::Type::getInt32Ty(M.getContext()), 4)));
-  Metadata.push_back(llvm::MDString::get(M.getContext(), "nvvm-prec-div"));
-  Metadata.push_back(llvm::ValueAsMetadata::getConstant(
-          llvm::ConstantInt::get(llvm::Type::getInt32Ty(M.getContext()), Mode)));
-
-  M.getModuleFlagsMetadata()->addOperand(llvm::MDTuple::get(M.getContext(), Metadata));
+  setNVVMReflectParameter(M, "prec-div", Mode);
 }
 
 void setPrecSqrt(llvm::Module& M, int Mode) {
-  
-  llvm::SmallVector<llvm::Metadata*, 4> Metadata;
-  Metadata.push_back(llvm::ValueAsMetadata::getConstant(
-          llvm::ConstantInt::get(llvm::Type::getInt32Ty(M.getContext()), 4)));
-  Metadata.push_back(llvm::MDString::get(M.getContext(), "nvvm-prec-sqrt"));
-  Metadata.push_back(llvm::ValueAsMetadata::getConstant(
-          llvm::ConstantInt::get(llvm::Type::getInt32Ty(M.getContext()), Mode)));
-
-  M.getModuleFlagsMetadata()->addOperand(llvm::MDTuple::get(M.getContext(), Metadata));
+  setNVVMReflectParameter(M, "prec-sqrt", Mode);
 }
 
 }
@@ -153,6 +140,15 @@ bool LLVMToPtxTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
 
   M.setTargetTriple(Triple);
   M.setDataLayout(DataLayout);
+
+  // Initialize libdevice parameters. These values are < 0 in case no explicit
+  // setting has been done.
+  if(FlushDenormalsToZero < 0)
+    FlushDenormalsToZero = IsFastMath ? 1 : 0;
+  if(PreciseDiv < 0)
+    PreciseDiv = IsFastMath ? 0 : 1;
+  if(PreciseSqrt < 0)
+    PreciseSqrt = IsFastMath ? 0 : 1;
 
   setFTZMode(M, FlushDenormalsToZero);
   setPrecDiv(M, PreciseDiv);
@@ -274,6 +270,8 @@ bool LLVMToPtxTranslator::translateToBackendFormat(llvm::Module &FlavoredModule,
                                                     "-o",
                                                     OutputFilename,
                                                     InputFile->TmpName};
+  if(IsFastMath)
+    Invocation.push_back("-ffast-math");
 
   std::string ArgString;
   for(const auto& S : Invocation) {

--- a/src/runtime/cuda/cuda_queue.cpp
+++ b/src/runtime/cuda/cuda_queue.cpp
@@ -618,6 +618,10 @@ result cuda_queue::submit_sscp_kernel_from_code_object(
   config.append_base_configuration(
       glue::kernel_base_config_parameter::hcf_object_id, hcf_object);
   
+  for(const auto& flag : kernel_info->get_compilation_flags())
+    config.set_build_flag(flag);
+  for(const auto& opt : kernel_info->get_compilation_options())
+    config.set_build_option(opt.first, opt.second);
   // TODO This is incorrect, we should attempt to find a better way to determine
   // the right ptx version
   config.set_build_option("ptx-version", compute_capability);

--- a/src/runtime/hip/hip_queue.cpp
+++ b/src/runtime/hip/hip_queue.cpp
@@ -623,6 +623,11 @@ result hip_queue::submit_sscp_kernel_from_code_object(
   config.append_base_configuration(
       glue::kernel_base_config_parameter::hcf_object_id, hcf_object);
 
+  for(const auto& flag : kernel_info->get_compilation_flags())
+    config.set_build_flag(flag);
+  for(const auto& opt : kernel_info->get_compilation_options())
+    config.set_build_option(opt.first, opt.second);
+  
   config.set_build_option("amdgpu-target-device", target_arch_name);
   
   auto binary_configuration_id = adaptivity_engine.finalize_binary_configuration(config);

--- a/src/runtime/kernel_cache.cpp
+++ b/src/runtime/kernel_cache.cpp
@@ -111,6 +111,17 @@ hcf_kernel_info::hcf_kernel_info(
     _original_arg_indices.push_back(arg_original_index);
   }
 
+  if(const auto* flags_node = kernel_node->get_subnode("compile-flags")) {
+    for(const auto& flag : flags_node->key_value_pairs) {
+      _compilation_flags.push_back(flag.first);
+    }
+  }
+  if(const auto* options_node = kernel_node->get_subnode("compile-options")) {
+    for(const auto& flag : options_node->key_value_pairs) {
+      _compilation_flags.push_back(flag.first);
+    }
+  }
+
   _parsing_successful = true;
 }
 
@@ -146,6 +157,15 @@ hcf_kernel_info::get_images_containing_kernel() const {
 
 hcf_object_id hcf_kernel_info::get_hcf_object_id() const {
   return _id;
+}
+
+const std::vector<std::string> &hcf_kernel_info::get_compilation_flags() const {
+  return _compilation_flags;
+}
+
+const std::vector<std::pair<std::string, std::string>> &
+hcf_kernel_info::get_compilation_options() const {
+  return _compilation_options;
 }
 
 const std::string& hcf_image_info::get_format() const {

--- a/src/runtime/ocl/ocl_code_object.cpp
+++ b/src/runtime/ocl/ocl_code_object.cpp
@@ -66,9 +66,16 @@ ocl_executable_object::ocl_executable_object(const cl::Context& ctx, cl::Device&
                    error_code{"CL", static_cast<int>(err)}});
     return;
   }
+  
+  std::string options_string="-cl-uniform-work-group-size";
+  for(const auto& flag : config.build_flags()) {
+    if(flag == "fast-math") {
+      options_string += " -cl-fast-relaxed-math";
+    }
+  }
 
   err = _program.build(
-      _dev, nullptr /*options - we may want to expose that in the future*/);
+      _dev, options_string.c_str());
 
   if(err != CL_SUCCESS) {
     std::string build_log = "<build log not available>";

--- a/src/runtime/ocl/ocl_queue.cpp
+++ b/src/runtime/ocl/ocl_queue.cpp
@@ -444,6 +444,11 @@ result ocl_queue::submit_sscp_kernel_from_code_object(
   config.append_base_configuration(
       glue::kernel_base_config_parameter::hcf_object_id, hcf_object);
 
+  for(const auto& flag : kernel_info->get_compilation_flags())
+    config.set_build_flag(flag);
+  for(const auto& opt : kernel_info->get_compilation_options())
+    config.set_build_option(opt.first, opt.second);
+
   config.set_build_option("spirv-dynamic-local-mem-allocation-size", local_mem_size);
 
   // TODO: Enable this if we are on Intel

--- a/src/runtime/ze/ze_queue.cpp
+++ b/src/runtime/ze/ze_queue.cpp
@@ -587,6 +587,11 @@ result ze_queue::submit_sscp_kernel_from_code_object(
   config.append_base_configuration(
       glue::kernel_base_config_parameter::hcf_object_id, hcf_object);
   
+  for(const auto& flag : kernel_info->get_compilation_flags())
+    config.set_build_flag(flag);
+  for(const auto& opt : kernel_info->get_compilation_options())
+    config.set_build_option(opt.first, opt.second);
+  
   config.set_build_option("spirv-dynamic-local-mem-allocation-size", local_mem_size);
   config.set_build_flag("enable-intel-llvm-spirv-options");
 


### PR DESCRIPTION
Currently, SSCP does not completely leverage the `-ffast-math` flag if it was provided by users, because the information about fast math is not propagated to JIT time.

This PR
* Adds a mechanism to let `acpp` inform the stage 1 SSCP compiler that fast-math is used;
* Adds logic for the stage 1 SSCP compiler to embed information about optimization flags relevant for JIT in the HCF;
* Add support for backends to access optimization flags from the HCF and pass it to the llvm-to-backend infrastructure at JIT time;
* Add support for the new `fast-math` build option to the llvm-to-backend infrastructure, attaching corresponding fast math LLVM attributes to all functions prior to the optimization pipeline;
* Add backend-specific handling to `fast-math`, including e.g. linking optimized fast-math device libraries.

The fast math code path is implemented on all backends except Level Zero, where a fast-math build option does not seem to be documented.

This PR substanially improves performance for `-ffast-math` code for all SSCP users.
On Radeon Pro VII and RTX A5000, SSCP+fast-math now outperforms cuda/hip+fast-math compilation flows.

CC @VileLasagna 
