### PR TITLE
[NFC] [Doc] Adding documentation webpage using mkdocs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,63 @@
+name: Documentation
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+  workflow_call:
+
+
+jobs:
+
+  #make shamrock documentation
+  make_documentation:
+    name: "Build : Documentation"
+
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
+
+      - name: pip install packages (Jupyter book)
+        run: pip install -U mkdocs-material mkdocs-git-revision-date-localized-plugin mkdocs-git-authors-plugin
+
+      - name: run mkdocs
+        run: mkdocs build
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./site
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+
+
+
+
+  deploy_page:
+
+    if: github.ref == 'refs/heads/develop'
+
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: make_documentation
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
 
-  #make shamrock documentation
   make_documentation:
     name: "Build : Documentation"
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           python-version: '3.10' 
 
-      - name: pip install packages (Jupyter book)
+      - name: pip install packages
         run: pip install -U mkdocs-material mkdocs-git-revision-date-localized-plugin mkdocs-git-authors-plugin
 
       - name: run mkdocs

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -44,7 +44,7 @@ In other words, while the SYCL interface calls into the runtime, the inverse is 
 The AdaptiveCpp runtime follows a [specification](runtime-spec.md) that expands on the Khronos SYCL specification.
 
 The following image illustrates the runtime architecture:
-![Runtime architecture](/doc/img/runtime.png)
+![Runtime architecture](img/runtime.png)
 
 ## Compiler
 

--- a/doc/compilation.md
+++ b/doc/compilation.md
@@ -8,7 +8,7 @@ AdaptiveCpp supports multiple types of compilation flows:
    3. Intel GPUs through SPIR-V (Level Zero);
    4. SPIR-V compatible OpenCL devices supporting Intel USM extensions or fine-grained system SVM (such as Intel's OpenCL implementation for CPUs or GPUs);
    5. The host CPU through LLVM
-2. Interoperability-focused multipass compilation flows. **AdaptiveCpp can aggregate existing clang toolchains and augment them with support for SYCL constructs**. This allows for a high degree of interoperability between SYCL and other models such as CUDA or HIP. For example, in this mode, the AdaptiveCpp CUDA and ROCm backends rely on the clang CUDA/HIP frontends that have been augmented by AdaptiveCpp to *additionally* also understand other models like SYCL. This means that the AdaptiveCpp compiler can not only compile SYCL code, but also CUDA/HIP code *even if they are mixed in the same source file*, making all CUDA/HIP features - such as the latest device intrinsics - also available from SYCL code ([details](doc/hip-source-interop.md)). Additionally, vendor-optimized template libraries such as rocPRIM or CUB can also be used with AdaptiveCpp. This allows for highly optimized code paths in SYCL code for specific devices. Support includes:
+2. Interoperability-focused multipass compilation flows. **AdaptiveCpp can aggregate existing clang toolchains and augment them with support for SYCL constructs**. This allows for a high degree of interoperability between SYCL and other models such as CUDA or HIP. For example, in this mode, the AdaptiveCpp CUDA and ROCm backends rely on the clang CUDA/HIP frontends that have been augmented by AdaptiveCpp to *additionally* also understand other models like SYCL. This means that the AdaptiveCpp compiler can not only compile SYCL code, but also CUDA/HIP code *even if they are mixed in the same source file*, making all CUDA/HIP features - such as the latest device intrinsics - also available from SYCL code ([details](hip-source-interop.md)). Additionally, vendor-optimized template libraries such as rocPRIM or CUB can also be used with AdaptiveCpp. This allows for highly optimized code paths in SYCL code for specific devices. Support includes:
    1. Any LLVM-supported CPU (including e.g. x86, arm, power etc) through the regular clang host toolchain with dedicated compiler transformation to accelerate SYCL constructs;
    2. NVIDIA CUDA GPUs through the clang CUDA toolchain;
    3. AMD ROCm GPUs through the clang HIP toolchain
@@ -17,7 +17,7 @@ AdaptiveCpp supports multiple types of compilation flows:
    2. NVIDIA GPUs through CUDA and the NVIDIA nvc++ compiler, bringing NVIDIA vendor support and day 1 hardware support to the SYCL ecosystem
 
 The following illustration shows the complete stack and its capabilities to target hardware:
-![Compiler stack](/doc/img/stack.png)
+![Compiler stack](img/stack.png)
 
 
 ## Generic SSCP compilation flow (`--acpp-targets=generic`)
@@ -122,7 +122,7 @@ For more details, see the [installation instructions](installing.md) and the doc
 The `acpp` compilation driver is responsible for controlling the active compilation flows.
 The following image illustrates the different flows that AdaptiveCpp supports through `acpp`.
 
-![acpp design](/doc/img/acpp.png)
+![acpp design](img/acpp.png)
 
 ## File format for embedded device code
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,0 +1,17 @@
+# Welcome to MkDocs
+
+For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+
+## Commands
+
+* `mkdocs new [dir-name]` - Create a new project.
+* `mkdocs serve` - Start the live-reloading docs server.
+* `mkdocs build` - Build the documentation site.
+* `mkdocs -h` - Print help message and exit.
+
+## Project layout
+
+    mkdocs.yml    # The configuration file.
+    docs/
+        index.md  # The documentation homepage.
+        ...       # Other markdown pages, images and other files.

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,17 +1,30 @@
-# Welcome to MkDocs
+#
+![The Rust Logo](img/logo/logo-color.png)
 
-For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+Welcome to the documentation of the AdaptiveCpp !
 
-## Commands
+<div class="grid cards" markdown>
 
-* `mkdocs new [dir-name]` - Create a new project.
-* `mkdocs serve` - Start the live-reloading docs server.
-* `mkdocs build` - Build the documentation site.
-* `mkdocs -h` - Print help message and exit.
+-   :material-clock-fast:{ .lg .middle } __Installation__
 
-## Project layout
+    ---
 
-    mkdocs.yml    # The configuration file.
-    docs/
-        index.md  # The documentation homepage.
-        ...       # Other markdown pages, images and other files.
+    Configure and install AdaptiveCpp
+
+    [:octicons-arrow-right-24: Installation](./installing.md)
+
+-   :fontawesome-solid-gears:{ .lg .middle } __Can run on any hardware__
+
+    ---
+
+    We support CPUs, GPUs, from all vendors, either through multipass compilation.
+    Or through our single pass SSCP compiler
+
+    [:octicons-arrow-right-24: Usage](./using-hipsycl.md)
+
+
+</div>
+
+!!! note
+
+    This documentation webpage is WIP.

--- a/doc/serve_doc.sh
+++ b/doc/serve_doc.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+SCRIPTDIR=$(dirname "$0")
+
+PYENVDIR=$SCRIPTDIR/../AdaptiveCppEnv
+
+cd $SCRIPTDIR/..
+
+if [ ! -d $PYENVDIR ]; then
+  echo "$PYENVDIR does not exist, creating the venv"
+  python3 -m venv AdaptiveCppEnv
+fi
+
+source $SCRIPTDIR/../AdaptiveCppEnv/bin/activate
+
+pip install mkdocs-material mkdocs-git-revision-date-localized-plugin mkdocs-git-authors-plugin
+
+mkdocs serve

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,7 @@ nav:
       - 'HCF' : 'hcf.md'
 
   - 'Extensions overview' : 'extensions.md'
-  - 'Compiler Extensions doc' :
+  - 'Extensions in detail' :
       - 'Accessor variants' : 'accessor-variants.md'
       - 'Buffer USM interop' : 'buffer-usm-interop.md'
       - 'Enqueue custom operation' : 'enqueue-custom-operation.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,7 @@ nav:
       - 'Env variables' : 'env_variables.md'
       - 'Macros' : 'macros.md'
       - 'SYCL interoperability' : 'hip-source-interop.md'
-      - 'Std par' : 'stdpar.md'
+      - 'C++ standard parallelism offloading (stdpar)' : 'stdpar.md'
 
   - 'AdaptiveCpp design' : 
       - 'Architecture' : 'architecture.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,8 +3,6 @@ site_name: AdaptiveCpp Documentation
 repo_url: https://github.com/AdaptiveCpp/AdaptiveCpp
 repo_name: AdaptiveCpp
 
-copyright: Copyright(C) 2021-2023 Timothée David--Cléris
-
 docs_dir: doc
 
 nav:
@@ -41,8 +39,6 @@ nav:
       - 'OpenCL' : 'install-ocl.md'
       - 'Level Zero' : 'install-spirv.md'
 
-  - 'Limitations' : 'limitations.md'
-  - 'History' : 'history.md'
 
 theme:
   name: material
@@ -57,6 +53,19 @@ plugins:
       enable_creation_date: true
 
 markdown_extensions:
+  # for the grid in index.md
+  - attr_list
+  - md_in_html
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+
+  # code blocks
   - pymdownx.highlight:
       use_pygments: true
+  - pymdownx.superfences
+
+
+  - admonition
+  - pymdownx.details
   - pymdownx.superfences

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,7 +39,7 @@ nav:
       - 'CUDA' : 'install-cuda.md'
       - 'ROCM' : 'install-rocm.md'
       - 'OpenCL' : 'install-ocl.md'
-      - 'SPIR-V' : 'install-spirv.md'
+      - 'Level Zero' : 'install-spirv.md'
 
   - 'Limitations' : 'limitations.md'
   - 'History' : 'history.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,62 @@
+site_name: AdaptiveCpp Documentation
+
+repo_url: https://github.com/AdaptiveCpp/AdaptiveCpp
+repo_name: AdaptiveCpp
+
+copyright: Copyright(C) 2021-2023 Timothée David--Cléris
+
+docs_dir: doc
+
+nav:
+  - 'Acpp documentation': 'index.md'
+
+
+  - 'Usage' :
+      - 'Using Acpp' : 'using-hipsycl.md'
+      - 'Compilation' : 'compilation.md'
+      - 'Env variables' : 'env_variables.md'
+      - 'Macros' : 'macros.md'
+      - 'SYCL interoperability' : 'hip-source-interop.md'
+      - 'Std par' : 'stdpar.md'
+
+  - 'Acpp design' : 
+      - 'Architecture' : 'architecture.md'
+      - 'Runtime Specification' : 'runtime-spec.md'
+      - 'HCF' : 'hcf.md'
+
+  - 'Extensions' : 'extensions.md'
+  - 'Compiler Extensions doc' :
+      - 'Accessor variants' : 'accessor-variants.md'
+      - 'Buffer USM interop' : 'buffer-usm-interop.md'
+      - 'Enqueue custom operation' : 'enqueue-custom-operation.md'
+      - 'Explicit buffer policies' : 'explicit-buffer-policies.md'
+      - 'Multi device queue' : 'multi-device-queue.md'
+      - 'Scoped parallelism' : 'scoped-parallelism.md'
+
+  - 'Installing Acpp' : 'installing.md'
+  - 'Installation doc' :
+      - 'LLVM' : 'install-llvm.md'
+      - 'CUDA' : 'install-cuda.md'
+      - 'ROCM' : 'install-rocm.md'
+      - 'OpenCL' : 'install-ocl.md'
+      - 'SPIR-V' : 'install-spirv.md'
+
+  - 'Limitations' : 'limitations.md'
+  - 'History' : 'history.md'
+
+theme:
+  name: material
+  icon:
+    repo: fontawesome/brands/github
+
+
+plugins:
+  - git-authors
+  - search
+  - git-revision-date-localized:
+      enable_creation_date: true
+
+markdown_extensions:
+  - pymdownx.highlight:
+      use_pygments: true
+  - pymdownx.superfences

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,7 +13,7 @@ nav:
 
   - 'Usage' :
       - 'Using AdaptiveCpp' : 'using-hipsycl.md'
-      - 'Compilation' : 'compilation.md'
+      - 'Compilation model' : 'compilation.md'
       - 'Env variables' : 'env_variables.md'
       - 'Macros' : 'macros.md'
       - 'SYCL interoperability' : 'hip-source-interop.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,7 @@ nav:
       - 'SYCL interoperability' : 'hip-source-interop.md'
       - 'Std par' : 'stdpar.md'
 
-  - 'Acpp design' : 
+  - 'AdaptiveCpp design' : 
       - 'Architecture' : 'architecture.md'
       - 'Runtime Specification' : 'runtime-spec.md'
       - 'HCF' : 'hcf.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,7 @@ nav:
       - 'Runtime Specification' : 'runtime-spec.md'
       - 'HCF' : 'hcf.md'
 
-  - 'Extensions' : 'extensions.md'
+  - 'Extensions overview' : 'extensions.md'
   - 'Compiler Extensions doc' :
       - 'Accessor variants' : 'accessor-variants.md'
       - 'Buffer USM interop' : 'buffer-usm-interop.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,7 +33,7 @@ nav:
       - 'Multi device queue' : 'multi-device-queue.md'
       - 'Scoped parallelism' : 'scoped-parallelism.md'
 
-  - 'Installing Acpp' : 'installing.md'
+  - 'Installing AdaptiveCpp' : 'installing.md'
   - 'Installation doc' :
       - 'LLVM' : 'install-llvm.md'
       - 'CUDA' : 'install-cuda.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ copyright: Copyright(C) 2021-2023 Timothée David--Cléris
 docs_dir: doc
 
 nav:
-  - 'Acpp documentation': 'index.md'
+  - 'AdaptiveCpp documentation': 'index.md'
 
 
   - 'Usage' :

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,7 @@ nav:
 
 
   - 'Usage' :
-      - 'Using Acpp' : 'using-hipsycl.md'
+      - 'Using AdaptiveCpp' : 'using-hipsycl.md'
       - 'Compilation' : 'compilation.md'
       - 'Env variables' : 'env_variables.md'
       - 'Macros' : 'macros.md'


### PR DESCRIPTION
# Adding Mkdocs documentation

Use mkdocs material to generate a documentation page from the existing markdown documentation. 
This PR aims at providing this with as few changes as possible to the existing doc. 

So far the only real change is that i have to move the markdown files in a folder within doc (maybe it is possible to change that though).

# TODOs
- [x] Add utility script to get mkdocs & run doc page
- [x] Add utility script to build
- [x] CI for mkdocs
- [x] Can the subfolder `docs` be removed (may be a bit messy to have the sources next to the config though) ?