### PR TITLE
Replace deprecated APIs in the src and tests

### DIFF
--- a/src/compiler/cbs/LoopSplitterInlining.cpp
+++ b/src/compiler/cbs/LoopSplitterInlining.cpp
@@ -137,7 +137,7 @@ bool fillTransitiveSplitterCallers(llvm::Function &F,
   std::transform(F.begin(), F.end(), std::back_inserter(Blocks), [](auto &BB) { return &BB; });
 
   if (fillTransitiveSplitterCallers(Blocks, SAA, FuncsWSplitter,
-                                    InIntrinsic || F.getName().startswith("__hipsycl_sscp"))) {
+                                    InIntrinsic || F.getName().starts_with("__hipsycl_sscp"))) {
     FuncsWSplitter.insert(&F);
     return true;
   }

--- a/src/compiler/cbs/SubCfgFormation.cpp
+++ b/src/compiler/cbs/SubCfgFormation.cpp
@@ -145,7 +145,7 @@ getLocalSizeArgumentFromAnnotation(llvm::Function &F) {
   for (auto &BB : F)
     for (auto &I : BB)
       if (auto *UI = llvm::dyn_cast<llvm::CallInst>(&I))
-        if (UI->getCalledFunction()->getName().startswith("llvm.var.annotation")) {
+        if (UI->getCalledFunction()->getName().starts_with("llvm.var.annotation")) {
           HIPSYCL_DEBUG_INFO << *UI << '\n';
           llvm::GlobalVariable *AnnotateStr = nullptr;
           if (auto *CE = llvm::dyn_cast<llvm::ConstantExpr>(UI->getOperand(1));
@@ -160,7 +160,7 @@ getLocalSizeArgumentFromAnnotation(llvm::Function &F) {
             if (auto *Data =
                     llvm::dyn_cast<llvm::ConstantDataSequential>(AnnotateStr->getInitializer())) {
               if (Data->isString() &&
-                  Data->getAsString().startswith("hipsycl_nd_kernel_local_size_arg")) {
+                  Data->getAsString().starts_with("hipsycl_nd_kernel_local_size_arg")) {
                 if (auto *BC = llvm::dyn_cast<llvm::BitCastInst>(UI->getOperand(0)))
                   return {BC->getOperand(0), UI};
                 return {UI->getOperand(0), UI};

--- a/src/compiler/llvm-to-backend/AddressSpaceInferencePass.cpp
+++ b/src/compiler/llvm-to-backend/AddressSpaceInferencePass.cpp
@@ -149,10 +149,10 @@ llvm::PreservedAnalyses AddressSpaceInferencePass::run(llvm::Module &M,
             forEachUseOfPointerValue(AI, [&](llvm::Value* U){
               if(auto* CB = llvm::dyn_cast<llvm::CallBase>(U)) {
                 llvm::StringRef CalleeName = CB->getCalledFunction()->getName();
-                if(CalleeName.startswith("llvm.lifetime")) {
+                if(CalleeName.starts_with("llvm.lifetime")) {
                   InstsToRemove.push_back(CB);
 
-                  llvm::Intrinsic::ID Id = CalleeName.startswith("llvm.lifetime.start")
+                  llvm::Intrinsic::ID Id = CalleeName.starts_with("llvm.lifetime.start")
                                                ? llvm::Intrinsic::lifetime_start
                                                : llvm::Intrinsic::lifetime_end;
 

--- a/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
+++ b/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
@@ -212,8 +212,8 @@ bool LLVMToSpirvTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
     for(auto& BB : F) {
       for(auto& I : BB) {
         if(llvm::CallBase* CB = llvm::dyn_cast<llvm::CallBase>(&I)) {
-          if (CB->getCalledFunction()->getName().startswith("llvm.lifetime.start") ||
-              CB->getCalledFunction()->getName().startswith("llvm.lifetime.end")) {
+          if (CB->getCalledFunction()->getName().starts_with("llvm.lifetime.start") ||
+              CB->getCalledFunction()->getName().starts_with("llvm.lifetime.end")) {
             Calls.push_back(CB);
           }
         }

--- a/src/compiler/sscp/TargetSeparationPass.cpp
+++ b/src/compiler/sscp/TargetSeparationPass.cpp
@@ -304,7 +304,7 @@ std::unique_ptr<llvm::Module> generateDeviceIR(llvm::Module &M,
       // if they are not defined, not an intrinsic and don't start with
       // __ like our hipSYCL builtins. This is a hack, it would
       // be better if we could tell clang to annotate the declaration for us :(
-      if(!F.isIntrinsic() && !F.getName().startswith("__"))
+      if(!F.isIntrinsic() && !F.getName().starts_with("__"))
         ImportedSymbolsOutput.push_back(F.getName().str());
     }
   }

--- a/src/compiler/stdpar/MallocToUSM.cpp
+++ b/src/compiler/stdpar/MallocToUSM.cpp
@@ -90,7 +90,7 @@ bool NameStartsWithItaniumIdentifier(llvm::StringRef Name, llvm::StringRef Ident
 
 bool isRestrictedToRegularMalloc(llvm::Function* F) {
   llvm::StringRef Name = F->getName();
-  if(!Name.startswith("_Z"))
+  if(!Name.starts_with("_Z"))
     return false;
   
   if(NameStartsWithItaniumIdentifier(Name, "hipsycl"))
@@ -101,7 +101,7 @@ bool isRestrictedToRegularMalloc(llvm::Function* F) {
 
 bool isStdFunction(llvm::Function* F) {
   llvm::StringRef Name = F->getName();
-  if(Name.startswith("_ZNSt") || Name.startswith("_ZSt") || Name.startswith("_ZNKSt"))
+  if(Name.starts_with("_ZNSt") || Name.starts_with("_ZSt") || Name.starts_with("_ZNKSt"))
     return true;
   return false;
 }

--- a/src/compiler/stdpar/SyncElision.cpp
+++ b/src/compiler/stdpar/SyncElision.cpp
@@ -101,7 +101,7 @@ void identifyStoresPotentiallyForStdparArgHandling(
                 if (StdparFunctions.contains(CB->getCalledFunction())) {
                   Users.push_back(Current);
                   return true;
-                } else if(CB->getCalledFunction()->getName().startswith("llvm.lifetime")) {
+                } else if(CB->getCalledFunction()->getName().starts_with("llvm.lifetime")) {
                   return true;
                 }
               }
@@ -153,7 +153,7 @@ bool functionDoesNotAccessMemory(llvm::Function* F){
   if(!F)
     return true;
   if(F->isIntrinsic()) {
-    if(F->getName().startswith("llvm.lifetime")){
+    if(F->getName().starts_with("llvm.lifetime")){
       return true;
     }
   }

--- a/tests/sycl/group_functions/group_functions.hpp
+++ b/tests/sycl/group_functions/group_functions.hpp
@@ -158,7 +158,7 @@ T initialize_type(T init) {
 template<typename T, typename std::enable_if_t<!std::is_arithmetic_v<T>, int> = 0>
 HIPSYCL_KERNEL_TARGET
 T initialize_type(elementType<T> init) {
-  constexpr size_t N = T::get_count();
+  constexpr size_t N = T::size();
 
   if constexpr (std::is_same_v<elementType<T>, bool>)
     return T{init};


### PR DESCRIPTION
While building ACPP from source and running the built-in tests, I noticed a few warnings caused by deprecated APIs.

1. bool llvm::StringRef::startswith(llvm::StringRef) const (in the source)
```
warning: ‘bool llvm::StringRef::startswith(llvm::StringRef) const’ is deprecated: Use starts_with instead [-Wdeprecated-declarations]
```
2. Atomic accessors in SYCL 2020 (in the tests)
```
warning: 'operator[]' is deprecated: Atomic accessors are deprecated as of SYCL 2020 [-Wdeprecated-declarations]
```
3. 'get_count' in SYCL 2020 (in the tests)
```
warning: 'get_count' is deprecated: renamed to 'size' in SYCL 2020 Specification [-Wdeprecated-declarations]
```

I'm still new to SYCL, so please let me know if the proposed change contains any errors. Thanks!