### PR TITLE
[SSCP][llvm-to-host] If -ffast-math was set, link with bitcode libraries built with -ffast-math

### DIFF
--- a/src/compiler/llvm-to-backend/host/LLVMToHost.cpp
+++ b/src/compiler/llvm-to-backend/host/LLVMToHost.cpp
@@ -96,9 +96,12 @@ bool LLVMToHostTranslator::toBackendFlavor(llvm::Module &M, PassHandler &PH) {
     }
   }
 
+  std::string BuiltinBitcodeFileName = "libkernel-sscp-host-full.bc";
+  if(IsFastMath)
+    BuiltinBitcodeFileName = "libkernel-sscp-host-fast-full.bc";
   std::string BuiltinBitcodeFile =
       common::filesystem::join_path(common::filesystem::get_install_directory(),
-                                    {"lib", "hipSYCL", "bitcode", "libkernel-sscp-host-full.bc"});
+                                    {"lib", "hipSYCL", "bitcode", BuiltinBitcodeFileName});
 
   if (!this->linkBitcodeFile(M, BuiltinBitcodeFile))
     return false;
@@ -124,7 +127,6 @@ bool LLVMToHostTranslator::toBackendFlavor(llvm::Module &M, PassHandler &PH) {
 
 bool LLVMToHostTranslator::translateToBackendFormat(llvm::Module &FlavoredModule,
                                                     std::string &out) {
-
   auto InputFile = llvm::sys::fs::TempFile::create("hipsycl-sscp-host-%%%%%%.bc");
   auto OutputFile = llvm::sys::fs::TempFile::create("hipsycl-sscp-host-%%%%%%.so");
 

--- a/src/libkernel/sscp/host/CMakeLists.txt
+++ b/src/libkernel/sscp/host/CMakeLists.txt
@@ -2,8 +2,28 @@ if(WITH_LLVM_TO_HOST)
   if(NOT DEFINED LLVM_TARGET_TRIPLE)
     set(LLVM_TARGET_TRIPLE ${TARGET_TRIPLE})
   endif()
+
+  set(HOST_LIBKERNEL_BITCODE_SOURCES
+    atomic.cpp
+    barrier.cpp
+    core.cpp
+    integer.cpp
+    half.cpp
+    math.cpp
+    native.cpp
+    print.cpp
+    relational.cpp
+    localmem.cpp
+    subgroup.cpp)
+
   libkernel_generate_bitcode_target(
       TARGETNAME host 
       TRIPLE ${LLVM_TARGET_TRIPLE}
-      SOURCES atomic.cpp barrier.cpp core.cpp integer.cpp half.cpp math.cpp native.cpp print.cpp relational.cpp localmem.cpp subgroup.cpp)
+      SOURCES ${HOST_LIBKERNEL_BITCODE_SOURCES})
+
+  libkernel_generate_bitcode_target(
+      TARGETNAME host-fast
+      TRIPLE ${LLVM_TARGET_TRIPLE}
+      SOURCES ${HOST_LIBKERNEL_BITCODE_SOURCES}
+      ADDITIONAL_ARGS -ffast-math)
 endif()


### PR DESCRIPTION
@fodinabor @MarkusBuettner This should cause SSCP host JIT to emit approximate math builtins if `-ffast-math` was used during compilation.