### PR TITLE
[CI] Run `apt update` before installing packages

### DIFF
--- a/.github/workflows/linux-lit.yml
+++ b/.github/workflows/linux-lit.yml
@@ -21,6 +21,7 @@ jobs:
           submodules: 'recursive'
       - name: install LLVM
         run: |
+          sudo apt update
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh ${{matrix.clang}}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,6 +39,7 @@ jobs:
         submodules: 'recursive'
     - name: Install OpenCL development files
       run : |
+        sudo apt update
         sudo apt install ocl-icd-opencl-dev
     - name: Install TBB for PSTL tests
       run : |


### PR DESCRIPTION
The recent CI failures are due to some apt-get 404 errors, maybe this will fix it 