### PR TITLE
Add ACPP_APPDB_DIR env variable to override appdb location

### DIFF
--- a/doc/env_variables.md
+++ b/doc/env_variables.md
@@ -28,3 +28,4 @@
 * `ACPP_STDPAR_OHC_MIN_TIME`: stdpar offload heuristic configuration (ohc): If set, offloading decisions will only be reevaluated after at least this much time in seconds has passed.
 * `ACPP_RT_NO_JIT_CACHE_POPULATION`: If set to `1`, prevents the kernel cache from storing SSCP JIT-compiled binaries in the persistent on-disk cache. This can be useful e.g. in an MPI context, where it is sufficient that only one process among many populates the cache.
 * `ACPP_ADAPTIVITY_LEVEL`: Controls the optimization level of the adaptivity engine. This is currently only relevant for the generic SSCP target. A higher value implies JIT-compiling more specialized kernels at the expense of more frequent JIT compilations. A value of 0 disables all adaptivity (not recommended).
+* `ACPP_APPDB_DIR`: By default, AdaptiveCpp stores its application db (which in particular includes the per-app JIT cache) in `$HOME/.acpp`. This environment variable can be used to override the location.

--- a/src/common/filesystem.cpp
+++ b/src/common/filesystem.cpp
@@ -30,6 +30,8 @@
 #include "hipSYCL/common/stable_running_hash.hpp"
 #include "hipSYCL/common/debug.hpp"
 
+#include "hipSYCL/runtime/settings.hpp"
+
 #include <fstream>
 #include <random>
 #include <cassert>
@@ -184,11 +186,13 @@ tuningdb::tuningdb() {
     return false;
   };
 
-  std::string home, subdirectory;
-  if(get_home(home, subdirectory)) {
-    _base_dir = (fs::path{home} / subdirectory).string();
-  } else {
-    _base_dir = (fs::current_path() / ".acpp").string();
+  if(!rt::try_get_environment_variable("appdb_dir", _base_dir)) {
+    std::string home, subdirectory;
+    if (get_home(home, subdirectory)) {
+      _base_dir = (fs::path{home} / subdirectory).string();
+    } else {
+      _base_dir = (fs::current_path() / ".acpp").string();
+    }
   }
 
   auto get_app_path = []() -> std::string{


### PR DESCRIPTION
This introduces `ACPP_APPDB_DIR` environment variable to override the location of the app db (by default `~/.acpp`) which can be useful e.g. in containerized environments where there might be no writable home directory by default.

@gonzalobg