### PR TITLE
Fix simultaneous compilation for generic and SMCP flows by not instantiating sscp kernel launcher in device pass

### DIFF
--- a/include/hipSYCL/glue/kernel_launcher_factory.hpp
+++ b/include/hipSYCL/glue/kernel_launcher_factory.hpp
@@ -102,7 +102,8 @@ make_kernel_launchers(sycl::id<Dim> offset, sycl::range<Dim> local_range,
   }
 #endif
 
-#ifdef __HIPSYCL_ENABLE_LLVM_SSCP_TARGET__
+#if defined(__HIPSYCL_ENABLE_LLVM_SSCP_TARGET__) && \
+  !defined(SYCL_DEVICE_ONLY)
   {
     auto launcher = std::make_unique<sscp_kernel_launcher>();
     launcher->bind<name_traits, Type>(offset, global_range, local_range,


### PR DESCRIPTION
Previously `--acpp-targets=generic;cuda:..` or `--acpp-targets=generic;hip:...` was broken because the sscp kernel launcher was also instantiated in the SMCP device pass, where ondemand iteration info is active.
This PR fixes this.