### PR TITLE
Update the year listed by the acpp compilation driver

### DIFF
--- a/bin/acpp
+++ b/bin/acpp
@@ -1925,7 +1925,7 @@ def print_config(config):
 
 def print_version(config):
   version = config.version
-  print("acpp [AdaptiveCpp compilation driver], Copyright (C) 2018-2023 Aksel Alpay and the AdaptiveCpp project")
+  print("acpp [AdaptiveCpp compilation driver], Copyright (C) 2018-2024 Aksel Alpay and the AdaptiveCpp project")
   print("  AdaptiveCpp version: {}.{}.{}{}".format(version[0],version[1],version[2],version[3]))
   print("  Installation root:",os.path.abspath(config.acpp_installation_path))
   if config.has_plugin:


### PR DESCRIPTION
As part of my recent packaging efforts, I have been running `acpp --acpp-version` quite a lot. I could not help but notice that something was ever so slightly off... 🙂