### PR TITLE
Add `max_size` function to accessor class

### DIFF
--- a/include/hipSYCL/sycl/libkernel/accessor.hpp
+++ b/include/hipSYCL/sycl/libkernel/accessor.hpp
@@ -31,6 +31,7 @@
 
 #include <exception>
 #include <iterator>
+#include <limits>
 #include <memory>
 #include <type_traits>
 #include <cassert>
@@ -1052,7 +1053,10 @@ public:
     return get_count();
   }
 
-  //size_type max_size() const noexcept;
+  size_type max_size() const noexcept {
+    return std::numeric_limits<difference_type>::max();
+  }
+
   template <bool IsAllowed = has_size_queries,
             std::enable_if_t<IsAllowed, int> = 0>
   bool empty() const noexcept {
@@ -1749,7 +1753,9 @@ public:
     return _impl.get_count();
   }
 
-  //size_type max_size() const noexcept;
+  size_type max_size() const noexcept {
+    return std::numeric_limits<difference_type>::max();
+  }
 
   bool empty() const noexcept {
     return size() == 0;
@@ -1980,7 +1986,10 @@ public:
     return _num_elements.size();
   }
 
-  // size_type max_size() const noexcept;
+  size_type max_size() const noexcept
+  {
+    return std::numeric_limits<difference_type>::max();
+  }
 
   range<dimensions> get_range() const
   {

--- a/tests/sycl/accessor.cpp
+++ b/tests/sycl/accessor.cpp
@@ -32,6 +32,7 @@
 
 #include <algorithm>
 #include <array>
+#include <limits>
 #include <numeric>
 #include <vector>
 
@@ -238,6 +239,18 @@ BOOST_AUTO_TEST_CASE(accessor_api) {
   la1.swap(la1_copy);
   la2.swap(la2_copy);
   la3.swap(la3_copy);
+
+  // Test max_size
+  {
+    s::accessor<int, 1> acc;
+    s::host_accessor<int, 1> hacc;
+    s::local_accessor<int, 1> lacc;
+
+    const auto expected = std::numeric_limits<std::ptrdiff_t>::max();
+    BOOST_REQUIRE(acc.max_size() == expected);
+    BOOST_REQUIRE(hacc.max_size() == expected);
+    BOOST_REQUIRE(lacc.max_size() == expected);
+  }
 }
 
 BOOST_AUTO_TEST_CASE(nested_subscript) {


### PR DESCRIPTION
The spec describes this functions as:
> Returns the maximum number of elements any accessor of this type would be able to access.

So I think just implementing it by returning the maximal possible index should be fine.  