### PR TITLE
[CI] Fix benchmark action

### DIFF
--- a/.github/workflows/benchmark-self-hosted.yml
+++ b/.github/workflows/benchmark-self-hosted.yml
@@ -2,15 +2,14 @@ name: Benchmark on self-hosted runners
 
 on:
   pull_request:
-    types:
-      - labeled
+    types: [opened,edited,synchronize,labeled]
 
 env:
   SYCL_BENCH_BENCHMARKS: scalar_prod 2DConvolution
 
 jobs:
   run-benchmark:
-    if: (${{ github.event.issue.pull_request }} && contains(github.event.comment.body, '/run-benchmark')) || ${{ github.event.label.name == 'benchmark' }}
+    if: contains(github.event.pull_request.labels.*.name, 'benchmark')
     runs-on: [self-hosted, gpu-nvidia]
     strategy:
       matrix:
@@ -59,4 +58,5 @@ jobs:
         comment-on-alert: true
         summary-always: true
         comment-always: true
+
 

--- a/.github/workflows/benchmark-self-hosted.yml
+++ b/.github/workflows/benchmark-self-hosted.yml
@@ -11,6 +11,7 @@ jobs:
   run-benchmark:
     if: contains(github.event.pull_request.labels.*.name, 'benchmark')
     runs-on: [self-hosted, gpu-nvidia]
+    permissions: write-all
     strategy:
       matrix:
         clang_version: ['15']

--- a/.github/workflows/benchmark-self-hosted.yml
+++ b/.github/workflows/benchmark-self-hosted.yml
@@ -1,7 +1,7 @@
 name: Benchmark on self-hosted runners
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened,edited,synchronize,labeled]
 
 env:

--- a/.github/workflows/benchmark-self-hosted.yml
+++ b/.github/workflows/benchmark-self-hosted.yml
@@ -28,7 +28,7 @@ jobs:
         git clone https://github.com/bcosenza/sycl-bench.git
         cd sycl-bench
         mkdir build && cd build
-        cmake .. -DSYCL_IMPL=hipSYCL -DhipSYCL_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/hipSYCL/ -DHIPSYCL_TARGETS=cuda:sm_61
+        cmake .. -DSYCL_IMPL=AdaptiveCpp -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp/ -DACPP_TARGETS=cuda:sm_61
         make $SYCL_BENCH_BENCHMARKS
         
     - name: Run SYCL-Bench


### PR DESCRIPTION
This (hopefully) makes the benchmark action useful.

The action is enabled for PRs that are labeled with the `benchmark` label and is run when such a PR is opened, edited, or when new commits are added to the PR. The label can either be added directly when opening the PR or also later on (adding the label also triggers the action). For now, this always compares new commits against the base commit.