### PR TITLE
Fix string_build_config_mapper potentially becoming invalid due to ODR issues when restarting the runtime

### DIFF
--- a/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/generic/hiplike/hiplike_kernel_launcher.hpp
@@ -33,7 +33,7 @@
 #include <cstdlib>
 #include <string>
 
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/runtime/allocator.hpp"
 #include "hipSYCL/runtime/hints.hpp"
 #include "hipSYCL/runtime/operations.hpp"
@@ -877,7 +877,7 @@ public:
   }
 
   virtual void invoke(rt::dag_node *node,
-                      const kernel_configuration &) final override {
+                      const rt::kernel_configuration &) final override {
     _invoker(node);
   }
 

--- a/include/hipSYCL/glue/kernel_configuration.hpp
+++ b/include/hipSYCL/glue/kernel_configuration.hpp
@@ -84,6 +84,13 @@ enum class kernel_build_flag : int {
   spirv_enable_intel_llvm_spirv_options
 };
 
+// This anonymous namespace is necessary to ensure that each backend plugin
+// has its own instance of the singleton. Otherwise there might be problems
+// when the runtime is restarted.
+// TODO: A cleaner solution might be to move the kernel_configuration content
+// from glue to rt, and define these functions inside a .cpp file.
+namespace {
+
 class string_build_config_mapper {
 public:
   string_build_config_mapper() {
@@ -178,6 +185,8 @@ to_build_flag(const std::string& s) {
     return {};
   return it->second;
 }
+
+} // anonymous namespace
 
 class kernel_configuration {
 

--- a/include/hipSYCL/glue/llvm-sscp/jit.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/jit.hpp
@@ -35,7 +35,7 @@
 #include "hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp"
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/kernel_cache.hpp"
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/runtime/application.hpp"
 #include <cstddef>
 #include <vector>
@@ -214,7 +214,7 @@ private:
 
 inline rt::result compile(compiler::LLVMToBackendTranslator *translator,
                           const std::string &source,
-                          const glue::kernel_configuration &config,
+                          const rt::kernel_configuration &config,
                           const symbol_list_t& imported_symbol_names,
                           std::string &output) {
 
@@ -238,7 +238,7 @@ inline rt::result compile(compiler::LLVMToBackendTranslator *translator,
   }
 
   for(const auto& option : config.build_options()) {
-    std::string option_name = glue::to_string(option.first);
+    std::string option_name = rt::to_string(option.first);
     std::string option_value =
         option.second.int_value.has_value()
             ? std::to_string(option.second.int_value.value())
@@ -248,7 +248,7 @@ inline rt::result compile(compiler::LLVMToBackendTranslator *translator,
   }
 
   for(const auto& flag : config.build_flags()) {
-    translator->setBuildFlag(glue::to_string(flag));
+    translator->setBuildFlag(rt::to_string(flag));
   }
 
   // Transform code
@@ -286,7 +286,7 @@ inline rt::result compile(compiler::LLVMToBackendTranslator *translator,
 inline rt::result compile(compiler::LLVMToBackendTranslator* translator,
                           const common::hcf_container* hcf,
                           const std::string& image_name,
-                          const glue::kernel_configuration &config,
+                          const rt::kernel_configuration &config,
                           std::string &output) {
   assert(hcf);
   assert(hcf->root_node());
@@ -332,7 +332,7 @@ inline rt::result compile(compiler::LLVMToBackendTranslator* translator,
 inline rt::result compile(compiler::LLVMToBackendTranslator* translator,
                           rt::hcf_object_id hcf_object,
                           const std::string& image_name,
-                          const glue::kernel_configuration &config,
+                          const rt::kernel_configuration &config,
                           std::string &output) {
   const common::hcf_container* hcf = rt::hcf_cache::get().get_hcf(hcf_object);
   if(!hcf) {

--- a/include/hipSYCL/glue/llvm-sscp/sscp_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/sscp_kernel_launcher.hpp
@@ -30,8 +30,8 @@
 
 #include "hipSYCL/common/hcf_container.hpp"
 #include "hipSYCL/glue/generic/code_object.hpp"
-#include "hipSYCL/glue/kernel_configuration.hpp"
 #include "hipSYCL/glue/llvm-sscp/s1_ir_constants.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/kernel_launcher.hpp"
 #include "hipSYCL/runtime/operations.hpp"
@@ -328,7 +328,7 @@ public:
   }
 
   virtual void invoke(rt::dag_node *node,
-                      const kernel_configuration &config) final override {
+                      const rt::kernel_configuration &config) final override {
     _configuration = &config;
     _invoker(node);
   }
@@ -441,7 +441,7 @@ private:
 
   std::function<void (rt::dag_node*)> _invoker;
   rt::kernel_type _type;
-  const kernel_configuration* _configuration = nullptr;
+  const rt::kernel_configuration* _configuration = nullptr;
   void* _params = nullptr;
 };
 

--- a/include/hipSYCL/glue/omp/omp_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/omp/omp_kernel_launcher.hpp
@@ -28,7 +28,7 @@
 #ifndef HIPSYCL_OPENMP_KERNEL_LAUNCHER_HPP
 #define HIPSYCL_OPENMP_KERNEL_LAUNCHER_HPP
 
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 #include <cassert>
 #include <tuple>
 #ifdef _OPENMP
@@ -542,7 +542,7 @@ public:
   }
 
   virtual void invoke(rt::dag_node *node,
-                      const kernel_configuration &) final override {
+                      const rt::kernel_configuration &) final override {
     _invoker(node);
   }
 

--- a/include/hipSYCL/glue/ze/ze_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/ze/ze_kernel_launcher.hpp
@@ -33,7 +33,7 @@
 #include <tuple>
 
 #include "hipSYCL/common/debug.hpp"
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/dag_node.hpp"
 #include "hipSYCL/runtime/ze/ze_queue.hpp"
@@ -364,7 +364,7 @@ public:
   }
 
   virtual void invoke(rt::dag_node *node,
-                      const kernel_configuration &config) final override {
+                      const rt::kernel_configuration &config) final override {
     _invoker(node);
   }
 

--- a/include/hipSYCL/runtime/code_object_invoker.hpp
+++ b/include/hipSYCL/runtime/code_object_invoker.hpp
@@ -30,7 +30,7 @@
 #define HIPSYCL_CODE_OBJECT_INVOKER_HPP
 
 #include "error.hpp"
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "util.hpp"
 #include "kernel_cache.hpp"
 #include "operations.hpp"
@@ -60,7 +60,7 @@ public:
                                unsigned local_mem_size, void **args,
                                std::size_t *arg_sizes, std::size_t num_args,
                                const std::string &kernel_name,
-                               const glue::kernel_configuration& config) = 0;
+                               const kernel_configuration& config) = 0;
 
   virtual rt::range<3> select_group_size(const rt::range<3> &global_range,
                                          const rt::range<3> &group_size) const {

--- a/include/hipSYCL/runtime/cuda/cuda_code_object.hpp
+++ b/include/hipSYCL/runtime/cuda/cuda_code_object.hpp
@@ -31,7 +31,7 @@
 #include <vector>
 #include <string>
 
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
 #include "hipSYCL/runtime/kernel_cache.hpp"
@@ -91,7 +91,7 @@ public:
                               hcf_object_id hcf_source,
                               const std::vector<std::string> &kernel_names,
                               int device,
-                              const glue::kernel_configuration &config);
+                              const kernel_configuration &config);
 
   virtual ~cuda_sscp_executable_object();
 
@@ -117,7 +117,7 @@ private:
   hcf_object_id _hcf;
   std::vector<std::string> _kernel_names;
   result _build_result;
-  glue::kernel_configuration::id_type _id;
+  kernel_configuration::id_type _id;
   int _device;
   CUmod_st* _module;
 };

--- a/include/hipSYCL/runtime/cuda/cuda_queue.hpp
+++ b/include/hipSYCL/runtime/cuda/cuda_queue.hpp
@@ -83,7 +83,7 @@ public:
                                unsigned local_mem_size, void **args,
                                std::size_t *arg_sizes, std::size_t num_args,
                                const std::string &kernel_name,
-                               const glue::kernel_configuration& config) override;
+                               const kernel_configuration& config) override;
 private:
   cuda_queue* _queue;
 };
@@ -130,7 +130,7 @@ public:
       const std::string &kernel_name, const rt::range<3> &num_groups,
       const rt::range<3> &group_size, unsigned local_mem_size, void **args,
       std::size_t *arg_sizes, std::size_t num_args,
-      const glue::kernel_configuration &config);
+      const kernel_configuration &config);
 
   const host_timestamped_event& get_timing_reference() const {
     return _reference_event;

--- a/include/hipSYCL/runtime/hip/hip_code_object.hpp
+++ b/include/hipSYCL/runtime/hip/hip_code_object.hpp
@@ -31,7 +31,7 @@
 #include <vector>
 #include <string>
 
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
 #include "hipSYCL/runtime/kernel_cache.hpp"
@@ -90,7 +90,7 @@ public:
                              hcf_object_id source,
                              const std::vector<std::string> &kernel_name,
                              int device,
-                             const glue::kernel_configuration &config);
+                             const kernel_configuration &config);
 
   virtual result get_build_result() const override;
 
@@ -115,7 +115,7 @@ private:
   hcf_object_id _origin;
   std::vector<std::string> _kernel_names;
   result _build_result;
-  glue::kernel_configuration::id_type _id;
+  kernel_configuration::id_type _id;
   int _device;
   ihipModule_t* _module;
 };

--- a/include/hipSYCL/runtime/hip/hip_queue.hpp
+++ b/include/hipSYCL/runtime/hip/hip_queue.hpp
@@ -76,7 +76,7 @@ public:
                                unsigned local_mem_size, void **args,
                                std::size_t *arg_sizes, std::size_t num_args,
                                const std::string &kernel_name,
-                               const glue::kernel_configuration& config) override;
+                               const kernel_configuration& config) override;
 private:
   hip_queue* _queue;
 };
@@ -122,7 +122,7 @@ public:
       const std::string &kernel_name, const rt::range<3> &num_groups,
       const rt::range<3> &group_size, unsigned local_mem_size, void **args,
       std::size_t *arg_sizes, std::size_t num_args,
-      const glue::kernel_configuration &config);
+      const kernel_configuration &config);
 
   const host_timestamped_event& get_timing_reference() const {
     return _reference_event;

--- a/include/hipSYCL/runtime/kernel_cache.hpp
+++ b/include/hipSYCL/runtime/kernel_cache.hpp
@@ -32,7 +32,7 @@
 #include <memory>
 #include "hipSYCL/common/hcf_container.hpp"
 #include "hipSYCL/common/small_map.hpp"
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
 #include "hipSYCL/runtime/error.hpp"
 
@@ -78,8 +78,8 @@ public:
   /// Returns the kernel configuration id. This can e.g. be used
   /// to distinguish kernels with different specialization constant values /
   /// S2 IR constant values.
-  virtual glue::kernel_configuration::id_type configuration_id() const {
-    return glue::kernel_configuration::id_type{};
+  virtual kernel_configuration::id_type configuration_id() const {
+    return kernel_configuration::id_type{};
   }
   
   // Do we really need this? Cannot be implemented on all backends,
@@ -121,8 +121,8 @@ public:
   const std::vector<std::string> &get_images_containing_kernel() const;
   hcf_object_id get_hcf_object_id() const;
 
-  const std::vector<glue::kernel_build_flag>& get_compilation_flags() const;
-  const std::vector<std::pair<glue::kernel_build_option, std::string>> &
+  const std::vector<rt::kernel_build_flag>& get_compilation_flags() const;
+  const std::vector<std::pair<rt::kernel_build_option, std::string>> &
   get_compilation_options() const;
 
 private:
@@ -136,8 +136,8 @@ private:
 
   std::vector<std::string> _image_providers;
   
-  std::vector<glue::kernel_build_flag> _compilation_flags;
-  std::vector<std::pair<glue::kernel_build_option, std::string>>
+  std::vector<rt::kernel_build_flag> _compilation_flags;
+  std::vector<std::pair<rt::kernel_build_option, std::string>>
       _compilation_options;
 
   hcf_object_id _id;
@@ -238,7 +238,7 @@ private:
 
 class kernel_cache {
 public:
-  using code_object_id = glue::kernel_configuration::id_type;
+  using code_object_id = kernel_configuration::id_type;
   using code_object_ptr = std::unique_ptr<const code_object>;
 
   static std::shared_ptr<kernel_cache> get();
@@ -293,11 +293,11 @@ public:
                                                       CodeObjectConstructor &&c) {
     if(auto* code_object = get_code_object(id_of_code_object)) {
       HIPSYCL_DEBUG_INFO << "kernel_cache: Cache hit for id "
-                         << glue::kernel_configuration::to_string(id_of_code_object) << "\n";
+                         << kernel_configuration::to_string(id_of_code_object) << "\n";
       return code_object;
     }
     HIPSYCL_DEBUG_INFO << "kernel_cache: Cache MISS for id "
-                      << glue::kernel_configuration::to_string(id_of_code_object) << "\n";
+                      << kernel_configuration::to_string(id_of_code_object) << "\n";
     
     std::string compiled_binary;
     // TODO: We might want to allow JIT compilation in parallel at some point
@@ -344,11 +344,11 @@ private:
     auto* existing_code_object = get_code_object_impl(id);
     if(existing_code_object) {
       HIPSYCL_DEBUG_INFO << "kernel_cache: Cache hit for id "
-                         << glue::kernel_configuration::to_string(id) << "\n";
+                         << kernel_configuration::to_string(id) << "\n";
       return existing_code_object;
     }
     HIPSYCL_DEBUG_INFO << "kernel_cache: Cache MISS for id "
-                      << glue::kernel_configuration::to_string(id) << "\n";
+                      << kernel_configuration::to_string(id) << "\n";
 
     const code_object* new_object = c();
     if(new_object) {
@@ -359,7 +359,7 @@ private:
 
   mutable std::mutex _mutex;
 
-  std::unordered_map<code_object_id, code_object_ptr, glue::kernel_id_hash>
+  std::unordered_map<code_object_id, code_object_ptr, rt::kernel_id_hash>
       _code_objects;
   
   bool _is_first_jit_compilation = true;

--- a/include/hipSYCL/runtime/kernel_configuration.hpp
+++ b/include/hipSYCL/runtime/kernel_configuration.hpp
@@ -85,102 +85,16 @@ enum class kernel_build_flag : int {
 };
 
 
-class string_build_config_mapper {
-public:
-  string_build_config_mapper() {
-    _options =  {
-      {"known-group-size-x", kernel_build_option::known_group_size_x},
-      {"known-group-size-y", kernel_build_option::known_group_size_y},
-      {"known-group-size-z", kernel_build_option::known_group_size_z},
-      {"known-local-mem-size", kernel_build_option::known_local_mem_size},
-      {"ptx-version", kernel_build_option::ptx_version},
-      {"ptx-target-device", kernel_build_option::ptx_target_device},
-      {"amdgpu-target-device", kernel_build_option::amdgpu_target_device},
-      {"rocm-device-libs-path", kernel_build_option::amdgpu_rocm_device_libs_path},
-      {"rocm-path", kernel_build_option::amdgpu_rocm_path},
-      {"spirv-dynamic-local-mem-allocation-size", kernel_build_option::spirv_dynamic_local_mem_allocation_size}
-    };
 
-    _flags = {
-      {"global-sizes-fit-in-int", kernel_build_flag::global_sizes_fit_in_int},
-      {"fast-math", kernel_build_flag::fast_math},
-      {"ptx-ftz", kernel_build_flag::ptx_ftz},
-      {"ptx-approx-div", kernel_build_flag::ptx_approx_div},
-      {"ptx-approx-sqrt", kernel_build_flag::ptx_approx_sqrt},
-      {"spirv-enable-intel-llvm-spirv-options", kernel_build_flag::spirv_enable_intel_llvm_spirv_options}
-    };
+std::string to_string(kernel_build_flag f);
 
-    for(const auto& elem : _options) {
-      _inverse_options[elem.second] = elem.first;
-    }
+std::string to_string(kernel_build_option o);
 
-    for(const auto& elem : _flags) {
-      _inverse_flags[elem.second] = elem.first;
-    }
-  }
+std::optional<kernel_build_option>
+to_build_option(const std::string& s);
 
-  const auto&
-  string_to_build_option_map() const{
-    return _options;
-  }
-
-  const auto&
-  string_to_build_flag_map() const {
-    return _flags;
-  }
-
-  const auto&
-  build_option_to_string_map() const {
-    return _inverse_options;
-  }
-
-  const auto&
-  build_flag_to_string_map() const {
-    return _inverse_flags;
-  }
-
-  static string_build_config_mapper& get();
-private:
-
-  std::unordered_map<std::string, kernel_build_option> _options;
-  std::unordered_map<std::string, kernel_build_flag> _flags;
-  std::unordered_map<kernel_build_option, std::string> _inverse_options;
-  std::unordered_map<kernel_build_flag, std::string> _inverse_flags;
-};
-
-inline std::string to_string(kernel_build_flag f) {
-  const auto& map = string_build_config_mapper::get().build_flag_to_string_map();
-  auto it = map.find(f);
-  if(it == map.end())
-    return {};
-  return it->second;
-}
-
-inline std::string to_string(kernel_build_option o) {
-  const auto& map = string_build_config_mapper::get().build_option_to_string_map();
-  auto it = map.find(o);
-  if(it == map.end())
-    return {};
-  return it->second;
-}
-
-inline std::optional<kernel_build_option>
-to_build_option(const std::string& s) {
-  const auto& map = string_build_config_mapper::get().string_to_build_option_map();
-  auto it = map.find(s);
-  if(it == map.end())
-    return {};
-  return it->second;
-}
-
-inline std::optional<kernel_build_flag>
-to_build_flag(const std::string& s) {
-  const auto& map = string_build_config_mapper::get().string_to_build_flag_map();
-  auto it = map.find(s);
-  if(it == map.end())
-    return {};
-  return it->second;
-}
+std::optional<kernel_build_flag>
+to_build_flag(const std::string& s);
 
 
 class kernel_configuration {

--- a/include/hipSYCL/runtime/kernel_configuration.hpp
+++ b/include/hipSYCL/runtime/kernel_configuration.hpp
@@ -45,7 +45,7 @@
 
 
 namespace hipsycl {
-namespace glue {
+namespace rt {
 
 enum class kernel_base_config_parameter : int {
   backend_id = 0,
@@ -84,12 +84,6 @@ enum class kernel_build_flag : int {
   spirv_enable_intel_llvm_spirv_options
 };
 
-// This anonymous namespace is necessary to ensure that each backend plugin
-// has its own instance of the singleton. Otherwise there might be problems
-// when the runtime is restarted.
-// TODO: A cleaner solution might be to move the kernel_configuration content
-// from glue to rt, and define these functions inside a .cpp file.
-namespace {
 
 class string_build_config_mapper {
 public:
@@ -125,26 +119,28 @@ public:
     }
   }
 
-  static const auto& string_to_build_option_map() {
-    return get()._options;
+  const auto&
+  string_to_build_option_map() const{
+    return _options;
   }
 
-  static const auto& string_to_build_flag_map() {
-    return get()._flags;
+  const auto&
+  string_to_build_flag_map() const {
+    return _flags;
   }
 
-  static const auto& build_option_to_string_map() {
-    return get()._inverse_options;
+  const auto&
+  build_option_to_string_map() const {
+    return _inverse_options;
   }
 
-  static const auto& build_flag_to_string_map() {
-    return get()._inverse_flags;
+  const auto&
+  build_flag_to_string_map() const {
+    return _inverse_flags;
   }
+
+  static string_build_config_mapper& get();
 private:
-  static string_build_config_mapper& get() {
-    static string_build_config_mapper mapper;
-    return mapper;
-  }
 
   std::unordered_map<std::string, kernel_build_option> _options;
   std::unordered_map<std::string, kernel_build_flag> _flags;
@@ -153,7 +149,7 @@ private:
 };
 
 inline std::string to_string(kernel_build_flag f) {
-  const auto& map = string_build_config_mapper::build_flag_to_string_map();
+  const auto& map = string_build_config_mapper::get().build_flag_to_string_map();
   auto it = map.find(f);
   if(it == map.end())
     return {};
@@ -161,7 +157,7 @@ inline std::string to_string(kernel_build_flag f) {
 }
 
 inline std::string to_string(kernel_build_option o) {
-  const auto& map = string_build_config_mapper::build_option_to_string_map();
+  const auto& map = string_build_config_mapper::get().build_option_to_string_map();
   auto it = map.find(o);
   if(it == map.end())
     return {};
@@ -170,7 +166,7 @@ inline std::string to_string(kernel_build_option o) {
 
 inline std::optional<kernel_build_option>
 to_build_option(const std::string& s) {
-  const auto& map = string_build_config_mapper::string_to_build_option_map();
+  const auto& map = string_build_config_mapper::get().string_to_build_option_map();
   auto it = map.find(s);
   if(it == map.end())
     return {};
@@ -179,14 +175,13 @@ to_build_option(const std::string& s) {
 
 inline std::optional<kernel_build_flag>
 to_build_flag(const std::string& s) {
-  const auto& map = string_build_config_mapper::string_to_build_flag_map();
+  const auto& map = string_build_config_mapper::get().string_to_build_flag_map();
   auto it = map.find(s);
   if(it == map.end())
     return {};
   return it->second;
 }
 
-} // anonymous namespace
 
 class kernel_configuration {
 

--- a/include/hipSYCL/runtime/kernel_launcher.hpp
+++ b/include/hipSYCL/runtime/kernel_launcher.hpp
@@ -39,7 +39,7 @@
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/hints.hpp"
 #include "hipSYCL/runtime/util.hpp"
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 
 #include "backend.hpp"
 
@@ -94,7 +94,7 @@ public:
   // Additional backend-specific parameters (e.g. queue)
   virtual void set_params(void*) = 0;
   virtual void invoke(dag_node *node,
-                      const glue::kernel_configuration &config) = 0;
+                      const kernel_configuration &config) = 0;
 
   void set_backend_capabilities(const backend_kernel_launch_capabilities& cap) {
     _capabilities = cap;
@@ -141,13 +141,13 @@ public:
     return selected_launcher;
   }
 
-  const glue::kernel_configuration& get_kernel_configuration() const {
+  const kernel_configuration& get_kernel_configuration() const {
     return _kernel_config;
   }
 private:
   common::auto_small_vector<std::unique_ptr<backend_kernel_launcher>>
       _kernels;
-  glue::kernel_configuration _kernel_config;
+  kernel_configuration _kernel_config;
 };
 
 

--- a/include/hipSYCL/runtime/ocl/ocl_code_object.hpp
+++ b/include/hipSYCL/runtime/ocl/ocl_code_object.hpp
@@ -35,7 +35,7 @@
 #include "hipSYCL/runtime/code_object_invoker.hpp"
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/kernel_cache.hpp"
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 
 namespace hipsycl {
 namespace rt {
@@ -56,7 +56,7 @@ public:
                                unsigned local_mem_size, void **args,
                                std::size_t *arg_sizes, std::size_t num_args,
                                const std::string &kernel_name,
-                               const glue::kernel_configuration& config) override;
+                               const kernel_configuration& config) override;
 private:
   ocl_queue* _queue;
 };
@@ -66,7 +66,7 @@ class ocl_executable_object : public code_object {
 public:
   ocl_executable_object(const cl::Context &ctx, cl::Device &dev,
                         hcf_object_id source, const std::string &code_image,
-                        const glue::kernel_configuration &config);
+                        const kernel_configuration &config);
   virtual ~ocl_executable_object();
 
   result get_build_result() const;
@@ -82,7 +82,7 @@ public:
   virtual bool contains(const std::string &backend_kernel_name) const override;
 
   virtual compilation_flow source_compilation_flow() const override;
-  virtual glue::kernel_configuration::id_type configuration_id() const override;
+  virtual kernel_configuration::id_type configuration_id() const override;
 
   cl::Device get_cl_device() const;
   cl::Context get_cl_context() const;
@@ -98,7 +98,7 @@ private:
   mutable std::unordered_map<std::string, cl::Kernel> _kernel_handles;
 
   result _build_status;
-  glue::kernel_configuration::id_type _id;
+  kernel_configuration::id_type _id;
 };
 
 

--- a/include/hipSYCL/runtime/ocl/ocl_queue.hpp
+++ b/include/hipSYCL/runtime/ocl/ocl_queue.hpp
@@ -82,7 +82,7 @@ public:
       const std::string &kernel_name, const rt::range<3> &num_groups,
       const rt::range<3> &group_size, unsigned local_mem_size, void **args,
       std::size_t *arg_sizes, std::size_t num_args,
-      const glue::kernel_configuration &config);
+      const kernel_configuration &config);
 
 private:
   void register_submitted_op(cl::Event);

--- a/include/hipSYCL/runtime/omp/omp_code_object.hpp
+++ b/include/hipSYCL/runtime/omp/omp_code_object.hpp
@@ -31,7 +31,7 @@
 #include <string>
 #include <vector>
 
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/kernel_cache.hpp"
@@ -61,7 +61,7 @@ public:
   omp_sscp_executable_object(const std::string &shared_lib_path,
                              hcf_object_id hcf_source,
                              const std::vector<std::string> &kernel_names,
-                             const glue::kernel_configuration &config);
+                             const kernel_configuration &config);
 
   virtual ~omp_sscp_executable_object();
 
@@ -85,7 +85,7 @@ private:
   result build(const std::string &source, const std::vector<std::string> &kernel_names);
 
   hcf_object_id _hcf;
-  glue::kernel_configuration::id_type _id;
+  kernel_configuration::id_type _id;
   std::string _kernel_cache_path;
 
   result _build_result;

--- a/include/hipSYCL/runtime/omp/omp_queue.hpp
+++ b/include/hipSYCL/runtime/omp/omp_queue.hpp
@@ -52,7 +52,7 @@ public:
                                unsigned local_mem_size, void **args,
                                std::size_t *arg_sizes, std::size_t num_args,
                                const std::string &kernel_name,
-                               const glue::kernel_configuration& config) override;
+                               const kernel_configuration& config) override;
   
   virtual rt::range<3> select_group_size(const rt::range<3> &num_groups,
                                          const rt::range<3> &group_size) const override;
@@ -93,7 +93,7 @@ public:
       const std::string &kernel_name, const rt::range<3> &num_groups,
       const rt::range<3> &group_size, unsigned local_mem_size, void **args,
       std::size_t *arg_sizes, std::size_t num_args,
-      const glue::kernel_configuration &config);
+      const kernel_configuration &config);
 
   worker_thread& get_worker();
 private:

--- a/include/hipSYCL/runtime/ze/ze_code_object.hpp
+++ b/include/hipSYCL/runtime/ze/ze_code_object.hpp
@@ -35,7 +35,7 @@
 #include "hipSYCL/runtime/code_object_invoker.hpp"
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/kernel_cache.hpp"
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 
 namespace hipsycl {
 namespace rt {
@@ -75,7 +75,7 @@ public:
                                unsigned local_mem_size, void **args,
                                std::size_t *arg_sizes, std::size_t num_args,
                                const std::string &kernel_name,
-                               const glue::kernel_configuration& config) override;
+                               const kernel_configuration& config) override;
 private:
   ze_queue* _queue;
 };
@@ -127,13 +127,13 @@ public:
   ze_sscp_executable_object(ze_context_handle_t ctx, ze_device_handle_t dev,
                             hcf_object_id source,
                             const std::string &spirv_image,
-                            const glue::kernel_configuration &config);
+                            const kernel_configuration &config);
   ~ze_sscp_executable_object() {}
 
   virtual compilation_flow source_compilation_flow() const override;
-  virtual glue::kernel_configuration::id_type configuration_id() const override;
+  virtual kernel_configuration::id_type configuration_id() const override;
 private:
-  glue::kernel_configuration::id_type _id;
+  kernel_configuration::id_type _id;
 };
 
 }

--- a/include/hipSYCL/runtime/ze/ze_queue.hpp
+++ b/include/hipSYCL/runtime/ze/ze_queue.hpp
@@ -94,7 +94,7 @@ public:
       const std::string &kernel_name, const rt::range<3> &num_groups,
       const rt::range<3> &group_size, unsigned local_mem_size, void **args,
       std::size_t *arg_sizes, std::size_t num_args,
-      const glue::kernel_configuration &config);
+      const kernel_configuration &config);
 
 private:
   const std::vector<std::shared_ptr<dag_node_event>>&

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(acpp-rt SHARED
   data.cpp
   inorder_executor.cpp
   kernel_cache.cpp
+  kernel_configuration.cpp
   multi_queue_executor.cpp
   dag.cpp
   dag_node.cpp

--- a/src/runtime/adaptivity_engine.cpp
+++ b/src/runtime/adaptivity_engine.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "hipSYCL/runtime/adaptivity_engine.hpp"
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/glue/llvm-sscp/jit.hpp"
 #include "hipSYCL/runtime/application.hpp"
 
@@ -49,31 +49,31 @@ kernel_adaptivity_engine::kernel_adaptivity_engine(
   _adaptivity_level = application::get_settings().get<setting::adaptivity_level>();
 }
 
-glue::kernel_configuration::id_type
+kernel_configuration::id_type
 kernel_adaptivity_engine::finalize_binary_configuration(
-    glue::kernel_configuration &config) {
+    kernel_configuration &config) {
 
   if(_adaptivity_level > 0) {
     // Enter single-kernel code model
     config.append_base_configuration(
-        glue::kernel_base_config_parameter::single_kernel, _kernel_name);
+        kernel_base_config_parameter::single_kernel, _kernel_name);
 
     // Hard-code group sizes into the JIT binary
-    config.set_build_option(glue::kernel_build_option::known_group_size_x,
+    config.set_build_option(kernel_build_option::known_group_size_x,
                             _block_size[0]);
-    config.set_build_option(glue::kernel_build_option::known_group_size_y,
+    config.set_build_option(kernel_build_option::known_group_size_y,
                             _block_size[1]);
-    config.set_build_option(glue::kernel_build_option::known_group_size_z,
+    config.set_build_option(kernel_build_option::known_group_size_z,
                             _block_size[2]);
 
     // Try to optimize size_t -> i32 for queries if those fit in int
     auto global_size = _num_groups * _block_size;
     auto int_max = std::numeric_limits<int>::max();
     if (global_size[0] * global_size[1] * global_size[2] < int_max)
-      config.set_build_flag(glue::kernel_build_flag::global_sizes_fit_in_int);
+      config.set_build_flag(kernel_build_flag::global_sizes_fit_in_int);
 
     // Hard-code local memory size into the JIT binary
-    config.set_build_option(glue::kernel_build_option::known_local_mem_size,
+    config.set_build_option(kernel_build_option::known_local_mem_size,
                             _local_mem_size);
 
     // Handle kernel parameter optimization hints

--- a/src/runtime/cuda/cuda_code_object.cpp
+++ b/src/runtime/cuda/cuda_code_object.cpp
@@ -35,7 +35,7 @@
 #include <cuda.h>
 
 #include "hipSYCL/common/hcf_container.hpp"
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/runtime/cuda/cuda_code_object.hpp"
 #include "hipSYCL/runtime/cuda/cuda_device_manager.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
@@ -222,7 +222,7 @@ int cuda_multipass_executable_object::get_device() const {
 cuda_sscp_executable_object::cuda_sscp_executable_object(
     const std::string &ptx_source, const std::string &target_arch,
     hcf_object_id hcf_source, const std::vector<std::string> &kernel_names,
-    int device, const glue::kernel_configuration &config)
+    int device, const kernel_configuration &config)
     : _target_arch{target_arch}, _hcf{hcf_source}, _kernel_names{kernel_names},
       _id{config.generate_id()}, _device{device}, _module{nullptr} {
   _build_result = build(ptx_source);

--- a/src/runtime/cuda/cuda_queue.cpp
+++ b/src/runtime/cuda/cuda_queue.cpp
@@ -27,7 +27,7 @@
 
 #include "driver_types.h"
 #include "hipSYCL/common/hcf_container.hpp"
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/runtime/adaptivity_engine.hpp"
 #include "hipSYCL/runtime/application.hpp"
 #include "hipSYCL/runtime/code_object_invoker.hpp"
@@ -498,22 +498,22 @@ result cuda_queue::submit_multipass_kernel_from_code_object(
 
   int device = _dev.get_id();
 
-  glue::kernel_configuration config;
+  kernel_configuration config;
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::backend_id, backend_id::cuda);
+      kernel_base_config_parameter::backend_id, backend_id::cuda);
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::compilation_flow,
+      kernel_base_config_parameter::compilation_flow,
       compilation_flow::explicit_multipass);
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::hcf_object_id, hcf_object);
+      kernel_base_config_parameter::hcf_object_id, hcf_object);
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::target_arch, selected_target);
+      kernel_base_config_parameter::target_arch, selected_target);
 
   auto binary_configuration_id = config.generate_id();
   auto code_object_configuration_id = binary_configuration_id;
-  glue::kernel_configuration::extend_hash(
+  kernel_configuration::extend_hash(
       code_object_configuration_id,
-      glue::kernel_base_config_parameter::runtime_device, device);
+      kernel_base_config_parameter::runtime_device, device);
 
   // Will be invoked by the kernel cache in case there is a miss in the kernel
   // cache and we have to construct a new code object
@@ -583,7 +583,7 @@ result cuda_queue::submit_sscp_kernel_from_code_object(
     const std::string &kernel_name, const rt::range<3> &num_groups,
     const rt::range<3> &group_size, unsigned local_mem_size, void **args,
     std::size_t *arg_sizes, std::size_t num_args,
-    const glue::kernel_configuration &initial_config) {
+    const kernel_configuration &initial_config) {
 #ifdef HIPSYCL_WITH_SSCP_COMPILER
 
   this->activate_device();
@@ -619,15 +619,15 @@ result cuda_queue::submit_sscp_kernel_from_code_object(
       hcf_object, kernel_name, kernel_info, arg_mapper, num_groups,
       group_size, args,        arg_sizes,   num_args, local_mem_size};
 
-  static thread_local glue::kernel_configuration config;
+  static thread_local kernel_configuration config;
   config = initial_config;
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::backend_id, backend_id::cuda);
+      kernel_base_config_parameter::backend_id, backend_id::cuda);
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::compilation_flow,
+      kernel_base_config_parameter::compilation_flow,
       compilation_flow::sscp);
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::hcf_object_id, hcf_object);
+      kernel_base_config_parameter::hcf_object_id, hcf_object);
   
   for(const auto& flag : kernel_info->get_compilation_flags())
     config.set_build_flag(flag);
@@ -635,16 +635,16 @@ result cuda_queue::submit_sscp_kernel_from_code_object(
     config.set_build_option(opt.first, opt.second);
   // TODO This is incorrect, we should attempt to find a better way to determine
   // the right ptx version
-  config.set_build_option(glue::kernel_build_option::ptx_version,
+  config.set_build_option(kernel_build_option::ptx_version,
                           compute_capability);
-  config.set_build_option(glue::kernel_build_option::ptx_target_device,
+  config.set_build_option(kernel_build_option::ptx_target_device,
                           compute_capability);
 
   auto binary_configuration_id = adaptivity_engine.finalize_binary_configuration(config);
   auto code_object_configuration_id = binary_configuration_id;
-  glue::kernel_configuration::extend_hash(
+  kernel_configuration::extend_hash(
       code_object_configuration_id,
-      glue::kernel_base_config_parameter::runtime_device, device);
+      kernel_base_config_parameter::runtime_device, device);
 
   auto get_image_and_kernel_names =
       [&](std::vector<std::string> &contained_kernels) -> std::string {
@@ -772,7 +772,7 @@ result cuda_sscp_code_object_invoker::submit_kernel(
     const rt::range<3> &num_groups, const rt::range<3> &group_size,
     unsigned local_mem_size, void **args, std::size_t *arg_sizes,
     std::size_t num_args, const std::string &kernel_name,
-    const glue::kernel_configuration &config) {
+    const kernel_configuration &config) {
 
   return _queue->submit_sscp_kernel_from_code_object(
       op, hcf_object, kernel_name, num_groups, group_size, local_mem_size, args,

--- a/src/runtime/hip/hip_code_object.cpp
+++ b/src/runtime/hip/hip_code_object.cpp
@@ -26,7 +26,7 @@
  */
 
 #include "hipSYCL/runtime/hip/hip_code_object.hpp"
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/hip/hip_device_manager.hpp"
@@ -146,7 +146,7 @@ result hip_multipass_executable_object::build(const std::string& hip_fat_binary)
 hip_sscp_executable_object::hip_sscp_executable_object(
     const std::string &code_image, const std::string &target_arch,
     hcf_object_id hcf_source, const std::vector<std::string> &kernel_names,
-    int device, const glue::kernel_configuration &config)
+    int device, const kernel_configuration &config)
     : _target{target_arch}, _origin{hcf_source}, _kernel_names{kernel_names},
       _device{device}, _id{config.generate_id()}, _module{nullptr} {
   _build_result = build(code_image);

--- a/src/runtime/hip/hip_queue.cpp
+++ b/src/runtime/hip/hip_queue.cpp
@@ -25,7 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/runtime/adaptivity_engine.hpp"
 #include "hipSYCL/runtime/hip/hip_target.hpp"
 #include "hipSYCL/common/hcf_container.hpp"
@@ -515,22 +515,22 @@ result hip_queue::submit_multipass_kernel_from_code_object(
   std::string selected_target = available_targets[0];
   int device = _dev.get_id();
   
-  glue::kernel_configuration config;
+  kernel_configuration config;
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::backend_id, backend_id::hip);
+      kernel_base_config_parameter::backend_id, backend_id::hip);
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::compilation_flow,
+      kernel_base_config_parameter::compilation_flow,
       compilation_flow::explicit_multipass);
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::hcf_object_id, hcf_object);
+      kernel_base_config_parameter::hcf_object_id, hcf_object);
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::target_arch, selected_target);
+      kernel_base_config_parameter::target_arch, selected_target);
 
   auto binary_configuration_id = config.generate_id();
   auto code_object_configuration_id = binary_configuration_id;
-  glue::kernel_configuration::extend_hash(
+  kernel_configuration::extend_hash(
       code_object_configuration_id,
-      glue::kernel_base_config_parameter::runtime_device, device);
+      kernel_base_config_parameter::runtime_device, device);
 
   // Will be invoked by the kernel cache in case there is a miss in the kernel
   // cache and we have to construct a new code object
@@ -590,7 +590,7 @@ result hip_queue::submit_sscp_kernel_from_code_object(
       const std::string &kernel_name, const rt::range<3> &num_groups,
       const rt::range<3> &group_size, unsigned local_mem_size, void **args,
       std::size_t *arg_sizes, std::size_t num_args,
-      const glue::kernel_configuration &initial_config) {
+      const kernel_configuration &initial_config) {
 #ifdef HIPSYCL_WITH_SSCP_COMPILER
   this->activate_device();
   
@@ -624,29 +624,29 @@ result hip_queue::submit_sscp_kernel_from_code_object(
       hcf_object, kernel_name, kernel_info, arg_mapper, num_groups,
       group_size, args,        arg_sizes,   num_args, local_mem_size};
   
-  static thread_local glue::kernel_configuration config;
+  static thread_local kernel_configuration config;
   config = initial_config;
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::backend_id, backend_id::hip);
+      kernel_base_config_parameter::backend_id, backend_id::hip);
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::compilation_flow,
+      kernel_base_config_parameter::compilation_flow,
       compilation_flow::sscp);
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::hcf_object_id, hcf_object);
+      kernel_base_config_parameter::hcf_object_id, hcf_object);
 
   for(const auto& flag : kernel_info->get_compilation_flags())
     config.set_build_flag(flag);
   for(const auto& opt : kernel_info->get_compilation_options())
     config.set_build_option(opt.first, opt.second);
 
-  config.set_build_option(glue::kernel_build_option::amdgpu_target_device,
+  config.set_build_option(kernel_build_option::amdgpu_target_device,
                           target_arch_name);
 
   auto binary_configuration_id = adaptivity_engine.finalize_binary_configuration(config);
   auto code_object_configuration_id = binary_configuration_id;
-  glue::kernel_configuration::extend_hash(
+  kernel_configuration::extend_hash(
       code_object_configuration_id,
-      glue::kernel_base_config_parameter::runtime_device, device);
+      kernel_base_config_parameter::runtime_device, device);
 
   auto get_image_and_kernel_names =
       [&](std::vector<std::string> &contained_kernels) -> std::string {
@@ -756,7 +756,7 @@ result hip_sscp_code_object_invoker::submit_kernel(
     const rt::range<3> &num_groups, const rt::range<3> &group_size,
     unsigned local_mem_size, void **args, std::size_t *arg_sizes,
     std::size_t num_args, const std::string &kernel_name,
-    const glue::kernel_configuration &config) {
+    const kernel_configuration &config) {
 
   return _queue->submit_sscp_kernel_from_code_object(
       op, hcf_object, kernel_name, num_groups, group_size, local_mem_size, args,

--- a/src/runtime/kernel_cache.cpp
+++ b/src/runtime/kernel_cache.cpp
@@ -29,7 +29,7 @@
 #include "hipSYCL/common/debug.hpp"
 #include "hipSYCL/common/filesystem.hpp"
 #include "hipSYCL/common/hcf_container.hpp"
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/runtime/backend.hpp"
 #include <algorithm>
 #include <cstddef>
@@ -128,14 +128,14 @@ hcf_kernel_info::hcf_kernel_info(
 
   if(const auto* flags_node = kernel_node->get_subnode("compile-flags")) {
     for(const auto& flag : flags_node->key_value_pairs) {
-      auto f = glue::to_build_flag(flag.first);
+      auto f = to_build_flag(flag.first);
       if(f.has_value())
         _compilation_flags.push_back(f.value());
     }
   }
   if(const auto* options_node = kernel_node->get_subnode("compile-options")) {
     for(const auto& option : options_node->key_value_pairs) {
-      auto o = glue::to_build_option(option.first);
+      auto o = to_build_option(option.first);
       if(o.has_value())
         _compilation_options.push_back(
             std::make_pair(o.value(), option.second));
@@ -189,12 +189,12 @@ hcf_object_id hcf_kernel_info::get_hcf_object_id() const {
   return _id;
 }
 
-const std::vector<glue::kernel_build_flag> &
+const std::vector<kernel_build_flag> &
 hcf_kernel_info::get_compilation_flags() const {
   return _compilation_flags;
 }
 
-const std::vector<std::pair<glue::kernel_build_option, std::string>> &
+const std::vector<std::pair<kernel_build_option, std::string>> &
 hcf_kernel_info::get_compilation_options() const {
   return _compilation_options;
 }
@@ -452,7 +452,7 @@ const code_object* kernel_cache::get_code_object_impl(code_object_id id) const {
 std::string kernel_cache::get_persistent_cache_file(code_object_id id_of_binary) {
   using namespace common::filesystem;
   std::string cache_dir = tuningdb::get().get_jit_cache_dir();
-  return join_path(cache_dir, glue::kernel_configuration::to_string(id_of_binary)+".jit");
+  return join_path(cache_dir, kernel_configuration::to_string(id_of_binary)+".jit");
 }
 
 bool kernel_cache::persistent_cache_lookup(code_object_id id_of_binary,
@@ -464,7 +464,7 @@ bool kernel_cache::persistent_cache_lookup(code_object_id id_of_binary,
     return false;
 
   HIPSYCL_DEBUG_INFO << "kernel_cache: Persistent cache hit for id "
-                     << glue::kernel_configuration::to_string(id_of_binary)
+                     << kernel_configuration::to_string(id_of_binary)
                      << " in file " << filename << std::endl;
 
   std::streamsize file_size = file.tellg();
@@ -483,7 +483,7 @@ void kernel_cache::persistent_cache_store(code_object_id id_of_binary,
   std::string filename = get_persistent_cache_file(id_of_binary);
 
   HIPSYCL_DEBUG_INFO << "kernel_cache: Storing compiled binary with id "
-                     << glue::kernel_configuration::to_string(id_of_binary)
+                     << kernel_configuration::to_string(id_of_binary)
                      << " in persistent cache file " << filename << std::endl;
   
 

--- a/src/runtime/kernel_configuration.cpp
+++ b/src/runtime/kernel_configuration.cpp
@@ -1,5 +1,5 @@
 /*
- * This file is part of hipSYCL, a SYCL implementation based on CUDA/HIP
+ * This file is part of hipSYCL, a SYCL implementation based on OMP/HIP
  *
  * Copyright (c) 2024 Aksel Alpay
  * All rights reserved.
@@ -25,52 +25,16 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef HIPSYCL_ADAPTIVITY_ENGINE_HPP
-#define HIPSYCL_ADAPTIVITY_ENGINE_HPP
-
-
-#include "hipSYCL/glue/llvm-sscp/jit.hpp"
 #include "hipSYCL/runtime/kernel_configuration.hpp"
-#include "hipSYCL/runtime/util.hpp"
-#include "hipSYCL/runtime/kernel_cache.hpp"
 
 namespace hipsycl {
 namespace rt {
 
-class kernel_adaptivity_engine {
-public:
-  kernel_adaptivity_engine(
-    hcf_object_id hcf_object,
-    const std::string& backend_kernel_name,
-    const hcf_kernel_info* kernel_info,
-    const glue::jit::cxx_argument_mapper& arg_mapper,
-    const range<3>& num_groups,
-    const range<3>& block_size,
-    void** args,
-    std::size_t* arg_sizes,
-    std::size_t num_args,
-    std::size_t local_mem_size);
-
-  kernel_configuration::id_type
-  finalize_binary_configuration(kernel_configuration &config);
-
-  std::string select_image_and_kernels(std::vector<std::string>* kernel_names_out);
-private:
-  hcf_object_id _hcf;
-  const std::string& _kernel_name;
-  const hcf_kernel_info* _kernel_info;
-  const glue::jit::cxx_argument_mapper& _arg_mapper;
-  const range<3>& _num_groups;
-  const range<3>& _block_size;
-  void** _args;
-  std::size_t* _arg_sizes;
-  std::size_t _num_args;
-  std::size_t _local_mem_size;
-
-  int _adaptivity_level;
-};
+string_build_config_mapper& string_build_config_mapper::get() {
+  static string_build_config_mapper mapper;
+  return mapper;
+}
 
 }
 }
 
-#endif

--- a/src/runtime/kernel_configuration.cpp
+++ b/src/runtime/kernel_configuration.cpp
@@ -30,10 +30,111 @@
 namespace hipsycl {
 namespace rt {
 
-string_build_config_mapper& string_build_config_mapper::get() {
-  static string_build_config_mapper mapper;
-  return mapper;
+namespace {
+class string_build_config_mapper {
+public:
+  string_build_config_mapper() {
+    _options =  {
+      {"known-group-size-x", kernel_build_option::known_group_size_x},
+      {"known-group-size-y", kernel_build_option::known_group_size_y},
+      {"known-group-size-z", kernel_build_option::known_group_size_z},
+      {"known-local-mem-size", kernel_build_option::known_local_mem_size},
+      {"ptx-version", kernel_build_option::ptx_version},
+      {"ptx-target-device", kernel_build_option::ptx_target_device},
+      {"amdgpu-target-device", kernel_build_option::amdgpu_target_device},
+      {"rocm-device-libs-path", kernel_build_option::amdgpu_rocm_device_libs_path},
+      {"rocm-path", kernel_build_option::amdgpu_rocm_path},
+      {"spirv-dynamic-local-mem-allocation-size", kernel_build_option::spirv_dynamic_local_mem_allocation_size}
+    };
+
+    _flags = {
+      {"global-sizes-fit-in-int", kernel_build_flag::global_sizes_fit_in_int},
+      {"fast-math", kernel_build_flag::fast_math},
+      {"ptx-ftz", kernel_build_flag::ptx_ftz},
+      {"ptx-approx-div", kernel_build_flag::ptx_approx_div},
+      {"ptx-approx-sqrt", kernel_build_flag::ptx_approx_sqrt},
+      {"spirv-enable-intel-llvm-spirv-options", kernel_build_flag::spirv_enable_intel_llvm_spirv_options}
+    };
+
+    for(const auto& elem : _options) {
+      _inverse_options[elem.second] = elem.first;
+    }
+
+    for(const auto& elem : _flags) {
+      _inverse_flags[elem.second] = elem.first;
+    }
+  }
+
+  const auto&
+  string_to_build_option_map() const{
+    return _options;
+  }
+
+  const auto&
+  string_to_build_flag_map() const {
+    return _flags;
+  }
+
+  const auto&
+  build_option_to_string_map() const {
+    return _inverse_options;
+  }
+
+  const auto&
+  build_flag_to_string_map() const {
+    return _inverse_flags;
+  }
+
+  static string_build_config_mapper& get() {
+    static string_build_config_mapper mapper;
+    return mapper;
+  }
+private:
+
+  std::unordered_map<std::string, kernel_build_option> _options;
+  std::unordered_map<std::string, kernel_build_flag> _flags;
+  std::unordered_map<kernel_build_option, std::string> _inverse_options;
+  std::unordered_map<kernel_build_flag, std::string> _inverse_flags;
+};
+
 }
+
+
+
+std::string to_string(kernel_build_flag f) {
+  const auto& map = string_build_config_mapper::get().build_flag_to_string_map();
+  auto it = map.find(f);
+  if(it == map.end())
+    return {};
+  return it->second;
+}
+
+std::string to_string(kernel_build_option o) {
+  const auto& map = string_build_config_mapper::get().build_option_to_string_map();
+  auto it = map.find(o);
+  if(it == map.end())
+    return {};
+  return it->second;
+}
+
+std::optional<kernel_build_option>
+to_build_option(const std::string& s) {
+  const auto& map = string_build_config_mapper::get().string_to_build_option_map();
+  auto it = map.find(s);
+  if(it == map.end())
+    return {};
+  return it->second;
+}
+
+std::optional<kernel_build_flag>
+to_build_flag(const std::string& s) {
+  const auto& map = string_build_config_mapper::get().string_to_build_flag_map();
+  auto it = map.find(s);
+  if(it == map.end())
+    return {};
+  return it->second;
+}
+
 
 }
 }

--- a/src/runtime/ocl/ocl_code_object.cpp
+++ b/src/runtime/ocl/ocl_code_object.cpp
@@ -27,7 +27,7 @@
 
 #include "hipSYCL/runtime/ocl/ocl_code_object.hpp"
 #include "hipSYCL/common/string_utils.hpp"
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/ocl/ocl_queue.hpp"
@@ -40,7 +40,7 @@ result ocl_sscp_code_object_invoker::submit_kernel(
     const rt::range<3> &num_groups, const rt::range<3> &group_size,
     unsigned int local_mem_size, void **args, std::size_t *arg_sizes,
     std::size_t num_args, const std::string &kernel_name,
-    const glue::kernel_configuration &config) {
+    const kernel_configuration &config) {
 
   assert(_queue);
 
@@ -50,7 +50,7 @@ result ocl_sscp_code_object_invoker::submit_kernel(
 }
 
 ocl_executable_object::ocl_executable_object(const cl::Context& ctx, cl::Device& dev,
-    hcf_object_id source, const std::string& code_image, const glue::kernel_configuration &config)
+    hcf_object_id source, const std::string& code_image, const kernel_configuration &config)
 : _source{source}, _ctx{ctx}, _dev{dev}, _id{config.generate_id()} {
 
   std::vector<char> ir(code_image.size());
@@ -69,7 +69,7 @@ ocl_executable_object::ocl_executable_object(const cl::Context& ctx, cl::Device&
   
   std::string options_string="-cl-uniform-work-group-size";
   for(const auto& flag : config.build_flags()) {
-    if(flag == glue::kernel_build_flag::fast_math) {
+    if(flag == kernel_build_flag::fast_math) {
       options_string += " -cl-fast-relaxed-math";
     }
   }
@@ -172,7 +172,7 @@ compilation_flow ocl_executable_object::source_compilation_flow() const {
   return compilation_flow::sscp;
 }
 
-glue::kernel_configuration::id_type
+kernel_configuration::id_type
 ocl_executable_object::configuration_id() const {
   return _id;
 }

--- a/src/runtime/ocl/ocl_queue.cpp
+++ b/src/runtime/ocl/ocl_queue.cpp
@@ -26,7 +26,7 @@
  */
 
 
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/runtime/adaptivity_engine.hpp"
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/serialization/serialization.hpp"
@@ -409,7 +409,7 @@ result ocl_queue::submit_sscp_kernel_from_code_object(
     const std::string &kernel_name, const rt::range<3> &num_groups,
     const rt::range<3> &group_size, unsigned local_mem_size, void **args,
     std::size_t *arg_sizes, std::size_t num_args,
-    const glue::kernel_configuration &initial_config) {
+    const kernel_configuration &initial_config) {
 
 
 #ifdef HIPSYCL_WITH_SSCP_COMPILER
@@ -444,16 +444,16 @@ result ocl_queue::submit_sscp_kernel_from_code_object(
 
   // Need to create custom config to ensure we can distinguish other
   // kernels compiled with different values e.g. of local mem allocation size
-  static thread_local glue::kernel_configuration config;
+  static thread_local kernel_configuration config;
   config = initial_config;
   
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::backend_id, backend_id::ocl);
+      kernel_base_config_parameter::backend_id, backend_id::ocl);
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::compilation_flow,
+      kernel_base_config_parameter::compilation_flow,
       compilation_flow::sscp);
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::hcf_object_id, hcf_object);
+      kernel_base_config_parameter::hcf_object_id, hcf_object);
   
   for(const auto& flag : kernel_info->get_compilation_flags())
     config.set_build_flag(flag);
@@ -461,20 +461,20 @@ result ocl_queue::submit_sscp_kernel_from_code_object(
     config.set_build_option(opt.first, opt.second);
 
   config.set_build_option(
-      glue::kernel_build_option::spirv_dynamic_local_mem_allocation_size,
+      kernel_build_option::spirv_dynamic_local_mem_allocation_size,
       local_mem_size);
 
   // TODO: Enable this if we are on Intel
-  // config.set_build_flag(glue::kernel_build_flag::spirv_enable_intel_llvm_spirv_options);
+  // config.set_build_flag(kernel_build_flag::spirv_enable_intel_llvm_spirv_options);
 
   auto binary_configuration_id = adaptivity_engine.finalize_binary_configuration(config);
   auto code_object_configuration_id = binary_configuration_id;
-  glue::kernel_configuration::extend_hash(
+  kernel_configuration::extend_hash(
       code_object_configuration_id,
-      glue::kernel_base_config_parameter::runtime_device, dev.get());
-  glue::kernel_configuration::extend_hash(
+      kernel_base_config_parameter::runtime_device, dev.get());
+  kernel_configuration::extend_hash(
       code_object_configuration_id,
-      glue::kernel_base_config_parameter::runtime_context, ctx.get());
+      kernel_base_config_parameter::runtime_context, ctx.get());
 
  
 

--- a/src/runtime/omp/omp_code_object.cpp
+++ b/src/runtime/omp/omp_code_object.cpp
@@ -39,7 +39,7 @@
 #include "hipSYCL/common/debug.hpp"
 #include "hipSYCL/common/filesystem.hpp"
 #include "hipSYCL/common/hcf_container.hpp"
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
 #include "hipSYCL/runtime/dylib_loader.hpp"
 #include "hipSYCL/runtime/error.hpp"
@@ -79,7 +79,7 @@ result make_shared_library_from_blob(void *&module, const std::string &blob,
 omp_sscp_executable_object::omp_sscp_executable_object(
     const std::string &binary, hcf_object_id hcf_source,
     const std::vector<std::string> &kernel_names,
-    const glue::kernel_configuration &config)
+    const kernel_configuration &config)
     : _hcf{hcf_source}, _id{config.generate_id()}, _module{nullptr},
       _kernel_cache_path(kernel_cache::get_persistent_cache_file(_id) + ".so") {
   _build_result = build(binary, kernel_names);

--- a/src/runtime/omp/omp_queue.cpp
+++ b/src/runtime/omp/omp_queue.cpp
@@ -45,7 +45,7 @@
 
 #ifdef HIPSYCL_WITH_SSCP_COMPILER
 #include "hipSYCL/compiler/llvm-to-backend/host/LLVMToHostFactory.hpp"
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/glue/llvm-sscp/jit.hpp"
 #include "hipSYCL/runtime/adaptivity_engine.hpp"
 #include "hipSYCL/runtime/omp/omp_code_object.hpp"
@@ -388,7 +388,7 @@ result omp_queue::submit_kernel(kernel_operation &op, dag_node_ptr node) {
   launcher->set_backend_capabilities(cap);
 
   rt::dag_node *node_ptr = node.get();
-  const glue::kernel_configuration *config =
+  const kernel_configuration *config =
       &(op.get_launcher().get_kernel_configuration());
 
   omp_instrumentation_setup instrumentation_setup{op, node};
@@ -407,7 +407,7 @@ result omp_queue::submit_sscp_kernel_from_code_object(
     const std::string &kernel_name, const rt::range<3> &num_groups,
     const rt::range<3> &group_size, unsigned local_mem_size, void **args,
     std::size_t *arg_sizes, std::size_t num_args,
-    const glue::kernel_configuration &initial_config) {
+    const kernel_configuration &initial_config) {
 #ifdef HIPSYCL_WITH_SSCP_COMPILER
 
   const hcf_kernel_info *kernel_info =
@@ -433,16 +433,16 @@ result omp_queue::submit_sscp_kernel_from_code_object(
       hcf_object, kernel_name, kernel_info, arg_mapper, num_groups,
       group_size, args,        arg_sizes,   num_args, local_mem_size};
 
-  static thread_local glue::kernel_configuration config;
+  static thread_local kernel_configuration config;
   config = initial_config;
   
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::backend_id, backend_id::omp);
+      kernel_base_config_parameter::backend_id, backend_id::omp);
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::compilation_flow,
+      kernel_base_config_parameter::compilation_flow,
       compilation_flow::sscp);
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::hcf_object_id, hcf_object);
+      kernel_base_config_parameter::hcf_object_id, hcf_object);
 
   auto binary_configuration_id =
       adaptivity_engine.finalize_binary_configuration(config);
@@ -616,7 +616,7 @@ result omp_sscp_code_object_invoker::submit_kernel(
     const rt::range<3> &num_groups, const rt::range<3> &group_size,
     unsigned local_mem_size, void **args, std::size_t *arg_sizes,
     std::size_t num_args, const std::string &kernel_name,
-    const glue::kernel_configuration &config) {
+    const kernel_configuration &config) {
 
   return _queue->submit_sscp_kernel_from_code_object(
       op, hcf_object, kernel_name, num_groups, group_size,

--- a/src/runtime/ze/ze_code_object.cpp
+++ b/src/runtime/ze/ze_code_object.cpp
@@ -66,7 +66,7 @@ result ze_sscp_code_object_invoker::submit_kernel(
     const rt::range<3> &num_groups, const rt::range<3> &group_size,
     unsigned int local_mem_size, void **args, std::size_t *arg_sizes,
     std::size_t num_args, const std::string &kernel_name,
-    const glue::kernel_configuration &config) {
+    const kernel_configuration &config) {
 
   assert(_queue);
 
@@ -269,7 +269,7 @@ result ze_executable_object::get_kernel(const std::string &kernel_name,
 ze_sscp_executable_object::ze_sscp_executable_object(ze_context_handle_t ctx, ze_device_handle_t dev,
                           hcf_object_id source,
                           const std::string &spirv_image,
-                          const glue::kernel_configuration &config)
+                          const kernel_configuration &config)
     : ze_executable_object(ctx, dev, source, ze_source_format::spirv,
                             spirv_image),
       _id{config.generate_id()} {}
@@ -279,7 +279,7 @@ compilation_flow ze_sscp_executable_object::source_compilation_flow() const {
   return compilation_flow::sscp;
 }
 
-glue::kernel_configuration::id_type ze_sscp_executable_object::configuration_id() const{
+kernel_configuration::id_type ze_sscp_executable_object::configuration_id() const{
   return _id;
 }
 

--- a/src/runtime/ze/ze_queue.cpp
+++ b/src/runtime/ze/ze_queue.cpp
@@ -33,7 +33,7 @@
 #include <vector>
 
 #include "hipSYCL/common/hcf_container.hpp"
-#include "hipSYCL/glue/kernel_configuration.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/runtime/adaptivity_engine.hpp"
 #include "hipSYCL/runtime/code_object_invoker.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
@@ -466,24 +466,24 @@ result ze_queue::submit_multipass_kernel_from_code_object(
 
   // Need to create custom config to ensure we can distinguish other
   // kernels compiled with different values e.g. of local mem allocation size
-  glue::kernel_configuration config;
+  kernel_configuration config;
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::backend_id, backend_id::level_zero);
+      kernel_base_config_parameter::backend_id, backend_id::level_zero);
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::compilation_flow,
+      kernel_base_config_parameter::compilation_flow,
       compilation_flow::explicit_multipass);
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::hcf_object_id, hcf_object);
+      kernel_base_config_parameter::hcf_object_id, hcf_object);
   
   auto binary_configuration_id = config.generate_id();
   auto code_object_configuration_id = binary_configuration_id;
   
-  glue::kernel_configuration::extend_hash(
+  kernel_configuration::extend_hash(
       code_object_configuration_id,
-      glue::kernel_base_config_parameter::runtime_device, dev);
-  glue::kernel_configuration::extend_hash(
+      kernel_base_config_parameter::runtime_device, dev);
+  kernel_configuration::extend_hash(
       code_object_configuration_id,
-      glue::kernel_base_config_parameter::runtime_context, ctx);
+      kernel_base_config_parameter::runtime_context, ctx);
 
   auto code_object_constructor = [&]() -> code_object* {
     const common::hcf_container* hcf = rt::hcf_cache::get().get_hcf(hcf_object);
@@ -553,7 +553,7 @@ result ze_queue::submit_sscp_kernel_from_code_object(
       const std::string &kernel_name, const rt::range<3> &num_groups,
       const rt::range<3> &group_size, unsigned local_mem_size, void **args,
       std::size_t *arg_sizes, std::size_t num_args,
-      const glue::kernel_configuration &initial_config) {
+      const kernel_configuration &initial_config) {
 
 #ifdef HIPSYCL_WITH_SSCP_COMPILER
 
@@ -588,16 +588,16 @@ result ze_queue::submit_sscp_kernel_from_code_object(
 
   // Need to create custom config to ensure we can distinguish other
   // kernels compiled with different values e.g. of local mem allocation size
-  static thread_local glue::kernel_configuration config;
+  static thread_local kernel_configuration config;
   config = initial_config;
   
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::backend_id, backend_id::level_zero);
+      kernel_base_config_parameter::backend_id, backend_id::level_zero);
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::compilation_flow,
+      kernel_base_config_parameter::compilation_flow,
       compilation_flow::sscp);
   config.append_base_configuration(
-      glue::kernel_base_config_parameter::hcf_object_id, hcf_object);
+      kernel_base_config_parameter::hcf_object_id, hcf_object);
   
   for(const auto& flag : kernel_info->get_compilation_flags())
     config.set_build_flag(flag);
@@ -605,20 +605,20 @@ result ze_queue::submit_sscp_kernel_from_code_object(
     config.set_build_option(opt.first, opt.second);
 
   config.set_build_option(
-      glue::kernel_build_option::spirv_dynamic_local_mem_allocation_size,
+      kernel_build_option::spirv_dynamic_local_mem_allocation_size,
       local_mem_size);
   config.set_build_flag(
-      glue::kernel_build_flag::spirv_enable_intel_llvm_spirv_options);
+      kernel_build_flag::spirv_enable_intel_llvm_spirv_options);
 
   auto binary_configuration_id = adaptivity_engine.finalize_binary_configuration(config);
   auto code_object_configuration_id = binary_configuration_id;
   
-  glue::kernel_configuration::extend_hash(
+  kernel_configuration::extend_hash(
       code_object_configuration_id,
-      glue::kernel_base_config_parameter::runtime_device, dev);
-  glue::kernel_configuration::extend_hash(
+      kernel_base_config_parameter::runtime_device, dev);
+  kernel_configuration::extend_hash(
       code_object_configuration_id,
-      glue::kernel_base_config_parameter::runtime_context, ctx);
+      kernel_base_config_parameter::runtime_context, ctx);
 
   auto jit_compiler = [&](std::string& compiled_image) -> bool {
     const common::hcf_container* hcf = rt::hcf_cache::get().get_hcf(hcf_object);


### PR DESCRIPTION
When no SYCL objects are around anymore, the AdaptiveCpp runtime shuts down. Because of this, defining multiple test cases as e.g. in catch2 causes runtime shutdown/restart patterns.
It seems that in this case, the `string_build_config_mapper` can become invalid as it might be destoryed when backends unload, and might then not be reconstructed correctly due to ODR issues.

This PR fixes this by moving `kernel_configuration` to the runtime, and moving the singleton definition for the name mapper to a .cpp file.

Hopefully fixes #1455 
@TomMelt For me this fixes your issue. Can you confirm?