### PR TITLE
Compile runtime with LTO if possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.9)
 if(NOT CMAKE_VERSION VERSION_LESS 3.12)
   cmake_policy(SET CMP0074 NEW) # Don't complain about using BOOST_ROOT...
 endif()

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -1,5 +1,9 @@
 find_package(Threads REQUIRED)
 
+
+include(CheckIPOSupported)
+check_ipo_supported(RESULT is_ipo_supported OUTPUT ipo_error)
+
 set(HIPSYCL_RT_EXTRA_CXX_FLAGS "")
 set(HIPSYCL_RT_EXTRA_LINKER_FLAGS "")
 
@@ -81,6 +85,9 @@ else()
     set(HIPSYCL_RT_LIBRARY_OUTPUT_NAME "lib${HIPSYCL_RT_LIBRARY_OUTPUT_NAME}.dylib" PARENT_SCOPE)
   endif()
 endif()
+if(is_ipo_supported)
+  set_property(TARGET acpp-rt PROPERTY INTERPROCEDURAL_OPTIMIZATION True)
+endif()
 
 install(TARGETS acpp-rt
         EXPORT install_exports
@@ -115,6 +122,10 @@ if(WITH_CUDA_BACKEND)
   if(WITH_SSCP_COMPILER)
     target_compile_definitions(rt-backend-cuda PRIVATE -DHIPSYCL_WITH_SSCP_COMPILER)
     target_link_libraries(rt-backend-cuda PRIVATE llvm-to-ptx)
+  endif()
+
+  if(is_ipo_supported)
+    set_property(TARGET rt-backend-cuda PROPERTY INTERPROCEDURAL_OPTIMIZATION True)
   endif()
 
   install(TARGETS rt-backend-cuda
@@ -159,6 +170,10 @@ if(WITH_ROCM_BACKEND)
     target_link_libraries(rt-backend-hip PRIVATE llvm-to-amdgpu)
   endif()
 
+  if(is_ipo_supported)
+    set_property(TARGET rt-backend-hip PROPERTY INTERPROCEDURAL_OPTIMIZATION True)
+  endif()
+
   install(TARGETS rt-backend-hip
         RUNTIME DESTINATION bin/hipSYCL
         LIBRARY DESTINATION lib/hipSYCL
@@ -183,6 +198,10 @@ if(WITH_LEVEL_ZERO_BACKEND)
   if(WITH_SSCP_COMPILER)
     target_compile_definitions(rt-backend-ze PRIVATE -DHIPSYCL_WITH_SSCP_COMPILER)
     target_link_libraries(rt-backend-ze PRIVATE llvm-to-spirv)
+  endif()
+
+  if(is_ipo_supported)
+    set_property(TARGET rt-backend-ze PROPERTY INTERPROCEDURAL_OPTIMIZATION True)
   endif()
 
   install(TARGETS rt-backend-ze
@@ -241,6 +260,10 @@ if(WITH_OPENCL_BACKEND)
     target_link_libraries(rt-backend-ocl PRIVATE llvm-to-spirv)
   endif()
 
+  if(is_ipo_supported)
+    set_property(TARGET rt-backend-ocl PROPERTY INTERPROCEDURAL_OPTIMIZATION True)
+  endif()
+
   install(TARGETS rt-backend-ocl
         LIBRARY DESTINATION lib/hipSYCL
         ARCHIVE DESTINATION lib/hipSYCL)
@@ -290,6 +313,10 @@ if(WITH_CPU_BACKEND)
 
   target_compile_options(rt-backend-omp PRIVATE ${HIPSYCL_RT_EXTRA_CXX_FLAGS})
   target_link_libraries(rt-backend-omp PRIVATE ${HIPSYCL_RT_EXTRA_LINKER_FLAGS})
+
+  if(is_ipo_supported)
+    set_property(TARGET rt-backend-omp PROPERTY INTERPROCEDURAL_OPTIMIZATION True)
+  endif()
 
   install(TARGETS rt-backend-omp
       RUNTIME DESTINATION bin/hipSYCL


### PR DESCRIPTION
Compile AdaptiveCpp runtime and runtime backends with LTO, if supported by the compiler.
This increases task throughput by ~15% in my testing. YMMV.

Minimum required cmake support had to be increased to 3.9 for cmake LTO support.