### PR TITLE
Fix host to host memcpy

### DIFF
--- a/src/runtime/cuda/cuda_queue.cpp
+++ b/src/runtime/cuda/cuda_queue.cpp
@@ -274,6 +274,9 @@ result cuda_queue::submit_memcpy(memcpy_operation & op, dag_node_ptr node) {
     if (dest_dev.get_full_backend_descriptor().sw_platform ==
         api_platform::cuda) {
       copy_kind = cudaMemcpyHostToDevice;
+    } else if (dest_dev.get_full_backend_descriptor().hw_platform ==
+        hardware_platform::cpu) {
+      copy_kind = cudaMemcpyHostToHost;
     } else
       assert(false && "Unknown copy destination platform");
   } else

--- a/src/runtime/hip/hip_queue.cpp
+++ b/src/runtime/hip/hip_queue.cpp
@@ -271,6 +271,9 @@ result hip_queue::submit_memcpy(memcpy_operation & op, dag_node_ptr node) {
     if (dest_dev.get_full_backend_descriptor().sw_platform ==
         api_platform::hip) {
       copy_kind = hipMemcpyHostToDevice;
+    } else if (dest_dev.get_full_backend_descriptor().hw_platform ==
+        hardware_platform::cpu) {
+      copy_kind = hipMemcpyHostToHost;
     } else
       assert(false && "Unknown copy destination platform");
   } else

--- a/tests/sycl/queue.cpp
+++ b/tests/sycl/queue.cpp
@@ -51,4 +51,20 @@ BOOST_AUTO_TEST_CASE(queue_wait) {
               sycl::info::event_command_status::complete);
 }
 
+BOOST_AUTO_TEST_CASE(queue_memcpy_host_to_host) {
+  try {
+    sycl::queue q{sycl::gpu_selector_v, sycl::property::queue::in_order{}};
+
+    auto source = sycl::malloc_host(sizeof(int), q);
+    auto dest = malloc(sizeof(int));
+
+    q.memcpy(dest, source, sizeof(int)).wait();
+
+    sycl::free(source, q);
+    free(dest);
+  } catch (sycl::exception e) {
+    BOOST_CHECK(true); // Skip the test if no GPU available
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
In #1474 it was reported that in some cases a host to host copy fails at runtime. This PR fixes this by adding a check if the destination is CPU and setting the copy type to `{cuda,hip}MemcpyHostToHost` in that case.

Fixes #1474