### PR TITLE
[SSCP] Add JIT optiimization to turn id and size queries from i64->i32

### DIFF
--- a/include/hipSYCL/compiler/llvm-to-backend/GlobalSizesFitInI32OptPass.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/GlobalSizesFitInI32OptPass.hpp
@@ -1,0 +1,59 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2019-2024 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HIPSYCL_SSCP_GLOBAL_SIZES_FIT_IN_I32_OPT_HPP
+#define HIPSYCL_SSCP_GLOBAL_SIZES_FIT_IN_I32_OPT_HPP
+
+#include <llvm/IR/PassManager.h>
+
+
+namespace hipsycl {
+namespace compiler {
+
+class GlobalSizesFitInI32OptPass : public llvm::PassInfoMixin<GlobalSizesFitInI32OptPass> {
+public:
+  GlobalSizesFitInI32OptPass(bool GlobalSizesFitInInt, int KnownGroupSizeX = -1,
+                             int KnownGroupSizeY = -1, int KnownGroupSizeZ = -1);
+  llvm::PreservedAnalyses run(llvm::Module &M,
+                              llvm::ModuleAnalysisManager &MAM);
+private:
+  int KnownGroupSizeX;
+  int KnownGroupSizeY;
+  int KnownGroupSizeZ;
+  bool GlobalSizesFitInInt;
+};
+
+
+// inserts llvm.assume calls to assert that x >= RangeMin && x < RangeMax.
+bool insertRangeAssumptionForBuiltinCalls(llvm::Module &M, llvm::StringRef BuiltinName,
+                                          long long RangeMin, long long RangeMax, bool MaxIsLessThanEqual = false);
+
+}
+}
+
+#endif
+

--- a/include/hipSYCL/compiler/llvm-to-backend/KnownGroupSizeOptPass.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/KnownGroupSizeOptPass.hpp
@@ -1,0 +1,53 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2019-2024 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef HIPSYCL_SSCP_KNOWN_GROUP_SIZE_OPT_HPP
+#define HIPSYCL_SSCP_KNOWN_GROUP_SIZE_OPT_HPP
+
+#include <llvm/IR/PassManager.h>
+
+
+namespace hipsycl {
+namespace compiler {
+
+class KnownGroupSizeOptPass : public llvm::PassInfoMixin<KnownGroupSizeOptPass> {
+public:
+  KnownGroupSizeOptPass(int KnownGroupSizeX = -1, int KnownGroupSizeY = -1,
+                        int KnownGroupSizeZ = -1);
+  llvm::PreservedAnalyses run(llvm::Module &M,
+                              llvm::ModuleAnalysisManager &MAM);
+private:
+  int KnownGroupSizeX;
+  int KnownGroupSizeY;
+  int KnownGroupSizeZ;
+};
+
+}
+}
+
+#endif
+

--- a/include/hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp
@@ -205,8 +205,11 @@ protected:
   int KnownGroupSizeX = 0;
   int KnownGroupSizeY = 0;
   int KnownGroupSizeZ = 0;
+
+  bool GlobalSizesFitInInt = false;
 private:
   bool optimizeForKnownGroupSizes(llvm::Module& M, PassHandler& PH);
+  bool optimizeIfGlobalSizesFitInInt(llvm::Module& M, PassHandler& PH);
 
   void resolveExternalSymbols(llvm::Module& M);
   void setFailedIR(llvm::Module& M);

--- a/include/hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp
@@ -208,8 +208,6 @@ protected:
 
   bool GlobalSizesFitInInt = false;
 private:
-  bool optimizeForKnownGroupSizes(llvm::Module& M, PassHandler& PH);
-  bool optimizeIfGlobalSizesFitInInt(llvm::Module& M, PassHandler& PH);
 
   void resolveExternalSymbols(llvm::Module& M);
   void setFailedIR(llvm::Module& M);

--- a/include/hipSYCL/sycl/libkernel/backend.hpp
+++ b/include/hipSYCL/sycl/libkernel/backend.hpp
@@ -177,4 +177,13 @@
   ((HIPSYCL_LIBKERNEL_IS_DEVICE_PASS_##backend) &&                             \
    !HIPSYCL_LIBKERNEL_IS_UNIFIED_HOST_DEVICE_PASS)
 
+
+
+ #define __hipsycl_return_wrapped_if_sscp(wrapper, content) \
+  __hipsycl_backend_switch(return content, \
+    return wrapper(content), \
+    return content, \
+    return content, \
+    return content)
+
 #endif

--- a/include/hipSYCL/sycl/libkernel/backend.hpp
+++ b/include/hipSYCL/sycl/libkernel/backend.hpp
@@ -179,11 +179,5 @@
 
 
 
- #define __hipsycl_return_wrapped_if_sscp(wrapper, content) \
-  __hipsycl_backend_switch(return content, \
-    return wrapper(content), \
-    return content, \
-    return content, \
-    return content)
 
 #endif

--- a/include/hipSYCL/sycl/libkernel/group.hpp
+++ b/include/hipSYCL/sycl/libkernel/group.hpp
@@ -151,6 +151,7 @@ public:
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
     return detail::get_group_id<Dimensions>();
 #else
+    __hipsycl_if_target_sscp(return detail::get_group_id<Dimensions>(););
     return _group_id;
 #endif
   }
@@ -168,6 +169,7 @@ public:
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
     return detail::get_group_id<Dimensions>(dimension);
 #else
+    __hipsycl_if_target_sscp(return detail::get_group_id<Dimensions>(dimension);)
     return _group_id[dimension];
 #endif
   }
@@ -186,6 +188,7 @@ public:
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
     return detail::get_global_size<Dimensions>();
 #else
+    __hipsycl_if_target_sscp(return __hipsycl_sscp_get_global_size<Dimensions>(););
     return _num_groups * _local_range;
 #endif
   }
@@ -197,6 +200,7 @@ public:
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
     return detail::get_global_size<Dimensions>(dimension);
 #else
+    __hipsycl_if_target_sscp(return detail::get_global_size<Dimensions>(dimension););
     return _num_groups[dimension] * _local_range[dimension];
 #endif
   }
@@ -209,6 +213,7 @@ public:
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
     return detail::get_local_size<Dimensions>();
 #else
+    __hipsycl_if_target_sscp(return detail::get_local_size<Dimensions>(););
     return _local_range;
 #endif
   }
@@ -219,6 +224,7 @@ public:
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
     return detail::get_local_size<Dimensions>(dimension);
 #else
+    __hipsycl_if_target_sscp(return detail::get_local_size<Dimensions>(dimension););
     return _local_range[dimension];
 #endif
   }
@@ -226,6 +232,7 @@ public:
   HIPSYCL_KERNEL_TARGET
   size_t get_local_linear_range() const
   {
+    __hipsycl_if_target_sscp(return __hipsycl_sscp_get_local_size<Dimensions>(););
     return get_local_range().size();
   }
 
@@ -239,6 +246,7 @@ public:
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
     return detail::get_grid_size<Dimensions>();
 #else
+    __hipsycl_if_target_sscp(return detail::get_grid_size<Dimensions>(););
     return _num_groups;
 #endif
   }
@@ -249,6 +257,7 @@ public:
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
     return detail::get_grid_size<Dimensions>(dimension);
 #else
+    __hipsycl_if_target_sscp(return detail::get_grid_size<Dimensions>(dimension););
     return _num_groups[dimension];
 #endif
   }
@@ -256,6 +265,7 @@ public:
   HIPSYCL_KERNEL_TARGET
   size_t get_group_linear_range() const
   {
+    __hipsycl_if_target_sscp(return __hipsycl_sscp_get_num_groups<Dimensions>(););
     return get_group_range().size();
   }
 
@@ -265,6 +275,7 @@ public:
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
     return detail::get_group_id<Dimensions>(dimension);
 #else
+    __hipsycl_if_target_sscp(return detail::get_group_id<Dimensions>(dimension););
     return _group_id[dimension];
 #endif
   }
@@ -282,6 +293,7 @@ public:
   HIPSYCL_KERNEL_TARGET
   size_t get_group_linear_id() const
   {
+    __hipsycl_if_target_sscp(return __hipsycl_sscp_get_group_linear_id<Dimensions>(););
     return detail::linear_id<Dimensions>::get(get_id(),
                                               get_group_range());
   }
@@ -300,6 +312,7 @@ public:
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
     return detail::get_local_id<Dimensions>();
 #else
+    __hipsycl_if_target_sscp(return detail::get_local_id<Dimensions>(););
     return _local_id;
 #endif
   }
@@ -310,6 +323,7 @@ public:
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
     return detail::get_local_id<Dimensions>(dimension);
 #else
+    __hipsycl_if_target_sscp(return detail::get_local_id<Dimensions>(dimension););
     return _local_id[dimension];
 #endif
   }
@@ -321,6 +335,7 @@ public:
     return detail::linear_id<Dimensions>::get(detail::get_local_id<Dimensions>(),
                                               detail::get_local_size<Dimensions>());
 #else
+    __hipsycl_if_target_sscp(return __hipsycl_sscp_get_local_linear_id<Dimensions>(););
     return detail::linear_id<Dimensions>::get(_local_id,
                                               _local_range);
 #endif

--- a/include/hipSYCL/sycl/libkernel/nd_item.hpp
+++ b/include/hipSYCL/sycl/libkernel/nd_item.hpp
@@ -198,7 +198,8 @@ struct nd_item
   size_t get_group_linear_id() const
   {
 #ifdef HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO
-    return detail::get_group_linear_id<Dimensions>();
+    return detail::linear_id<Dimensions>::get(detail::get_group_id<Dimensions>(),
+                                              detail::get_grid_size<Dimensions>());
 #else
     __hipsycl_if_target_sscp(
         return __hipsycl_sscp_get_group_linear_id<Dimensions>(););

--- a/include/hipSYCL/sycl/libkernel/nd_item.hpp
+++ b/include/hipSYCL/sycl/libkernel/nd_item.hpp
@@ -98,7 +98,10 @@ struct nd_item
   HIPSYCL_KERNEL_TARGET
   size_t get_global_linear_id() const
   {
-    return detail::linear_id<Dimensions>::get(get_global_id(), get_global_range());
+    __hipsycl_return_wrapped_if_sscp(
+        __hipsycl_sscp_as_i32_if_global_sizes_fit_in_int,
+        detail::linear_id<Dimensions>::get(get_global_id(),
+                                           get_global_range()));
   }
 
   HIPSYCL_KERNEL_TARGET friend bool operator ==(const nd_item<Dimensions>& lhs, const nd_item<Dimensions>& rhs)

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/core.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/core.hpp
@@ -48,4 +48,11 @@ HIPSYCL_SSCP_BUILTIN __hipsycl_uint64 __hipsycl_sscp_get_num_groups_x();
 HIPSYCL_SSCP_BUILTIN __hipsycl_uint64 __hipsycl_sscp_get_num_groups_y();
 HIPSYCL_SSCP_BUILTIN __hipsycl_uint64 __hipsycl_sscp_get_num_groups_z();
 
+// This is used to implement the optimization in llvm-to-backend to treat
+// all queries as fitting into int.
+// This is a llvm-to-backend optimization hint and does not need to be implemented
+// in backend bitcode libraries.
+HIPSYCL_SSCP_BUILTIN_DEFAULT_LINKAGE size_t
+__hipsycl_sscp_as_i32_if_global_sizes_fit_in_int(size_t s);
+
 #endif

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/core.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/core.hpp
@@ -106,7 +106,7 @@ T __hipsycl_sscp_typed_get_global_linear_id() {
 
 
 template<int Dim, class T>
-T __hipsycl_sscp_typed_get_group_linear_id() {
+T __hipsycl_sscp_typed_get_local_linear_id() {
   if constexpr(Dim == 1) {
     return (T)__hipsycl_sscp_get_local_id_x();
   } else if constexpr(Dim == 2) {
@@ -132,9 +132,9 @@ T __hipsycl_sscp_typed_get_group_linear_id() {
 
 
 template<int Dim, class T>
-T __hipsycl_sscp_typed_get_local_linear_id() {
+T __hipsycl_sscp_typed_get_group_linear_id() {
   if constexpr(Dim == 1) {
-    return (T)__hipsycl_sscp_get_local_id_x();
+    return (T)__hipsycl_sscp_get_group_id_x();
   } else if constexpr(Dim == 2) {
     T gid_x = (T)__hipsycl_sscp_get_group_id_x();
     T gid_y = (T)__hipsycl_sscp_get_group_id_y();

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/core.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/core.hpp
@@ -50,9 +50,228 @@ HIPSYCL_SSCP_BUILTIN __hipsycl_uint64 __hipsycl_sscp_get_num_groups_z();
 
 // This is used to implement the optimization in llvm-to-backend to treat
 // all queries as fitting into int.
-// This is a llvm-to-backend optimization hint and does not need to be implemented
-// in backend bitcode libraries.
-HIPSYCL_SSCP_BUILTIN_DEFAULT_LINKAGE size_t
-__hipsycl_sscp_as_i32_if_global_sizes_fit_in_int(size_t s);
+// The implementation is provided by the compiler and does not need to be implemented
+// by backends.
+HIPSYCL_SSCP_BUILTIN bool
+__hipsycl_sscp_if_global_sizes_fit_in_int();
+
+template<int Dim, class T>
+T __hipsycl_sscp_typed_get_global_linear_id() {
+  if constexpr(Dim == 1) {
+    T gid_x = (T)__hipsycl_sscp_get_group_id_x();
+    T lsize_x = (T)__hipsycl_sscp_get_local_size_x();
+    T lid_x = (T)__hipsycl_sscp_get_local_id_x();
+
+    return gid_x * lsize_x + lid_x;
+  } else if constexpr(Dim == 2) {
+    T gid_x = (T)__hipsycl_sscp_get_group_id_x();
+    T gid_y = (T)__hipsycl_sscp_get_group_id_y();
+    T lsize_x = (T)__hipsycl_sscp_get_local_size_x();
+    T lsize_y = (T)__hipsycl_sscp_get_local_size_y();
+    T lid_x = (T)__hipsycl_sscp_get_local_id_x();
+    T lid_y = (T)__hipsycl_sscp_get_local_id_y();
+    T ngroups_x = (T)__hipsycl_sscp_get_num_groups_x();
+
+    T id_x = gid_x * lsize_x + lid_x;
+    T id_y = gid_y * lsize_y + lid_y;
+
+    T global_size_x = lsize_x * ngroups_x;
+
+    return global_size_x * id_y + id_x;
+  } else if constexpr(Dim == 3) {
+    T gid_x = (T)__hipsycl_sscp_get_group_id_x();
+    T gid_y = (T)__hipsycl_sscp_get_group_id_y();
+    T gid_z = (T)__hipsycl_sscp_get_group_id_z();
+    T lsize_x = (T)__hipsycl_sscp_get_local_size_x();
+    T lsize_y = (T)__hipsycl_sscp_get_local_size_y();
+    T lsize_z = (T)__hipsycl_sscp_get_local_size_z();
+    T lid_x = (T)__hipsycl_sscp_get_local_id_x();
+    T lid_y = (T)__hipsycl_sscp_get_local_id_y();
+    T lid_z = (T)__hipsycl_sscp_get_local_id_z();
+    T ngroups_x = (T)__hipsycl_sscp_get_num_groups_x();
+    T ngroups_y = (T)__hipsycl_sscp_get_num_groups_y();
+    
+    T id_x = gid_x * lsize_x + lid_x;
+    T id_y = gid_y * lsize_y + lid_y;
+    T id_z = gid_z * lsize_z + lid_z;
+
+    T global_size_x = lsize_x * ngroups_x;
+    T global_size_y = lsize_y * ngroups_y;
+
+    return global_size_x * global_size_y * id_z + global_size_x * id_y + id_x;
+  } else {
+    return 0;
+  }
+}
+
+
+template<int Dim, class T>
+T __hipsycl_sscp_typed_get_group_linear_id() {
+  if constexpr(Dim == 1) {
+    return (T)__hipsycl_sscp_get_local_id_x();
+  } else if constexpr(Dim == 2) {
+    T lid_x = (T)__hipsycl_sscp_get_local_id_x();
+    T lid_y = (T)__hipsycl_sscp_get_local_id_y();
+
+    T lsize_x = (T)__hipsycl_sscp_get_local_size_x();
+
+    return lsize_x * lid_y + lid_x;
+  } else if constexpr(Dim == 3) {
+    T lid_x = (T)__hipsycl_sscp_get_local_id_x();
+    T lid_y = (T)__hipsycl_sscp_get_local_id_y();
+    T lid_z = (T)__hipsycl_sscp_get_local_id_z();
+
+    T lsize_x = (T)__hipsycl_sscp_get_local_size_x();
+    T lsize_y = (T)__hipsycl_sscp_get_local_size_y();
+
+    return lsize_x * lsize_y * lid_z + lsize_x * lid_y + lid_x;
+  } else {
+    return 0;
+  }
+}
+
+
+template<int Dim, class T>
+T __hipsycl_sscp_typed_get_local_linear_id() {
+  if constexpr(Dim == 1) {
+    return (T)__hipsycl_sscp_get_local_id_x();
+  } else if constexpr(Dim == 2) {
+    T gid_x = (T)__hipsycl_sscp_get_group_id_x();
+    T gid_y = (T)__hipsycl_sscp_get_group_id_y();
+
+    T ngroups_x = (T)__hipsycl_sscp_get_num_groups_x();
+
+    return ngroups_x * gid_y + gid_x;
+  } else if constexpr(Dim == 3) {
+    T gid_x = (T)__hipsycl_sscp_get_group_id_x();
+    T gid_y = (T)__hipsycl_sscp_get_group_id_y();
+    T gid_z = (T)__hipsycl_sscp_get_group_id_z();
+
+    T ngroups_x = (T)__hipsycl_sscp_get_num_groups_x();
+    T ngroups_y = (T)__hipsycl_sscp_get_num_groups_y();
+
+    return ngroups_x * ngroups_y * gid_z + ngroups_x * gid_y + gid_x;
+  } else {
+    return 0;
+  }
+}
+
+template<int Dim, class T>
+T __hipsycl_sscp_typed_get_global_size() {
+  if constexpr(Dim == 1) {
+    return (T)__hipsycl_sscp_get_local_size_x() * (T)__hipsycl_sscp_get_num_groups_x();
+  } else if constexpr(Dim == 2) {
+    T size_x = (T)__hipsycl_sscp_get_local_size_x() * (T)__hipsycl_sscp_get_num_groups_x();
+    T size_y = (T)__hipsycl_sscp_get_local_size_y() * (T)__hipsycl_sscp_get_num_groups_y();
+
+    return size_x * size_y;
+  } else if constexpr(Dim == 3) {
+    T size_x = (T)__hipsycl_sscp_get_local_size_x() * (T)__hipsycl_sscp_get_num_groups_x();
+    T size_y = (T)__hipsycl_sscp_get_local_size_y() * (T)__hipsycl_sscp_get_num_groups_y();
+    T size_z = (T)__hipsycl_sscp_get_local_size_z() * (T)__hipsycl_sscp_get_num_groups_z();
+
+    return size_x * size_y * size_z;
+  } else {
+    return 0;
+  }
+}
+
+
+template<int Dim, class T>
+T __hipsycl_sscp_typed_get_local_size() {
+  if constexpr(Dim == 1) {
+    return (T)__hipsycl_sscp_get_local_size_x();
+  } else if constexpr(Dim == 2) {
+    T size_x = (T)__hipsycl_sscp_get_local_size_x();
+    T size_y = (T)__hipsycl_sscp_get_local_size_y();
+
+    return size_x * size_y;
+  } else if constexpr(Dim == 3) {
+    T size_x = (T)__hipsycl_sscp_get_local_size_x();
+    T size_y = (T)__hipsycl_sscp_get_local_size_y();
+    T size_z = (T)__hipsycl_sscp_get_local_size_z();
+
+    return size_x * size_y * size_z;
+  } else {
+    return 0;
+  }
+}
+
+
+template<int Dim, class T>
+T __hipsycl_sscp_typed_get_num_groups() {
+  if constexpr(Dim == 1) {
+    return (T)__hipsycl_sscp_get_num_groups_x();
+  } else if constexpr(Dim == 2) {
+    T size_x = (T)__hipsycl_sscp_get_num_groups_x();
+    T size_y = (T)__hipsycl_sscp_get_num_groups_y();
+
+    return size_x * size_y;
+  } else if constexpr(Dim == 3) {
+    T size_x = (T)__hipsycl_sscp_get_num_groups_x();
+    T size_y = (T)__hipsycl_sscp_get_num_groups_y();
+    T size_z = (T)__hipsycl_sscp_get_num_groups_z();
+
+    return size_x * size_y * size_z;
+  } else {
+    return 0;
+  }
+}
+
+
+
+template<int Dim>
+size_t __hipsycl_sscp_get_global_linear_id() {
+  if(__hipsycl_sscp_if_global_sizes_fit_in_int()) {
+    return __hipsycl_sscp_typed_get_global_linear_id<Dim, int>();
+  } else {
+    return __hipsycl_sscp_typed_get_global_linear_id<Dim, size_t>();
+  }
+}
+
+template<int Dim>
+size_t __hipsycl_sscp_get_group_linear_id() {
+  if(__hipsycl_sscp_if_global_sizes_fit_in_int()) {
+    return __hipsycl_sscp_typed_get_group_linear_id<Dim, int>();
+  } else {
+    return __hipsycl_sscp_typed_get_group_linear_id<Dim, size_t>();
+  }
+}
+
+template<int Dim>
+size_t __hipsycl_sscp_get_local_linear_id() {
+  if(__hipsycl_sscp_if_global_sizes_fit_in_int()) {
+    return __hipsycl_sscp_typed_get_local_linear_id<Dim, int>();
+  } else {
+    return __hipsycl_sscp_typed_get_local_linear_id<Dim, size_t>();
+  }
+}
+
+template<int Dim>
+size_t __hipsycl_sscp_get_global_size() {
+  if(__hipsycl_sscp_if_global_sizes_fit_in_int()) {
+    return __hipsycl_sscp_typed_get_global_size<Dim, int>();
+  } else {
+    return __hipsycl_sscp_typed_get_global_size<Dim, size_t>();
+  }
+}
+
+template<int Dim>
+size_t __hipsycl_sscp_get_local_size() {
+  if(__hipsycl_sscp_if_global_sizes_fit_in_int()) {
+    return __hipsycl_sscp_typed_get_local_size<Dim, int>();
+  } else {
+    return __hipsycl_sscp_typed_get_local_size<Dim, size_t>();
+  }
+}
+
+template<int Dim>
+size_t __hipsycl_sscp_get_num_groups() {
+  if(__hipsycl_sscp_if_global_sizes_fit_in_int()) {
+    return __hipsycl_sscp_typed_get_num_groups<Dim, int>();
+  } else {
+    return __hipsycl_sscp_typed_get_num_groups<Dim, size_t>();
+  }
+}
 
 #endif

--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -106,7 +106,12 @@ include(ExternalProject)
 if(WITH_SSCP_COMPILER)
   create_llvm_based_library(
     TARGET llvm-to-backend
-    SOURCES LLVMToBackend.cpp AddressSpaceInferencePass.cpp ../sscp/KernelOutliningPass.cpp)
+    SOURCES 
+      LLVMToBackend.cpp 
+      AddressSpaceInferencePass.cpp
+      KnownGroupSizeOptPass.cpp
+      GlobalSizesFitInI32OptPass.cpp
+      ../sscp/KernelOutliningPass.cpp)
 
   if(WITH_LLVM_TO_SPIRV)
     add_hipsycl_llvm_backend(

--- a/src/compiler/llvm-to-backend/GlobalSizesFitInI32OptPass.cpp
+++ b/src/compiler/llvm-to-backend/GlobalSizesFitInI32OptPass.cpp
@@ -1,0 +1,144 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2019-2024 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "hipSYCL/compiler/llvm-to-backend/GlobalSizesFitInI32OptPass.hpp"
+
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Intrinsics.h>
+#include <llvm/IR/Constants.h>
+
+namespace hipsycl {
+namespace compiler {
+
+
+// inserts llvm.assume calls to assert that x >= RangeMin && x < RangeMax.
+bool insertRangeAssumptionForBuiltinCalls(llvm::Module &M, llvm::StringRef BuiltinName,
+                                          long long RangeMin, long long RangeMax, bool MaxIsLessThanEqual) {
+  llvm::Function *AssumeIntrinsic = llvm::Intrinsic::getDeclaration(&M, llvm::Intrinsic::assume);
+  if(!AssumeIntrinsic)
+    return false;
+
+  if(auto* F = M.getFunction(BuiltinName)) {
+
+    auto *ReturnedIntType = llvm::dyn_cast<llvm::IntegerType>(F->getReturnType());
+    if(!ReturnedIntType)
+      return false;
+
+    for(auto* U : F->users()) {
+      if(auto* C = llvm::dyn_cast<llvm::CallInst>(U)) {
+        auto* NextInst = C->getNextNonDebugInstruction();
+
+        auto *GreaterEqualMin = llvm::ICmpInst::Create(
+            llvm::Instruction::OtherOps::ICmp, llvm::ICmpInst::Predicate::ICMP_SGE, C,
+            llvm::ConstantInt::get(M.getContext(),
+                                   llvm::APInt(ReturnedIntType->getBitWidth(), RangeMin)),
+            "", NextInst);
+        
+        llvm::ICmpInst::Predicate MaxPredicate = llvm::ICmpInst::ICMP_SLT;
+        if(MaxIsLessThanEqual)
+          MaxPredicate = llvm::ICmpInst::ICMP_SLE;
+        auto *LesserThanMax = llvm::ICmpInst::Create(
+            llvm::Instruction::OtherOps::ICmp, MaxPredicate, C,
+            llvm::ConstantInt::get(M.getContext(),
+                                  llvm::APInt(ReturnedIntType->getBitWidth(), RangeMax)),
+            "", NextInst);
+        
+
+        llvm::SmallVector<llvm::Value*> CallArgGreaterEqualMin{GreaterEqualMin};
+        llvm::SmallVector<llvm::Value*> CallArgLesserThanMax{LesserThanMax};
+        llvm::CallInst::Create(llvm::FunctionCallee(AssumeIntrinsic), CallArgGreaterEqualMin,
+                                            "", NextInst);
+        llvm::CallInst::Create(llvm::FunctionCallee(AssumeIntrinsic), CallArgLesserThanMax,
+                                            "", NextInst);
+      }
+    }
+  }
+
+  return true;
+}
+
+GlobalSizesFitInI32OptPass::GlobalSizesFitInI32OptPass(bool FitsInInt, int GroupSizeX,
+                                                       int GroupSizeY, int GroupSizeZ)
+    : GlobalSizesFitInInt{FitsInInt}, KnownGroupSizeX{GroupSizeX}, KnownGroupSizeY{GroupSizeY},
+      KnownGroupSizeZ{GroupSizeZ} {}
+
+llvm::PreservedAnalyses GlobalSizesFitInI32OptPass::run(llvm::Module &M,
+                                                        llvm::ModuleAnalysisManager &MAM) {
+  static const char* IfFitsInIntBuiltinName = "__hipsycl_sscp_if_global_sizes_fit_in_int";
+  if(auto* F = M.getFunction(IfFitsInIntBuiltinName)) {
+    // Add definition
+    if(F->size() == 0) {
+      llvm::BasicBlock *BB =
+          llvm::BasicBlock::Create(M.getContext(), "", F);
+      llvm::ReturnInst::Create(
+          M.getContext(),
+          llvm::ConstantInt::get(
+              M.getContext(),
+              llvm::APInt(F->getReturnType()->getIntegerBitWidth(), GlobalSizesFitInInt ? 1 : 0)),
+          BB);
+    }
+  }
+
+  std::size_t MaxInt = std::numeric_limits<int>::max();
+  // This needs to be called regardless of whether the GlobalSizesFitInInt optimization is
+  // active.
+
+  if(GlobalSizesFitInInt) {
+
+    if (KnownGroupSizeX > 0) {
+      insertRangeAssumptionForBuiltinCalls(M, "__hipsycl_sscp_get_num_groups_x", 0,
+                                                MaxInt / KnownGroupSizeX, true);
+    }
+    if (KnownGroupSizeY > 0) {
+      insertRangeAssumptionForBuiltinCalls(M, "__hipsycl_sscp_get_num_groups_y", 0,
+                                                MaxInt / KnownGroupSizeY, true);
+    }
+    if (KnownGroupSizeZ > 0) {
+      insertRangeAssumptionForBuiltinCalls(M, "__hipsycl_sscp_get_num_groups_z", 0,
+                                                MaxInt / KnownGroupSizeZ, true);
+    }
+
+
+    if (KnownGroupSizeX > 0) {
+      insertRangeAssumptionForBuiltinCalls(M, "__hipsycl_sscp_get_group_id_x", 0,
+                                                MaxInt / KnownGroupSizeX);
+    }
+    if (KnownGroupSizeY > 0) {
+      insertRangeAssumptionForBuiltinCalls(M, "__hipsycl_sscp_get_group_id_y", 0,
+                                                MaxInt / KnownGroupSizeY);
+    }
+    if (KnownGroupSizeZ > 0) {
+      insertRangeAssumptionForBuiltinCalls(M, "__hipsycl_sscp_get_group_id_z", 0,
+                                                MaxInt / KnownGroupSizeZ);
+    }
+
+  }
+
+  return llvm::PreservedAnalyses::none();
+}
+}
+}

--- a/src/compiler/llvm-to-backend/KnownGroupSizeOptPass.cpp
+++ b/src/compiler/llvm-to-backend/KnownGroupSizeOptPass.cpp
@@ -1,0 +1,113 @@
+/*
+ * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ *
+ * Copyright (c) 2019-2024 Aksel Alpay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "hipSYCL/compiler/llvm-to-backend/KnownGroupSizeOptPass.hpp"
+#include "hipSYCL/compiler/llvm-to-backend/GlobalSizesFitInI32OptPass.hpp"
+
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/Instructions.h>
+
+
+namespace hipsycl {
+namespace compiler {
+
+namespace {
+
+
+bool applyKnownGroupSize(llvm::Module &M, int KnownGroupSize,
+                         llvm::StringRef GetGroupSizeBuiltinName,
+                         llvm::StringRef GetLocalIdBuiltinName) {
+
+  // First create replacement functions for GetGroupSizeBuiltinName
+  // which directly return the known group size, and replace all
+  // uses.
+  if(auto* GetGroupSizeF = M.getFunction(GetGroupSizeBuiltinName)) {
+    std::string NewFunctionName = std::string{GetGroupSizeBuiltinName}+"_known_size";
+
+    auto *NewGetGroupSizeF = llvm::dyn_cast<llvm::Function>(
+        M.getOrInsertFunction(NewFunctionName, GetGroupSizeF->getFunctionType(),
+                              GetGroupSizeF->getAttributes())
+            .getCallee());
+    if(!NewGetGroupSizeF)
+      return false;
+
+    if(!NewGetGroupSizeF->hasFnAttribute(llvm::Attribute::AlwaysInline))
+      NewGetGroupSizeF->addFnAttr(llvm::Attribute::AlwaysInline);
+
+    llvm::BasicBlock *BB =
+        llvm::BasicBlock::Create(M.getContext(), "", NewGetGroupSizeF);
+
+    auto *ReturnedIntType = llvm::dyn_cast<llvm::IntegerType>(GetGroupSizeF->getReturnType());
+    if(!ReturnedIntType)
+      return false;
+
+    llvm::Constant *ReturnedValue = llvm::ConstantInt::get(
+        M.getContext(), llvm::APInt(ReturnedIntType->getBitWidth(), KnownGroupSize));
+
+    llvm::ReturnInst::Create(M.getContext(), ReturnedValue, BB);
+
+    GetGroupSizeF->replaceNonMetadataUsesWith(NewGetGroupSizeF);
+  }
+
+  // Insert __builtin_assume(0 <= local_id); __builtin_assume(local_id < group_size);
+  // for every call to GetLocalIdBuiltinName
+  if(!insertRangeAssumptionForBuiltinCalls(M, GetLocalIdBuiltinName, 0, KnownGroupSize))
+    return false;
+
+  return true;
+}
+
+}
+
+KnownGroupSizeOptPass::KnownGroupSizeOptPass(int GroupSizeX, int GroupSizeY, int GroupSizeZ)
+    : KnownGroupSizeX{GroupSizeX}, KnownGroupSizeY{GroupSizeY}, KnownGroupSizeZ{GroupSizeZ} {}
+
+
+llvm::PreservedAnalyses KnownGroupSizeOptPass::run(llvm::Module &M,
+                                                        llvm::ModuleAnalysisManager &MAM) {
+  if (KnownGroupSizeX > 0) {
+    applyKnownGroupSize(M, KnownGroupSizeX, "__hipsycl_sscp_get_local_size_x",
+                        "__hipsycl_sscp_get_local_id_x");
+  }
+
+  if (KnownGroupSizeY > 0) {
+    applyKnownGroupSize(M, KnownGroupSizeY, "__hipsycl_sscp_get_local_size_y",
+                        "__hipsycl_sscp_get_local_id_y");
+  }
+
+  if (KnownGroupSizeZ > 0) {
+    applyKnownGroupSize(M, KnownGroupSizeZ, "__hipsycl_sscp_get_local_size_z",
+                        "__hipsycl_sscp_get_local_id_z");
+  }
+
+  return llvm::PreservedAnalyses::none();
+
+}
+
+
+}
+}

--- a/src/runtime/adaptivity_engine.cpp
+++ b/src/runtime/adaptivity_engine.cpp
@@ -40,6 +40,8 @@ std::string group_size_build_opt_x = "known-group-size-x";
 std::string group_size_build_opt_y = "known-group-size-y";
 std::string group_size_build_opt_z = "known-group-size-z";
 
+std::string global_sizes_fit_in_int_opt = "global-sizes-fit-in-int";
+
 }
 
 kernel_adaptivity_engine::kernel_adaptivity_engine(hcf_object_id hcf_object,
@@ -72,6 +74,12 @@ kernel_adaptivity_engine::finalize_binary_configuration(
                             std::to_string(_block_size[1]));
     config.set_build_option(group_size_build_opt_z,
                             std::to_string(_block_size[2]));
+
+    // Try to optimize size_t -> i32 for queries if those fit in int
+    auto global_size = _num_groups * _block_size;
+    auto int_max = std::numeric_limits<int>::max();
+    if (global_size[0] * global_size[1] * global_size[2] < int_max)
+      config.set_build_flag(global_sizes_fit_in_int_opt);
   }
 
   return config.generate_id();


### PR DESCRIPTION
If `ACPP_ADAPTIVITY_LEVEL>=1`, this PR adds functionality:
* to detect at runtime whether the global range fits in i32, and if so:
  * Add `llvm.assume` instructions after every builtin query about id and group size (that was not already handle by the known-group-size optimization)
  * Activate code path in the header to perform more complex index and range calculations as `int`.
 
This can substantially simplify the generated code. See #829.

Closes #829