### PR TITLE
[SSCP][llvm-to-spirv] Fix ldexp, frexp, lgamma_r, rootn builtins for double

### DIFF
--- a/src/libkernel/sscp/spirv/math.cpp
+++ b/src/libkernel/sscp/spirv/math.cpp
@@ -125,25 +125,45 @@ HIPSYCL_SSCP_BUILTIN float __hipsycl_sscp_fract_f32(float x, float* y ) { return
 HIPSYCL_SSCP_BUILTIN double __hipsycl_sscp_fract_f64(double x, double* y) { return __spirv_ocl_fract(x, y); }
 
 float __spirv_ocl_frexp(float x, __hipsycl_int32* y);
-double __spirv_ocl_frexp(double x, __hipsycl_int64* y);
+double __spirv_ocl_frexp(double x, __hipsycl_int32* y);
 HIPSYCL_SSCP_BUILTIN float __hipsycl_sscp_frexp_f32(float x, __hipsycl_int32* y ) { return __spirv_ocl_frexp(x, y); }
-HIPSYCL_SSCP_BUILTIN double __hipsycl_sscp_frexp_f64(double x, __hipsycl_int64* y) { return __spirv_ocl_frexp(x, y); }
+HIPSYCL_SSCP_BUILTIN double __hipsycl_sscp_frexp_f64(double x, __hipsycl_int64* y) {
+  __hipsycl_int32 v;
+  auto res = __spirv_ocl_frexp(x, &v);
+  *y = v;
+  return res;
+}
 
 HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN2(hypot)
 HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN(ilogb)
 
 float __spirv_ocl_ldexp(float x, __hipsycl_int32 k);
-double __spirv_ocl_ldexp(double x, __hipsycl_int64 k);
-HIPSYCL_SSCP_BUILTIN float __hipsycl_sscp_ldexp_f32(float x, __hipsycl_int32 k) { return __spirv_ocl_ldexp(x, k); }
-HIPSYCL_SSCP_BUILTIN double __hipsycl_sscp_ldexp_f64(double x, __hipsycl_int64 k) { return __spirv_ocl_ldexp(x, k); }
+double __spirv_ocl_ldexp(double x, __hipsycl_int32 k);
+HIPSYCL_SSCP_BUILTIN float __hipsycl_sscp_ldexp_f32(float x,
+                                                    __hipsycl_int32 k) {
+  return __spirv_ocl_ldexp(x, k);
+}
+HIPSYCL_SSCP_BUILTIN double __hipsycl_sscp_ldexp_f64(double x,
+                                                     __hipsycl_int64 k) {
+  return __spirv_ocl_ldexp(x, static_cast<__hipsycl_int32>(k));
+}
 
 HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN(tgamma)
 HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN(lgamma)
 
 float __spirv_ocl_lgamma_r(float x, __hipsycl_int32* y);
-double __spirv_ocl_lgamma_r(double x, __hipsycl_int64* y);
-HIPSYCL_SSCP_BUILTIN float __hipsycl_sscp_lgamma_r_f32(float x, __hipsycl_int32* y ) { return __spirv_ocl_lgamma_r(x, y); }
-HIPSYCL_SSCP_BUILTIN double __hipsycl_sscp_lgamma_r_f64(double x, __hipsycl_int64* y) { return __spirv_ocl_lgamma_r(x, y); }
+double __spirv_ocl_lgamma_r(double x, __hipsycl_int32* y);
+HIPSYCL_SSCP_BUILTIN float __hipsycl_sscp_lgamma_r_f32(float x,
+                                                       __hipsycl_int32 *y) {
+  return __spirv_ocl_lgamma_r(x, y);
+}
+HIPSYCL_SSCP_BUILTIN double __hipsycl_sscp_lgamma_r_f64(double x,
+                                                        __hipsycl_int64 *y) {
+  __hipsycl_int32 v;
+  auto res = __spirv_ocl_lgamma_r(x, &v);
+  *y = v;
+  return res;
+}
 
 HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN(log)
 HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN(log2)
@@ -174,10 +194,13 @@ HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN(rint)
 
 
 float __spirv_ocl_rootn(float, __hipsycl_int32);
-double __spirv_ocl_rootn(double, __hipsycl_int64);
+double __spirv_ocl_rootn(double, __hipsycl_int32);
 
 HIPSYCL_SSCP_BUILTIN float __hipsycl_sscp_rootn_f32(float x, __hipsycl_int32 y) { return __spirv_ocl_rootn(x, y); }
-HIPSYCL_SSCP_BUILTIN double __hipsycl_sscp_rootn_f64(double x, __hipsycl_int64 y) {return __spirv_ocl_rootn(x, y); }
+HIPSYCL_SSCP_BUILTIN double __hipsycl_sscp_rootn_f64(double x,
+                                                     __hipsycl_int64 y) {
+  return __spirv_ocl_rootn(x, static_cast<__hipsycl_int32>(y));
+}
 
 HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN(round)
 HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN(rsqrt)


### PR DESCRIPTION
These builtins had the wrong signature and caused a JIT failure. With this PR, I can run all of the `math_tests` on Intel GPU through OpenCL.