### PR TITLE
default selector: Don't pick up OpenCL CPU if only omp has been targeted

### DIFF
--- a/include/hipSYCL/sycl/device_selector.hpp
+++ b/include/hipSYCL/sycl/device_selector.hpp
@@ -109,7 +109,9 @@ inline int select_cpu(const device& dev) {
 }
 
 inline int select_host(const device& dev) {
-  return select_cpu(dev);
+  if(dev == detail::get_host_device())
+    return 1;
+  return -1;
 }
 
 inline int select_default(const device& dev) {


### PR DESCRIPTION
Fixes #1494 