### PR TITLE
[SSCP] Report JIT compiler errors from CUDA

### DIFF
--- a/src/runtime/cuda/cuda_code_object.cpp
+++ b/src/runtime/cuda/cuda_code_object.cpp
@@ -94,7 +94,7 @@ result build_cuda_module_from_ptx(CUmod_st *&module, int device,
 
   // set up size of compilation log buffer
   option_names[0] = CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES;
-  static constexpr std::size_t error_log_buffer_size = 1024*1024;
+  static constexpr std::size_t error_log_buffer_size = 10*1024;
   option_vals[0] = reinterpret_cast<void*>(error_log_buffer_size);
 
   // set up pointer to the compilation log buffer

--- a/src/runtime/cuda/cuda_code_object.cpp
+++ b/src/runtime/cuda/cuda_code_object.cpp
@@ -66,7 +66,7 @@ void unload_cuda_module(CUmod_st* module, int device) {
 
     auto err = cuModuleUnload(module);
 
-    if (err != CUDA_SUCCESS && 
+    if (err != CUDA_SUCCESS &&
         // It can happen that during shutdown of the CUDA
         // driver we cannot unload anymore.
         // TODO: Find a better solution
@@ -81,7 +81,7 @@ void unload_cuda_module(CUmod_st* module, int device) {
 
 result build_cuda_module_from_ptx(CUmod_st *&module, int device,
                                   const std::string &source) {
-  
+
   cuda_device_manager::get().activate_device(device);
   // This guarantees that the CUDA runtime API initializes the CUDA
   // context on that device. This is important for the subsequent driver
@@ -109,18 +109,21 @@ result build_cuda_module_from_ptx(CUmod_st *&module, int device,
   if (err != CUDA_SUCCESS) {
     const auto error_log_size = reinterpret_cast<std::size_t>(option_vals[0]);
     error_log_buffer.resize(error_log_size);
-    return make_error(__hipsycl_here(),
-                      error_info{error_log_buffer,
-                                error_code{"CU", static_cast<int>(err)}});
+    return make_error(
+        __hipsycl_here(),
+        error_info{
+            "cuda_executable_object: Could not load module, CUDA JIT log: " +
+                error_log_buffer,
+            error_code{"CU", static_cast<int>(err)}});
   }
-  
+
   assert(module);
 
   return make_success();
 }
 
 std::vector<std::string> extract_kernel_names_from_ptx(const std::string& source) {
-  
+
   std::vector<std::string> kernel_names;
   std::istringstream code_stream(source);
   std::string line;


### PR DESCRIPTION
Use `CU_JIT_ERROR_LOG_BUFFER` when JIT compiling CUDA code, and report the error log in case of compilation failure.

For example, the following kernel I might (did) naively expect to work
```c++
using Allocator = sycl::usm_allocator<char, sycl::usm::alloc::shared>;
std::vector<char, Allocator> vals(Allocator{q});
static constexpr std::size_t buff_len = 20;
vals.resize(buff_len);

sycl::range<1> work_items{vals.size()};
q.submit(
	[&](sycl::handler & cgh)
	{
		cgh.parallel_for<class vector_double>(
			work_items,
			[buff = vals.data()](sycl::id<1> tid) {
				std::format_to_n(
					buff, buff_len, "Hello from thread {}", static_cast<int>(tid));
			});
	});
q.wait_and_throw();
```

Without this patch the output is not too helpful
```
1: [AdaptiveCpp Error] from /home/dave/workspace/conan_recipe_staging/adaptivecpp/all/src/src/runtime/cuda/cuda_code_object.cpp:96 @ build_cuda_module_from_ptx(): cuda_executable_object: could not load module (error code = CU:218)
1: [AdaptiveCpp Error] from /home/dave/workspace/conan_recipe_staging/adaptivecpp/all/src/src/runtime/cuda/cuda_queue.cpp:692 @ submit_sscp_kernel_from_code_object(): cuda_queue: Code object construction failed
```

With this patch the output tells you why it failed
```
1: [AdaptiveCpp Error] from /home/dave/workspace/conan_recipe_staging/adaptivecpp/all/src/src/runtime/cuda/cuda_code_object.cpp:112 @ build_cuda_module_from_ptx(): ptxas fatal   : Unresolved extern function 'memchr' (error code = CU:218)
1: [AdaptiveCpp Error] from /home/dave/workspace/conan_recipe_staging/adaptivecpp/all/src/src/runtime/cuda/cuda_queue.cpp:692 @ submit_sscp_kernel_from_code_object(): cuda_queue: Code object construction failed
```

I had a look at the unit tests and couldn't see anywhere a test for CUDA-specific failure modes could fit. Happy to add one if someone can point the way.