### PR TITLE
Only check for OpenCL if user has not explicitly set WITH_SSCP_COMPILER to False

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,8 +90,15 @@ endif()
 list(INSERT CMAKE_MODULE_PATH 0 "${PROJECT_SOURCE_DIR}/cmake/")
 find_package(CUDA QUIET)
 find_package(HIP QUIET HINTS ${ROCM_PATH} ${ROCM_PATH}/lib/cmake)
-# Check for OpenCL
-find_package(OpenCL QUIET)
+
+# Check for OpenCL unless user has explicitly set WITH_SSCP_COMPILER to False
+if (DEFINED WITH_SSCP_COMPILER)
+  if (WITH_SSCP_COMPILER)
+    find_package(OpenCL QUIET)
+  endif()
+else()
+  find_package(OpenCL QUIET)
+endif()
 
 # In case HIP is not found via the cmake pkgs we fall back to the legacy rocm discovery:
 if (NOT HIP_FOUND)


### PR DESCRIPTION
If `-DWITH_SSCP_COMPILER=False` is passed during CMake config but OpenCL is found, then `WITH_SSCP_COMPILER` is later set to true, which is unexpected.