### PR TITLE
[CI] Update deprecated GitHub Actions

### DIFF
--- a/.github/workflows/linux-lit.yml
+++ b/.github/workflows/linux-lit.yml
@@ -16,7 +16,7 @@ jobs:
           - clang: 12
             os: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
       - name: install LLVM
@@ -79,7 +79,7 @@ jobs:
         clang: [14, 15, 16, 17]
         os: [ubuntu-22.04]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
       - name: install LLVM

--- a/.github/workflows/linux-self-hosted.yml
+++ b/.github/workflows/linux-self-hosted.yml
@@ -12,7 +12,7 @@ jobs:
         cuda: ['11.0']
         nvhpc_version: ['22.11']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: build
       run : |
         mkdir build && cd build
@@ -86,7 +86,7 @@ jobs:
         clang_version: ['15']
         cuda: ['11.0'] # Just to be able to build the backend for explicit multipass
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: build
       run : |
         mkdir build && cd build
@@ -133,7 +133,7 @@ jobs:
       matrix:
         clang_version: ['15']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: build
       run : |
         mkdir build && cd build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,7 +34,7 @@ jobs:
             cuda: 11.0.2
             rocm: 5.6.1
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Install OpenCL development files
@@ -129,7 +129,7 @@ jobs:
         nvhpc: [23.9]
         cuda: [12.2]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Free Disk Space (Ubuntu)

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,7 +7,7 @@ jobs:
     name: AppleClang [macOS]
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: install dependencies

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,14 +17,14 @@ jobs:
 
     - name: Cache Boost
       id: cache-boost
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{github.workspace}}/boost_1_81_0
         key: ${{runner.os}}-boost1810
 
     - name: Cache LLVM ${{matrix.clang}}
       id: cache-llvm
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{github.workspace}}/llvm
         key: ${{runner.os}}-llvm-${{matrix.clang}}


### PR DESCRIPTION
GitHub is complaining about checkout@v2 using a deprecated Node version, so let's bump them all.