### PR TITLE
CI: Temporarily disable clang 14 / Ubuntu 20.04

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,10 +25,6 @@ jobs:
             os: ubuntu-20.04
             cuda: 11.0.2
             rocm: 4.0.1
-          - clang: 14
-            os: ubuntu-20.04
-            cuda: 11.0.2
-            rocm: 4.0.1
           - clang: 17
             os: ubuntu-22.04
             cuda: 11.0.2


### PR DESCRIPTION
CI for Ubuntu 20.04 with clang 14 broke recently without any related changes to our codebase. Now, the SSCP tests crash in the very first kernel submission when the `static thread_local kernel_configuration` object inside `omp_queue` is accessed.

So far, I could not reproduce the issue locally on Ubuntu 20.04 and clang 14. Address sanitizer is happy locally as well. When running address sanitizer in github CI, it finds an issue during the access of the `static thread_local` object. Making that object non-thread-local causes execution to progress - until the next (totally unrelated) `static thread_local` object is hit. This happens both when using clang 14 as well as gcc to compile AdaptiveCpp in CI.

Given the information listed above, I suspect that recently a new Ubuntu 20.04 github actions image was rolled out with some changes (e.g. glibc) that broke support for `thread_local` objects.

I currently do not have the time to look deeper into what exactly causes the issue, and whether we can work around it on our side. However, this issue currently blocks CI for all PRs. Therefore, in order to make progress on other PRs and since the issue might not be related to AdaptiveCpp, this PR temporarily disables the problematic configuration.