### PR TITLE
kernel_operation: Store const char* instead of std::string for reduced launch latency

### DIFF
--- a/include/hipSYCL/runtime/operations.hpp
+++ b/include/hipSYCL/runtime/operations.hpp
@@ -331,7 +331,7 @@ class kernel_operation : public operation
 {
 public:
   kernel_operation(
-      const std::string &kernel_name,
+      const char* kernel_name,
       common::auto_small_vector<std::unique_ptr<backend_kernel_launcher>>
           kernels,
       const requirements_list &requirements);
@@ -376,11 +376,11 @@ public:
     }
   }
 
-  const std::string& get_global_kernel_name() const {
+  const char* get_global_kernel_name() const {
     return _kernel_name;
   }
 private:
-  std::string _kernel_name;
+  const char* _kernel_name;
   kernel_launcher _launcher;
   // We store shared_ptr to the memory requirement nodes to make sure
   // that they are alive as long as kernel operations live.

--- a/src/runtime/operations.cpp
+++ b/src/runtime/operations.cpp
@@ -41,7 +41,7 @@ const instrumentation_set &operation::get_instrumentations() const {
 }
 
 kernel_operation::kernel_operation(
-    const std::string &kernel_name,
+    const char* kernel_name,
     common::auto_small_vector<
         std::unique_ptr<backend_kernel_launcher>> kernels,
     const requirements_list &reqs)

--- a/tests/dump_test/dump_test.cpp
+++ b/tests/dump_test/dump_test.cpp
@@ -48,7 +48,7 @@ int main()
   hipsycl::common::auto_small_vector<std::unique_ptr<backend_kernel_launcher>>
       backend_kernel_list;
   std::string kernel_name = "test_kernel";
-  kernel_operation kernel_op(kernel_name, std::move(backend_kernel_list), reqs);
+  kernel_operation kernel_op(kernel_name.c_str(), std::move(backend_kernel_list), reqs);
   kernel_op.dump(std::cout);
 
 


### PR DESCRIPTION
 This avoids `std::string` construction for every kernel launch, saving us one dynamic memory allocation for each kernel launch, and hopefully making launch latency a bit happier :)