### PR TITLE
Remove deprecated spirv driver from acpp and documentation

### DIFF
--- a/bin/acpp
+++ b/bin/acpp
@@ -338,7 +338,6 @@ class acpp_config:
                                          (see --acpp-explicit-multipass)
                - hip.integrated-multipass: Force HIP backend to operate in integrated
                                            multipass mode.
-      * spirv - use clang SYCL driver to generate spirv
       * generic - use generic LLVM SSCP compilation flow, and JIT at runtime to target device"""),
 
       'stdpar-prefetch-mode' : option("--acpp-stdpar-prefetch-mode", "ACPP_STDPAR_PREFETCH_MODE", "default-stdpar-prefetch-mode", 
@@ -1194,101 +1193,6 @@ class hip_multipass_invocation:
     
     header.write_header(self._integration_header)
 
-class spirv_multipass_invocation:
-  @property
-  def unique_name(self):
-    return "spirv"
-
-  @property
-  def is_integrated_multipass(self):
-    return False
-
-  @property
-  def is_explicit_multipass(self):
-    return not self.is_integrated_multipass
-
-
-  def __init__(self, config):
-    self._config = config
-    self._acpp_lib_path = os.path.join(
-      config.acpp_installation_path, "lib/")
-    self.set_temp_dir("/tmp")
-
-  def set_temp_dir(self, temp_dir):
-    self._temp_dir = temp_dir
-    self._integration_header = os.path.join(
-      self._temp_dir,"__acpp_embedded_spirv_kernels.hpp")
-
-  def get_requested_targets(self):
-    return ["spirv"]
-
-  def get_device_compiler(self):
-    return self._config.clang_path
-
-  def get_compiler_preference(self):
-    return (self._config.clang_path, 100)
-
-  def set_host_compiler(self, host_compiler):
-    pass
-
-  def enable_extended_host_pass(self):
-    pass
-
-  @property
-  def is_extended_host_pass_enabled(self):
-    return False
-
-  def get_host_pass_requirements(self):
-    return {
-      'requires-extended-host-pass' : False,
-      'extended-host-pass-providers' : [],
-      'conflicts' : ['cuda-nvcxx'],
-      'caveats' : []
-    }
-
-  def get_flags(self, target):
-    flags = self._config.cuda_cxx_flags
-    
-    flags += [
-        "-fsycl-device-only",
-        "-fsycl-unnamed-lambda",
-        "-fno-sycl-use-bitcode",
-        "-D__HIPSYCL_ENABLE_SPIRV_TARGET__",
-        "-D__HIPSYCL_SPIRV__",
-        "-o",self._explicit_pass_output_file(target)
-      ]
-
-    return flags
-
-  # CXX flags for main pass
-  def get_cxx_flags(self):
-    return [
-      "-Xclang", "-fsycl-is-host",
-      "-D__HIPSYCL_MULTIPASS_SPIRV_HEADER__=\"{}\"".format(
-            self._integration_header),
-      "-D__HIPSYCL_ENABLE_SPIRV_TARGET__"
-    ]
-
-  # Linker flags for main pass
-  def get_linker_flags(self):
-    return []
-
-  def _explicit_pass_output_file(self, target):
-    return os.path.join(self._temp_dir, "acpp-kernels.spv")
-
-  def create_code_objects(self, targets):
-
-    if len(targets) != 1 or targets[0] != "spirv":
-      raise RuntimeError("SPIR-V multipass invocation: Invalid target")
-
-    with open(self._explicit_pass_output_file(targets[0]), "rb") as f:
-      data = f.read()
-
-      header = integration_header("spirv")
-      header.hcf_object.attach_binary_content(header.hcf_object.root, data)
-    
-      header.write_header(self._integration_header)
-
 
 class cuda_invocation:
 
@@ -1743,12 +1647,6 @@ class compiler:
       elif backend == "hip.explicit-multipass":
         self._multipass_backends.append(
           hip_multipass_invocation(config, config.targets["hip.explicit-multipass"]))
-      elif backend == 'spirv':
-        print_warning("'spirv' target is deprecated, incomplete and may not work. It should not be "
-              "used outside of experiments and will be removed in a future version. Production "
-              "use cases should use 'generic' target instead to target SPIR-V devices.")
-        self._multipass_backends.append(
-          spirv_multipass_invocation(config))
       elif backend == 'sscp' or backend == 'generic':
         self._backends.append(llvm_sscp_invocation(config, config.targets[backend]))
       else:

--- a/doc/compilation.md
+++ b/doc/compilation.md
@@ -28,7 +28,6 @@ Not all backends support all models. The following compilation flows are current
 | `cuda-nvcxx` | NVIDIA GPUs | Library-only | CUDA backend using nvc++ |
 | `hip.integrated-multipass` | AMD GPUs (supported by ROCm) | Integrated SMCP | HIP backend |
 | `hip.explicit-multipass` | AMD GPUs (supported by ROCm) | Explicit SMCP | HIP backend |
-| `spirv` | Intel GPUs | Explicit SMCP | SPIR-V/Level Zero backend |
 | `generic` | (see below) | Generic SSCP | Generic single-pass flow |
 
 **Note:** 

--- a/doc/hip-source-interop.md
+++ b/doc/hip-source-interop.md
@@ -11,9 +11,6 @@ void optimized_codepaths()
   __hipsycl_if_target_hip(
     // Only executed on HIP device. ROCm specific device functions can be called here
   );
-  __hipsycl_if_target_spirv(
-    // Only executed on SPIR-V device. SPIR-V specific code here
-  );
   __hipsycl_if_target_host(
     // Host-specific code here. Since this runs exclusively on host, this can be any
     // arbitrary C++ code, and the usual SYCL kernel restrictions don't apply.

--- a/doc/install-spirv.md
+++ b/doc/install-spirv.md
@@ -1,13 +1,10 @@
-# AdaptiveCpp installation instructions for SPIR-V/Level Zero
+# AdaptiveCpp installation instructions for SPIR-V devices with Level Zero
+
+**Note: Targeting SPIR-V devices through OpenCL is currently more mature and may yield better results.**
 
 Please install the Level Zero loader and a Level Zero driver such as the Intel [compute runtime](https://github.com/intel/compute-runtime) for Intel GPUs.
 
 The Level Zero backend can be enabled using `cmake -DWITH_LEVEL_ZERO_BACKEND=ON` when building AdaptiveCpp.
 
 
-## For the legacy SPIR-V compilation flow (`--acpp-targets=spirv`)
-**Please ignore the following if you actually want to use the more modern generic single-pass compiler (`--acpp-targets=generic`), which is recommended.**
-
-Please build AdaptiveCpp against a clang/LLVM that has Intel's patches to generate SPIR-V, following the [LLVM installation instructions](install-llvm.md). Once all required patches are upstreamed this will work with regular clang distributions; until then AdaptiveCpp needs to be built against DPC++/Intel's LLVM [fork](https://github.com/intel/llvm).
-Unfortunately, the binary distribution of DPC++ do not contain development headers, so the clang plugin required by the CUDA and ROCm backends cannot be compiled, but the open source fork should be able to also target CUDA and ROCm.
 

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -24,7 +24,6 @@ In addition, the various supported [compilation flows](compilation.md) and progr
 | `cuda.explicit-multipass` | NVIDIA GPUs | CUDA backend (clang, can be targeted simultaneously with other backends) | CUDA >= 10, LLVM 11 or 13+ |
 | `cuda-nvcxx` | NVIDIA GPUs | CUDA backend (nvc++) | Latest NVIDIA HPC SDK |
 | `hip.integrated-multipass` | AMD GPUs (supported by ROCm) | HIP backend (clang) | ROCm >= 4.0, LLVM >= 10 |
-| `spirv` | Intel GPUs | SPIR-V/Level Zero backend | Level Zero driver and loader, clang with SYCL patches (e.g DPC++) |
 | `generic` | NVIDIA, AMD, Intel GPUs, OpenCL SPIR-V devices | Generic single-pass compiler | LLVM >= 14. When dispatching kernels to AMD hardware, ROCm >= 5.3 is recommended. When dispatching to NVIDIA, clang needs nvptx64 backend enabled. AdaptiveCpp runtime backends for the respective target hardware need to be available. |
 
 #### Models
@@ -96,9 +95,6 @@ The default installation prefix is `/usr/local`. Change this to your liking.
 
 * See the ROCm [installation instructions](install-rocm.md) instructions.
 
-###### spirv
-
-* No specific cmake flags are currently available.
 
 ## Manual installation (Mac)
 

--- a/doc/macros.md
+++ b/doc/macros.md
@@ -12,7 +12,6 @@
 * `__hipsycl_if_target_cuda(code)` - `code` will only be compiled for the CUDA backend.
 * `__hipsycl_if_target_hip(code)` - `code` will only be compiled for the HIP backend.
 * `__hipsycl_if_target_hiplike(code)` - `code` will only be compiled for the CUDA and HIP backend.
-* `__hipsycl_if_target_spirv(code)` - `code` will only be compiled for the SPIR-V backend.
 
 ## Information about current compiler
 
@@ -20,7 +19,6 @@
 
 * `HIPSYCL_LIBKERNEL_COMPILER_SUPPORTS_CUDA` - Set to 1 if the compiler currently compiling the code supports CUDA language extensions. 0 otherwise.
 * `HIPSYCL_LIBKERNEL_COMPILER_SUPPORTS_HIP` - Set to 1 if the compiler currently compiling the code supports HIP language extensions. 0 otherwise.
-* `HIPSYCL_LIBKERNEL_COMPILER_SUPPORTS_SPIRV` - Set to 1 if the compiler currently compiling the code supports SPIR-V builtins.
 * `HIPSYCL_LIBKERNEL_COMPILER_SUPPORTS_HOST` - Always set to 1, since every compiler supports the host language, which is just C++.
 
 ## Information about compilation passes
@@ -36,7 +34,7 @@ Note: Some compiler drivers that AdaptiveCpp supports can compile for multiple b
 ### Properties of current compilation pass
 
 * `HIPSYCL_LIBKERNEL_IS_DEVICE_PASS` - Set to 1 if the current compilation pass targets at least one device backend. 0 otherwise.
-* `HIPSYCL_LIBKERNEL_IS_EXCLUSIVE_PASS(backend)` - returns 1 if the current compilation pass targets the provided backend (`CUDA|HIP|SPIRV|HOST`) and no other backend.
+* `HIPSYCL_LIBKERNEL_IS_EXCLUSIVE_PASS(backend)` - returns 1 if the current compilation pass targets the provided backend (`CUDA|HIP|HOST`) and no other backend.
 * `HIPSYCL_LIBKERNEL_IS_UNIFIED_HOST_DEVICE_PASS` - Set to 1 if the current compilation pass compiles for both host and device in a single, unified compilation pass.
 * `SYCL_DEVICE_ONLY` - defined if the current compilation pass targets a device backend and `HIPSYCL_LIBKERNEL_IS_UNIFIED_HOST_DEVICE_PASS` is 0. **Note**: `SYCL_DEVICE_ONLY` is not defined for `cuda-nvcxx` where host and device are compiled in a single pass. This is therefore in general not suitable to implement specialized code paths for host and device in a portable way
 * `__HIPSYCL_CLANG__` - defined by `acpp` when compiling with the clang plugin
@@ -56,7 +54,6 @@ Note: Some compiler drivers that AdaptiveCpp supports can compile for multiple b
 
 * (deprecated) `HIPSYCL_PLATFORM_CUDA` - defined when CUDA language extensions are available
 * (deprecated) `HIPSYCL_PLATFORM_ROCM`, `HIPSYCL_PLATFORM_HIP` - defined when HIP language extensions are available
-* (deprecated) `HIPSYCL_PLATFORM_SPIRV` - defined if SPIR-V intrinsics are available 
 * (deprecated) `HIPSYCL_PLATFORM_CPU` - defined if compiling for the host
 
 

--- a/doc/using-hipsycl.md
+++ b/doc/using-hipsycl.md
@@ -18,7 +18,7 @@ Whether a compilation flow needs to be followed by a target list or not varies b
 
 For the following compilation flows, targets cannot be specified:
 * `omp.*`
-* `spirv`
+* `generic`
 
 For the following compilation flows, targets can optionally be specified:
 * `cuda-nvcxx` - Targets take the format of `ccXY` where `XY` stands for the compute capability of the device.
@@ -214,7 +214,12 @@ Options are:
       * hip  - HIP backend
                Requires specification of targets of the form gfxXYZ,
                e.g. gfx906 for Vega 20, gfx900 for Vega 10
-      * spirv - use clang SYCL driver to generate spirv
+               Backend Flavors:
+               - hip.explicit-multipass: HIP backend in explicit multipass mode
+                                         (see --acpp-explicit-multipass)
+               - hip.integrated-multipass: Force HIP backend to operate in integrated
+                                           multipass mode.
+      * generic - use generic LLVM SSCP compilation flow, and JIT at runtime to target device""")
 
 --acpp-use-accelerated-cpu
   [can also be set by setting environment variable HIPSYCL_USE_ACCELERATED_CPU to any value other than false|off|0 ]


### PR DESCRIPTION
This removes the old, deprecated spirv multipass compilation driver from `acpp` and the documentation. It hasn't been tested or maintained in a long time, and very likely was broken anyway.
In a next step, this allows us to remove all of the old headers related to spirv.

(For those not so familiar with more recent developments in the project, **this does not mean that SPIR-V devices won't be supported anymore as they are covered by the `generic` target which is a much, much more capable compiler than the old driver. Both in terms of performance and functionality.**)