### PR TITLE
Improve task throughput by avoiding shared_ptr refcount changes and HCF cache improvements

### DIFF
--- a/include/hipSYCL/runtime/cuda/cuda_queue.hpp
+++ b/include/hipSYCL/runtime/cuda/cuda_queue.hpp
@@ -101,15 +101,15 @@ public:
   virtual std::shared_ptr<dag_node_event> insert_event() override;
   virtual std::shared_ptr<dag_node_event> create_queue_completion_event() override;
 
-  virtual result submit_memcpy(memcpy_operation &, dag_node_ptr) override;
-  virtual result submit_kernel(kernel_operation &, dag_node_ptr) override;
-  virtual result submit_prefetch(prefetch_operation &, dag_node_ptr) override;
-  virtual result submit_memset(memset_operation &, dag_node_ptr) override;
+  virtual result submit_memcpy(memcpy_operation &, const dag_node_ptr&) override;
+  virtual result submit_kernel(kernel_operation &, const dag_node_ptr&) override;
+  virtual result submit_prefetch(prefetch_operation &, const dag_node_ptr&) override;
+  virtual result submit_memset(memset_operation &, const dag_node_ptr&) override;
 
   /// Causes the queue to wait until an event on another queue has occured.
   /// the other queue must be from the same backend
-  virtual result submit_queue_wait_for(dag_node_ptr evt) override;
-  virtual result submit_external_wait_for(dag_node_ptr node) override;
+  virtual result submit_queue_wait_for(const dag_node_ptr& evt) override;
+  virtual result submit_external_wait_for(const dag_node_ptr& node) override;
 
   virtual result wait() override;
 

--- a/include/hipSYCL/runtime/executor.hpp
+++ b/include/hipSYCL/runtime/executor.hpp
@@ -53,11 +53,11 @@ public:
   virtual bool is_taskgraph() const = 0;
 
   virtual void
-  submit_directly(dag_node_ptr node, operation *op,
+  submit_directly(const dag_node_ptr& node, operation *op,
                   const node_list_t &reqs) = 0;
 
   virtual bool can_execute_on_device(const device_id& dev) const = 0;
-  virtual bool is_submitted_by_me(dag_node_ptr node) const = 0;
+  virtual bool is_submitted_by_me(const dag_node_ptr& node) const = 0;
 
   virtual ~backend_executor(){}
 };

--- a/include/hipSYCL/runtime/hip/hip_queue.hpp
+++ b/include/hipSYCL/runtime/hip/hip_queue.hpp
@@ -94,15 +94,15 @@ public:
   virtual std::shared_ptr<dag_node_event> insert_event() override;
   virtual std::shared_ptr<dag_node_event> create_queue_completion_event() override;
 
-  virtual result submit_memcpy(memcpy_operation&, dag_node_ptr) override;
-  virtual result submit_kernel(kernel_operation&, dag_node_ptr) override;
-  virtual result submit_prefetch(prefetch_operation &, dag_node_ptr) override;
-  virtual result submit_memset(memset_operation&, dag_node_ptr) override;
+  virtual result submit_memcpy(memcpy_operation&, const dag_node_ptr&) override;
+  virtual result submit_kernel(kernel_operation&, const dag_node_ptr&) override;
+  virtual result submit_prefetch(prefetch_operation &, const dag_node_ptr&) override;
+  virtual result submit_memset(memset_operation&, const dag_node_ptr&) override;
   
   /// Causes the queue to wait until an event on another queue has occured.
   /// the other queue must be from the same backend
-  virtual result submit_queue_wait_for(dag_node_ptr evt) override;
-  virtual result submit_external_wait_for(dag_node_ptr node) override;
+  virtual result submit_queue_wait_for(const dag_node_ptr& evt) override;
+  virtual result submit_external_wait_for(const dag_node_ptr& node) override;
 
   virtual result wait() override;
 

--- a/include/hipSYCL/runtime/inorder_executor.hpp
+++ b/include/hipSYCL/runtime/inorder_executor.hpp
@@ -55,13 +55,13 @@ public:
   bool is_taskgraph() const final override;
 
   virtual void
-  submit_directly(dag_node_ptr node, operation *op,
+  submit_directly(const dag_node_ptr& node, operation *op,
                   const node_list_t &reqs) override;
 
   inorder_queue* get_queue() const;
 
   bool can_execute_on_device(const device_id& dev) const override;
-  bool is_submitted_by_me(dag_node_ptr node) const override;
+  bool is_submitted_by_me(const dag_node_ptr& node) const override;
 private:
   std::unique_ptr<inorder_queue> _q;
   std::atomic<std::size_t> _num_submitted_operations;

--- a/include/hipSYCL/runtime/inorder_queue.hpp
+++ b/include/hipSYCL/runtime/inorder_queue.hpp
@@ -64,15 +64,15 @@ public:
   virtual std::shared_ptr<dag_node_event> insert_event() = 0;
   virtual std::shared_ptr<dag_node_event> create_queue_completion_event() = 0;
 
-  virtual result submit_memcpy(memcpy_operation&, dag_node_ptr) = 0;
-  virtual result submit_kernel(kernel_operation&, dag_node_ptr) = 0;
-  virtual result submit_prefetch(prefetch_operation &, dag_node_ptr) = 0;
-  virtual result submit_memset(memset_operation&, dag_node_ptr) = 0;
+  virtual result submit_memcpy(memcpy_operation&, const dag_node_ptr&) = 0;
+  virtual result submit_kernel(kernel_operation&, const dag_node_ptr&) = 0;
+  virtual result submit_prefetch(prefetch_operation &, const dag_node_ptr&) = 0;
+  virtual result submit_memset(memset_operation&, const dag_node_ptr&) = 0;
   
   /// Causes the queue to wait until an event on another queue has occured.
   /// the other queue must be from the same backend
-  virtual result submit_queue_wait_for(dag_node_ptr evt) = 0;
-  virtual result submit_external_wait_for(dag_node_ptr node) = 0;
+  virtual result submit_queue_wait_for(const dag_node_ptr& evt) = 0;
+  virtual result submit_external_wait_for(const dag_node_ptr& node) = 0;
 
   virtual result wait() = 0;
 

--- a/include/hipSYCL/runtime/multi_queue_executor.hpp
+++ b/include/hipSYCL/runtime/multi_queue_executor.hpp
@@ -146,7 +146,7 @@ public:
   get_kernel_execution_lane_range(device_id dev) const;
 
   virtual void
-  submit_directly(dag_node_ptr node, operation *op,
+  submit_directly(const dag_node_ptr& node, operation *op,
                   const node_list_t &reqs) override;
 
   template <class F> void for_each_queue(rt::device_id dev, F handler) const {
@@ -156,9 +156,9 @@ public:
   }
 
   virtual bool can_execute_on_device(const device_id& dev) const override;
-  virtual bool is_submitted_by_me(dag_node_ptr node) const override;
+  virtual bool is_submitted_by_me(const dag_node_ptr& node) const override;
 
-  bool find_assigned_lane_index(dag_node_ptr node, std::size_t& index_out) const;
+  bool find_assigned_lane_index(const dag_node_ptr& node, std::size_t& index_out) const;
 private:
   
 

--- a/include/hipSYCL/runtime/ocl/ocl_queue.hpp
+++ b/include/hipSYCL/runtime/ocl/ocl_queue.hpp
@@ -57,15 +57,15 @@ public:
   virtual std::shared_ptr<dag_node_event> insert_event() override;
   virtual std::shared_ptr<dag_node_event> create_queue_completion_event() override;
 
-  virtual result submit_memcpy(memcpy_operation&, dag_node_ptr) override;
-  virtual result submit_kernel(kernel_operation&, dag_node_ptr) override;
-  virtual result submit_prefetch(prefetch_operation &, dag_node_ptr) override;
-  virtual result submit_memset(memset_operation&, dag_node_ptr) override;
+  virtual result submit_memcpy(memcpy_operation&, const dag_node_ptr&) override;
+  virtual result submit_kernel(kernel_operation&, const dag_node_ptr&) override;
+  virtual result submit_prefetch(prefetch_operation &, const dag_node_ptr&) override;
+  virtual result submit_memset(memset_operation&, const dag_node_ptr&) override;
   
   /// Causes the queue to wait until an event on another queue has occured.
   /// the other queue must be from the same backend
-  virtual result submit_queue_wait_for(dag_node_ptr evt) override;
-  virtual result submit_external_wait_for(dag_node_ptr node) override;
+  virtual result submit_queue_wait_for(const dag_node_ptr& evt) override;
+  virtual result submit_external_wait_for(const dag_node_ptr& node) override;
 
   virtual result wait() override;
 

--- a/include/hipSYCL/runtime/omp/omp_queue.hpp
+++ b/include/hipSYCL/runtime/omp/omp_queue.hpp
@@ -71,15 +71,15 @@ public:
   virtual std::shared_ptr<dag_node_event> insert_event() override;
   virtual std::shared_ptr<dag_node_event> create_queue_completion_event() override;
 
-  virtual result submit_memcpy(memcpy_operation&, dag_node_ptr) override;
-  virtual result submit_kernel(kernel_operation&, dag_node_ptr) override;
-  virtual result submit_prefetch(prefetch_operation &, dag_node_ptr) override;
-  virtual result submit_memset(memset_operation&, dag_node_ptr) override;
+  virtual result submit_memcpy(memcpy_operation&, const dag_node_ptr&) override;
+  virtual result submit_kernel(kernel_operation&, const dag_node_ptr&) override;
+  virtual result submit_prefetch(prefetch_operation &, const dag_node_ptr&) override;
+  virtual result submit_memset(memset_operation&, const dag_node_ptr&) override;
   
   /// Causes the queue to wait until an event on another queue has occured.
   /// the other queue must be from the same backend
-  virtual result submit_queue_wait_for(dag_node_ptr evt) override;
-  virtual result submit_external_wait_for(dag_node_ptr node) override;
+  virtual result submit_queue_wait_for(const dag_node_ptr& evt) override;
+  virtual result submit_external_wait_for(const dag_node_ptr& node) override;
 
   virtual result wait() override;
 

--- a/include/hipSYCL/runtime/operations.hpp
+++ b/include/hipSYCL/runtime/operations.hpp
@@ -72,10 +72,10 @@ using node_list_t = common::small_vector<dag_node_ptr, 8>;
 class operation_dispatcher
 {
 public:
-  virtual result dispatch_kernel(kernel_operation* op, dag_node_ptr node) = 0;
-  virtual result dispatch_memcpy(memcpy_operation* op, dag_node_ptr node) = 0;
-  virtual result dispatch_prefetch(prefetch_operation *op, dag_node_ptr node) = 0;
-  virtual result dispatch_memset(memset_operation* op, dag_node_ptr node) = 0;
+  virtual result dispatch_kernel(kernel_operation* op, const dag_node_ptr& node) = 0;
+  virtual result dispatch_memcpy(memcpy_operation* op, const dag_node_ptr& node) = 0;
+  virtual result dispatch_prefetch(prefetch_operation *op, const dag_node_ptr& node) = 0;
+  virtual result dispatch_memset(memset_operation* op, const dag_node_ptr& node) = 0;
   virtual ~operation_dispatcher(){}
 };
 
@@ -94,7 +94,7 @@ public:
     return false;
   }
 
-  virtual result dispatch(operation_dispatcher* dispatch, dag_node_ptr node) = 0;
+  virtual result dispatch(operation_dispatcher* dispatch, const dag_node_ptr& node) = 0;
 
   instrumentation_set &get_instrumentations();
   const instrumentation_set &get_instrumentations() const;
@@ -112,7 +112,8 @@ public:
   virtual bool is_requirement() const final override
   { return true; }
 
-  virtual result dispatch(operation_dispatcher *dispatch, dag_node_ptr node) final override {
+  virtual result dispatch(operation_dispatcher *dispatch,
+                          const dag_node_ptr &node) final override {
     assert(false && "Cannot dispatch implicit requirements");
     return make_success();
   }
@@ -341,7 +342,8 @@ public:
 
   void dump(std::ostream & ostr, int indentation=0) const override;
 
-  result dispatch(operation_dispatcher* dispatcher, dag_node_ptr node) override {
+  result dispatch(operation_dispatcher *dispatcher,
+                  const dag_node_ptr &node) override {
     return dispatcher->dispatch_kernel(this, node);
   }
 
@@ -451,7 +453,7 @@ public:
 
   virtual bool is_data_transfer() const final override;
   virtual result dispatch(operation_dispatcher *op,
-                          dag_node_ptr node) final override {
+                          const dag_node_ptr& node) final override {
     return op->dispatch_memcpy(this, node);
   }
   void dump(std::ostream &ostr, int indentation = 0) const override final;
@@ -482,7 +484,7 @@ public:
       : _ptr{ptr}, _num_bytes{num_bytes}, _target{target} {}
 
   result dispatch(operation_dispatcher *dispatcher,
-                  dag_node_ptr node) final override {
+                  const dag_node_ptr& node) final override {
     return dispatcher->dispatch_prefetch(this, node);
   }
 
@@ -504,7 +506,7 @@ public:
       : _ptr{ptr}, _pattern{pattern}, _num_bytes{num_bytes} {}
 
   result dispatch(operation_dispatcher *dispatcher,
-                  dag_node_ptr node) final override {
+                  const dag_node_ptr& node) final override {
     return dispatcher->dispatch_memset(this, node);
   }
 

--- a/include/hipSYCL/runtime/ze/ze_queue.hpp
+++ b/include/hipSYCL/runtime/ze/ze_queue.hpp
@@ -57,15 +57,15 @@ public:
   virtual std::shared_ptr<dag_node_event> insert_event() override;
   virtual std::shared_ptr<dag_node_event> create_queue_completion_event() override;
 
-  virtual result submit_memcpy(memcpy_operation&, dag_node_ptr) override;
-  virtual result submit_kernel(kernel_operation&, dag_node_ptr) override;
-  virtual result submit_prefetch(prefetch_operation &, dag_node_ptr) override;
-  virtual result submit_memset(memset_operation&, dag_node_ptr) override;
+  virtual result submit_memcpy(memcpy_operation&, const dag_node_ptr&) override;
+  virtual result submit_kernel(kernel_operation&, const dag_node_ptr&) override;
+  virtual result submit_prefetch(prefetch_operation &, const dag_node_ptr&) override;
+  virtual result submit_memset(memset_operation&, const dag_node_ptr&) override;
   
   /// Causes the queue to wait until an event on another queue has occured.
   /// the other queue must be from the same backend
-  virtual result submit_queue_wait_for(dag_node_ptr evt) override;
-  virtual result submit_external_wait_for(dag_node_ptr node) override;
+  virtual result submit_queue_wait_for(const dag_node_ptr& evt) override;
+  virtual result submit_external_wait_for(const dag_node_ptr& node) override;
 
   virtual result wait() override;
 

--- a/src/runtime/cuda/cuda_queue.cpp
+++ b/src/runtime/cuda/cuda_queue.cpp
@@ -248,7 +248,7 @@ std::shared_ptr<dag_node_event> cuda_queue::create_queue_completion_event() {
 }
 
 
-result cuda_queue::submit_memcpy(memcpy_operation & op, dag_node_ptr node) {
+result cuda_queue::submit_memcpy(memcpy_operation & op, const dag_node_ptr& node) {
 
   device_id source_dev = op.source().get_device();
   device_id dest_dev = op.dest().get_device();
@@ -359,7 +359,7 @@ result cuda_queue::submit_memcpy(memcpy_operation & op, dag_node_ptr node) {
   return make_success();
 }
 
-result cuda_queue::submit_kernel(kernel_operation &op, dag_node_ptr node) {
+result cuda_queue::submit_kernel(kernel_operation &op, const dag_node_ptr& node) {
 
   this->activate_device();
   rt::backend_kernel_launcher *l =
@@ -379,7 +379,7 @@ result cuda_queue::submit_kernel(kernel_operation &op, dag_node_ptr node) {
   return make_success();
 }
 
-result cuda_queue::submit_prefetch(prefetch_operation& op, dag_node_ptr node) {
+result cuda_queue::submit_prefetch(prefetch_operation& op, const dag_node_ptr& node) {
 #ifndef _WIN32
   
   cudaError_t err = cudaSuccess;
@@ -406,7 +406,7 @@ result cuda_queue::submit_prefetch(prefetch_operation& op, dag_node_ptr node) {
   return make_success();
 }
 
-result cuda_queue::submit_memset(memset_operation &op, dag_node_ptr node) {
+result cuda_queue::submit_memset(memset_operation &op, const dag_node_ptr& node) {
 
   cuda_instrumentation_guard instrumentation{this, op, node};
   
@@ -425,7 +425,7 @@ result cuda_queue::submit_memset(memset_operation &op, dag_node_ptr node) {
 
 /// Causes the queue to wait until an event on another queue has occured.
 /// the other queue must be from the same backend
-result cuda_queue::submit_queue_wait_for(dag_node_ptr node) {
+result cuda_queue::submit_queue_wait_for(const dag_node_ptr& node) {
   auto evt = node->get_event();
   assert(dynamic_is<inorder_queue_event<cudaEvent_t>>(evt.get()));
 
@@ -442,7 +442,7 @@ result cuda_queue::submit_queue_wait_for(dag_node_ptr node) {
   return make_success();
 }
 
-result cuda_queue::submit_external_wait_for(dag_node_ptr node) {
+result cuda_queue::submit_external_wait_for(const dag_node_ptr& node) {
 
   dag_node_ptr* user_data = new dag_node_ptr;
   assert(user_data);
@@ -611,7 +611,7 @@ result cuda_queue::submit_sscp_kernel_from_code_object(
   }
 
 
-  glue::jit::cxx_argument_mapper arg_mapper{*kernel_info, args, arg_sizes,
+glue::jit::cxx_argument_mapper arg_mapper{*kernel_info, args, arg_sizes,
                                             num_args};
   if(!arg_mapper.mapping_available()) {
     return make_error(
@@ -624,7 +624,7 @@ result cuda_queue::submit_sscp_kernel_from_code_object(
       hcf_object, kernel_name, kernel_info, arg_mapper, num_groups,
       group_size, args,        arg_sizes,   num_args, local_mem_size};
 
-  static thread_local kernel_configuration config;
+static thread_local kernel_configuration config;
   config = initial_config;
   config.append_base_configuration(
       kernel_base_config_parameter::backend_id, backend_id::cuda);

--- a/src/runtime/hip/hip_queue.cpp
+++ b/src/runtime/hip/hip_queue.cpp
@@ -241,7 +241,7 @@ std::shared_ptr<dag_node_event> hip_queue::create_queue_completion_event() {
 
 
 
-result hip_queue::submit_memcpy(memcpy_operation & op, dag_node_ptr node) {
+result hip_queue::submit_memcpy(memcpy_operation & op, const dag_node_ptr& node) {
 
   device_id source_dev = op.source().get_device();
   device_id dest_dev = op.dest().get_device();
@@ -352,7 +352,7 @@ result hip_queue::submit_memcpy(memcpy_operation & op, dag_node_ptr node) {
   return make_success();
 }
 
-result hip_queue::submit_kernel(kernel_operation &op, dag_node_ptr node) {
+result hip_queue::submit_kernel(kernel_operation &op, const dag_node_ptr& node) {
 
   this->activate_device();
   rt::backend_kernel_launcher *l =
@@ -375,7 +375,7 @@ result hip_queue::submit_kernel(kernel_operation &op, dag_node_ptr node) {
   return make_success();
 }
 
-result hip_queue::submit_prefetch(prefetch_operation& op, dag_node_ptr node) {
+result hip_queue::submit_prefetch(prefetch_operation& op, const dag_node_ptr& node) {
   // Need to enable instrumentation even if we cannot enable actual
   // prefetches so that the user will be able to access instrumentation
   // properties of the event.
@@ -407,7 +407,7 @@ result hip_queue::submit_prefetch(prefetch_operation& op, dag_node_ptr node) {
   return make_success();
 }
 
-result hip_queue::submit_memset(memset_operation &op, dag_node_ptr node) {
+result hip_queue::submit_memset(memset_operation &op, const dag_node_ptr& node) {
 
   hip_instrumentation_guard instrumentation{this, op, node};
   hipError_t err = hipMemsetAsync(op.get_pointer(), op.get_pattern(),
@@ -452,7 +452,7 @@ result hip_queue::query_status(inorder_queue_status &status) {
 
 /// Causes the queue to wait until an event on another queue has occured.
 /// the other queue must be from the same backend
-result hip_queue::submit_queue_wait_for(dag_node_ptr node) {
+result hip_queue::submit_queue_wait_for(const dag_node_ptr& node) {
   auto evt = node->get_event();
   assert(dynamic_is<inorder_queue_event<hipEvent_t>>(evt.get()));
 
@@ -468,7 +468,7 @@ result hip_queue::submit_queue_wait_for(dag_node_ptr node) {
   return make_success();
 }
 
-result hip_queue::submit_external_wait_for(dag_node_ptr node) {
+result hip_queue::submit_external_wait_for(const dag_node_ptr& node) {
 
   dag_node_ptr* user_data = new dag_node_ptr;
   assert(user_data);

--- a/src/runtime/inorder_executor.cpp
+++ b/src/runtime/inorder_executor.cpp
@@ -47,23 +47,23 @@ public:
   virtual ~queue_operation_dispatcher(){}
 
   virtual result dispatch_kernel(kernel_operation *op,
-                                 dag_node_ptr node) final override {
+                                 const dag_node_ptr& node) final override {
 
     return _queue->submit_kernel(*op, node);
   }
 
   virtual result dispatch_memcpy(memcpy_operation *op,
-                                 dag_node_ptr node) final override {
+                                 const dag_node_ptr& node) final override {
     return _queue->submit_memcpy(*op, node);
   }
 
   virtual result dispatch_prefetch(prefetch_operation *op,
-                                   dag_node_ptr node) final override {
+                                   const dag_node_ptr& node) final override {
     return _queue->submit_prefetch(*op, node);
   }
 
   virtual result dispatch_memset(memset_operation *op,
-                                 dag_node_ptr node) final override {
+                                 const dag_node_ptr& node) final override {
     return _queue->submit_memset(*op, node);
   }
 
@@ -105,7 +105,7 @@ bool inorder_executor::is_taskgraph() const {
   return false;
 }
 
-void inorder_executor::submit_directly(dag_node_ptr node, operation *op,
+void inorder_executor::submit_directly(const dag_node_ptr& node, operation *op,
                                        const node_list_t &reqs) {
   
   HIPSYCL_DEBUG_INFO << "inorder_executor: Processing node " << node.get()
@@ -210,7 +210,7 @@ bool inorder_executor::can_execute_on_device(const device_id& dev) const {
   return _q->get_device() == dev;
 }
 
-bool inorder_executor::is_submitted_by_me(dag_node_ptr node) const {
+bool inorder_executor::is_submitted_by_me(const dag_node_ptr& node) const {
   if(!node->is_submitted())
     return false;
   return node->get_assigned_executor() == this;

--- a/src/runtime/kernel_cache.cpp
+++ b/src/runtime/kernel_cache.cpp
@@ -312,7 +312,7 @@ hcf_object_id hcf_cache::register_hcf_object(const common::hcf_container &obj) {
                 << " original index = "
                 << kernel_info->get_original_argument_index(i) << std::endl;
           }
-          _hcf_kernel_info[std::make_pair(id, kernel_name)] =
+          _hcf_kernel_info[generate_info_id(id, kernel_name)] =
               std::move(kernel_info);
         }
       }
@@ -327,7 +327,7 @@ hcf_object_id hcf_cache::register_hcf_object(const common::hcf_container &obj) {
           HIPSYCL_DEBUG_INFO << "hcf_cache: Registering image info for image "
                              << image_name << " from HCF object " << id
                              << std::endl;
-          _hcf_image_info[std::make_pair(id, image_name)] =
+          _hcf_image_info[generate_info_id(id, image_name)] =
               std::move(image_info);
         }
       }
@@ -405,7 +405,7 @@ const hcf_kernel_info *
 hcf_cache::get_kernel_info(hcf_object_id obj,
                            const std::string &kernel_name) const {
   std::lock_guard<std::mutex> lock{_mutex};
-  auto it = _hcf_kernel_info.find(std::make_pair(obj, kernel_name));
+  auto it = _hcf_kernel_info.find(generate_info_id(obj, kernel_name));
   if(it == _hcf_kernel_info.end())
     return nullptr;
   return it->second.get();
@@ -415,7 +415,7 @@ const hcf_image_info *
 hcf_cache::get_image_info(hcf_object_id obj,
                           const std::string &image_name) const {
   std::lock_guard<std::mutex> lock{_mutex};
-  auto it = _hcf_image_info.find(std::make_pair(obj, image_name));
+  auto it = _hcf_image_info.find(generate_info_id(obj, image_name));
   if(it == _hcf_image_info.end())
     return nullptr;
   return it->second.get();

--- a/src/runtime/multi_queue_executor.cpp
+++ b/src/runtime/multi_queue_executor.cpp
@@ -45,7 +45,7 @@ namespace rt {
 
 namespace {
 
-std::size_t determine_target_lane(dag_node_ptr node,
+std::size_t determine_target_lane(const dag_node_ptr& node,
                                   const node_list_t& nonvirtual_reqs,
                                   const multi_queue_executor* executor,
                                   const moving_statistics& device_submission_statistics,
@@ -63,7 +63,7 @@ std::size_t determine_target_lane(dag_node_ptr node,
 
   common::small_vector<int, 8> synchronization_cost(lane_range.num_lanes);
 
-  for(dag_node_ptr req : nonvirtual_reqs){
+  for(auto& req : nonvirtual_reqs){
     assert(req);
     assert(req->is_submitted());
 
@@ -204,7 +204,7 @@ multi_queue_executor::get_kernel_execution_lane_range(device_id dev) const {
 }
 
 void multi_queue_executor::submit_directly(
-    dag_node_ptr node, operation *op,
+    const dag_node_ptr& node, operation *op,
     const node_list_t &reqs) {
 
   HIPSYCL_DEBUG_INFO << "multi_queue_executor: Processing node " << node.get()
@@ -247,7 +247,7 @@ bool multi_queue_executor::can_execute_on_device(const device_id &dev) const {
   return _backend == dev.get_backend();
 }
 
-bool multi_queue_executor::is_submitted_by_me(dag_node_ptr node) const {
+bool multi_queue_executor::is_submitted_by_me(const dag_node_ptr& node) const {
   if(!node->is_submitted())
     return false;
 
@@ -261,7 +261,8 @@ bool multi_queue_executor::is_submitted_by_me(dag_node_ptr node) const {
   return false;
 }
 
-bool multi_queue_executor::find_assigned_lane_index(dag_node_ptr node, std::size_t& index_out) const {
+bool multi_queue_executor::find_assigned_lane_index(
+    const dag_node_ptr &node, std::size_t &index_out) const {
   if(!node->is_submitted())
     return false;
 
@@ -279,6 +280,5 @@ bool multi_queue_executor::find_assigned_lane_index(dag_node_ptr node, std::size
 
   return false;
 }
-
 }
 }

--- a/src/runtime/ocl/ocl_queue.cpp
+++ b/src/runtime/ocl/ocl_queue.cpp
@@ -184,7 +184,7 @@ std::shared_ptr<dag_node_event> ocl_queue::create_queue_completion_event() {
       this);
 }
 
-result ocl_queue::submit_memcpy(memcpy_operation &op, dag_node_ptr) {
+result ocl_queue::submit_memcpy(memcpy_operation &op, const dag_node_ptr&) {
 
   HIPSYCL_DEBUG_INFO << "ocl_queue: On device "
                      << _hw_manager->get_device_id(_device_index)
@@ -247,7 +247,7 @@ result ocl_queue::submit_memcpy(memcpy_operation &op, dag_node_ptr) {
   return make_success();
 }
 
-result ocl_queue::submit_kernel(kernel_operation &op, dag_node_ptr node) {
+result ocl_queue::submit_kernel(kernel_operation &op, const dag_node_ptr& node) {
 
   rt::backend_kernel_launcher *l =
       op.get_launcher().find_launcher(backend_id::ocl);
@@ -266,7 +266,7 @@ result ocl_queue::submit_kernel(kernel_operation &op, dag_node_ptr node) {
   return make_success();
 }
 
-result ocl_queue::submit_prefetch(prefetch_operation &op, dag_node_ptr) {
+result ocl_queue::submit_prefetch(prefetch_operation &op, const dag_node_ptr&) {
   ocl_hardware_context *ocl_ctx = static_cast<ocl_hardware_context *>(
         _hw_manager->get_device(_device_index));
   ocl_usm* usm = ocl_ctx->get_usm_provider();
@@ -292,7 +292,7 @@ result ocl_queue::submit_prefetch(prefetch_operation &op, dag_node_ptr) {
   return make_success();
 }
 
-result ocl_queue::submit_memset(memset_operation& op, dag_node_ptr) {
+result ocl_queue::submit_memset(memset_operation& op, const dag_node_ptr&) {
   ocl_hardware_context *ocl_ctx = static_cast<ocl_hardware_context *>(
         _hw_manager->get_device(_device_index));
   ocl_usm* usm = ocl_ctx->get_usm_provider();
@@ -313,7 +313,7 @@ result ocl_queue::submit_memset(memset_operation& op, dag_node_ptr) {
 
 /// Causes the queue to wait until an event on another queue has occured.
 /// the other queue must be from the same backend
-result ocl_queue::submit_queue_wait_for(dag_node_ptr evt) {
+result ocl_queue::submit_queue_wait_for(const dag_node_ptr& evt) {
 
   ocl_node_event *ocl_evt =
       static_cast<ocl_node_event *>(evt->get_event().get());
@@ -339,7 +339,7 @@ result ocl_queue::submit_queue_wait_for(dag_node_ptr evt) {
   return make_success();
 }
 
-result ocl_queue::submit_external_wait_for(dag_node_ptr node) {
+result ocl_queue::submit_external_wait_for(const dag_node_ptr& node) {
   ocl_hardware_context* hw_ctx = static_cast<ocl_hardware_context *>(
       _hw_manager->get_device(_device_index));
   cl_int err;

--- a/src/runtime/omp/omp_queue.cpp
+++ b/src/runtime/omp/omp_queue.cpp
@@ -272,7 +272,7 @@ std::shared_ptr<dag_node_event> omp_queue::create_queue_completion_event() {
       this);
 }
 
-result omp_queue::submit_memcpy(memcpy_operation &op, dag_node_ptr node) {
+result omp_queue::submit_memcpy(memcpy_operation &op, const dag_node_ptr& node) {
   HIPSYCL_DEBUG_INFO << "omp_queue: Submitting memcpy operation..."
                      << std::endl;
 
@@ -370,7 +370,7 @@ result omp_queue::submit_memcpy(memcpy_operation &op, dag_node_ptr node) {
   return make_success();
 }
 
-result omp_queue::submit_kernel(kernel_operation &op, dag_node_ptr node) {
+result omp_queue::submit_kernel(kernel_operation &op, const dag_node_ptr& node) {
   HIPSYCL_DEBUG_INFO << "omp_queue: Submitting kernel..." << std::endl;
 
   rt::backend_kernel_launcher *launcher =
@@ -520,7 +520,7 @@ result omp_queue::submit_sscp_kernel_from_code_object(
 #endif
 }
 
-result omp_queue::submit_prefetch(prefetch_operation &op, dag_node_ptr node) {
+result omp_queue::submit_prefetch(prefetch_operation &op, const dag_node_ptr& node) {
   HIPSYCL_DEBUG_INFO
       << "omp_queue: Received prefetch submission request, ignoring"
       << std::endl;
@@ -536,7 +536,7 @@ result omp_queue::submit_prefetch(prefetch_operation &op, dag_node_ptr node) {
   return make_success();
 }
 
-result omp_queue::submit_memset(memset_operation &op, dag_node_ptr node) {
+result omp_queue::submit_memset(memset_operation &op, const dag_node_ptr& node) {
   void *ptr = op.get_pointer();
   std::size_t bytes = op.get_num_bytes();
   int pattern = op.get_pattern();
@@ -560,7 +560,7 @@ result omp_queue::submit_memset(memset_operation &op, dag_node_ptr node) {
 
 /// Causes the queue to wait until an event on another queue has occured.
 /// the other queue must be from the same backend
-result omp_queue::submit_queue_wait_for(dag_node_ptr node) {
+result omp_queue::submit_queue_wait_for(const dag_node_ptr& node) {
   HIPSYCL_DEBUG_INFO << "omp_queue: Submitting wait for other queue..."
                      << std::endl;
   auto evt = node->get_event();
@@ -586,7 +586,7 @@ result omp_queue::query_status(inorder_queue_status &status) {
   return make_success();
 }
 
-result omp_queue::submit_external_wait_for(dag_node_ptr node) {
+result omp_queue::submit_external_wait_for(const dag_node_ptr& node) {
   HIPSYCL_DEBUG_INFO << "omp_queue: Submitting wait for external node..."
                      << std::endl;
 

--- a/src/runtime/ze/ze_queue.cpp
+++ b/src/runtime/ze/ze_queue.cpp
@@ -249,7 +249,7 @@ std::shared_ptr<dag_node_event> ze_queue::insert_event() {
   return _last_submitted_op_event;
 }
 
-result ze_queue::submit_memcpy(memcpy_operation& op, dag_node_ptr node) {
+result ze_queue::submit_memcpy(memcpy_operation& op, const dag_node_ptr& node) {
   std::lock_guard<std::mutex> lock{_mutex};
 
   // TODO We could probably unify some of the logic here between
@@ -309,7 +309,7 @@ result ze_queue::submit_memcpy(memcpy_operation& op, dag_node_ptr node) {
   return make_success();
 }
 
-result ze_queue::submit_kernel(kernel_operation& op, dag_node_ptr node) {
+result ze_queue::submit_kernel(kernel_operation& op, const dag_node_ptr& node) {
   std::lock_guard<std::mutex> lock{_mutex};
 
   rt::backend_kernel_launcher *l = 
@@ -331,11 +331,11 @@ result ze_queue::submit_kernel(kernel_operation& op, dag_node_ptr node) {
   return make_success();
 }
 
-result ze_queue::submit_prefetch(prefetch_operation &, dag_node_ptr node) {
+result ze_queue::submit_prefetch(prefetch_operation &, const dag_node_ptr& node) {
   return make_success();
 }
 
-result ze_queue::submit_memset(memset_operation& op, dag_node_ptr node) {
+result ze_queue::submit_memset(memset_operation& op, const dag_node_ptr& node) {
   std::lock_guard<std::mutex> lock{_mutex};
 
   std::shared_ptr<dag_node_event> completion_evt = create_event();
@@ -371,7 +371,7 @@ result ze_queue::wait() {
   return make_success();
 }
 
-result ze_queue::submit_queue_wait_for(dag_node_ptr node) {
+result ze_queue::submit_queue_wait_for(const dag_node_ptr& node) {
   std::lock_guard<std::mutex> lock{_mutex};
 
   auto evt = node->get_event();
@@ -379,7 +379,7 @@ result ze_queue::submit_queue_wait_for(dag_node_ptr node) {
   return make_success();
 }
 
-result ze_queue::submit_external_wait_for(dag_node_ptr node) {
+result ze_queue::submit_external_wait_for(const dag_node_ptr& node) {
   std::lock_guard<std::mutex> lock{_mutex};
 
   // Clean up old futures before adding new ones


### PR DESCRIPTION
This PR changes two things:
- Pass `dag_node_ptr` as `const dag_node_ptr&` through our layers, which avoids creating temporary shared ptrs and refcount changes
- Change HCF cache to not use std::string as key.

With these changes, I get ~10% SSCP task throughput improvements (instant submission, in order queue, coarse-grained events).