### PR TITLE
Specializations that make sense: Add support for sycl::specialized<T>

### DIFF
--- a/include/hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp
@@ -234,7 +234,7 @@ private:
   std::vector<std::string> Kernels;
 
   std::vector<std::string> Errors;
-  std::unordered_map<std::string, std::function<void(llvm::Module &)>> S2IRConstantApplicators;
+  std::unordered_map<std::string, std::function<void(llvm::Module &)>> SpecializationApplicators;
   ExternalSymbolResolver SymbolResolver;
   bool HasExternalSymbolResolver = false;
 

--- a/include/hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp
@@ -62,7 +62,8 @@ struct TranslationHints {
 class LLVMToBackendTranslator {
 public:
   LLVMToBackendTranslator(int S2IRConstantCurrentBackendId,
-    const std::vector<std::string>& OutliningEntrypoints);
+    const std::vector<std::string>& OutliningEntrypoints,
+    const std::vector<std::string>& KernelNames);
 
   virtual ~LLVMToBackendTranslator() {}
 
@@ -83,6 +84,8 @@ public:
   }
 
   void setS2IRConstant(const std::string& name, const void* ValueBuffer);
+  void specializeKernelArgument(const std::string &KernelName, int ParamIndex,
+                                const void *ValueBuffer);
 
   bool setBuildFlag(const std::string &Flag);
   bool setBuildOption(const std::string &Option, const std::string &Value);
@@ -109,6 +112,14 @@ public:
   // Returns IR that caused the error in case an error occurs
   const std::string& getFailedIR() const {
     return ErroringCode;
+  }
+
+  const std::vector<std::string>& getOutliningEntrypoints() const {
+    return OutliningEntrypoints;
+  }
+
+  const std::vector<std::string>& getKernels () const {
+    return Kernels;
   }
 
   std::string getErrorLogAsString() const {
@@ -218,7 +229,10 @@ private:
   void setFailedIR(llvm::Module& M);
 
   int S2IRConstantBackendId;
+  
   std::vector<std::string> OutliningEntrypoints;
+  std::vector<std::string> Kernels;
+
   std::vector<std::string> Errors;
   std::unordered_map<std::string, std::function<void(llvm::Module &)>> S2IRConstantApplicators;
   ExternalSymbolResolver SymbolResolver;

--- a/include/hipSYCL/glue/kernel_configuration.hpp
+++ b/include/hipSYCL/glue/kernel_configuration.hpp
@@ -256,6 +256,11 @@ public:
     _s2_ir_configurations.push_back(entry);
   }
 
+  void set_specialized_kernel_argument(int param_index, uint64_t buffer_value) {
+    _specialized_kernel_args.push_back(
+        std::make_pair(param_index, buffer_value));
+  }
+
   void set_build_option(kernel_build_option option, const std::string& value) {
     int_or_string ios;
     ios.string_value = value;
@@ -323,6 +328,12 @@ public:
                         "", 0);
     }
 
+    for(const auto& entry : _specialized_kernel_args) {
+      uint64_t numeric_option_id = static_cast<uint64_t>(entry.first) | (1ull << 34);
+      add_entry_to_hash(result, &numeric_option_id, sizeof(numeric_option_id),
+                        &entry.second, sizeof(entry.second));
+    }
+
     return result;
   }
 
@@ -336,6 +347,10 @@ public:
 
   const auto& build_flags() const {
     return _build_flags;
+  }
+
+  const auto& specialized_arguments() const {
+    return _specialized_kernel_args;
   }
 
 private:
@@ -389,6 +404,7 @@ private:
   std::vector<s2_ir_configuration_entry> _s2_ir_configurations;
   std::vector<kernel_build_flag> _build_flags;
   std::vector<std::pair<kernel_build_option, int_or_string>> _build_options;
+  std::vector<std::pair<int, uint64_t>> _specialized_kernel_args;
 
   id_type _base_configuration_result = {};
 };

--- a/include/hipSYCL/glue/llvm-sscp/jit.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/jit.hpp
@@ -86,6 +86,10 @@ public:
     return _mapped_data.data();
   }
 
+  void* const* get_mapped_args() const {
+    return _mapped_data.data();
+  }
+
   const std::size_t* get_mapped_arg_sizes() const {
     return _mapped_sizes.data();
   }
@@ -223,6 +227,14 @@ inline rt::result compile(compiler::LLVMToBackendTranslator *translator,
       translator->getBackendId());
   for(const auto& entry : config.s2_ir_entries()) {
     translator->setS2IRConstant(entry.get_name(), entry.get_data_buffer());
+  }
+  if(translator->getKernels().size() == 1) {
+    // Currently we only can specialize kernel arguments for the 
+    // single-kernel code object model
+    for(const auto& entry : config.specialized_arguments()) {
+      translator->specializeKernelArgument(translator->getKernels().front(),
+                                          entry.first, &entry.second);
+    }
   }
 
   for(const auto& option : config.build_options()) {

--- a/include/hipSYCL/runtime/adaptivity_engine.hpp
+++ b/include/hipSYCL/runtime/adaptivity_engine.hpp
@@ -29,6 +29,7 @@
 #define HIPSYCL_ADAPTIVITY_ENGINE_HPP
 
 #include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/glue/llvm-sscp/jit.hpp"
 #include "hipSYCL/runtime/util.hpp"
 #include "hipSYCL/runtime/kernel_cache.hpp"
 
@@ -41,6 +42,7 @@ public:
     hcf_object_id hcf_object,
     const std::string& backend_kernel_name,
     const hcf_kernel_info* kernel_info,
+    const glue::jit::cxx_argument_mapper& arg_mapper,
     const range<3>& num_groups,
     const range<3>& block_size,
     void** args,
@@ -56,6 +58,7 @@ private:
   hcf_object_id _hcf;
   const std::string& _kernel_name;
   const hcf_kernel_info* _kernel_info;
+  const glue::jit::cxx_argument_mapper& _arg_mapper;
   const range<3>& _num_groups;
   const range<3>& _block_size;
   void** _args;

--- a/include/hipSYCL/sycl/specialized.hpp
+++ b/include/hipSYCL/sycl/specialized.hpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
  *
- * Copyright (c) 2019 Aksel Alpay
+ * Copyright (c) 2018-2024 Aksel Alpay and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,36 +25,36 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef HIPSYCL_EXTENSIONS_HPP
-#define HIPSYCL_EXTENSIONS_HPP
+#ifndef HIPSYCL_SPECIALIZED_HPP
+#define HIPSYCL_SPECIALIZED_HPP
 
-#ifdef HIPSYCL_EXT_ENABLE_ALL
- #define HIPSYCL_EXT_FP_ATOMICS
-#endif
+namespace hipsycl {
+namespace sycl {
 
-#define HIPSYCL_EXT_AUTO_PLACEHOLDER_REQUIRE
-#define HIPSYCL_EXT_CUSTOM_PFWI_SYNCHRONIZATION
-#define HIPSYCL_EXT_SCOPED_PARALLELISM_V2
-#define HIPSYCL_EXT_ENQUEUE_CUSTOM_OPERATION
-#define HIPSYCL_EXT_CG_PROPERTY_RETARGET
-#define HIPSYCL_EXT_CG_PROPERTY_PREFER_GROUP_SIZE
-#define HIPSYCL_EXT_CG_PROPERTY_PREFER_EXECUTION_LANE
-#define HIPSYCL_EXT_BUFFER_USM_INTEROP
-#define HIPSYCL_EXT_PREFETCH_HOST
-#define HIPSYCL_EXT_SYNCHRONOUS_MEM_ADVISE
-#define HIPSYCL_EXT_BUFFER_PAGE_SIZE
-#define HIPSYCL_EXT_EXPLICIT_BUFFER_POLICIES
-#define HIPSYCL_EXT_ACCESSOR_VARIANTS
+namespace detail {
 
-#ifndef HIPSYCL_STRICT_ACCESSOR_DEDUCTION
- #define HIPSYCL_EXT_ACCESSOR_VARIANT_DEDUCTION
-#endif
+template<class T>
+struct __hipsycl_sscp_emit_param_type_annotation_specialized {
+  T value;
+};
 
-#define HIPSYCL_EXT_UPDATE_DEVICE
-#define HIPSYCL_EXT_QUEUE_WAIT_LIST
-#define HIPSYCL_EXT_MULTI_DEVICE_QUEUE
-#define HIPSYCL_EXT_COARSE_GRAINED_EVENTS
-#define HIPSYCL_EXT_QUEUE_PRIORITY
-#define HIPSYCL_EXT_SPECIALIZED
+}
+
+template<class T>
+class specialized {
+public:
+  specialized(const T& value)
+  : _value{value} {}
+
+  operator T () const {
+    return _value.value;
+  }
+private:
+  detail::__hipsycl_sscp_emit_param_type_annotation_specialized<T> _value;
+};
+
+
+}
+}
 
 #endif

--- a/include/hipSYCL/sycl/sycl.hpp
+++ b/include/hipSYCL/sycl/sycl.hpp
@@ -99,6 +99,7 @@
 #include "backend_interop.hpp"
 #include "interop_handle.hpp"
 #include "buffer_explicit_behavior.hpp"
+#include "specialized.hpp"
 
 // Support SYCL_EXTERNAL for SSCP - we cannot have SYCL_EXTERNAL if accelerated CPU
 // is active at the same time :(

--- a/src/compiler/llvm-to-backend/LLVMToBackend.cpp
+++ b/src/compiler/llvm-to-backend/LLVMToBackend.cpp
@@ -98,8 +98,10 @@ void setFastMathFunctionAttribs(llvm::Module& M) {
 }
 
 LLVMToBackendTranslator::LLVMToBackendTranslator(int S2IRConstantCurrentBackendId,
-  const std::vector<std::string>& OutliningEPs)
-: S2IRConstantBackendId(S2IRConstantCurrentBackendId), OutliningEntrypoints{OutliningEPs} {}
+                                                 const std::vector<std::string> &OutliningEPs,
+                                                 const std::vector<std::string> &KernelNames)
+    : S2IRConstantBackendId(S2IRConstantCurrentBackendId),
+      OutliningEntrypoints{OutliningEPs}, Kernels{KernelNames} {}
 
 bool LLVMToBackendTranslator::setBuildFlag(const std::string &Flag) {
   HIPSYCL_DEBUG_INFO << "LLVMToBackend: Using build flag: " << Flag << "\n";
@@ -360,6 +362,11 @@ void LLVMToBackendTranslator::setS2IRConstant(const std::string &name, const voi
     S2IRConstant C = S2IRConstant::getFromConstantName(M, name);
     C.set(ValueBuffer);
   };
+}
+
+void LLVMToBackendTranslator::specializeKernelArgument(const std::string &KernelName, int ParamIndex,
+                                const void *ValueBuffer) {
+  
 }
 
 void LLVMToBackendTranslator::provideExternalSymbolResolver(ExternalSymbolResolver Resolver) {

--- a/src/compiler/llvm-to-backend/LLVMToBackend.cpp
+++ b/src/compiler/llvm-to-backend/LLVMToBackend.cpp
@@ -385,7 +385,7 @@ void LLVMToBackendTranslator::specializeKernelArgument(const std::string &Kernel
 
           llvm::Constant *ReturnedValue = nullptr;
           std::size_t ParamByteSize = M.getDataLayout().getTypeSizeInBits(ParamType) / CHAR_BIT;
-          
+
           if(ParamType->isIntegerTy()) {
             uint64_t Value = 0;
             std::memcpy(&Value, ValueBuffer, ParamByteSize);
@@ -403,7 +403,7 @@ void LLVMToBackendTranslator::specializeKernelArgument(const std::string &Kernel
             uint64_t Value = 0;
             std::memcpy(&Value, ValueBuffer, ParamByteSize);
             auto* IntPtr = llvm::ConstantInt::get(
-              M.getContext(), llvm::APInt(ParamType->getIntegerBitWidth(), Value));
+              M.getContext(), llvm::APInt(ParamByteSize * CHAR_BIT, Value));
             ReturnedValue = llvm::ConstantExpr::getIntToPtr(
                 IntPtr, ParamType);
           }
@@ -415,6 +415,7 @@ void LLVMToBackendTranslator::specializeKernelArgument(const std::string &Kernel
 
           llvm::BasicBlock *BB =
               llvm::BasicBlock::Create(M.getContext(), "", GetConstant);
+
           llvm::ReturnInst::Create(M.getContext(), ReturnedValue, BB);
 
           llvm::Instruction* InsertionPt = &(*F->getEntryBlock().getFirstInsertionPt());

--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -194,7 +194,7 @@ public:
 };
 
 LLVMToAmdgpuTranslator::LLVMToAmdgpuTranslator(const std::vector<std::string> &KN)
-    : LLVMToBackendTranslator{sycl::jit::backend::amdgpu, KN}, KernelNames{KN} {
+    : LLVMToBackendTranslator{sycl::jit::backend::amdgpu, KN, KN}, KernelNames{KN} {
   RocmDeviceLibsPath = common::filesystem::join_path(RocmPath,
                                                      std::vector<std::string>{"amdgcn", "bitcode"});
 }

--- a/src/compiler/llvm-to-backend/host/LLVMToHost.cpp
+++ b/src/compiler/llvm-to-backend/host/LLVMToHost.cpp
@@ -76,7 +76,7 @@ namespace hipsycl {
 namespace compiler {
 
 LLVMToHostTranslator::LLVMToHostTranslator(const std::vector<std::string> &KN)
-    : LLVMToBackendTranslator{sycl::jit::backend::host, KN}, KernelNames{KN} {}
+    : LLVMToBackendTranslator{sycl::jit::backend::host, KN, KN}, KernelNames{KN} {}
 
 bool LLVMToHostTranslator::toBackendFlavor(llvm::Module &M, PassHandler &PH) {
 

--- a/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
+++ b/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
@@ -129,8 +129,7 @@ void setPrecSqrt(llvm::Module& M, int Mode) {
 }
 
 LLVMToPtxTranslator::LLVMToPtxTranslator(const std::vector<std::string> &KN)
-    : LLVMToBackendTranslator{sycl::jit::backend::ptx, KN}, KernelNames{KN} {}
-
+    : LLVMToBackendTranslator{sycl::jit::backend::ptx, KN, KN}, KernelNames{KN} {}
 
 bool LLVMToPtxTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
   std::string Triple = "nvptx64-nvidia-cuda";

--- a/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
+++ b/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
@@ -127,8 +127,7 @@ bool removeDynamicLocalMemorySupport(llvm::Module& M) {
 }
 
 LLVMToSpirvTranslator::LLVMToSpirvTranslator(const std::vector<std::string> &KN)
-    : LLVMToBackendTranslator{sycl::jit::backend::spirv, KN}, KernelNames{KN} {}
-
+    : LLVMToBackendTranslator{sycl::jit::backend::spirv, KN, KN}, KernelNames{KN} {}
 
 bool LLVMToSpirvTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
   

--- a/src/runtime/ze/ze_queue.cpp
+++ b/src/runtime/ze/ze_queue.cpp
@@ -571,8 +571,18 @@ result ze_queue::submit_sscp_kernel_from_code_object(
             kernel_name});
   }
 
+
+  glue::jit::cxx_argument_mapper arg_mapper{*kernel_info, args, arg_sizes,
+                                            num_args};
+  if(!arg_mapper.mapping_available()) {
+    return make_error(
+        __hipsycl_here(),
+        error_info{
+            "ze_queue: Could not map C++ arguments to kernel arguments"});
+  }
+
   kernel_adaptivity_engine adaptivity_engine{
-      hcf_object, kernel_name, kernel_info, num_groups,
+      hcf_object, kernel_name, kernel_info, arg_mapper, num_groups,
       group_size, args,        arg_sizes,   num_args, local_mem_size};
 
 
@@ -668,16 +678,6 @@ result ze_queue::submit_sscp_kernel_from_code_object(
 
   HIPSYCL_DEBUG_INFO << "ze_queue: Attempting to submit SSCP kernel"
                      << std::endl;
-
-
-  glue::jit::cxx_argument_mapper arg_mapper{*kernel_info, args, arg_sizes,
-                                            num_args};
-  if(!arg_mapper.mapping_available()) {
-    return make_error(
-        __hipsycl_here(),
-        error_info{
-            "ze_queue: Could not map C++ arguments to kernel arguments"});
-  }
 
   auto submission_err = submit_ze_kernel(
       kernel, get_ze_command_list(),

--- a/tests/compiler/sscp/common.hpp
+++ b/tests/compiler/sscp/common.hpp
@@ -1,9 +1,12 @@
 
 #pragma once
 
+#include <vector>
 #include <sycl/sycl.hpp>
 
 inline sycl::queue get_queue() {
+  std::vector<sycl::device> sscp_devices;
+
   for(const auto& dev : sycl::device::get_devices()) {
     auto dev_id = dev.hipSYCL_device_id();
     auto* rt = dev.hipSYCL_runtime();
@@ -11,8 +14,19 @@ inline sycl::queue get_queue() {
     if(rt->backends().get(dev_id.get_backend())
                    ->get_hardware_manager()
                    ->get_device(dev_id.get_id())->has(hipsycl::rt::device_support_aspect::sscp_kernels)) {
-      return sycl::queue{dev};  
+      sscp_devices.push_back(dev);
     }
   }
-  throw std::runtime_error{"No suitable device was found"};
+
+  if(sscp_devices.size() == 0)
+    throw std::runtime_error{"No suitable device was found"};
+
+  for(const auto& dev : sscp_devices)
+    if(!dev.is_cpu())
+      return sycl::queue{dev};
+  for(const auto& dev : sscp_devices)
+    if (dev.hipSYCL_device_id().get_backend() != hipsycl::rt::backend_id::omp)
+      return sycl::queue{dev};
+
+  return sycl::queue{sscp_devices[0]};
 }

--- a/tests/compiler/sscp/specialized.cpp
+++ b/tests/compiler/sscp/specialized.cpp
@@ -1,0 +1,63 @@
+// RUN: %acpp %s -o %t --acpp-targets=generic
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s -o %t --acpp-targets=generic -O3
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s -o %t --acpp-targets=generic -g
+// RUN: %t | FileCheck %s
+
+
+#include <cstdint>
+#include <iostream>
+#include <sycl/sycl.hpp>
+#include "common.hpp"
+
+class test_kernel {
+public:
+  template <class T1, class T2, class T3, class T4, class T5, class T6,
+            class T7>
+  test_kernel(uint64_t *data, T1 v1, T2 v2, T3 v3, T4 v4, T5 v5, T6 v6, T7 v7)
+      : _data{data}, _v1{static_cast<uint8_t>(v1)},
+        _v2{static_cast<uint16_t>(v2)}, _v3{static_cast<uint32_t>(v3)},
+        _v4{static_cast<uint64_t>(v4)}, _v5{static_cast<float>(v5)},
+        _v6{static_cast<double>(v6)}, _v7{reinterpret_cast<int*>(v7)} {}
+
+  void operator()() const noexcept {
+    *_data *=  static_cast<uint64_t>(_v1); 
+    *_data *=  static_cast<uint64_t>(_v2);
+    *_data *=  static_cast<uint64_t>(_v3);
+    *_data *=  static_cast<uint64_t>(_v4);
+    *_data *=  static_cast<uint64_t>(_v5);
+    *_data *=  static_cast<uint64_t>(_v6);
+    *_data +=  reinterpret_cast<uint64_t>((int*)_v7);
+  }
+
+private:
+  uint64_t* _data;
+  sycl::specialized<uint8_t> _v1;
+  sycl::specialized<uint16_t> _v2;
+  sycl::specialized<uint32_t> _v3;
+  sycl::specialized<uint64_t> _v4;
+  sycl::specialized<float> _v5;
+  sycl::specialized<double> _v6;
+  sycl::specialized<int*> _v7;
+};
+
+int main () {
+  sycl::queue q = get_queue();
+
+  uint64_t* data = sycl::malloc_shared<uint64_t>(1, q);
+
+  *data = 1;
+  q.single_task(test_kernel{data, 0, 2, 3, 4, 5, 6, 7}).wait();
+  // CHECK: 7
+  std::cout << *data << std::endl;
+
+  *data = 1;
+  q.single_task(test_kernel{data, 1, 2, 3, 1, 1, 1, 7}).wait();
+  // CHECK: 13
+  std::cout << *data << std::endl;
+
+
+  sycl::free(data, q);
+  
+}


### PR DESCRIPTION
SYCL 2020 introduces specialization constants. Specialization constants allow turning runtime values into constants at JIT-time and can thus lead to substantial performance improvements.

The SYCL 2020 specialization constant API however suffers from two main issues:
- they are very cumbersome to use
- in case they need to be emulated (which happens whenever an ahead-of-time compiler is used instead of a JIT compiler) they add additional overhead due to the API design. This is especially unfortunate since due to their use case as an advanced kernel optimization feature, they are likely to appear the hottest parts of the code.

In summary, SYCL 2020 specialization constants require effort to use and then can be actively detrimental for performance. Because of this, we do not not want to recommend using them and do not support them in AdaptiveCpp - they are just not useful in their current form.


This PR introduces an alternative mechanism for the same problem. The basic reasoning is that if specialization constants potentially have to be emulated, it is perhaps better to express them as optimization hints to the runtime.
This is done in this PR: If a kernel argument is wrapped inside `sycl::specialized<T>` when passed inside the kernel, if possible, the runtime will introduce a constant based on the runtime value of the argument into the kernel at JIT time.

This makes specialization constants trivial to use, and, since `sycl::specialized` is a trivial wrapper, also a zero-cost abstraction when they need to be emulated.

The `sycl::specialized` hint only affects code generation for the SSCP compiler. For the other compilation flows, code still compiles and works if it uses `sycl::specialized`, but no performance impact is expected compared to code not using `sycl::specialized` (in fact, it is expected that the exact same code is generated).

Example:

```c++

sycl::queue q;

sycl::specialized<float> scaling_factor = // some runtime value
float* data = ...

q.parallel_for(range, [=](auto idx){
  // The JIT compiler will treat the value of scaling_factor as a constant at JIT-time.
  // E.g, if scaling_factor is 1 at runtime, the compiler may generate an empty kernel.
  data *= scaling_factor;
});

```

@Luigi-Crisci fyi, if somebody asks about this at your IWOCL talk - this is the AdaptiveCpp answer to specialization constants.