### PR TITLE
[CBS] Fix potential miscompiles for accelerated CPU due to uniformity analysis

### DIFF
--- a/include/hipSYCL/compiler/cbs/VectorShape.hpp
+++ b/include/hipSYCL/compiler/cbs/VectorShape.hpp
@@ -66,6 +66,7 @@ public:
   bool isUniform() const { return isStrided(0); }
   bool greaterThanUniform() const { return !isUniform() && isDefined(); }
   inline bool isContiguous() const { return isStrided(1); }
+  inline bool isContiguousOrStrided() const { return hasStridedShape() && stride > 0; }
 
   static VectorShape varying(align_t aligned = 1) { return VectorShape(aligned); }
   static VectorShape strided(stride_t stride, align_t aligned = 1) {

--- a/src/compiler/cbs/VectorShapeTransformer.cpp
+++ b/src/compiler/cbs/VectorShapeTransformer.cpp
@@ -155,7 +155,7 @@ VectorShape VectorShapeTransformer::computeIdealShapeForInst(const Instruction &
       // These coincide because a >= b is equivalent to !(a < b)
       {
         const int vectorWidth = (int)vecInfo.getVectorWidth();
-        const int stride = diffShape.getStride();
+        const stride_t stride = diffShape.getStride();
         const int alignment = diffShape.getAlignmentFirst();
 
         if (stride >= 0 && alignment >= stride * vectorWidth)
@@ -504,7 +504,7 @@ VectorShape VectorShapeTransformer::computeShapeForCastInst(const CastInst &cast
   const auto &BB = *castI.getParent();
   const Value *castOp = castI.getOperand(0);
   const VectorShape &castOpShape = getObservedShape(BB, *castOp);
-  const int castOpStride = castOpShape.getStride();
+  const stride_t castOpStride = castOpShape.getStride();
 
   const int aligned = !returnsVoidPtr(castI) ? castOpShape.getAlignmentFirst() : 1;
 


### PR DESCRIPTION
This fixes two issues that could have led to miscompilations on the CPU due to the uniformity analysis failing or being misinterpreted.
