### PR TITLE
[stdpar] specialize memory streaming for host sscp

### DIFF
--- a/include/hipSYCL/algorithms/util/memory_streaming.hpp
+++ b/include/hipSYCL/algorithms/util/memory_streaming.hpp
@@ -77,11 +77,16 @@ public:
     
     // TODO: This actually should be something like if_device_cpu, which
     //  we cannot express yet.
-    __hipsycl_if_target_device(
-      const std::size_t gid = idx.get_global_id(0);
-      for (std::size_t i = gid; i < problem_size; i += idx.get_global_range(0)) {
-        f(sycl::id<1>{i});
+    __hipsycl_if_target_sscp(
+      if(sycl::jit::introspect<sycl::jit::current_backend, int>() == sycl::jit::backend::host) {
+        run_host(problem_size, idx, f);
+      } else {
+        run_device(problem_size, idx, f);
       }
+      return;
+    );
+    __hipsycl_if_target_device(
+      run_device(problem_size, idx, f);
     );
     __hipsycl_if_target_host(
       run_host(problem_size, idx, f);
@@ -90,6 +95,14 @@ public:
 
 private:
   static constexpr int cpu_work_per_item = 8;
+
+  template<class F>
+  static void run_device(std::size_t problem_size, sycl::nd_item<1> idx, F&& f) noexcept {
+    const std::size_t gid = idx.get_global_id(0);
+    for (std::size_t i = gid; i < problem_size; i += idx.get_global_range(0)) {
+      f(sycl::id<1>{i});
+    }
+  }
 
   template<class F>
   static void run_host(std::size_t problem_size, sycl::nd_item<1> idx, F&& f) noexcept {

--- a/include/hipSYCL/algorithms/util/memory_streaming.hpp
+++ b/include/hipSYCL/algorithms/util/memory_streaming.hpp
@@ -74,9 +74,6 @@ public:
   template <class F>
   static void run(std::size_t problem_size, sycl::nd_item<1> idx,
                   F &&f) noexcept {
-    
-    // TODO: This actually should be something like if_device_cpu, which
-    //  we cannot express yet.
     __hipsycl_if_target_sscp(
       if(sycl::jit::introspect<sycl::jit::current_backend, int>() == sycl::jit::backend::host) {
         run_host(problem_size, idx, f);

--- a/include/hipSYCL/compiler/sscp/IRConstantReplacer.hpp
+++ b/include/hipSYCL/compiler/sscp/IRConstantReplacer.hpp
@@ -147,17 +147,17 @@ public:
     if(!isValid())
       return;
 
-    if(Var->getType()->isIntegerTy(8)) {
+    if(Var->getValueType()->isIntegerTy(8)) {
       set(bit_cast<int8_t>(Buffer));
-    } else if(Var->getType()->isIntegerTy(16)) {
+    } else if(Var->getValueType()->isIntegerTy(16)) {
       set(bit_cast<int16_t>(Buffer));
-    } else if(Var->getType()->isIntegerTy(32)) {
+    } else if(Var->getValueType()->isIntegerTy(32)) {
       set(bit_cast<int32_t>(Buffer));
-    } else if(Var->getType()->isIntegerTy(64)) {
+    } else if(Var->getValueType()->isIntegerTy(64)) {
       set(bit_cast<int64_t>(Buffer));
-    } else if(Var->getType()->isFloatTy()) {
+    } else if(Var->getValueType()->isFloatTy()) {
       set(bit_cast<float>(Buffer));
-    } else if(Var->getType()->isDoubleTy()) {
+    } else if(Var->getValueType()->isDoubleTy()) {
       set(bit_cast<double>(Buffer));
     } else {
       M->getContext().emitError(

--- a/include/hipSYCL/glue/llvm-sscp/ir_constants.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/ir_constants.hpp
@@ -28,6 +28,8 @@
 #ifndef HIPSYCL_IR_CONSTANTS_HPP
 #define HIPSYCL_IR_CONSTANTS_HPP
 
+#include <type_traits>
+
 #include "s1_ir_constants.hpp"
 #include "s2_ir_constants.hpp"
 
@@ -51,9 +53,12 @@ ValueT __hipsycl_sscp_s2_ir_constant<ConstantName, ValueT>::get(
   }
 }
 
-template<auto& ConstantName, class ValueT>
-ValueT ir_constant(ValueT default_value = ValueT{}) noexcept {
+namespace hipsycl::sycl::jit {
+
+template <auto &ConstantName, class ValueT>
+auto introspect(ValueT default_value = {}) noexcept {
   return __hipsycl_sscp_s2_ir_constant<ConstantName, ValueT>::get(default_value);
+}
 }
 
 #endif

--- a/include/hipSYCL/glue/llvm-sscp/jit.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/jit.hpp
@@ -219,7 +219,7 @@ inline rt::result compile(compiler::LLVMToBackendTranslator *translator,
   runtime_linker configure_linker {translator, imported_symbol_names};
 
   // Apply configuration
-  translator->setS2IRConstant<sycl::sscp::current_backend, int>(
+  translator->setS2IRConstant<sycl::jit::current_backend, int>(
       translator->getBackendId());
   for(const auto& entry : config.s2_ir_entries()) {
     translator->setS2IRConstant(entry.get_name(), entry.get_data_buffer());

--- a/include/hipSYCL/glue/llvm-sscp/s2_ir_constants.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/s2_ir_constants.hpp
@@ -50,7 +50,7 @@ namespace hipsycl::glue::sscp {
   struct ir_constant_name {};
 }
 
-namespace hipsycl::sycl::sscp {
+namespace hipsycl::sycl::jit {
 
 namespace backend {
 

--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -194,7 +194,7 @@ public:
 };
 
 LLVMToAmdgpuTranslator::LLVMToAmdgpuTranslator(const std::vector<std::string> &KN)
-    : LLVMToBackendTranslator{sycl::sscp::backend::amdgpu, KN}, KernelNames{KN} {
+    : LLVMToBackendTranslator{sycl::jit::backend::amdgpu, KN}, KernelNames{KN} {
   RocmDeviceLibsPath = common::filesystem::join_path(RocmPath,
                                                      std::vector<std::string>{"amdgcn", "bitcode"});
 }

--- a/src/compiler/llvm-to-backend/host/LLVMToHost.cpp
+++ b/src/compiler/llvm-to-backend/host/LLVMToHost.cpp
@@ -76,7 +76,7 @@ namespace hipsycl {
 namespace compiler {
 
 LLVMToHostTranslator::LLVMToHostTranslator(const std::vector<std::string> &KN)
-    : LLVMToBackendTranslator{sycl::sscp::backend::host, KN}, KernelNames{KN} {}
+    : LLVMToBackendTranslator{sycl::jit::backend::host, KN}, KernelNames{KN} {}
 
 bool LLVMToHostTranslator::toBackendFlavor(llvm::Module &M, PassHandler &PH) {
 

--- a/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
+++ b/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
@@ -129,7 +129,7 @@ void setPrecSqrt(llvm::Module& M, int Mode) {
 }
 
 LLVMToPtxTranslator::LLVMToPtxTranslator(const std::vector<std::string> &KN)
-    : LLVMToBackendTranslator{sycl::sscp::backend::ptx, KN}, KernelNames{KN} {}
+    : LLVMToBackendTranslator{sycl::jit::backend::ptx, KN}, KernelNames{KN} {}
 
 
 bool LLVMToPtxTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {

--- a/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
+++ b/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
@@ -127,7 +127,7 @@ bool removeDynamicLocalMemorySupport(llvm::Module& M) {
 }
 
 LLVMToSpirvTranslator::LLVMToSpirvTranslator(const std::vector<std::string> &KN)
-    : LLVMToBackendTranslator{sycl::sscp::backend::spirv, KN}, KernelNames{KN} {}
+    : LLVMToBackendTranslator{sycl::jit::backend::spirv, KN}, KernelNames{KN} {}
 
 
 bool LLVMToSpirvTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {


### PR DESCRIPTION
Previously, host stdpar memory streaming (e.g. used for `transform_reduce`) has assumed that whenever `__hipsycl_if_target_device()` is active, the GPU-optimized code path should be taken.
This assumption is no longer correct with the host SSCP backend. Here, it can happen that we run on the host even though we are in a device code path.

This RP adds a host/device specialization within SSCP JIT, which improves performance on Milan for babelstream dot (std-data model) from 50GB/s to 380GBs.
This means that SSCP on host now substantially outperforms the old compiler in this case, which only achieves ~280GB/s.

I'd like to work on the code specialization API for SSCP a bit more, so it's quite possible that this is not the final API that we can advertise to users. But it's something that works today which we can use to fix the mentioned performance regression.