### PR TITLE
Change configuration to only search for boost filesystem if std::filesystem has not been found

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -14,7 +14,11 @@ target_include_directories(acpp-common
 target_link_libraries(acpp-common PRIVATE ${HIPSYCL_STDPAR_RT_LINKER_FLAGS})
 
 list(INSERT CMAKE_MODULE_PATH 0 "${PROJECT_SOURCE_DIR}/cmake/")
-find_package(Filesystem REQUIRED Final Experimental Boost)
+find_package(Filesystem Final Experimental)
+if(NOT Filesystem_FOUND)
+    # we only try to find Boost filesystem if neither the regular nor experimental std::filesystem have been found
+    find_package(Filesystem REQUIRED Boost)
+endif()
 set(CXX_FILESYSTEM_HEADER "${CXX_FILESYSTEM_HEADER}" PARENT_SCOPE)
 set(CXX_FILESYSTEM_NAMESPACE "${CXX_FILESYSTEM_NAMESPACE}" PARENT_SCOPE)
 list(REMOVE_AT CMAKE_MODULE_PATH 0)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -14,7 +14,7 @@ target_include_directories(acpp-common
 target_link_libraries(acpp-common PRIVATE ${HIPSYCL_STDPAR_RT_LINKER_FLAGS})
 
 list(INSERT CMAKE_MODULE_PATH 0 "${PROJECT_SOURCE_DIR}/cmake/")
-find_package(Filesystem Final Experimental)
+find_package(Filesystem COMPONENTS Final Experimental)
 if(NOT Filesystem_FOUND)
     # we only try to find Boost filesystem if neither the regular nor experimental std::filesystem have been found
     find_package(Filesystem REQUIRED Boost)


### PR DESCRIPTION
Small fix for configuration to only try to detect and use boost filesystem if a previous search for it in the stdlib hasn't been successful.

After applying this fix the linking issue I have been observing are no longer present, but I'm not sure if it might break something else.

Refs #1345