### PR TITLE
cmake: add src subdirectory later so that rt can access cmake variables

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -118,7 +118,7 @@ jobs:
     - name: run CPU tests
       run: |
         cd ${GITHUB_WORKSPACE}/build/tests-cpu
-        LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ./sycl_tests
+        ACPP_VISIBILITY_MASK="omp" LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ./sycl_tests
   test-nvcxx-based:
     name: nvcxx ${{matrix.nvhpc}}, ${{matrix.os}}, CUDA ${{matrix.cuda}}
     runs-on: ${{ matrix.os }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,8 +295,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_subdirectory(src)
-
 set(ACPP_CONFIG_FILE_PATH "${PROJECT_BINARY_DIR}")
 set(ACPP_CONFIG_FILE_GLOBAL_INSTALLATION false CACHE BOOL 
   "Whether to install the AdaptiveCpp configuration files into a global directory (typically, /etc/AdaptiveCpp). This is generally not recommended.")
@@ -469,6 +467,12 @@ if(NOT DEFAULT_TARGETS)
 endif()
 
 message(STATUS "Default compilation target(s): ${DEFAULT_TARGETS}")
+
+##########################################################
+## Do not define any variables that might be used by build
+## targets below this line.
+##########################################################
+add_subdirectory(src)
 
 
 set(ACPP_CORE_CONFIG_FILE "{

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,12 @@ endif()
 
 set(ROCM_LIBS "-L${ROCM_PATH}/lib -L${ROCM_PATH}/hip/lib -lamdhip64" CACHE STRING "Necessary libraries for ROCm")
 
+##########################################################
+## Do not define any variables that might be used by build
+## targets below this line.
+##########################################################
+add_subdirectory(src)
+
 set(DEFAULT_WIN32_CUDA_LINK_LINE "-L$HIPSYCL_CUDA_LIB_PATH -lcudart")
 set(DEFAULT_CUDA_LINK_LINE "-Wl,-rpath=$HIPSYCL_CUDA_LIB_PATH -L$HIPSYCL_CUDA_LIB_PATH -lcudart")
 
@@ -467,12 +473,6 @@ if(NOT DEFAULT_TARGETS)
 endif()
 
 message(STATUS "Default compilation target(s): ${DEFAULT_TARGETS}")
-
-##########################################################
-## Do not define any variables that might be used by build
-## targets below this line.
-##########################################################
-add_subdirectory(src)
 
 
 set(ACPP_CORE_CONFIG_FILE "{


### PR DESCRIPTION
`add_subdirectory(src)` in the top-level `CMakeLists.txt` was invoked before all required variables were set. In particular, `ROCM_LIBS` was only set at a later point. This could cause the HIP backend plugin to fail to load due to incomplete linking.

This PR fixes these issues by moving `add_subdirectory(src)` further down.