### PR TITLE
dag_builder: Use std::exchange to avoid sbo free() warning

### DIFF
--- a/src/runtime/dag_builder.cpp
+++ b/src/runtime/dag_builder.cpp
@@ -34,6 +34,7 @@
 #include "hipSYCL/sycl/access.hpp"
 
 #include <mutex>
+#include <utility>
 
 // TODO: Implement the following optimization:
 // - Reorder requirements such that larger accesses come first. This will cause
@@ -228,8 +229,7 @@ dag dag_builder::finish_and_reset()
 {
   std::lock_guard<std::mutex> lock{_mutex};
 
-  dag final_dag = _current_dag;
-  _current_dag = dag{};
+  dag final_dag = std::exchange(_current_dag, {});
 
   HIPSYCL_DEBUG_INFO << "dag_builder: DAG contains operations: " << std::endl;
   int operation_index = 0;


### PR DESCRIPTION
@al42and For me this avoids the warning from #1381. My guess is that something in the auto-generated move assignment triggers  the warning. Perhaps we don't see it in other places because this is the only place where auto-generated move assignment was used with `small_vector` or similar.