### PR TITLE
Fix UB in some test cases

### DIFF
--- a/tests/sycl/half.cpp
+++ b/tests/sycl/half.cpp
@@ -121,10 +121,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(half_operators, T, half_test_types) {
   s::host_accessor hacc_T{buff_T};
   for(int i = 0; i < num_ops; ++i){
     float current_reference_half = reference_half[i];
-    T current_reference_T = reference_T[i];
+    float current_reference_T = reference_T[i];
     
     float current_computed_half = hacc_half[i];
-    T current_computed_T = hacc_T[i];
+    float current_computed_T = hacc_T[i];
     
     BOOST_TEST(current_reference_half == current_computed_half, tolerance);
     BOOST_TEST(current_reference_T == current_computed_T, tolerance);

--- a/tests/sycl/math.cpp
+++ b/tests/sycl/math.cpp
@@ -243,13 +243,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_binary, T,
   constexpr int FUN_COUNT = 8;
 
   // build inputs
-  s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
-  s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
 
   s::queue queue;
   s::buffer<T> buf{{FUN_COUNT + 2}};
   {
     auto acc = buf.template get_access<s::access::mode::write>();
+    s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
+    s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
     acc[0] = get_math_input<DT, D>(v1);
     acc[1] = get_math_input<DT, D>(v2);
     for(int i = 2; i < FUN_COUNT + 2; ++i) {
@@ -309,8 +309,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(common_functions, T,
   constexpr int FUN_COUNT = 23;
 
   // build inputs
-  s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
-  s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
 
   s::queue queue;
   s::buffer<T> buf{{FUN_COUNT + 2}};
@@ -319,6 +317,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(common_functions, T,
   constexpr DT mix_input_2 = 0.8f;
   {
     auto acc = buf.template get_access<s::access::mode::write>();
+    s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
+    s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
     acc[0] = get_math_input<DT, D>(v1);
     acc[1] = get_math_input<DT, D>(v2);
     for(int i = 2; i < FUN_COUNT + 2; ++i) {
@@ -409,13 +409,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(builtin_int_basic, T, math_test_genints::type) {
   constexpr int FUN_COUNT = 5;
 
   // build inputs
-  s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
-  s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
 
   s::queue queue;
   s::buffer<T> buf{{FUN_COUNT + 2}};
   {
     auto acc = buf.template get_access<s::access::mode::write>();
+    s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
+    s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
     acc[0] = get_math_input<DT, D>(v1);
     acc[1] = get_math_input<DT, D>(v2);
     for(int i = 2; i < FUN_COUNT + 2; ++i) {
@@ -474,13 +474,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(geometric_cross, T, math_test_crossinputs::type) {
   constexpr int FUN_COUNT = 1;
 
   // build inputs
-  s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
-  s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
 
   s::queue queue;
   s::buffer<T> buf{{FUN_COUNT + 2}};
   {
     auto acc = buf.template get_access<s::access::mode::write>();
+    s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
+    s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
     acc[0] = get_math_input<DT, D>(v1);
     acc[1] = get_math_input<DT, D>(v2);
     for (int i = 2; i < FUN_COUNT + 2; ++i) {
@@ -538,13 +538,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(geometric, T, math_test_gengeo::type) {
   constexpr int FUN_COUNT = 4;
 
   // build inputs
-  s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
-  s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
 
   s::queue queue;
   s::buffer<T> buf{{FUN_COUNT + 2}};
   {
     auto acc = buf.template get_access<s::access::mode::write>();
+    s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
+    s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
     acc[0] = get_math_input<DT, D>(v1);
     acc[1] = get_math_input<DT, D>(v2);
     for(int i = 2; i < FUN_COUNT + 2; ++i) {
@@ -594,13 +594,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(fast_geometric, T, math_test_gengeofloats::type) {
   constexpr int FUN_COUNT = 3;
 
   // build inputs
-  s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
-  s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
 
   s::queue queue;
   s::buffer<T> buf{{FUN_COUNT + 2}};
   {
     auto acc = buf.template get_access<s::access::mode::write>();
+    s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
+    s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
     acc[0] = get_math_input<DT, D>(v1);
     acc[1] = get_math_input<DT, D>(v2);
     for(int i = 2; i < FUN_COUNT + 2; ++i) {
@@ -648,7 +648,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_int, T,
   constexpr int FUN_COUNT = 1;
 
   // build inputs and allocate outputs
-  s::vec<DT, 16> v{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
 
   s::queue queue;
   s::buffer<T> in{{1}};
@@ -656,6 +655,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_int, T,
   {
     auto inputs  = in.get_host_access();
     auto outputs = out.get_host_access();
+    s::vec<DT, 16> v{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
     inputs[0] = get_math_input<DT, D>(v);
     for(int i = 0; i < FUN_COUNT; ++i) {
       outputs[i] = T{DT{0}};
@@ -697,8 +697,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_genint, T,
   constexpr int FUN_COUNT = 3;
 
   // build inputs and allocate outputs
-  s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
-  s::vec<int, 16> v2{17, -4, -2, 3, 7, -8, 9, -1, 17, -4, -2, 3, 7, -8, 9, -1};
 
   s::queue queue;
   s::buffer<T> float_in{{1}};
@@ -708,6 +706,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_genint, T,
     auto float_inputs = float_in.get_host_access();
     auto int_inputs = int_in.get_host_access();
     auto outputs = out.get_host_access();
+    s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
+    s::vec<int, 16> v2{17, -4, -2, 3, 7, -8, 9, -1, 17, -4, -2, 3, 7, -8, 9, -1};
     float_inputs[0] = get_math_input<DT, D>(v1);
     int_inputs[1] = get_math_input<int, D>(v2);
     for(int i = 0; i < FUN_COUNT; ++i) {

--- a/tests/sycl/math.cpp
+++ b/tests/sycl/math.cpp
@@ -248,8 +248,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_binary, T,
   s::buffer<T> buf{{FUN_COUNT + 2}};
   {
     auto acc = buf.template get_access<s::access::mode::write>();
-    acc[0] = get_math_input<DT, D>({7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0});
-    acc[1] = get_math_input<DT, D>({17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0});
+    s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
+    s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
+    acc[0] = get_math_input<DT, D>(v1);
+    acc[1] = get_math_input<DT, D>(v2);
     for(int i = 2; i < FUN_COUNT + 2; ++i) {
       acc[i] = T{DT{0}};
     }
@@ -315,8 +317,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(common_functions, T,
   constexpr DT mix_input_2 = 0.8f;
   {
     auto acc = buf.template get_access<s::access::mode::write>();
-    acc[0] = get_math_input<DT, D>({7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0});
-    acc[1] = get_math_input<DT, D>({17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0});
+    s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
+    s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
+    acc[0] = get_math_input<DT, D>(v1);
+    acc[1] = get_math_input<DT, D>(v2);
     for(int i = 2; i < FUN_COUNT + 2; ++i) {
       acc[i] = T{DT{0}};
     }
@@ -410,8 +414,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(builtin_int_basic, T, math_test_genints::type) {
   s::buffer<T> buf{{FUN_COUNT + 2}};
   {
     auto acc = buf.template get_access<s::access::mode::write>();
-    acc[0] = get_math_input<DT, D>({7, -8, 9, -1, 17, -4, -2, 3, 7, -8, 9, -1, 17, -4, -2, 3});
-    acc[1] = get_math_input<DT, D>({17, -4, -2, 3, 7, -8, 9, -1, 17, -4, -2, 3, 7, -8, 9, -1});
+    s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
+    s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
+    acc[0] = get_math_input<DT, D>(v1);
+    acc[1] = get_math_input<DT, D>(v2);
     for(int i = 2; i < FUN_COUNT + 2; ++i) {
       acc[i] = T{DT{0}};
     }
@@ -473,8 +479,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(geometric_cross, T, math_test_crossinputs::type) {
   s::buffer<T> buf{{FUN_COUNT + 2}};
   {
     auto acc = buf.template get_access<s::access::mode::write>();
-    acc[0] = get_math_input<DT, D>({7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0});
-    acc[1] = get_math_input<DT, D>({17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0});
+    s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
+    s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
+    acc[0] = get_math_input<DT, D>(v1);
+    acc[1] = get_math_input<DT, D>(v2);
     for (int i = 2; i < FUN_COUNT + 2; ++i) {
       acc[i] = T{DT{0}};
     }
@@ -535,8 +543,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(geometric, T, math_test_gengeo::type) {
   s::buffer<T> buf{{FUN_COUNT + 2}};
   {
     auto acc = buf.template get_access<s::access::mode::write>();
-    acc[0] = get_math_input<DT, D>({7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0});
-    acc[1] = get_math_input<DT, D>({17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0});
+    s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
+    s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
+    acc[0] = get_math_input<DT, D>(v1);
+    acc[1] = get_math_input<DT, D>(v2);
     for(int i = 2; i < FUN_COUNT + 2; ++i) {
       acc[i] = T{DT{0}};
     }
@@ -589,8 +599,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(fast_geometric, T, math_test_gengeofloats::type) {
   s::buffer<T> buf{{FUN_COUNT + 2}};
   {
     auto acc = buf.template get_access<s::access::mode::write>();
-    acc[0] = get_math_input<DT, D>({7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0});
-    acc[1] = get_math_input<DT, D>({17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0});
+    s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
+    s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
+    acc[0] = get_math_input<DT, D>(v1);
+    acc[1] = get_math_input<DT, D>(v2);
     for(int i = 2; i < FUN_COUNT + 2; ++i) {
       acc[i] = T{DT{0}};
     }
@@ -643,7 +655,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_int, T,
   {
     auto inputs  = in.get_host_access();
     auto outputs = out.get_host_access();
-    inputs[0] = get_math_input<DT, D>({7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0});
+    s::vec<DT, 16> v{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
+    inputs[0] = get_math_input<DT, D>(v);
     for(int i = 0; i < FUN_COUNT; ++i) {
       outputs[i] = T{DT{0}};
     }
@@ -693,8 +706,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_genint, T,
     auto float_inputs = float_in.get_host_access();
     auto int_inputs = int_in.get_host_access();
     auto outputs = out.get_host_access();
-    float_inputs[0] = get_math_input<DT, D>({7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0});
-    int_inputs[0] = get_math_input<int, D>({17, -4, -2, 3, 7, -8, 9, -1, 17, -4, -2, 3, 7, -8, 9, -1});
+    s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
+    s::vec<int, 16> v2{17, -4, -2, 3, 7, -8, 9, -1, 17, -4, -2, 3, 7, -8, 9, -1};
+    float_inputs[0] = get_math_input<DT, D>(v1);
+    int_inputs[1] = get_math_input<int, D>(v2);
     for(int i = 0; i < FUN_COUNT; ++i) {
       outputs[i] = T{DT{0}};
     }

--- a/tests/sycl/math.cpp
+++ b/tests/sycl/math.cpp
@@ -709,7 +709,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_genint, T,
     s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
     s::vec<int, 16> v2{17, -4, -2, 3, 7, -8, 9, -1, 17, -4, -2, 3, 7, -8, 9, -1};
     float_inputs[0] = get_math_input<DT, D>(v1);
-    int_inputs[1] = get_math_input<int, D>(v2);
+    int_inputs[0] = get_math_input<int, D>(v2);
     for(int i = 0; i < FUN_COUNT; ++i) {
       outputs[i] = T{DT{0}};
     }

--- a/tests/sycl/math.cpp
+++ b/tests/sycl/math.cpp
@@ -243,13 +243,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_binary, T,
   constexpr int FUN_COUNT = 8;
 
   // build inputs
+  s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
+  s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
 
   s::queue queue;
   s::buffer<T> buf{{FUN_COUNT + 2}};
   {
     auto acc = buf.template get_access<s::access::mode::write>();
-    s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
-    s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
     acc[0] = get_math_input<DT, D>(v1);
     acc[1] = get_math_input<DT, D>(v2);
     for(int i = 2; i < FUN_COUNT + 2; ++i) {
@@ -309,6 +309,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(common_functions, T,
   constexpr int FUN_COUNT = 23;
 
   // build inputs
+  s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
+  s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
 
   s::queue queue;
   s::buffer<T> buf{{FUN_COUNT + 2}};
@@ -317,8 +319,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(common_functions, T,
   constexpr DT mix_input_2 = 0.8f;
   {
     auto acc = buf.template get_access<s::access::mode::write>();
-    s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
-    s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
     acc[0] = get_math_input<DT, D>(v1);
     acc[1] = get_math_input<DT, D>(v2);
     for(int i = 2; i < FUN_COUNT + 2; ++i) {
@@ -409,13 +409,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(builtin_int_basic, T, math_test_genints::type) {
   constexpr int FUN_COUNT = 5;
 
   // build inputs
+  s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
+  s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
 
   s::queue queue;
   s::buffer<T> buf{{FUN_COUNT + 2}};
   {
     auto acc = buf.template get_access<s::access::mode::write>();
-    s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
-    s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
     acc[0] = get_math_input<DT, D>(v1);
     acc[1] = get_math_input<DT, D>(v2);
     for(int i = 2; i < FUN_COUNT + 2; ++i) {
@@ -474,13 +474,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(geometric_cross, T, math_test_crossinputs::type) {
   constexpr int FUN_COUNT = 1;
 
   // build inputs
+  s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
+  s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
 
   s::queue queue;
   s::buffer<T> buf{{FUN_COUNT + 2}};
   {
     auto acc = buf.template get_access<s::access::mode::write>();
-    s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
-    s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
     acc[0] = get_math_input<DT, D>(v1);
     acc[1] = get_math_input<DT, D>(v2);
     for (int i = 2; i < FUN_COUNT + 2; ++i) {
@@ -538,13 +538,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(geometric, T, math_test_gengeo::type) {
   constexpr int FUN_COUNT = 4;
 
   // build inputs
+  s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
+  s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
 
   s::queue queue;
   s::buffer<T> buf{{FUN_COUNT + 2}};
   {
     auto acc = buf.template get_access<s::access::mode::write>();
-    s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
-    s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
     acc[0] = get_math_input<DT, D>(v1);
     acc[1] = get_math_input<DT, D>(v2);
     for(int i = 2; i < FUN_COUNT + 2; ++i) {
@@ -594,13 +594,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(fast_geometric, T, math_test_gengeofloats::type) {
   constexpr int FUN_COUNT = 3;
 
   // build inputs
+  s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
+  s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
 
   s::queue queue;
   s::buffer<T> buf{{FUN_COUNT + 2}};
   {
     auto acc = buf.template get_access<s::access::mode::write>();
-    s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
-    s::vec<DT, 16> v2{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
     acc[0] = get_math_input<DT, D>(v1);
     acc[1] = get_math_input<DT, D>(v2);
     for(int i = 2; i < FUN_COUNT + 2; ++i) {
@@ -648,6 +648,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_int, T,
   constexpr int FUN_COUNT = 1;
 
   // build inputs and allocate outputs
+  s::vec<DT, 16> v{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
 
   s::queue queue;
   s::buffer<T> in{{1}};
@@ -655,7 +656,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_int, T,
   {
     auto inputs  = in.get_host_access();
     auto outputs = out.get_host_access();
-    s::vec<DT, 16> v{17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0};
     inputs[0] = get_math_input<DT, D>(v);
     for(int i = 0; i < FUN_COUNT; ++i) {
       outputs[i] = T{DT{0}};
@@ -697,6 +697,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_genint, T,
   constexpr int FUN_COUNT = 3;
 
   // build inputs and allocate outputs
+  s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
+  s::vec<int, 16> v2{17, -4, -2, 3, 7, -8, 9, -1, 17, -4, -2, 3, 7, -8, 9, -1};
 
   s::queue queue;
   s::buffer<T> float_in{{1}};
@@ -706,8 +708,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_genint, T,
     auto float_inputs = float_in.get_host_access();
     auto int_inputs = int_in.get_host_access();
     auto outputs = out.get_host_access();
-    s::vec<DT, 16> v1{7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0};
-    s::vec<int, 16> v2{17, -4, -2, 3, 7, -8, 9, -1, 17, -4, -2, 3, 7, -8, 9, -1};
     float_inputs[0] = get_math_input<DT, D>(v1);
     int_inputs[1] = get_math_input<int, D>(v2);
     for(int i = 0; i < FUN_COUNT; ++i) {

--- a/tests/sycl/math.cpp
+++ b/tests/sycl/math.cpp
@@ -110,8 +110,8 @@ namespace {
 
   // utility functions for generic testing
 
-  template<typename DT, int D>
-  auto get_math_input(vec<DT, 16> v) {
+  template <typename DT, int D>
+  auto get_math_input(const vec<DT, 16> &v) {
     if constexpr(D==0) {
       return v.template swizzle<0>();
     } else if constexpr(D==2) {

--- a/tests/sycl/relational.cpp
+++ b/tests/sycl/relational.cpp
@@ -86,7 +86,7 @@ namespace {
   // utility functions for generic testing
 
   template<typename DT, int D>
-  auto get_subvector(vec<DT, 16> v) {
+  auto get_subvector(const vec<DT, 16> &v) {
     if constexpr(D==0) {
       return v.template swizzle<0>();
     } else if constexpr(D==2) {

--- a/tests/sycl/relational.cpp
+++ b/tests/sycl/relational.cpp
@@ -135,13 +135,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(rel_genfloat_unary, T,
   {
     auto inputs  = in.get_host_access();
     auto outputs = out.get_host_access();
-    inputs[0] = get_subvector<DT, D>({NAN, INFINITY, INFINITY - INFINITY,
-                                      0.0, 0.0/0.0, 1.0/0.0, sqrt(-1),
-                                      std::numeric_limits<float>::min(),
-                                      std::numeric_limits<float>::denorm_min(),
-                                      std::numeric_limits<double>::min(),
-                                      std::numeric_limits<double>::denorm_min(),
-                                      -1.0, 17.0, -4.0, -2.0, 3.0});
+    s::vec<DT, 16> v{NAN, INFINITY, INFINITY - INFINITY,
+		     0.0, 0.0/0.0, 1.0/0.0, sqrt(-1),
+		     std::numeric_limits<float>::min(),
+		     std::numeric_limits<float>::denorm_min(),
+		     std::numeric_limits<double>::min(),
+		     std::numeric_limits<double>::denorm_min(),
+		     -1.0, 17.0, -4.0, -2.0, 3.0};
+    inputs[0] = get_subvector<DT, D>(v);
     for(int i = 0; i < FUN_COUNT; ++i) {
       outputs[i] = OutType{IntType{0}};
     }


### PR DESCRIPTION
Compiling the tests with `-fsanitize=address,undefined` revealed some problems:
- In the atomic tests, reductions were performed on pointer types that were UB (it's UB to add to a non-zero offset to nullptr; but the reductions always started with the value 0). For the pointer types, the reductions now start either from 1 (when the reduction is adding values) or from `std::numeric_limits<int>::max()` (when the reduction is subtracting values).
- In the half tests, some variables had wrong types that could not represent the stored value (e.g., the result of `(unsigned int)1 - sycl::half{2}` was stored in a `unsigned int`)
- Two other tests contain helper functions that take a `sycl::vec` and return certain swizzles. However, the functions were called like `foo({1,2,3})` which causes the vec to be destroyed immediately after the function call, causing use-after-free errors (since the returned swizzles are views into the - now destroyed - vec). Constructing the vecs before the function call (and passing them by const ref) fixes this.

The tests still don't run clean when compiled with `-fsanitize=address,undefined`, there is an integer overflow somewhere in the group tests. I had a quick look at it, but I think the group tests are a bit too complex for a "quick look". We should probably look into this though, maybe it's the reason for the errors reported in #1431.