### PR TITLE
[SSCP][llvm-to-amdgpu] Make device library detection more resilient w.r.t unusual ROCm installs

### DIFF
--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -157,8 +157,6 @@ public:
 
     Invocation = {ClangPath, "-x", "ir",
       "--cuda-device-only", "-O3",
-      RocmPathFlag,
-      RocmDeviceLibsFlag,
       OffloadArchFlag,
       "-nogpuinc",
       "/dev/null",
@@ -168,13 +166,35 @@ public:
     if(IsFastMath)
       Invocation.push_back("-ffast-math");
     
+    if(!llvm::StringRef{ClangPath}.endswith("hipcc")) {
+      // Normally we try to use hipcc. However, when that fails,
+      // we may have fallen back to clang. In that case we may
+      // have to additionally set --rocm-path and --rocm-device-lib-path.
+      //
+      // When using hipcc, this is generally not needed as hipcc already
+      // knows how ROCm is configured. It might also have been specially
+      // tweaked by non-standard ROCm pacakges to find ROCm in unusual places.
+      //
+      // So we should not use --rocm-path and --rock-device-lib-path unless
+      // we really have to.
+      Invocation.push_back(RocmPathFlag);
+      Invocation.push_back(RocmDeviceLibsFlag);
+
+      if (!llvm::sys::fs::exists(common::filesystem::join_path(DeviceLibsPath, "ockl.bc"))) {
+        HIPSYCL_DEBUG_WARNING
+            << "LLVMToAmdgpu: Configured ROCm device bitcode library path " << DeviceLibsPath
+            << " does not seem to contain key ROCm bitcode libraries such as ockl.bc. It is "
+               "possible that builtin bitcode linking is incomplete.\n";
+      }
+    }
+    
     std::string Output;
     if(!getCommandOutput(ClangPath, Invocation, Output))
       return false;
 
     std::stringstream sstr{Output};
     std::string CurrentComponent;
-
+    
     bool ConsumeNext = false;
     while(sstr) {
       sstr >> CurrentComponent;


### PR DESCRIPTION
AdaptiveCpp ROCm JIT attempts to invoke hipcc/clang and parse its output to attempt to determine the correct set of ROCm bitcode libraries that need to be linked.

Previously, we have been passing `--rocm-path` and `--rocm-device-lib-path`. However, this might break things if the ROCm installation follows an unusual layout and bitcode libraries are not in `$ROCM_PATH/amdgcn/bitcode`. This might be the case for some distribution-pacakged ROCm installations (e.g. Debian).

By default we first try `hipcc`. With this PR, if `hipcc` is used we now no longer pass `--rocm-path` and `--rocm-device-lib-path`. This is because we can assume that hipcc is configured correctly to "just work" for the ROCm installation it is from. This should give us more resilience to also work for such unusual installations.

If we don't find `hipcc`, we fall back to clang - in this case, we still pass the two flags. However, with this PR we now check whether bitcode libraries are actually present in the directory where we expect them. If they are not, we emit a warning. This should make it easier for users to diagnose the issue instead of being confronted with just a JIT failure due to unresolved builtin functions.

@baryluk Can you please try whether this PR resolves your problem with the Debian-packaged ROCm?