### PR TITLE
[SSCP][llvm-to-amdgpu] Adjust data layout for LLVM >= 17

### DIFF
--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -203,10 +203,17 @@ LLVMToAmdgpuTranslator::LLVMToAmdgpuTranslator(const std::vector<std::string> &K
 bool LLVMToAmdgpuTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
   
   M.setTargetTriple(TargetTriple);
+#if LLVM_VERSION_MAJOR >= 17
+  M.setDataLayout(
+      "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-p7:160:256:256:32-p8:128:128-"
+      "i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-"
+      "n32:64-S32-A5-G1-ni:7:8");
+#else
   M.setDataLayout(
       "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-"
       "v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7");
-
+#endif
+  
   AddressSpaceMap ASMap = getAddressSpaceMap();
 
   KernelFunctionParameterRewriter ParamRewriter{


### PR DESCRIPTION
LLVM >= 17 has slightly changed data layout for amdgcn. This causes a JIT warning that modules with different data layout will be linked, since `llvm-to-amdgpu` currently assumes the older data layout.

While the changes are unlikely to affect us and code as far as I can see still works as expected, the warning can be confusing. This PR adjusts data layout for amdgpu target if LLVM >= 17 to silence this warning.