### PR TITLE
[SSCP] Optimize kernel_configuration latency

### DIFF
--- a/include/hipSYCL/glue/kernel_configuration.hpp
+++ b/include/hipSYCL/glue/kernel_configuration.hpp
@@ -38,7 +38,11 @@
 #include <vector>
 #include <functional>
 #include <cassert>
+#include <optional>
+#include <unordered_map>
+
 #include "hipSYCL/common/stable_running_hash.hpp"
+#include "hipSYCL/common/small_vector.hpp"
 
 namespace hipsycl {
 namespace glue {
@@ -52,6 +56,128 @@ enum class kernel_base_config_parameter : int {
   runtime_context = 5,
   single_kernel = 6
 };
+
+enum class kernel_build_option : int {
+  known_group_size_x,
+  known_group_size_y,
+  known_group_size_z,
+  known_local_mem_size,
+
+  ptx_version,
+  ptx_target_device,
+
+  amdgpu_target_device,
+  amdgpu_rocm_device_libs_path,
+  amdgpu_rocm_path,
+
+  spirv_dynamic_local_mem_allocation_size
+};
+
+enum class kernel_build_flag : int {
+  global_sizes_fit_in_int,
+  fast_math,
+
+  ptx_ftz,
+  ptx_approx_div,
+  ptx_approx_sqrt,
+
+  spirv_enable_intel_llvm_spirv_options
+};
+
+class string_build_config_mapper {
+public:
+  string_build_config_mapper() {
+    _options =  {
+      {"known-group-size-x", kernel_build_option::known_group_size_x},
+      {"known-group-size-y", kernel_build_option::known_group_size_y},
+      {"known-group-size-z", kernel_build_option::known_group_size_z},
+      {"known-local-mem-size", kernel_build_option::known_local_mem_size},
+      {"ptx-version", kernel_build_option::ptx_version},
+      {"ptx-target-device", kernel_build_option::ptx_target_device},
+      {"amdgpu-target-device", kernel_build_option::amdgpu_target_device},
+      {"rocm-device-libs-path", kernel_build_option::amdgpu_rocm_device_libs_path},
+      {"rocm-path", kernel_build_option::amdgpu_rocm_path},
+      {"spirv-dynamic-local-mem-allocation-size", kernel_build_option::spirv_dynamic_local_mem_allocation_size}
+    };
+
+    _flags = {
+      {"global-sizes-fit-in-int", kernel_build_flag::global_sizes_fit_in_int},
+      {"fast-math", kernel_build_flag::fast_math},
+      {"ptx-ftz", kernel_build_flag::ptx_ftz},
+      {"ptx-approx-div", kernel_build_flag::ptx_approx_div},
+      {"ptx-approx-sqrt", kernel_build_flag::ptx_approx_sqrt},
+      {"spirv-enable-intel-llvm-spirv-options", kernel_build_flag::spirv_enable_intel_llvm_spirv_options}
+    };
+
+    for(const auto& elem : _options) {
+      _inverse_options[elem.second] = elem.first;
+    }
+
+    for(const auto& elem : _flags) {
+      _inverse_flags[elem.second] = elem.first;
+    }
+  }
+
+  static const auto& string_to_build_option_map() {
+    return get()._options;
+  }
+
+  static const auto& string_to_build_flag_map() {
+    return get()._flags;
+  }
+
+  static const auto& build_option_to_string_map() {
+    return get()._inverse_options;
+  }
+
+  static const auto& build_flag_to_string_map() {
+    return get()._inverse_flags;
+  }
+private:
+  static string_build_config_mapper& get() {
+    static string_build_config_mapper mapper;
+    return mapper;
+  }
+
+  std::unordered_map<std::string, kernel_build_option> _options;
+  std::unordered_map<std::string, kernel_build_flag> _flags;
+  std::unordered_map<kernel_build_option, std::string> _inverse_options;
+  std::unordered_map<kernel_build_flag, std::string> _inverse_flags;
+};
+
+inline std::string to_string(kernel_build_flag f) {
+  const auto& map = string_build_config_mapper::build_flag_to_string_map();
+  auto it = map.find(f);
+  if(it == map.end())
+    return {};
+  return it->second;
+}
+
+inline std::string to_string(kernel_build_option o) {
+  const auto& map = string_build_config_mapper::build_option_to_string_map();
+  auto it = map.find(o);
+  if(it == map.end())
+    return {};
+  return it->second;
+}
+
+inline std::optional<kernel_build_option>
+to_build_option(const std::string& s) {
+  const auto& map = string_build_config_mapper::string_to_build_option_map();
+  auto it = map.find(s);
+  if(it == map.end())
+    return {};
+  return it->second;
+}
+
+inline std::optional<kernel_build_flag>
+to_build_flag(const std::string& s) {
+  const auto& map = string_build_config_mapper::string_to_build_flag_map();
+  auto it = map.find(s);
+  if(it == map.end())
+    return {};
+  return it->second;
+}
 
 class kernel_configuration {
 
@@ -108,7 +234,14 @@ class kernel_configuration {
     }
   };
 
+
+
 public:
+  struct int_or_string{
+    std::optional<uint64_t> int_value;
+    std::optional<std::string> string_value;
+  };
+
   using id_type = std::array<uint64_t, 2>;
 
   template<class T>
@@ -123,16 +256,25 @@ public:
     _s2_ir_configurations.push_back(entry);
   }
 
-  void set_build_option(const std::string& option, const std::string& value) {
-    _build_options.push_back(std::make_pair(option, value));
+  void set_build_option(kernel_build_option option, const std::string& value) {
+    int_or_string ios;
+    ios.string_value = value;
+    _build_options.push_back(std::make_pair(option, ios));
   }
 
-  template<class T>
-  void set_build_option(const std::string& option, const T& value) {
+  template<class T, std::enable_if_t<std::is_unsigned_v<T>, int> = 0>
+  void set_build_option(kernel_build_option option, T int_value) {
+    int_or_string ios;
+    ios.int_value = static_cast<uint64_t>(int_value);
+    _build_options.push_back(std::make_pair(option, ios));
+  }
+
+  template<class T, std::enable_if_t<!std::is_unsigned_v<T>, int> = 0>
+  void set_build_option(kernel_build_option option, const T& value) {
     set_build_option(option, std::to_string(value));
   }
 
-  void set_build_flag(const std::string& flag) {
+  void set_build_flag(kernel_build_flag flag) {
     _build_flags.push_back(flag);
   }
 
@@ -163,19 +305,28 @@ public:
     }
 
     for(const auto& entry : _build_options) {
-      add_entry_to_hash(result, entry.first.data(), entry.first.size(),
-                        entry.second.data(), entry.second.size());
+      uint64_t numeric_option_id = static_cast<uint64_t>(entry.first) | (1ull << 32);
+      if(entry.second.int_value) {
+        auto numeric_value = entry.second.int_value.value();
+        add_entry_to_hash(result, &numeric_option_id, sizeof(numeric_option_id),
+                        &numeric_value, sizeof(numeric_value));
+      } else {
+        const std::string& string_value = entry.second.string_value.value();
+        add_entry_to_hash(result, &numeric_option_id, sizeof(numeric_option_id),
+                        string_value.data(), string_value.size());
+      }
     }
 
     for(const auto& entry : _build_flags) {
-      add_entry_to_hash(result, entry.data(), entry.size(),
+      uint64_t numeric_flag_id = static_cast<uint64_t>(entry) | (1ull << 33);
+      add_entry_to_hash(result, &numeric_flag_id, sizeof(numeric_flag_id),
                         "", 0);
     }
 
     return result;
   }
 
-  const std::vector<s2_ir_configuration_entry>& s2_ir_entries() const {
+  const auto& s2_ir_entries() const {
     return _s2_ir_configurations;
   }
 
@@ -235,9 +386,9 @@ private:
   }
 
 
-  std::vector<s2_ir_configuration_entry> _s2_ir_configurations;
-  std::vector<std::string> _build_flags;
-  std::vector<std::pair<std::string, std::string>> _build_options;
+  common::small_vector<s2_ir_configuration_entry, 2> _s2_ir_configurations;
+  common::small_vector<kernel_build_flag, 8> _build_flags;
+  common::small_vector<std::pair<kernel_build_option, int_or_string>, 4> _build_options;
 
   id_type _base_configuration_result = {};
 };

--- a/include/hipSYCL/glue/kernel_configuration.hpp
+++ b/include/hipSYCL/glue/kernel_configuration.hpp
@@ -42,7 +42,7 @@
 #include <unordered_map>
 
 #include "hipSYCL/common/stable_running_hash.hpp"
-#include "hipSYCL/common/small_vector.hpp"
+
 
 namespace hipsycl {
 namespace glue {
@@ -306,7 +306,7 @@ public:
 
     for(const auto& entry : _build_options) {
       uint64_t numeric_option_id = static_cast<uint64_t>(entry.first) | (1ull << 32);
-      if(entry.second.int_value) {
+      if(entry.second.int_value.has_value()) {
         auto numeric_value = entry.second.int_value.value();
         add_entry_to_hash(result, &numeric_option_id, sizeof(numeric_option_id),
                         &numeric_value, sizeof(numeric_value));
@@ -386,9 +386,9 @@ private:
   }
 
 
-  common::small_vector<s2_ir_configuration_entry, 2> _s2_ir_configurations;
-  common::small_vector<kernel_build_flag, 8> _build_flags;
-  common::small_vector<std::pair<kernel_build_option, int_or_string>, 4> _build_options;
+  std::vector<s2_ir_configuration_entry> _s2_ir_configurations;
+  std::vector<kernel_build_flag> _build_flags;
+  std::vector<std::pair<kernel_build_option, int_or_string>> _build_options;
 
   id_type _base_configuration_result = {};
 };

--- a/include/hipSYCL/glue/llvm-sscp/jit.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/jit.hpp
@@ -228,7 +228,7 @@ inline rt::result compile(compiler::LLVMToBackendTranslator *translator,
   for(const auto& option : config.build_options()) {
     std::string option_name = glue::to_string(option.first);
     std::string option_value =
-        option.second.int_value
+        option.second.int_value.has_value()
             ? std::to_string(option.second.int_value.value())
             : option.second.string_value.value();
     

--- a/include/hipSYCL/glue/llvm-sscp/jit.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/jit.hpp
@@ -226,11 +226,17 @@ inline rt::result compile(compiler::LLVMToBackendTranslator *translator,
   }
 
   for(const auto& option : config.build_options()) {
-    translator->setBuildOption(option.first, option.second);
+    std::string option_name = glue::to_string(option.first);
+    std::string option_value =
+        option.second.int_value
+            ? std::to_string(option.second.int_value.value())
+            : option.second.string_value.value();
+    
+    translator->setBuildOption(option_name, option_value);
   }
 
   for(const auto& flag : config.build_flags()) {
-    translator->setBuildFlag(flag);
+    translator->setBuildFlag(glue::to_string(flag));
   }
 
   // Transform code

--- a/include/hipSYCL/runtime/kernel_cache.hpp
+++ b/include/hipSYCL/runtime/kernel_cache.hpp
@@ -115,8 +115,8 @@ public:
   const std::vector<std::string> &get_images_containing_kernel() const;
   hcf_object_id get_hcf_object_id() const;
 
-  const std::vector<std::string>& get_compilation_flags() const;
-  const std::vector<std::pair<std::string, std::string>> &
+  const std::vector<glue::kernel_build_flag>& get_compilation_flags() const;
+  const std::vector<std::pair<glue::kernel_build_option, std::string>> &
   get_compilation_options() const;
 
 private:
@@ -126,8 +126,9 @@ private:
   std::vector<argument_type> _arg_types;
   std::vector<std::string> _image_providers;
   
-  std::vector<std::string> _compilation_flags;
-  std::vector<std::pair<std::string, std::string>> _compilation_options;
+  std::vector<glue::kernel_build_flag> _compilation_flags;
+  std::vector<std::pair<glue::kernel_build_option, std::string>>
+      _compilation_options;
 
   hcf_object_id _id;
   bool _parsing_successful = false;

--- a/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
+++ b/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
@@ -315,13 +315,13 @@ bool LLVMToPtxTranslator::applyBuildOption(const std::string &Option, const std:
 }
 
 bool LLVMToPtxTranslator::applyBuildFlag(const std::string& Option) {
-  if(Option == "ftz") {
+  if(Option == "ptx-ftz") {
     this->FlushDenormalsToZero = 1;
     return true;
-  } else if(Option == "approx-div") {
+  } else if(Option == "ptx-approx-div") {
     this->PreciseDiv = 0;
     return true;
-  } else if(Option == "approx-sqrt") {
+  } else if(Option == "ptx-approx-sqrt") {
     this->PreciseSqrt = 0;
     return true;
   }

--- a/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
+++ b/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
@@ -314,7 +314,7 @@ bool LLVMToSpirvTranslator::applyBuildOption(const std::string &Option, const st
 }
 
 bool LLVMToSpirvTranslator::applyBuildFlag(const std::string& Flag) {
-  if(Flag == "enable-intel-llvm-spirv-options") {
+  if(Flag == "spirv-enable-intel-llvm-spirv-options") {
     UseIntelLLVMSpirvArgs = true;
     return true;
   }

--- a/src/runtime/adaptivity_engine.cpp
+++ b/src/runtime/adaptivity_engine.cpp
@@ -34,17 +34,6 @@
 namespace hipsycl {
 namespace rt {
 
-namespace {
-
-std::string group_size_build_opt_x = "known-group-size-x";
-std::string group_size_build_opt_y = "known-group-size-y";
-std::string group_size_build_opt_z = "known-group-size-z";
-
-std::string global_sizes_fit_in_int_opt = "global-sizes-fit-in-int";
-
-std::string local_mem_size_build_opt = "known-local-mem-size";
-}
-
 kernel_adaptivity_engine::kernel_adaptivity_engine(hcf_object_id hcf_object,
                                      const std::string &backend_kernel_name,
                                      const hcf_kernel_info* kernel_info,
@@ -70,22 +59,22 @@ kernel_adaptivity_engine::finalize_binary_configuration(
         glue::kernel_base_config_parameter::single_kernel, _kernel_name);
 
     // Hard-code group sizes into the JIT binary
-    config.set_build_option(group_size_build_opt_x,
-                            std::to_string(_block_size[0]));
-    config.set_build_option(group_size_build_opt_y,
-                            std::to_string(_block_size[1]));
-    config.set_build_option(group_size_build_opt_z,
-                            std::to_string(_block_size[2]));
+    config.set_build_option(glue::kernel_build_option::known_group_size_x,
+                            _block_size[0]);
+    config.set_build_option(glue::kernel_build_option::known_group_size_y,
+                            _block_size[1]);
+    config.set_build_option(glue::kernel_build_option::known_group_size_z,
+                            _block_size[2]);
 
     // Try to optimize size_t -> i32 for queries if those fit in int
     auto global_size = _num_groups * _block_size;
     auto int_max = std::numeric_limits<int>::max();
     if (global_size[0] * global_size[1] * global_size[2] < int_max)
-      config.set_build_flag(global_sizes_fit_in_int_opt);
+      config.set_build_flag(glue::kernel_build_flag::global_sizes_fit_in_int);
 
     // Hard-code local memory size into the JIT binary
-    config.set_build_option(local_mem_size_build_opt,
-                            std::to_string(_local_mem_size));
+    config.set_build_option(glue::kernel_build_option::known_local_mem_size,
+                            _local_mem_size);
   }
 
   return config.generate_id();

--- a/src/runtime/cuda/cuda_queue.cpp
+++ b/src/runtime/cuda/cuda_queue.cpp
@@ -624,9 +624,11 @@ result cuda_queue::submit_sscp_kernel_from_code_object(
     config.set_build_option(opt.first, opt.second);
   // TODO This is incorrect, we should attempt to find a better way to determine
   // the right ptx version
-  config.set_build_option("ptx-version", compute_capability);
-  config.set_build_option("ptx-target-device", compute_capability);
-  
+  config.set_build_option(glue::kernel_build_option::ptx_version,
+                          compute_capability);
+  config.set_build_option(glue::kernel_build_option::ptx_target_device,
+                          compute_capability);
+
   auto binary_configuration_id = adaptivity_engine.finalize_binary_configuration(config);
   auto code_object_configuration_id = binary_configuration_id;
   glue::kernel_configuration::extend_hash(

--- a/src/runtime/cuda/cuda_queue.cpp
+++ b/src/runtime/cuda/cuda_queue.cpp
@@ -609,7 +609,8 @@ result cuda_queue::submit_sscp_kernel_from_code_object(
       hcf_object, kernel_name, kernel_info, num_groups,
       group_size, args,        arg_sizes,   num_args, local_mem_size};
 
-  glue::kernel_configuration config = initial_config;
+  static thread_local glue::kernel_configuration config;
+  config = initial_config;
   config.append_base_configuration(
       glue::kernel_base_config_parameter::backend_id, backend_id::cuda);
   config.append_base_configuration(

--- a/src/runtime/hip/hip_queue.cpp
+++ b/src/runtime/hip/hip_queue.cpp
@@ -614,7 +614,8 @@ result hip_queue::submit_sscp_kernel_from_code_object(
       hcf_object, kernel_name, kernel_info, num_groups,
       group_size, args,        arg_sizes,   num_args, local_mem_size};
   
-  glue::kernel_configuration config = initial_config;
+  static thread_local glue::kernel_configuration config;
+  config = initial_config;
   config.append_base_configuration(
       glue::kernel_base_config_parameter::backend_id, backend_id::hip);
   config.append_base_configuration(

--- a/src/runtime/hip/hip_queue.cpp
+++ b/src/runtime/hip/hip_queue.cpp
@@ -627,9 +627,10 @@ result hip_queue::submit_sscp_kernel_from_code_object(
     config.set_build_flag(flag);
   for(const auto& opt : kernel_info->get_compilation_options())
     config.set_build_option(opt.first, opt.second);
-  
-  config.set_build_option("amdgpu-target-device", target_arch_name);
-  
+
+  config.set_build_option(glue::kernel_build_option::amdgpu_target_device,
+                          target_arch_name);
+
   auto binary_configuration_id = adaptivity_engine.finalize_binary_configuration(config);
   auto code_object_configuration_id = binary_configuration_id;
   glue::kernel_configuration::extend_hash(

--- a/src/runtime/kernel_cache.cpp
+++ b/src/runtime/kernel_cache.cpp
@@ -113,12 +113,17 @@ hcf_kernel_info::hcf_kernel_info(
 
   if(const auto* flags_node = kernel_node->get_subnode("compile-flags")) {
     for(const auto& flag : flags_node->key_value_pairs) {
-      _compilation_flags.push_back(flag.first);
+      auto f = glue::to_build_flag(flag.first);
+      if(f)
+        _compilation_flags.push_back(f.value());
     }
   }
   if(const auto* options_node = kernel_node->get_subnode("compile-options")) {
-    for(const auto& flag : options_node->key_value_pairs) {
-      _compilation_flags.push_back(flag.first);
+    for(const auto& option : options_node->key_value_pairs) {
+      auto o = glue::to_build_option(option.first);
+      if(o)
+        _compilation_options.push_back(
+            std::make_pair(o.value(), option.second));
     }
   }
 
@@ -159,11 +164,12 @@ hcf_object_id hcf_kernel_info::get_hcf_object_id() const {
   return _id;
 }
 
-const std::vector<std::string> &hcf_kernel_info::get_compilation_flags() const {
+const std::vector<glue::kernel_build_flag> &
+hcf_kernel_info::get_compilation_flags() const {
   return _compilation_flags;
 }
 
-const std::vector<std::pair<std::string, std::string>> &
+const std::vector<std::pair<glue::kernel_build_option, std::string>> &
 hcf_kernel_info::get_compilation_options() const {
   return _compilation_options;
 }

--- a/src/runtime/kernel_cache.cpp
+++ b/src/runtime/kernel_cache.cpp
@@ -114,14 +114,14 @@ hcf_kernel_info::hcf_kernel_info(
   if(const auto* flags_node = kernel_node->get_subnode("compile-flags")) {
     for(const auto& flag : flags_node->key_value_pairs) {
       auto f = glue::to_build_flag(flag.first);
-      if(f)
+      if(f.has_value())
         _compilation_flags.push_back(f.value());
     }
   }
   if(const auto* options_node = kernel_node->get_subnode("compile-options")) {
     for(const auto& option : options_node->key_value_pairs) {
       auto o = glue::to_build_option(option.first);
-      if(o)
+      if(o.has_value())
         _compilation_options.push_back(
             std::make_pair(o.value(), option.second));
     }

--- a/src/runtime/ocl/ocl_code_object.cpp
+++ b/src/runtime/ocl/ocl_code_object.cpp
@@ -69,7 +69,7 @@ ocl_executable_object::ocl_executable_object(const cl::Context& ctx, cl::Device&
   
   std::string options_string="-cl-uniform-work-group-size";
   for(const auto& flag : config.build_flags()) {
-    if(flag == "fast-math") {
+    if(flag == glue::kernel_build_flag::fast_math) {
       options_string += " -cl-fast-relaxed-math";
     }
   }

--- a/src/runtime/ocl/ocl_queue.cpp
+++ b/src/runtime/ocl/ocl_queue.cpp
@@ -443,16 +443,18 @@ result ocl_queue::submit_sscp_kernel_from_code_object(
       compilation_flow::sscp);
   config.append_base_configuration(
       glue::kernel_base_config_parameter::hcf_object_id, hcf_object);
-
+  
   for(const auto& flag : kernel_info->get_compilation_flags())
     config.set_build_flag(flag);
   for(const auto& opt : kernel_info->get_compilation_options())
     config.set_build_option(opt.first, opt.second);
 
-  config.set_build_option("spirv-dynamic-local-mem-allocation-size", local_mem_size);
+  config.set_build_option(
+      glue::kernel_build_option::spirv_dynamic_local_mem_allocation_size,
+      local_mem_size);
 
   // TODO: Enable this if we are on Intel
-  // config.set_build_flag("enable-intel-llvm-spirv-options");
+  // config.set_build_flag(glue::kernel_build_flag::spirv_enable_intel_llvm_spirv_options);
 
   auto binary_configuration_id = adaptivity_engine.finalize_binary_configuration(config);
   auto code_object_configuration_id = binary_configuration_id;

--- a/src/runtime/ocl/ocl_queue.cpp
+++ b/src/runtime/ocl/ocl_queue.cpp
@@ -434,7 +434,8 @@ result ocl_queue::submit_sscp_kernel_from_code_object(
 
   // Need to create custom config to ensure we can distinguish other
   // kernels compiled with different values e.g. of local mem allocation size
-  glue::kernel_configuration config = initial_config;
+  static thread_local glue::kernel_configuration config;
+  config = initial_config;
   
   config.append_base_configuration(
       glue::kernel_base_config_parameter::backend_id, backend_id::ocl);

--- a/src/runtime/omp/omp_queue.cpp
+++ b/src/runtime/omp/omp_queue.cpp
@@ -423,7 +423,9 @@ result omp_queue::submit_sscp_kernel_from_code_object(
       hcf_object, kernel_name, kernel_info, num_groups,
       group_size, args,        arg_sizes,   num_args, local_mem_size};
 
-  glue::kernel_configuration config = initial_config;
+  static thread_local glue::kernel_configuration config;
+  config = initial_config;
+  
   config.append_base_configuration(
       glue::kernel_base_config_parameter::backend_id, backend_id::omp);
   config.append_base_configuration(

--- a/src/runtime/ze/ze_queue.cpp
+++ b/src/runtime/ze/ze_queue.cpp
@@ -578,7 +578,9 @@ result ze_queue::submit_sscp_kernel_from_code_object(
 
   // Need to create custom config to ensure we can distinguish other
   // kernels compiled with different values e.g. of local mem allocation size
-  glue::kernel_configuration config = initial_config;
+  static thread_local glue::kernel_configuration config;
+  config = initial_config;
+  
   config.append_base_configuration(
       glue::kernel_base_config_parameter::backend_id, backend_id::level_zero);
   config.append_base_configuration(

--- a/src/runtime/ze/ze_queue.cpp
+++ b/src/runtime/ze/ze_queue.cpp
@@ -591,9 +591,12 @@ result ze_queue::submit_sscp_kernel_from_code_object(
     config.set_build_flag(flag);
   for(const auto& opt : kernel_info->get_compilation_options())
     config.set_build_option(opt.first, opt.second);
-  
-  config.set_build_option("spirv-dynamic-local-mem-allocation-size", local_mem_size);
-  config.set_build_flag("enable-intel-llvm-spirv-options");
+
+  config.set_build_option(
+      glue::kernel_build_option::spirv_dynamic_local_mem_allocation_size,
+      local_mem_size);
+  config.set_build_flag(
+      glue::kernel_build_flag::spirv_enable_intel_llvm_spirv_options);
 
   auto binary_configuration_id = adaptivity_engine.finalize_binary_configuration(config);
   auto code_object_configuration_id = binary_configuration_id;


### PR DESCRIPTION
In latency-bound scenarios, the current kernel configuration handling causes a minor performance regression (<10%), especially when adaptivity is enabled. This is due to the more complex kernel configuration handling.

This PR addresses this by
- ~Use small vector in `kernel_configuration`;~ this has caused issues on the CI system that I do not fully understand and could not reproduce on another machine. `small_vector` is thus no longer used in the current version of the PR. The PR now uses `static thread_local kernel_configuration` objects, which seem to be even faster.
- Use enumerations instead of `std::string` to identify kernel build flags and options;
- Store unsigned int option values directly as int inside `kernel_configuration` instead of converting to `std::string`.