### PR TITLE
[SSCP] Add support to emit kernel parameter type annotations

### DIFF
--- a/include/hipSYCL/compiler/sscp/AggregateArgumentExpansionPass.hpp
+++ b/include/hipSYCL/compiler/sscp/AggregateArgumentExpansionPass.hpp
@@ -39,11 +39,14 @@ namespace compiler {
 
 
 struct OriginalParamInfo {
-  OriginalParamInfo(std::size_t Offset, std::size_t OriginalIndex)
-  : OffsetInOriginalParam{Offset}, OriginalParamIndex{OriginalIndex} {}
+  OriginalParamInfo(std::size_t Offset, std::size_t OriginalIndex,
+                    const llvm::SmallVector<std::string> &Annotations)
+      : OffsetInOriginalParam{Offset}, OriginalParamIndex{OriginalIndex}, Annotations{Annotations} {
+  }
 
   std::size_t OffsetInOriginalParam;
   std::size_t OriginalParamIndex;
+  llvm::SmallVector<std::string> Annotations;
 };
 // Expands aggregates into primitive function arguments. Aggregate types to expand are
 // expected to be marked using the ByVal attribute.

--- a/include/hipSYCL/runtime/kernel_cache.hpp
+++ b/include/hipSYCL/runtime/kernel_cache.hpp
@@ -105,10 +105,16 @@ public:
     other
   };
 
+  enum annotation_type {
+    specialized
+  };
+
   std::size_t get_argument_offset(std::size_t i) const;
   std::size_t get_argument_size(std::size_t i) const;
   std::size_t get_original_argument_index(std::size_t i) const;
   argument_type get_argument_type(std::size_t i) const;
+  const std::vector<std::string>& get_string_annotations(std::size_t i) const;
+  const std::vector<annotation_type>& get_known_annotations(std::size_t i) const;
 
   bool is_valid() const;
 
@@ -120,10 +126,14 @@ public:
   get_compilation_options() const;
 
 private:
+  // We have one entry per kernel parameter for these
   std::vector<std::size_t> _arg_offsets;
   std::vector<std::size_t> _arg_sizes;
   std::vector<std::size_t> _original_arg_indices;
   std::vector<argument_type> _arg_types;
+  std::vector<std::vector<std::string>> _string_annotations;
+  std::vector<std::vector<annotation_type>> _known_annotations;
+
   std::vector<std::string> _image_providers;
   
   std::vector<glue::kernel_build_flag> _compilation_flags;

--- a/src/compiler/sscp/AggregateArgumentExpansionPass.cpp
+++ b/src/compiler/sscp/AggregateArgumentExpansionPass.cpp
@@ -82,7 +82,7 @@ struct ExpandedArgumentInfo {
   bool IsExpanded = false;
 };
 
-static const char* TypeAnnotationIdentifier = "__hipsycl_sscp_emit_type_annotation";
+static const char* TypeAnnotationIdentifier = "__hipsycl_sscp_emit_param_type_annotation";
 
 std::string ExtractAnnotationFromType(llvm::Type* T) {
   if(!T)

--- a/src/compiler/sscp/TargetSeparationPass.cpp
+++ b/src/compiler/sscp/TargetSeparationPass.cpp
@@ -148,6 +148,7 @@ struct KernelParam {
   std::size_t ArgByteOffset;
   std::size_t OriginalArgIndex;
   ParamType Type;
+  llvm::SmallVector<std::string> Annotations;
 };
 
 struct KernelInfo {
@@ -190,6 +191,7 @@ struct KernelInfo {
         KP.Type = PT;
         KP.ArgByteOffset = OriginalParamInfos[i].OffsetInOriginalParam;
         KP.OriginalArgIndex = OriginalParamInfos[i].OriginalParamIndex;
+        KP.Annotations = OriginalParamInfos[i].Annotations;
         this->Parameters.push_back(KP);
       }
     }
@@ -396,6 +398,11 @@ generateHCF(llvm::Module &DeviceModule, std::size_t HcfObjectId,
         TypeDescription = "other-by-value";
       }
       P->set("type", TypeDescription);
+
+      auto* AnnotationsNode = P->add_subnode("annotations");
+      for(const auto& A : ParamInfo.Annotations) {
+        AnnotationsNode->set(A, "1");
+      }
     }
   }
   

--- a/src/runtime/kernel_cache.cpp
+++ b/src/runtime/kernel_cache.cpp
@@ -109,6 +109,21 @@ hcf_kernel_info::hcf_kernel_info(
     _arg_offsets.push_back(arg_offset);
     _arg_sizes.push_back(arg_size);
     _original_arg_indices.push_back(arg_original_index);
+    // Let's accept annotation nodes not being provided
+    _string_annotations.push_back({});
+    _known_annotations.push_back({});
+    if(auto* annotation_node = param_info_node->get_subnode("annotations")){
+      for(const auto& entry : annotation_node->key_value_pairs) {
+        // Ignore entries that are not set to "1" for now
+        if(entry.second == "1") {
+          if(entry.first == "specialized") {
+            _known_annotations.back().push_back(annotation_type::specialized);
+          } else {
+            _string_annotations.back().push_back(entry.first);
+          }
+        }
+      }
+    }
   }
 
   if(const auto* flags_node = kernel_node->get_subnode("compile-flags")) {
@@ -153,6 +168,16 @@ std::size_t hcf_kernel_info::get_original_argument_index(std::size_t i) const {
 
 hcf_kernel_info::argument_type hcf_kernel_info::get_argument_type(std::size_t i) const {
   return _arg_types[i];
+}
+
+const std::vector<std::string> &
+hcf_kernel_info::get_string_annotations(std::size_t i) const {
+  return _string_annotations[i];
+}
+
+const std::vector<hcf_kernel_info::annotation_type> &
+hcf_kernel_info::get_known_annotations(std::size_t i) const {
+  return _known_annotations[i];
 }
 
 const std::vector<std::string> &

--- a/tests/compiler/sscp/type_annotation.cpp
+++ b/tests/compiler/sscp/type_annotation.cpp
@@ -1,0 +1,183 @@
+// RUN: %acpp %s -o %t --acpp-targets=generic
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s -o %t --acpp-targets=generic -O3
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s -o %t --acpp-targets=generic -g
+// RUN: %t | FileCheck %s
+
+
+#include <iostream>
+
+#include <limits>
+#include <sycl/sycl.hpp>
+#include "common.hpp"
+#include "hipSYCL/runtime/kernel_cache.hpp"
+
+template<class T>
+struct unannotated_wrapper {
+  T value;
+};
+
+template <class T>
+class __hipsycl_sscp_emit_param_type_annotation_custom_annotation1 {
+  T value;
+};
+
+template <class T>
+class __hipsycl_sscp_emit_param_type_annotation_specialized {
+  T value;
+};
+
+#define make_test_kernel(name, argT)                                           \
+  class name {                                                                 \
+  public:                                                                      \
+    name(int *data, argT arg) : _data{data} {}                                 \
+    void operator()() const { *_data += 1; };                                   \
+                                                                               \
+  private:                                                                     \
+    int *_data;                                                                \
+    argT _arg;                                                                 \
+  };
+
+make_test_kernel(__test_kernel1_, unannotated_wrapper<int>);
+make_test_kernel(__test_kernel2_,
+                 __hipsycl_sscp_emit_param_type_annotation_custom_annotation1<int>);
+make_test_kernel(__test_kernel3_,
+                 __hipsycl_sscp_emit_param_type_annotation_specialized<int>);
+make_test_kernel(
+    __test_kernel4_,
+    __hipsycl_sscp_emit_param_type_annotation_custom_annotation1<
+        __hipsycl_sscp_emit_param_type_annotation_custom_annotation1<int>>);
+make_test_kernel(
+    __test_kernel5_,
+    __hipsycl_sscp_emit_param_type_annotation_custom_annotation1<
+        __hipsycl_sscp_emit_param_type_annotation_specialized<int>>);
+
+using aggregate_type = std::pair<int, int>;
+make_test_kernel(__test_kernel6_,
+                 __hipsycl_sscp_emit_param_type_annotation_custom_annotation1<
+                     aggregate_type>);
+
+int main(int argc, char** argv)
+{
+  bool always_false = argc == std::numeric_limits<int>::max();
+  auto hcf_id = __hipsycl_local_sscp_hcf_object_id;
+
+  sycl::queue q = get_queue();
+  int* data = sycl::malloc_device<int>(1,q);
+
+  // This is just there to compile instantiate kernels, we don't actually want
+  // to run them. So always_false should always evaluate to false 
+  // without allowing the compiler to optimize it away.
+  if(always_false) {
+    q.single_task(__test_kernel1_{data, unannotated_wrapper<int>{}});
+    q.single_task(__test_kernel2_{
+        data,
+        __hipsycl_sscp_emit_param_type_annotation_custom_annotation1<int>{}});
+    q.single_task(__test_kernel3_{
+        data, __hipsycl_sscp_emit_param_type_annotation_specialized<int>{}});
+    q.single_task(__test_kernel4_{
+        data, __hipsycl_sscp_emit_param_type_annotation_custom_annotation1<
+                  __hipsycl_sscp_emit_param_type_annotation_custom_annotation1<
+                      int>>{}});
+    q.single_task(__test_kernel5_{
+        data,
+        __hipsycl_sscp_emit_param_type_annotation_custom_annotation1<
+            __hipsycl_sscp_emit_param_type_annotation_specialized<int>>{}});
+    q.single_task(__test_kernel6_{
+        data,
+        __hipsycl_sscp_emit_param_type_annotation_custom_annotation1<
+                     aggregate_type>{}});
+  }
+
+  q.wait();
+  sycl::free(data, q);
+
+  const hipsycl::rt::hcf_image_info *img_info =
+      hipsycl::rt::hcf_cache::get().get_image_info(hcf_id, "llvm-ir.global");
+  
+  auto get_kernel_name = [&](const std::string& fragment) {
+    for(const auto& candidate : img_info->get_contained_kernels())
+      if(candidate.find(fragment) != std::string::npos)
+        return candidate;
+    return std::string{};
+  };
+
+  auto get_kernel_info = [&](const std::string &kernel_name_fragment) {
+    return hipsycl::rt::hcf_cache::get().get_kernel_info(
+        hcf_id, get_kernel_name(kernel_name_fragment));
+  };
+
+  auto kernel_info1 = get_kernel_info("__test_kernel1_");
+  auto kernel_info2 = get_kernel_info("__test_kernel2_");
+  auto kernel_info3 = get_kernel_info("__test_kernel3_");
+  auto kernel_info4 = get_kernel_info("__test_kernel4_");
+  auto kernel_info5 = get_kernel_info("__test_kernel5_");
+  auto kernel_info6 = get_kernel_info("__test_kernel6_");
+
+  // CHECK: 0
+  // CHECK: 0
+  // CHECK: 0
+  // CHECK: 0
+  std::cout << kernel_info1->get_string_annotations(0).size() << std::endl;
+  std::cout << kernel_info1->get_string_annotations(1).size() << std::endl;
+  std::cout << kernel_info1->get_known_annotations(0).size() << std::endl;
+  std::cout << kernel_info1->get_known_annotations(1).size() << std::endl;
+
+  // CHECK: 0
+  // CHECK: 1
+  // CHECK: 0
+  // CHECK: 0
+  std::cout << kernel_info2->get_string_annotations(0).size() << std::endl;
+  std::cout << kernel_info2->get_string_annotations(1).size() << std::endl;
+  std::cout << kernel_info2->get_known_annotations(0).size() << std::endl;
+  std::cout << kernel_info2->get_known_annotations(1).size() << std::endl;
+  // CHECK: custom_annotation1
+  std::cout << kernel_info2->get_string_annotations(1)[0] << std::endl;
+  
+  // CHECK: 0
+  // CHECK: 0
+  // CHECK: 0
+  // CHECK: 1
+  std::cout << kernel_info3->get_string_annotations(0).size() << std::endl;
+  std::cout << kernel_info3->get_string_annotations(1).size() << std::endl;
+  std::cout << kernel_info3->get_known_annotations(0).size() << std::endl;
+  std::cout << kernel_info3->get_known_annotations(1).size() << std::endl;
+  // CHECK: 0
+  std::cout << kernel_info3->get_known_annotations(1)[0] << std::endl;
+
+  // CHECK: 0
+  // CHECK: 1
+  // CHECK: 0
+  // CHECK: 0
+  std::cout << kernel_info4->get_string_annotations(0).size() << std::endl;
+  std::cout << kernel_info4->get_string_annotations(1).size() << std::endl;
+  std::cout << kernel_info4->get_known_annotations(0).size() << std::endl;
+  std::cout << kernel_info4->get_known_annotations(1).size() << std::endl;
+  // CHECK: custom_annotation1
+  std::cout << kernel_info4->get_string_annotations(1)[0] << std::endl;
+
+  // CHECK: 0
+  // CHECK: 1
+  // CHECK: 0
+  // CHECK: 1
+  std::cout << kernel_info5->get_string_annotations(0).size() << std::endl;
+  std::cout << kernel_info5->get_string_annotations(1).size() << std::endl;
+  std::cout << kernel_info5->get_known_annotations(0).size() << std::endl;
+  std::cout << kernel_info5->get_known_annotations(1).size() << std::endl;
+  // CHECK: custom_annotation1
+  std::cout << kernel_info5->get_string_annotations(1)[0] << std::endl;
+  // CHECK: 0
+  std::cout << kernel_info5->get_known_annotations(1)[0] << std::endl;
+
+  // CHECK: 0
+  // CHECK: 1
+  // CHECK: 1
+  // CHECK: custom_annotation1
+  // CHECK: custom_annotation1
+  std::cout << kernel_info6->get_string_annotations(0).size() << std::endl;
+  std::cout << kernel_info6->get_string_annotations(1).size() << std::endl;
+  std::cout << kernel_info6->get_string_annotations(2).size() << std::endl;
+  std::cout << kernel_info5->get_string_annotations(1)[0] << std::endl;
+  std::cout << kernel_info5->get_string_annotations(1)[0] << std::endl;
+}


### PR DESCRIPTION
This PR adds support to add arbitrary annotations to types that get used as kernel parameters.
This could be used to e.g. determine whether a kernel argument is part of an accessor, or to add optimization hints to kernel parameters, which can be used at JIT-time.