### PR TITLE
For two read-only accesses, only replace the previous access in the data user tracker if it is part of the dependency tree of the new one

### DIFF
--- a/src/runtime/dag_builder.cpp
+++ b/src/runtime/dag_builder.cpp
@@ -27,6 +27,7 @@
 
 
 #include "hipSYCL/runtime/data.hpp"
+#include "hipSYCL/runtime/hints.hpp"
 #include "hipSYCL/runtime/util.hpp"
 #include "hipSYCL/runtime/operations.hpp"
 #include "hipSYCL/runtime/dag_builder.hpp"
@@ -45,6 +46,24 @@ namespace rt {
 
 namespace {
 
+// Attempts to find x in node's dependency graph
+bool find_dependency(const dag_node_ptr &node, const dag_node_ptr& x,
+                                    int max_num_levels = 2) {
+  if(max_num_levels <= 0)
+    return false;
+
+  for(auto& req : node->get_requirements()) {
+    if(auto req_locked = req.lock()) {
+      if(req_locked == x)
+        return true;
+    
+      if(find_dependency(req_locked, x, max_num_levels - 1))
+        return true;
+    }
+  }
+
+  return false;
+}
 
 // Add this node to the data users of the memory region of the specified
 // requirement
@@ -79,12 +98,21 @@ void add_to_data_users(dag_node_ptr node, memory_requirement *mem_req) {
 
       // Write accesses always create strong dependencies, so we can
       // safely replace the old user in any case
-      if(new_user_writes)
+      if(new_user_writes) {
         return true;
+      }
       // A read-only access is weaker than a write-access, so we can
       // only replace if the other user is also a read-only access.
       else if(!old_user_writes){
-        return true;
+        auto user_locked = user.user.lock();
+        // If user does not exist anymore, it can be replaced.
+        if(!user_locked)
+          return true;
+        // Replacement is only correct if the old user is part of the dependency chain
+        // of the new user, since two read accesses otherwise might not have a dependency.
+        if(find_dependency(node, user_locked)) {
+          return true;
+        }
       }
 
       return false;


### PR DESCRIPTION
A `buffer` needs to track which operations are currently using it. This is to
1. Be able to provide a list of dependencies for new operations that also use the buffer
2. Be able to wait for operations to complete when the buffer dies.

This tracking data structure can become so large that it can slow down program execution, especially for programs that submit many tasks. Therefore, we need to trim it to the most necessary tasks (e.g. leaf nodes in the dependency graph).

This is accomplished by replacing nodes in the tracking data structure which are superseded by a newer node. For example, if a new node access the same data as the old, it can usually replace the old node.

However, if both the new node and the old node have read-only access, there is a special case that so far was not handled correctly. In this case, there is not necessarily a dependency edge between them, because the runtime may want to run two read-only tasks concurrently. So, in this case, the new node must not replace the old one, unless we can find a dependency edge between them (i.e. the old one appears in the dependency graph of the new one). This check was previously missing, and is added by this PR.

This PR particularly can solve problems with host writebacks: The writeback operation is implemented as a read-only memory access. When a writeback is submitted, without this PR the writeback operation could have replaced previously enqueued kernels that only had read-only access to the buffer in the user tracking data structure. This in turn can cause the buffer destructor to only wait for the writeback to complete, but not the previously submitted read-only kernel.

Fixes #855

CC @tdavidcl 