### PR TITLE
More kernel submission latency optimizations

### DIFF
--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -172,6 +172,10 @@ struct AdaptiveCpp_retarget {
 };
 
 }
+
+namespace sycl::property::queue {
+struct AdaptiveCpp_retargetable {};
+}
 ```
 
 ##### Description
@@ -187,6 +191,8 @@ Compared to using multiple queues bound to different devices, using a single que
 
 * A single `queue::wait()` call guarantees that all operations submitted to the queue, no matter to which device they were retargeted, have completed. With multiple queues on the other hand, multiple `wait()` calls are necessary which can add some overhead.
 * If the queue is an in-order queue, the in-order property is *preserved even if the operations are retargeted to run on different devices*. This can be a highly convenient way to formulate in-order USM algorithms that require processing steps on different devices.
+
+The `AdaptiveCpp_retarget` property can only be used with queues that have been constructed with the `AdaptiveCpp_retargetable` property.
 
 
 #### `ACPP_EXT_CG_PROPERTY_PREFER_EXECUTION_LANE`

--- a/include/hipSYCL/common/stable_running_hash.hpp
+++ b/include/hipSYCL/common/stable_running_hash.hpp
@@ -28,8 +28,10 @@
 #ifndef HIPSYCL_STABLE_RUNNING_HASH_HPP
 #define HIPSYCL_STABLE_RUNNING_HASH_HPP
 
+#include <algorithm>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <utility>
 
 namespace hipsycl {
@@ -45,8 +47,10 @@ public:
   stable_running_hash() : value{offset} {}
 
   void operator()(const void *data, std::size_t size) {
-    for (std::size_t i = 0; i < size; ++i) {
-      uint8_t current = static_cast<const uint8_t *>(data)[i];
+    for(int i = 0; i < size; i += sizeof(uint64_t)) {
+      uint64_t current = 0;
+      int read_size = std::min(sizeof(uint64_t), size - i);
+      std::memcpy(&current, (char*)data + i, read_size);
       value ^= current;
       value *= prime;
     }

--- a/include/hipSYCL/common/unordered_dense.hpp
+++ b/include/hipSYCL/common/unordered_dense.hpp
@@ -1,0 +1,2032 @@
+///////////////////////// ankerl::unordered_dense::{map, set} /////////////////////////
+
+// A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion.
+// Version 4.4.0
+// https://github.com/martinus/unordered_dense
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022-2023 Martin Leitner-Ankerl <martin.ankerl@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef ANKERL_UNORDERED_DENSE_H
+#define ANKERL_UNORDERED_DENSE_H
+
+// see https://semver.org/spec/v2.0.0.html
+#define ANKERL_UNORDERED_DENSE_VERSION_MAJOR 4 // NOLINT(cppcoreguidelines-macro-usage) incompatible API changes
+#define ANKERL_UNORDERED_DENSE_VERSION_MINOR 4 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible functionality
+#define ANKERL_UNORDERED_DENSE_VERSION_PATCH 0 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible bug fixes
+
+// API versioning with inline namespace, see https://www.foonathan.net/2018/11/inline-namespaces/
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define ANKERL_UNORDERED_DENSE_VERSION_CONCAT1(major, minor, patch) v##major##_##minor##_##patch
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define ANKERL_UNORDERED_DENSE_VERSION_CONCAT(major, minor, patch) ANKERL_UNORDERED_DENSE_VERSION_CONCAT1(major, minor, patch)
+#define ANKERL_UNORDERED_DENSE_NAMESPACE   \
+    ANKERL_UNORDERED_DENSE_VERSION_CONCAT( \
+        ANKERL_UNORDERED_DENSE_VERSION_MAJOR, ANKERL_UNORDERED_DENSE_VERSION_MINOR, ANKERL_UNORDERED_DENSE_VERSION_PATCH)
+
+#if defined(_MSVC_LANG)
+#    define ANKERL_UNORDERED_DENSE_CPP_VERSION _MSVC_LANG
+#else
+#    define ANKERL_UNORDERED_DENSE_CPP_VERSION __cplusplus
+#endif
+
+#if defined(__GNUC__)
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#    define ANKERL_UNORDERED_DENSE_PACK(decl) decl __attribute__((__packed__))
+#elif defined(_MSC_VER)
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#    define ANKERL_UNORDERED_DENSE_PACK(decl) __pragma(pack(push, 1)) decl __pragma(pack(pop))
+#endif
+
+// exceptions
+#if defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND)
+#    define ANKERL_UNORDERED_DENSE_HAS_EXCEPTIONS() 1 // NOLINT(cppcoreguidelines-macro-usage)
+#else
+#    define ANKERL_UNORDERED_DENSE_HAS_EXCEPTIONS() 0 // NOLINT(cppcoreguidelines-macro-usage)
+#endif
+#ifdef _MSC_VER
+#    define ANKERL_UNORDERED_DENSE_NOINLINE __declspec(noinline)
+#else
+#    define ANKERL_UNORDERED_DENSE_NOINLINE __attribute__((noinline))
+#endif
+
+// defined in unordered_dense.cpp
+#if !defined(ANKERL_UNORDERED_DENSE_EXPORT)
+#    define ANKERL_UNORDERED_DENSE_EXPORT
+#endif
+
+#if ANKERL_UNORDERED_DENSE_CPP_VERSION < 201703L
+#    error ankerl::unordered_dense requires C++17 or higher
+#else
+#    include <array>            // for array
+#    include <cstdint>          // for uint64_t, uint32_t, uint8_t, UINT64_C
+#    include <cstring>          // for size_t, memcpy, memset
+#    include <functional>       // for equal_to, hash
+#    include <initializer_list> // for initializer_list
+#    include <iterator>         // for pair, distance
+#    include <limits>           // for numeric_limits
+#    include <memory>           // for allocator, allocator_traits, shared_ptr
+#    include <optional>         // for optional
+#    include <stdexcept>        // for out_of_range
+#    include <string>           // for basic_string
+#    include <string_view>      // for basic_string_view, hash
+#    include <tuple>            // for forward_as_tuple
+#    include <type_traits>      // for enable_if_t, declval, conditional_t, ena...
+#    include <utility>          // for forward, exchange, pair, as_const, piece...
+#    include <vector>           // for vector
+#    if ANKERL_UNORDERED_DENSE_HAS_EXCEPTIONS() == 0
+#        include <cstdlib> // for abort
+#    endif
+
+#    if defined(__has_include)
+#        if __has_include(<memory_resource>)
+#            define ANKERL_UNORDERED_DENSE_PMR std::pmr // NOLINT(cppcoreguidelines-macro-usage)
+#            include <memory_resource>                  // for polymorphic_allocator
+#        elif __has_include(<experimental/memory_resource>)
+#            define ANKERL_UNORDERED_DENSE_PMR std::experimental::pmr // NOLINT(cppcoreguidelines-macro-usage)
+#            include <experimental/memory_resource>                   // for polymorphic_allocator
+#        endif
+#    endif
+
+#    if defined(_MSC_VER) && defined(_M_X64)
+#        include <intrin.h>
+#        pragma intrinsic(_umul128)
+#    endif
+
+#    if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
+#        define ANKERL_UNORDERED_DENSE_LIKELY(x) __builtin_expect(x, 1)   // NOLINT(cppcoreguidelines-macro-usage)
+#        define ANKERL_UNORDERED_DENSE_UNLIKELY(x) __builtin_expect(x, 0) // NOLINT(cppcoreguidelines-macro-usage)
+#    else
+#        define ANKERL_UNORDERED_DENSE_LIKELY(x) (x)   // NOLINT(cppcoreguidelines-macro-usage)
+#        define ANKERL_UNORDERED_DENSE_UNLIKELY(x) (x) // NOLINT(cppcoreguidelines-macro-usage)
+#    endif
+
+namespace ankerl::unordered_dense {
+inline namespace ANKERL_UNORDERED_DENSE_NAMESPACE {
+
+namespace detail {
+
+#    if ANKERL_UNORDERED_DENSE_HAS_EXCEPTIONS()
+
+// make sure this is not inlined as it is slow and dramatically enlarges code, thus making other
+// inlinings more difficult. Throws are also generally the slow path.
+[[noreturn]] inline ANKERL_UNORDERED_DENSE_NOINLINE void on_error_key_not_found() {
+    throw std::out_of_range("ankerl::unordered_dense::map::at(): key not found");
+}
+[[noreturn]] inline ANKERL_UNORDERED_DENSE_NOINLINE void on_error_bucket_overflow() {
+    throw std::overflow_error("ankerl::unordered_dense: reached max bucket size, cannot increase size");
+}
+[[noreturn]] inline ANKERL_UNORDERED_DENSE_NOINLINE void on_error_too_many_elements() {
+    throw std::out_of_range("ankerl::unordered_dense::map::replace(): too many elements");
+}
+
+#    else
+
+[[noreturn]] inline void on_error_key_not_found() {
+    abort();
+}
+[[noreturn]] inline void on_error_bucket_overflow() {
+    abort();
+}
+[[noreturn]] inline void on_error_too_many_elements() {
+    abort();
+}
+
+#    endif
+
+} // namespace detail
+
+// hash ///////////////////////////////////////////////////////////////////////
+
+// This is a stripped-down implementation of wyhash: https://github.com/wangyi-fudan/wyhash
+// No big-endian support (because different values on different machines don't matter),
+// hardcodes seed and the secret, reformats the code, and clang-tidy fixes.
+namespace detail::wyhash {
+
+inline void mum(uint64_t* a, uint64_t* b) {
+#    if defined(__SIZEOF_INT128__)
+    __uint128_t r = *a;
+    r *= *b;
+    *a = static_cast<uint64_t>(r);
+    *b = static_cast<uint64_t>(r >> 64U);
+#    elif defined(_MSC_VER) && defined(_M_X64)
+    *a = _umul128(*a, *b, b);
+#    else
+    uint64_t ha = *a >> 32U;
+    uint64_t hb = *b >> 32U;
+    uint64_t la = static_cast<uint32_t>(*a);
+    uint64_t lb = static_cast<uint32_t>(*b);
+    uint64_t hi{};
+    uint64_t lo{};
+    uint64_t rh = ha * hb;
+    uint64_t rm0 = ha * lb;
+    uint64_t rm1 = hb * la;
+    uint64_t rl = la * lb;
+    uint64_t t = rl + (rm0 << 32U);
+    auto c = static_cast<uint64_t>(t < rl);
+    lo = t + (rm1 << 32U);
+    c += static_cast<uint64_t>(lo < t);
+    hi = rh + (rm0 >> 32U) + (rm1 >> 32U) + c;
+    *a = lo;
+    *b = hi;
+#    endif
+}
+
+// multiply and xor mix function, aka MUM
+[[nodiscard]] inline auto mix(uint64_t a, uint64_t b) -> uint64_t {
+    mum(&a, &b);
+    return a ^ b;
+}
+
+// read functions. WARNING: we don't care about endianness, so results are different on big endian!
+[[nodiscard]] inline auto r8(const uint8_t* p) -> uint64_t {
+    uint64_t v{};
+    std::memcpy(&v, p, 8U);
+    return v;
+}
+
+[[nodiscard]] inline auto r4(const uint8_t* p) -> uint64_t {
+    uint32_t v{};
+    std::memcpy(&v, p, 4);
+    return v;
+}
+
+// reads 1, 2, or 3 bytes
+[[nodiscard]] inline auto r3(const uint8_t* p, size_t k) -> uint64_t {
+    return (static_cast<uint64_t>(p[0]) << 16U) | (static_cast<uint64_t>(p[k >> 1U]) << 8U) | p[k - 1];
+}
+
+[[maybe_unused]] [[nodiscard]] inline auto hash(void const* key, size_t len) -> uint64_t {
+    static constexpr auto secret = std::array{UINT64_C(0xa0761d6478bd642f),
+                                              UINT64_C(0xe7037ed1a0b428db),
+                                              UINT64_C(0x8ebc6af09c88c6e3),
+                                              UINT64_C(0x589965cc75374cc3)};
+
+    auto const* p = static_cast<uint8_t const*>(key);
+    uint64_t seed = secret[0];
+    uint64_t a{};
+    uint64_t b{};
+    if (ANKERL_UNORDERED_DENSE_LIKELY(len <= 16)) {
+        if (ANKERL_UNORDERED_DENSE_LIKELY(len >= 4)) {
+            a = (r4(p) << 32U) | r4(p + ((len >> 3U) << 2U));
+            b = (r4(p + len - 4) << 32U) | r4(p + len - 4 - ((len >> 3U) << 2U));
+        } else if (ANKERL_UNORDERED_DENSE_LIKELY(len > 0)) {
+            a = r3(p, len);
+            b = 0;
+        } else {
+            a = 0;
+            b = 0;
+        }
+    } else {
+        size_t i = len;
+        if (ANKERL_UNORDERED_DENSE_UNLIKELY(i > 48)) {
+            uint64_t see1 = seed;
+            uint64_t see2 = seed;
+            do {
+                seed = mix(r8(p) ^ secret[1], r8(p + 8) ^ seed);
+                see1 = mix(r8(p + 16) ^ secret[2], r8(p + 24) ^ see1);
+                see2 = mix(r8(p + 32) ^ secret[3], r8(p + 40) ^ see2);
+                p += 48;
+                i -= 48;
+            } while (ANKERL_UNORDERED_DENSE_LIKELY(i > 48));
+            seed ^= see1 ^ see2;
+        }
+        while (ANKERL_UNORDERED_DENSE_UNLIKELY(i > 16)) {
+            seed = mix(r8(p) ^ secret[1], r8(p + 8) ^ seed);
+            i -= 16;
+            p += 16;
+        }
+        a = r8(p + i - 16);
+        b = r8(p + i - 8);
+    }
+
+    return mix(secret[1] ^ len, mix(a ^ secret[1], b ^ seed));
+}
+
+[[nodiscard]] inline auto hash(uint64_t x) -> uint64_t {
+    return detail::wyhash::mix(x, UINT64_C(0x9E3779B97F4A7C15));
+}
+
+} // namespace detail::wyhash
+
+ANKERL_UNORDERED_DENSE_EXPORT template <typename T, typename Enable = void>
+struct hash {
+    auto operator()(T const& obj) const noexcept(noexcept(std::declval<std::hash<T>>().operator()(std::declval<T const&>())))
+        -> uint64_t {
+        return std::hash<T>{}(obj);
+    }
+};
+
+template <typename CharT>
+struct hash<std::basic_string<CharT>> {
+    using is_avalanching = void;
+    auto operator()(std::basic_string<CharT> const& str) const noexcept -> uint64_t {
+        return detail::wyhash::hash(str.data(), sizeof(CharT) * str.size());
+    }
+};
+
+template <typename CharT>
+struct hash<std::basic_string_view<CharT>> {
+    using is_avalanching = void;
+    auto operator()(std::basic_string_view<CharT> const& sv) const noexcept -> uint64_t {
+        return detail::wyhash::hash(sv.data(), sizeof(CharT) * sv.size());
+    }
+};
+
+template <class T>
+struct hash<T*> {
+    using is_avalanching = void;
+    auto operator()(T* ptr) const noexcept -> uint64_t {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        return detail::wyhash::hash(reinterpret_cast<uintptr_t>(ptr));
+    }
+};
+
+template <class T>
+struct hash<std::unique_ptr<T>> {
+    using is_avalanching = void;
+    auto operator()(std::unique_ptr<T> const& ptr) const noexcept -> uint64_t {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        return detail::wyhash::hash(reinterpret_cast<uintptr_t>(ptr.get()));
+    }
+};
+
+template <class T>
+struct hash<std::shared_ptr<T>> {
+    using is_avalanching = void;
+    auto operator()(std::shared_ptr<T> const& ptr) const noexcept -> uint64_t {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        return detail::wyhash::hash(reinterpret_cast<uintptr_t>(ptr.get()));
+    }
+};
+
+template <typename Enum>
+struct hash<Enum, typename std::enable_if<std::is_enum<Enum>::value>::type> {
+    using is_avalanching = void;
+    auto operator()(Enum e) const noexcept -> uint64_t {
+        using underlying = typename std::underlying_type_t<Enum>;
+        return detail::wyhash::hash(static_cast<underlying>(e));
+    }
+};
+
+template <typename... Args>
+struct tuple_hash_helper {
+    // Converts the value into 64bit. If it is an integral type, just cast it. Mixing is doing the rest.
+    // If it isn't an integral we need to hash it.
+    template <typename Arg>
+    [[nodiscard]] constexpr static auto to64(Arg const& arg) -> uint64_t {
+        if constexpr (std::is_integral_v<Arg> || std::is_enum_v<Arg>) {
+            return static_cast<uint64_t>(arg);
+        } else {
+            return hash<Arg>{}(arg);
+        }
+    }
+
+    [[nodiscard]] static auto mix64(uint64_t state, uint64_t v) -> uint64_t {
+        return detail::wyhash::mix(state + v, uint64_t{0x9ddfea08eb382d69});
+    }
+
+    // Creates a buffer that holds all the data from each element of the tuple. If possible we memcpy the data directly. If
+    // not, we hash the object and use this for the array. Size of the array is known at compile time, and memcpy is optimized
+    // away, so filling the buffer is highly efficient. Finally, call wyhash with this buffer.
+    template <typename T, std::size_t... Idx>
+    [[nodiscard]] static auto calc_hash(T const& t, std::index_sequence<Idx...>) noexcept -> uint64_t {
+        auto h = uint64_t{};
+        ((h = mix64(h, to64(std::get<Idx>(t)))), ...);
+        return h;
+    }
+};
+
+template <typename... Args>
+struct hash<std::tuple<Args...>> : tuple_hash_helper<Args...> {
+    using is_avalanching = void;
+    auto operator()(std::tuple<Args...> const& t) const noexcept -> uint64_t {
+        return tuple_hash_helper<Args...>::calc_hash(t, std::index_sequence_for<Args...>{});
+    }
+};
+
+template <typename A, typename B>
+struct hash<std::pair<A, B>> : tuple_hash_helper<A, B> {
+    using is_avalanching = void;
+    auto operator()(std::pair<A, B> const& t) const noexcept -> uint64_t {
+        return tuple_hash_helper<A, B>::calc_hash(t, std::index_sequence_for<A, B>{});
+    }
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#    define ANKERL_UNORDERED_DENSE_HASH_STATICCAST(T)                    \
+        template <>                                                      \
+        struct hash<T> {                                                 \
+            using is_avalanching = void;                                 \
+            auto operator()(T const& obj) const noexcept -> uint64_t {   \
+                return detail::wyhash::hash(static_cast<uint64_t>(obj)); \
+            }                                                            \
+        }
+
+#    if defined(__GNUC__) && !defined(__clang__)
+#        pragma GCC diagnostic push
+#        pragma GCC diagnostic ignored "-Wuseless-cast"
+#    endif
+// see https://en.cppreference.com/w/cpp/utility/hash
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(bool);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(char);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(signed char);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(unsigned char);
+#    if ANKERL_UNORDERED_DENSE_CPP_VERSION >= 202002L && defined(__cpp_char8_t)
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(char8_t);
+#    endif
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(char16_t);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(char32_t);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(wchar_t);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(short);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(unsigned short);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(int);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(unsigned int);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(long);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(long long);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(unsigned long);
+ANKERL_UNORDERED_DENSE_HASH_STATICCAST(unsigned long long);
+
+#    if defined(__GNUC__) && !defined(__clang__)
+#        pragma GCC diagnostic pop
+#    endif
+
+// bucket_type //////////////////////////////////////////////////////////
+
+namespace bucket_type {
+
+struct standard {
+    static constexpr uint32_t dist_inc = 1U << 8U;             // skip 1 byte fingerprint
+    static constexpr uint32_t fingerprint_mask = dist_inc - 1; // mask for 1 byte of fingerprint
+
+    uint32_t m_dist_and_fingerprint; // upper 3 byte: distance to original bucket. lower byte: fingerprint from hash
+    uint32_t m_value_idx;            // index into the m_values vector.
+};
+
+ANKERL_UNORDERED_DENSE_PACK(struct big {
+    static constexpr uint32_t dist_inc = 1U << 8U;             // skip 1 byte fingerprint
+    static constexpr uint32_t fingerprint_mask = dist_inc - 1; // mask for 1 byte of fingerprint
+
+    uint32_t m_dist_and_fingerprint; // upper 3 byte: distance to original bucket. lower byte: fingerprint from hash
+    size_t m_value_idx;              // index into the m_values vector.
+});
+
+} // namespace bucket_type
+
+namespace detail {
+
+struct nonesuch {};
+
+template <class Default, class AlwaysVoid, template <class...> class Op, class... Args>
+struct detector {
+    using value_t = std::false_type;
+    using type = Default;
+};
+
+template <class Default, template <class...> class Op, class... Args>
+struct detector<Default, std::void_t<Op<Args...>>, Op, Args...> {
+    using value_t = std::true_type;
+    using type = Op<Args...>;
+};
+
+template <template <class...> class Op, class... Args>
+using is_detected = typename detail::detector<detail::nonesuch, void, Op, Args...>::value_t;
+
+template <template <class...> class Op, class... Args>
+constexpr bool is_detected_v = is_detected<Op, Args...>::value;
+
+template <typename T>
+using detect_avalanching = typename T::is_avalanching;
+
+template <typename T>
+using detect_is_transparent = typename T::is_transparent;
+
+template <typename T>
+using detect_iterator = typename T::iterator;
+
+template <typename T>
+using detect_reserve = decltype(std::declval<T&>().reserve(size_t{}));
+
+// enable_if helpers
+
+template <typename Mapped>
+constexpr bool is_map_v = !std::is_void_v<Mapped>;
+
+// clang-format off
+template <typename Hash, typename KeyEqual>
+constexpr bool is_transparent_v = is_detected_v<detect_is_transparent, Hash> && is_detected_v<detect_is_transparent, KeyEqual>;
+// clang-format on
+
+template <typename From, typename To1, typename To2>
+constexpr bool is_neither_convertible_v = !std::is_convertible_v<From, To1> && !std::is_convertible_v<From, To2>;
+
+template <typename T>
+constexpr bool has_reserve = is_detected_v<detect_reserve, T>;
+
+// base type for map has mapped_type
+template <class T>
+struct base_table_type_map {
+    using mapped_type = T;
+};
+
+// base type for set doesn't have mapped_type
+struct base_table_type_set {};
+
+} // namespace detail
+
+// Very much like std::deque, but faster for indexing (in most cases). As of now this doesn't implement the full std::vector
+// API, but merely what's necessary to work as an underlying container for ankerl::unordered_dense::{map, set}.
+// It allocates blocks of equal size and puts them into the m_blocks vector. That means it can grow simply by adding a new
+// block to the back of m_blocks, and doesn't double its size like an std::vector. The disadvantage is that memory is not
+// linear and thus there is one more indirection necessary for indexing.
+template <typename T, typename Allocator = std::allocator<T>, size_t MaxSegmentSizeBytes = 4096>
+class segmented_vector {
+    template <bool IsConst>
+    class iter_t;
+
+public:
+    using allocator_type = Allocator;
+    using pointer = typename std::allocator_traits<allocator_type>::pointer;
+    using const_pointer = typename std::allocator_traits<allocator_type>::const_pointer;
+    using difference_type = typename std::allocator_traits<allocator_type>::difference_type;
+    using value_type = T;
+    using size_type = std::size_t;
+    using reference = T&;
+    using const_reference = T const&;
+    using iterator = iter_t<false>;
+    using const_iterator = iter_t<true>;
+
+private:
+    using vec_alloc = typename std::allocator_traits<Allocator>::template rebind_alloc<pointer>;
+    std::vector<pointer, vec_alloc> m_blocks{};
+    size_t m_size{};
+
+    // Calculates the maximum number for x in  (s << x) <= max_val
+    static constexpr auto num_bits_closest(size_t max_val, size_t s) -> size_t {
+        auto f = size_t{0};
+        while (s << (f + 1) <= max_val) {
+            ++f;
+        }
+        return f;
+    }
+
+    using self_t = segmented_vector<T, Allocator, MaxSegmentSizeBytes>;
+    static constexpr auto num_bits = num_bits_closest(MaxSegmentSizeBytes, sizeof(T));
+    static constexpr auto num_elements_in_block = 1U << num_bits;
+    static constexpr auto mask = num_elements_in_block - 1U;
+
+    /**
+     * Iterator class doubles as const_iterator and iterator
+     */
+    template <bool IsConst>
+    class iter_t {
+        using ptr_t = typename std::conditional_t<IsConst, segmented_vector::const_pointer const*, segmented_vector::pointer*>;
+        ptr_t m_data{};
+        size_t m_idx{};
+
+        template <bool B>
+        friend class iter_t;
+
+    public:
+        using difference_type = segmented_vector::difference_type;
+        using value_type = T;
+        using reference = typename std::conditional_t<IsConst, value_type const&, value_type&>;
+        using pointer = typename std::conditional_t<IsConst, segmented_vector::const_pointer, segmented_vector::pointer>;
+        using iterator_category = std::forward_iterator_tag;
+
+        iter_t() noexcept = default;
+
+        template <bool OtherIsConst, typename = typename std::enable_if<IsConst && !OtherIsConst>::type>
+        // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
+        constexpr iter_t(iter_t<OtherIsConst> const& other) noexcept
+            : m_data(other.m_data)
+            , m_idx(other.m_idx) {}
+
+        constexpr iter_t(ptr_t data, size_t idx) noexcept
+            : m_data(data)
+            , m_idx(idx) {}
+
+        template <bool OtherIsConst, typename = typename std::enable_if<IsConst && !OtherIsConst>::type>
+        constexpr auto operator=(iter_t<OtherIsConst> const& other) noexcept -> iter_t& {
+            m_data = other.m_data;
+            m_idx = other.m_idx;
+            return *this;
+        }
+
+        constexpr auto operator++() noexcept -> iter_t& {
+            ++m_idx;
+            return *this;
+        }
+
+        constexpr auto operator+(difference_type diff) noexcept -> iter_t {
+            return {m_data, static_cast<size_t>(static_cast<difference_type>(m_idx) + diff)};
+        }
+
+        template <bool OtherIsConst>
+        constexpr auto operator-(iter_t<OtherIsConst> const& other) noexcept -> difference_type {
+            return static_cast<difference_type>(m_idx) - static_cast<difference_type>(other.m_idx);
+        }
+
+        constexpr auto operator*() const noexcept -> reference {
+            return m_data[m_idx >> num_bits][m_idx & mask];
+        }
+
+        constexpr auto operator->() const noexcept -> pointer {
+            return &m_data[m_idx >> num_bits][m_idx & mask];
+        }
+
+        template <bool O>
+        constexpr auto operator==(iter_t<O> const& o) const noexcept -> bool {
+            return m_idx == o.m_idx;
+        }
+
+        template <bool O>
+        constexpr auto operator!=(iter_t<O> const& o) const noexcept -> bool {
+            return !(*this == o);
+        }
+    };
+
+    // slow path: need to allocate a new segment every once in a while
+    void increase_capacity() {
+        auto ba = Allocator(m_blocks.get_allocator());
+        pointer block = std::allocator_traits<Allocator>::allocate(ba, num_elements_in_block);
+        m_blocks.push_back(block);
+    }
+
+    // Moves everything from other
+    void append_everything_from(segmented_vector&& other) {
+        reserve(size() + other.size());
+        for (auto&& o : other) {
+            emplace_back(std::move(o));
+        }
+    }
+
+    // Copies everything from other
+    void append_everything_from(segmented_vector const& other) {
+        reserve(size() + other.size());
+        for (auto const& o : other) {
+            emplace_back(o);
+        }
+    }
+
+    void dealloc() {
+        auto ba = Allocator(m_blocks.get_allocator());
+        for (auto ptr : m_blocks) {
+            std::allocator_traits<Allocator>::deallocate(ba, ptr, num_elements_in_block);
+        }
+    }
+
+    [[nodiscard]] static constexpr auto calc_num_blocks_for_capacity(size_t capacity) {
+        return (capacity + num_elements_in_block - 1U) / num_elements_in_block;
+    }
+
+public:
+    segmented_vector() = default;
+
+    // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
+    segmented_vector(Allocator alloc)
+        : m_blocks(vec_alloc(alloc)) {}
+
+    segmented_vector(segmented_vector&& other, Allocator alloc)
+        : segmented_vector(alloc) {
+        *this = std::move(other);
+    }
+
+    segmented_vector(segmented_vector const& other, Allocator alloc)
+        : m_blocks(vec_alloc(alloc)) {
+        append_everything_from(other);
+    }
+
+    segmented_vector(segmented_vector&& other) noexcept
+        : segmented_vector(std::move(other), get_allocator()) {}
+
+    segmented_vector(segmented_vector const& other) {
+        append_everything_from(other);
+    }
+
+    auto operator=(segmented_vector const& other) -> segmented_vector& {
+        if (this == &other) {
+            return *this;
+        }
+        clear();
+        append_everything_from(other);
+        return *this;
+    }
+
+    auto operator=(segmented_vector&& other) noexcept -> segmented_vector& {
+        clear();
+        dealloc();
+        if (other.get_allocator() == get_allocator()) {
+            m_blocks = std::move(other.m_blocks);
+            m_size = std::exchange(other.m_size, {});
+        } else {
+            // make sure to construct with other's allocator!
+            m_blocks = std::vector<pointer, vec_alloc>(vec_alloc(other.get_allocator()));
+            append_everything_from(std::move(other));
+        }
+        return *this;
+    }
+
+    ~segmented_vector() {
+        clear();
+        dealloc();
+    }
+
+    [[nodiscard]] constexpr auto size() const -> size_t {
+        return m_size;
+    }
+
+    [[nodiscard]] constexpr auto capacity() const -> size_t {
+        return m_blocks.size() * num_elements_in_block;
+    }
+
+    // Indexing is highly performance critical
+    [[nodiscard]] constexpr auto operator[](size_t i) const noexcept -> T const& {
+        return m_blocks[i >> num_bits][i & mask];
+    }
+
+    [[nodiscard]] constexpr auto operator[](size_t i) noexcept -> T& {
+        return m_blocks[i >> num_bits][i & mask];
+    }
+
+    [[nodiscard]] constexpr auto begin() -> iterator {
+        return {m_blocks.data(), 0U};
+    }
+    [[nodiscard]] constexpr auto begin() const -> const_iterator {
+        return {m_blocks.data(), 0U};
+    }
+    [[nodiscard]] constexpr auto cbegin() const -> const_iterator {
+        return {m_blocks.data(), 0U};
+    }
+
+    [[nodiscard]] constexpr auto end() -> iterator {
+        return {m_blocks.data(), m_size};
+    }
+    [[nodiscard]] constexpr auto end() const -> const_iterator {
+        return {m_blocks.data(), m_size};
+    }
+    [[nodiscard]] constexpr auto cend() const -> const_iterator {
+        return {m_blocks.data(), m_size};
+    }
+
+    [[nodiscard]] constexpr auto back() -> reference {
+        return operator[](m_size - 1);
+    }
+    [[nodiscard]] constexpr auto back() const -> const_reference {
+        return operator[](m_size - 1);
+    }
+
+    void pop_back() {
+        back().~T();
+        --m_size;
+    }
+
+    [[nodiscard]] auto empty() const {
+        return 0 == m_size;
+    }
+
+    void reserve(size_t new_capacity) {
+        m_blocks.reserve(calc_num_blocks_for_capacity(new_capacity));
+        while (new_capacity > capacity()) {
+            increase_capacity();
+        }
+    }
+
+    [[nodiscard]] auto get_allocator() const -> allocator_type {
+        return allocator_type{m_blocks.get_allocator()};
+    }
+
+    template <class... Args>
+    auto emplace_back(Args&&... args) -> reference {
+        if (m_size == capacity()) {
+            increase_capacity();
+        }
+        auto* ptr = static_cast<void*>(&operator[](m_size));
+        auto& ref = *new (ptr) T(std::forward<Args>(args)...);
+        ++m_size;
+        return ref;
+    }
+
+    void clear() {
+        if constexpr (!std::is_trivially_destructible_v<T>) {
+            for (size_t i = 0, s = size(); i < s; ++i) {
+                operator[](i).~T();
+            }
+        }
+        m_size = 0;
+    }
+
+    void shrink_to_fit() {
+        auto ba = Allocator(m_blocks.get_allocator());
+        auto num_blocks_required = calc_num_blocks_for_capacity(m_size);
+        while (m_blocks.size() > num_blocks_required) {
+            std::allocator_traits<Allocator>::deallocate(ba, m_blocks.back(), num_elements_in_block);
+            m_blocks.pop_back();
+        }
+        m_blocks.shrink_to_fit();
+    }
+};
+
+namespace detail {
+
+// This is it, the table. Doubles as map and set, and uses `void` for T when its used as a set.
+template <class Key,
+          class T, // when void, treat it as a set.
+          class Hash,
+          class KeyEqual,
+          class AllocatorOrContainer,
+          class Bucket,
+          bool IsSegmented>
+class table : public std::conditional_t<is_map_v<T>, base_table_type_map<T>, base_table_type_set> {
+    using underlying_value_type = typename std::conditional_t<is_map_v<T>, std::pair<Key, T>, Key>;
+    using underlying_container_type = std::conditional_t<IsSegmented,
+                                                         segmented_vector<underlying_value_type, AllocatorOrContainer>,
+                                                         std::vector<underlying_value_type, AllocatorOrContainer>>;
+
+public:
+    using value_container_type = std::
+        conditional_t<is_detected_v<detect_iterator, AllocatorOrContainer>, AllocatorOrContainer, underlying_container_type>;
+
+private:
+    using bucket_alloc =
+        typename std::allocator_traits<typename value_container_type::allocator_type>::template rebind_alloc<Bucket>;
+    using bucket_alloc_traits = std::allocator_traits<bucket_alloc>;
+
+    static constexpr uint8_t initial_shifts = 64 - 2; // 2^(64-m_shift) number of buckets
+    static constexpr float default_max_load_factor = 0.8F;
+
+public:
+    using key_type = Key;
+    using value_type = typename value_container_type::value_type;
+    using size_type = typename value_container_type::size_type;
+    using difference_type = typename value_container_type::difference_type;
+    using hasher = Hash;
+    using key_equal = KeyEqual;
+    using allocator_type = typename value_container_type::allocator_type;
+    using reference = typename value_container_type::reference;
+    using const_reference = typename value_container_type::const_reference;
+    using pointer = typename value_container_type::pointer;
+    using const_pointer = typename value_container_type::const_pointer;
+    using const_iterator = typename value_container_type::const_iterator;
+    using iterator = std::conditional_t<is_map_v<T>, typename value_container_type::iterator, const_iterator>;
+    using bucket_type = Bucket;
+
+private:
+    using value_idx_type = decltype(Bucket::m_value_idx);
+    using dist_and_fingerprint_type = decltype(Bucket::m_dist_and_fingerprint);
+
+    static_assert(std::is_trivially_destructible_v<Bucket>, "assert there's no need to call destructor / std::destroy");
+    static_assert(std::is_trivially_copyable_v<Bucket>, "assert we can just memset / memcpy");
+
+    value_container_type m_values{}; // Contains all the key-value pairs in one densely stored container. No holes.
+    using bucket_pointer = typename std::allocator_traits<bucket_alloc>::pointer;
+    bucket_pointer m_buckets{};
+    size_t m_num_buckets = 0;
+    size_t m_max_bucket_capacity = 0;
+    float m_max_load_factor = default_max_load_factor;
+    Hash m_hash{};
+    KeyEqual m_equal{};
+    uint8_t m_shifts = initial_shifts;
+
+    [[nodiscard]] auto next(value_idx_type bucket_idx) const -> value_idx_type {
+        return ANKERL_UNORDERED_DENSE_UNLIKELY(bucket_idx + 1U == m_num_buckets)
+                   ? 0
+                   : static_cast<value_idx_type>(bucket_idx + 1U);
+    }
+
+    // Helper to access bucket through pointer types
+    [[nodiscard]] static constexpr auto at(bucket_pointer bucket_ptr, size_t offset) -> Bucket& {
+        return *(bucket_ptr + static_cast<typename std::allocator_traits<bucket_alloc>::difference_type>(offset));
+    }
+
+    // use the dist_inc and dist_dec functions so that uint16_t types work without warning
+    [[nodiscard]] static constexpr auto dist_inc(dist_and_fingerprint_type x) -> dist_and_fingerprint_type {
+        return static_cast<dist_and_fingerprint_type>(x + Bucket::dist_inc);
+    }
+
+    [[nodiscard]] static constexpr auto dist_dec(dist_and_fingerprint_type x) -> dist_and_fingerprint_type {
+        return static_cast<dist_and_fingerprint_type>(x - Bucket::dist_inc);
+    }
+
+    // The goal of mixed_hash is to always produce a high quality 64bit hash.
+    template <typename K>
+    [[nodiscard]] constexpr auto mixed_hash(K const& key) const -> uint64_t {
+        if constexpr (is_detected_v<detect_avalanching, Hash>) {
+            // we know that the hash is good because is_avalanching.
+            if constexpr (sizeof(decltype(m_hash(key))) < sizeof(uint64_t)) {
+                // 32bit hash and is_avalanching => multiply with a constant to avalanche bits upwards
+                return m_hash(key) * UINT64_C(0x9ddfea08eb382d69);
+            } else {
+                // 64bit and is_avalanching => only use the hash itself.
+                return m_hash(key);
+            }
+        } else {
+            // not is_avalanching => apply wyhash
+            return wyhash::hash(m_hash(key));
+        }
+    }
+
+    [[nodiscard]] constexpr auto dist_and_fingerprint_from_hash(uint64_t hash) const -> dist_and_fingerprint_type {
+        return Bucket::dist_inc | (static_cast<dist_and_fingerprint_type>(hash) & Bucket::fingerprint_mask);
+    }
+
+    [[nodiscard]] constexpr auto bucket_idx_from_hash(uint64_t hash) const -> value_idx_type {
+        return static_cast<value_idx_type>(hash >> m_shifts);
+    }
+
+    [[nodiscard]] static constexpr auto get_key(value_type const& vt) -> key_type const& {
+        if constexpr (is_map_v<T>) {
+            return vt.first;
+        } else {
+            return vt;
+        }
+    }
+
+    template <typename K>
+    [[nodiscard]] auto next_while_less(K const& key) const -> Bucket {
+        auto hash = mixed_hash(key);
+        auto dist_and_fingerprint = dist_and_fingerprint_from_hash(hash);
+        auto bucket_idx = bucket_idx_from_hash(hash);
+
+        while (dist_and_fingerprint < at(m_buckets, bucket_idx).m_dist_and_fingerprint) {
+            dist_and_fingerprint = dist_inc(dist_and_fingerprint);
+            bucket_idx = next(bucket_idx);
+        }
+        return {dist_and_fingerprint, bucket_idx};
+    }
+
+    void place_and_shift_up(Bucket bucket, value_idx_type place) {
+        while (0 != at(m_buckets, place).m_dist_and_fingerprint) {
+            bucket = std::exchange(at(m_buckets, place), bucket);
+            bucket.m_dist_and_fingerprint = dist_inc(bucket.m_dist_and_fingerprint);
+            place = next(place);
+        }
+        at(m_buckets, place) = bucket;
+    }
+
+    [[nodiscard]] static constexpr auto calc_num_buckets(uint8_t shifts) -> size_t {
+        return (std::min)(max_bucket_count(), size_t{1} << (64U - shifts));
+    }
+
+    [[nodiscard]] constexpr auto calc_shifts_for_size(size_t s) const -> uint8_t {
+        auto shifts = initial_shifts;
+        while (shifts > 0 && static_cast<size_t>(static_cast<float>(calc_num_buckets(shifts)) * max_load_factor()) < s) {
+            --shifts;
+        }
+        return shifts;
+    }
+
+    // assumes m_values has data, m_buckets=m_buckets_end=nullptr, m_shifts is INITIAL_SHIFTS
+    void copy_buckets(table const& other) {
+        // assumes m_values has already the correct data copied over.
+        if (empty()) {
+            // when empty, at least allocate an initial buckets and clear them.
+            allocate_buckets_from_shift();
+            clear_buckets();
+        } else {
+            m_shifts = other.m_shifts;
+            allocate_buckets_from_shift();
+            std::memcpy(m_buckets, other.m_buckets, sizeof(Bucket) * bucket_count());
+        }
+    }
+
+    /**
+     * True when no element can be added any more without increasing the size
+     */
+    [[nodiscard]] auto is_full() const -> bool {
+        return size() > m_max_bucket_capacity;
+    }
+
+    void deallocate_buckets() {
+        auto ba = bucket_alloc(m_values.get_allocator());
+        if (nullptr != m_buckets) {
+            bucket_alloc_traits::deallocate(ba, m_buckets, bucket_count());
+            m_buckets = nullptr;
+        }
+        m_num_buckets = 0;
+        m_max_bucket_capacity = 0;
+    }
+
+    void allocate_buckets_from_shift() {
+        auto ba = bucket_alloc(m_values.get_allocator());
+        m_num_buckets = calc_num_buckets(m_shifts);
+        m_buckets = bucket_alloc_traits::allocate(ba, m_num_buckets);
+        if (m_num_buckets == max_bucket_count()) {
+            // reached the maximum, make sure we can use each bucket
+            m_max_bucket_capacity = max_bucket_count();
+        } else {
+            m_max_bucket_capacity = static_cast<value_idx_type>(static_cast<float>(m_num_buckets) * max_load_factor());
+        }
+    }
+
+    void clear_buckets() {
+        if (m_buckets != nullptr) {
+            std::memset(&*m_buckets, 0, sizeof(Bucket) * bucket_count());
+        }
+    }
+
+    void clear_and_fill_buckets_from_values() {
+        clear_buckets();
+        for (value_idx_type value_idx = 0, end_idx = static_cast<value_idx_type>(m_values.size()); value_idx < end_idx;
+             ++value_idx) {
+            auto const& key = get_key(m_values[value_idx]);
+            auto [dist_and_fingerprint, bucket] = next_while_less(key);
+
+            // we know for certain that key has not yet been inserted, so no need to check it.
+            place_and_shift_up({dist_and_fingerprint, value_idx}, bucket);
+        }
+    }
+
+    void increase_size() {
+        if (m_max_bucket_capacity == max_bucket_count()) {
+            // remove the value again, we can't add it!
+            m_values.pop_back();
+            on_error_bucket_overflow();
+        }
+        --m_shifts;
+        deallocate_buckets();
+        allocate_buckets_from_shift();
+        clear_and_fill_buckets_from_values();
+    }
+
+    template <typename Op>
+    void do_erase(value_idx_type bucket_idx, Op handle_erased_value) {
+        auto const value_idx_to_remove = at(m_buckets, bucket_idx).m_value_idx;
+
+        // shift down until either empty or an element with correct spot is found
+        auto next_bucket_idx = next(bucket_idx);
+        while (at(m_buckets, next_bucket_idx).m_dist_and_fingerprint >= Bucket::dist_inc * 2) {
+            at(m_buckets, bucket_idx) = {dist_dec(at(m_buckets, next_bucket_idx).m_dist_and_fingerprint),
+                                         at(m_buckets, next_bucket_idx).m_value_idx};
+            bucket_idx = std::exchange(next_bucket_idx, next(next_bucket_idx));
+        }
+        at(m_buckets, bucket_idx) = {};
+        handle_erased_value(std::move(m_values[value_idx_to_remove]));
+
+        // update m_values
+        if (value_idx_to_remove != m_values.size() - 1) {
+            // no luck, we'll have to replace the value with the last one and update the index accordingly
+            auto& val = m_values[value_idx_to_remove];
+            val = std::move(m_values.back());
+
+            // update the values_idx of the moved entry. No need to play the info game, just look until we find the values_idx
+            auto mh = mixed_hash(get_key(val));
+            bucket_idx = bucket_idx_from_hash(mh);
+
+            auto const values_idx_back = static_cast<value_idx_type>(m_values.size() - 1);
+            while (values_idx_back != at(m_buckets, bucket_idx).m_value_idx) {
+                bucket_idx = next(bucket_idx);
+            }
+            at(m_buckets, bucket_idx).m_value_idx = value_idx_to_remove;
+        }
+        m_values.pop_back();
+    }
+
+    template <typename K, typename Op>
+    auto do_erase_key(K&& key, Op handle_erased_value) -> size_t {
+        if (empty()) {
+            return 0;
+        }
+
+        auto [dist_and_fingerprint, bucket_idx] = next_while_less(key);
+
+        while (dist_and_fingerprint == at(m_buckets, bucket_idx).m_dist_and_fingerprint &&
+               !m_equal(key, get_key(m_values[at(m_buckets, bucket_idx).m_value_idx]))) {
+            dist_and_fingerprint = dist_inc(dist_and_fingerprint);
+            bucket_idx = next(bucket_idx);
+        }
+
+        if (dist_and_fingerprint != at(m_buckets, bucket_idx).m_dist_and_fingerprint) {
+            return 0;
+        }
+        do_erase(bucket_idx, handle_erased_value);
+        return 1;
+    }
+
+    template <class K, class M>
+    auto do_insert_or_assign(K&& key, M&& mapped) -> std::pair<iterator, bool> {
+        auto it_isinserted = try_emplace(std::forward<K>(key), std::forward<M>(mapped));
+        if (!it_isinserted.second) {
+            it_isinserted.first->second = std::forward<M>(mapped);
+        }
+        return it_isinserted;
+    }
+
+    template <typename... Args>
+    auto do_place_element(dist_and_fingerprint_type dist_and_fingerprint, value_idx_type bucket_idx, Args&&... args)
+        -> std::pair<iterator, bool> {
+
+        // emplace the new value. If that throws an exception, no harm done; index is still in a valid state
+        m_values.emplace_back(std::forward<Args>(args)...);
+
+        auto value_idx = static_cast<value_idx_type>(m_values.size() - 1);
+        if (ANKERL_UNORDERED_DENSE_UNLIKELY(is_full())) {
+            increase_size();
+        } else {
+            place_and_shift_up({dist_and_fingerprint, value_idx}, bucket_idx);
+        }
+
+        // place element and shift up until we find an empty spot
+        return {begin() + static_cast<difference_type>(value_idx), true};
+    }
+
+    template <typename K, typename... Args>
+    auto do_try_emplace(K&& key, Args&&... args) -> std::pair<iterator, bool> {
+        auto hash = mixed_hash(key);
+        auto dist_and_fingerprint = dist_and_fingerprint_from_hash(hash);
+        auto bucket_idx = bucket_idx_from_hash(hash);
+
+        while (true) {
+            auto* bucket = &at(m_buckets, bucket_idx);
+            if (dist_and_fingerprint == bucket->m_dist_and_fingerprint) {
+                if (m_equal(key, get_key(m_values[bucket->m_value_idx]))) {
+                    return {begin() + static_cast<difference_type>(bucket->m_value_idx), false};
+                }
+            } else if (dist_and_fingerprint > bucket->m_dist_and_fingerprint) {
+                return do_place_element(dist_and_fingerprint,
+                                        bucket_idx,
+                                        std::piecewise_construct,
+                                        std::forward_as_tuple(std::forward<K>(key)),
+                                        std::forward_as_tuple(std::forward<Args>(args)...));
+            }
+            dist_and_fingerprint = dist_inc(dist_and_fingerprint);
+            bucket_idx = next(bucket_idx);
+        }
+    }
+
+    template <typename K>
+    auto do_find(K const& key) -> iterator {
+        if (ANKERL_UNORDERED_DENSE_UNLIKELY(empty())) {
+            return end();
+        }
+
+        auto mh = mixed_hash(key);
+        auto dist_and_fingerprint = dist_and_fingerprint_from_hash(mh);
+        auto bucket_idx = bucket_idx_from_hash(mh);
+        auto* bucket = &at(m_buckets, bucket_idx);
+
+        // unrolled loop. *Always* check a few directly, then enter the loop. This is faster.
+        if (dist_and_fingerprint == bucket->m_dist_and_fingerprint && m_equal(key, get_key(m_values[bucket->m_value_idx]))) {
+            return begin() + static_cast<difference_type>(bucket->m_value_idx);
+        }
+        dist_and_fingerprint = dist_inc(dist_and_fingerprint);
+        bucket_idx = next(bucket_idx);
+        bucket = &at(m_buckets, bucket_idx);
+
+        if (dist_and_fingerprint == bucket->m_dist_and_fingerprint && m_equal(key, get_key(m_values[bucket->m_value_idx]))) {
+            return begin() + static_cast<difference_type>(bucket->m_value_idx);
+        }
+        dist_and_fingerprint = dist_inc(dist_and_fingerprint);
+        bucket_idx = next(bucket_idx);
+        bucket = &at(m_buckets, bucket_idx);
+
+        while (true) {
+            if (dist_and_fingerprint == bucket->m_dist_and_fingerprint) {
+                if (m_equal(key, get_key(m_values[bucket->m_value_idx]))) {
+                    return begin() + static_cast<difference_type>(bucket->m_value_idx);
+                }
+            } else if (dist_and_fingerprint > bucket->m_dist_and_fingerprint) {
+                return end();
+            }
+            dist_and_fingerprint = dist_inc(dist_and_fingerprint);
+            bucket_idx = next(bucket_idx);
+            bucket = &at(m_buckets, bucket_idx);
+        }
+    }
+
+    template <typename K>
+    auto do_find(K const& key) const -> const_iterator {
+        return const_cast<table*>(this)->do_find(key); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+    }
+
+    template <typename K, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto do_at(K const& key) -> Q& {
+        if (auto it = find(key); ANKERL_UNORDERED_DENSE_LIKELY(end() != it)) {
+            return it->second;
+        }
+        on_error_key_not_found();
+    }
+
+    template <typename K, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto do_at(K const& key) const -> Q const& {
+        return const_cast<table*>(this)->at(key); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+    }
+
+public:
+    explicit table(size_t bucket_count,
+                   Hash const& hash = Hash(),
+                   KeyEqual const& equal = KeyEqual(),
+                   allocator_type const& alloc_or_container = allocator_type())
+        : m_values(alloc_or_container)
+        , m_hash(hash)
+        , m_equal(equal) {
+        if (0 != bucket_count) {
+            reserve(bucket_count);
+        } else {
+            allocate_buckets_from_shift();
+            clear_buckets();
+        }
+    }
+
+    table()
+        : table(0) {}
+
+    table(size_t bucket_count, allocator_type const& alloc)
+        : table(bucket_count, Hash(), KeyEqual(), alloc) {}
+
+    table(size_t bucket_count, Hash const& hash, allocator_type const& alloc)
+        : table(bucket_count, hash, KeyEqual(), alloc) {}
+
+    explicit table(allocator_type const& alloc)
+        : table(0, Hash(), KeyEqual(), alloc) {}
+
+    template <class InputIt>
+    table(InputIt first,
+          InputIt last,
+          size_type bucket_count = 0,
+          Hash const& hash = Hash(),
+          KeyEqual const& equal = KeyEqual(),
+          allocator_type const& alloc = allocator_type())
+        : table(bucket_count, hash, equal, alloc) {
+        insert(first, last);
+    }
+
+    template <class InputIt>
+    table(InputIt first, InputIt last, size_type bucket_count, allocator_type const& alloc)
+        : table(first, last, bucket_count, Hash(), KeyEqual(), alloc) {}
+
+    template <class InputIt>
+    table(InputIt first, InputIt last, size_type bucket_count, Hash const& hash, allocator_type const& alloc)
+        : table(first, last, bucket_count, hash, KeyEqual(), alloc) {}
+
+    table(table const& other)
+        : table(other, other.m_values.get_allocator()) {}
+
+    table(table const& other, allocator_type const& alloc)
+        : m_values(other.m_values, alloc)
+        , m_max_load_factor(other.m_max_load_factor)
+        , m_hash(other.m_hash)
+        , m_equal(other.m_equal) {
+        copy_buckets(other);
+    }
+
+    table(table&& other) noexcept
+        : table(std::move(other), other.m_values.get_allocator()) {}
+
+    table(table&& other, allocator_type const& alloc) noexcept
+        : m_values(alloc) {
+        *this = std::move(other);
+    }
+
+    table(std::initializer_list<value_type> ilist,
+          size_t bucket_count = 0,
+          Hash const& hash = Hash(),
+          KeyEqual const& equal = KeyEqual(),
+          allocator_type const& alloc = allocator_type())
+        : table(bucket_count, hash, equal, alloc) {
+        insert(ilist);
+    }
+
+    table(std::initializer_list<value_type> ilist, size_type bucket_count, allocator_type const& alloc)
+        : table(ilist, bucket_count, Hash(), KeyEqual(), alloc) {}
+
+    table(std::initializer_list<value_type> init, size_type bucket_count, Hash const& hash, allocator_type const& alloc)
+        : table(init, bucket_count, hash, KeyEqual(), alloc) {}
+
+    ~table() {
+        if (nullptr != m_buckets) {
+            auto ba = bucket_alloc(m_values.get_allocator());
+            bucket_alloc_traits::deallocate(ba, m_buckets, bucket_count());
+        }
+    }
+
+    auto operator=(table const& other) -> table& {
+        if (&other != this) {
+            deallocate_buckets(); // deallocate before m_values is set (might have another allocator)
+            m_values = other.m_values;
+            m_max_load_factor = other.m_max_load_factor;
+            m_hash = other.m_hash;
+            m_equal = other.m_equal;
+            m_shifts = initial_shifts;
+            copy_buckets(other);
+        }
+        return *this;
+    }
+
+    auto operator=(table&& other) noexcept(noexcept(std::is_nothrow_move_assignable_v<value_container_type> &&
+                                                    std::is_nothrow_move_assignable_v<Hash> &&
+                                                    std::is_nothrow_move_assignable_v<KeyEqual>)) -> table& {
+        if (&other != this) {
+            deallocate_buckets(); // deallocate before m_values is set (might have another allocator)
+            m_values = std::move(other.m_values);
+            other.m_values.clear();
+
+            // we can only reuse m_buckets when both maps have the same allocator!
+            if (get_allocator() == other.get_allocator()) {
+                m_buckets = std::exchange(other.m_buckets, nullptr);
+                m_num_buckets = std::exchange(other.m_num_buckets, 0);
+                m_max_bucket_capacity = std::exchange(other.m_max_bucket_capacity, 0);
+                m_shifts = std::exchange(other.m_shifts, initial_shifts);
+                m_max_load_factor = std::exchange(other.m_max_load_factor, default_max_load_factor);
+                m_hash = std::exchange(other.m_hash, {});
+                m_equal = std::exchange(other.m_equal, {});
+                other.allocate_buckets_from_shift();
+                other.clear_buckets();
+            } else {
+                // set max_load_factor *before* copying the other's buckets, so we have the same
+                // behavior
+                m_max_load_factor = other.m_max_load_factor;
+
+                // copy_buckets sets m_buckets, m_num_buckets, m_max_bucket_capacity, m_shifts
+                copy_buckets(other);
+                // clear's the other's buckets so other is now already usable.
+                other.clear_buckets();
+                m_hash = other.m_hash;
+                m_equal = other.m_equal;
+            }
+            // map "other" is now already usable, it's empty.
+        }
+        return *this;
+    }
+
+    auto operator=(std::initializer_list<value_type> ilist) -> table& {
+        clear();
+        insert(ilist);
+        return *this;
+    }
+
+    auto get_allocator() const noexcept -> allocator_type {
+        return m_values.get_allocator();
+    }
+
+    // iterators //////////////////////////////////////////////////////////////
+
+    auto begin() noexcept -> iterator {
+        return m_values.begin();
+    }
+
+    auto begin() const noexcept -> const_iterator {
+        return m_values.begin();
+    }
+
+    auto cbegin() const noexcept -> const_iterator {
+        return m_values.cbegin();
+    }
+
+    auto end() noexcept -> iterator {
+        return m_values.end();
+    }
+
+    auto cend() const noexcept -> const_iterator {
+        return m_values.cend();
+    }
+
+    auto end() const noexcept -> const_iterator {
+        return m_values.end();
+    }
+
+    // capacity ///////////////////////////////////////////////////////////////
+
+    [[nodiscard]] auto empty() const noexcept -> bool {
+        return m_values.empty();
+    }
+
+    [[nodiscard]] auto size() const noexcept -> size_t {
+        return m_values.size();
+    }
+
+    [[nodiscard]] static constexpr auto max_size() noexcept -> size_t {
+        if constexpr ((std::numeric_limits<value_idx_type>::max)() == (std::numeric_limits<size_t>::max)()) {
+            return size_t{1} << (sizeof(value_idx_type) * 8 - 1);
+        } else {
+            return size_t{1} << (sizeof(value_idx_type) * 8);
+        }
+    }
+
+    // modifiers //////////////////////////////////////////////////////////////
+
+    void clear() {
+        m_values.clear();
+        clear_buckets();
+    }
+
+    auto insert(value_type const& value) -> std::pair<iterator, bool> {
+        return emplace(value);
+    }
+
+    auto insert(value_type&& value) -> std::pair<iterator, bool> {
+        return emplace(std::move(value));
+    }
+
+    template <class P, std::enable_if_t<std::is_constructible_v<value_type, P&&>, bool> = true>
+    auto insert(P&& value) -> std::pair<iterator, bool> {
+        return emplace(std::forward<P>(value));
+    }
+
+    auto insert(const_iterator /*hint*/, value_type const& value) -> iterator {
+        return insert(value).first;
+    }
+
+    auto insert(const_iterator /*hint*/, value_type&& value) -> iterator {
+        return insert(std::move(value)).first;
+    }
+
+    template <class P, std::enable_if_t<std::is_constructible_v<value_type, P&&>, bool> = true>
+    auto insert(const_iterator /*hint*/, P&& value) -> iterator {
+        return insert(std::forward<P>(value)).first;
+    }
+
+    template <class InputIt>
+    void insert(InputIt first, InputIt last) {
+        while (first != last) {
+            insert(*first);
+            ++first;
+        }
+    }
+
+    void insert(std::initializer_list<value_type> ilist) {
+        insert(ilist.begin(), ilist.end());
+    }
+
+    // nonstandard API: *this is emptied.
+    // Also see "A Standard flat_map" https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0429r9.pdf
+    auto extract() && -> value_container_type {
+        return std::move(m_values);
+    }
+
+    // nonstandard API:
+    // Discards the internally held container and replaces it with the one passed. Erases non-unique elements.
+    auto replace(value_container_type&& container) {
+        if (ANKERL_UNORDERED_DENSE_UNLIKELY(container.size() > max_size())) {
+            on_error_too_many_elements();
+        }
+        auto shifts = calc_shifts_for_size(container.size());
+        if (0 == m_num_buckets || shifts < m_shifts || container.get_allocator() != m_values.get_allocator()) {
+            m_shifts = shifts;
+            deallocate_buckets();
+            allocate_buckets_from_shift();
+        }
+        clear_buckets();
+
+        m_values = std::move(container);
+
+        // can't use clear_and_fill_buckets_from_values() because container elements might not be unique
+        auto value_idx = value_idx_type{};
+
+        // loop until we reach the end of the container. duplicated entries will be replaced with back().
+        while (value_idx != static_cast<value_idx_type>(m_values.size())) {
+            auto const& key = get_key(m_values[value_idx]);
+
+            auto hash = mixed_hash(key);
+            auto dist_and_fingerprint = dist_and_fingerprint_from_hash(hash);
+            auto bucket_idx = bucket_idx_from_hash(hash);
+
+            bool key_found = false;
+            while (true) {
+                auto const& bucket = at(m_buckets, bucket_idx);
+                if (dist_and_fingerprint > bucket.m_dist_and_fingerprint) {
+                    break;
+                }
+                if (dist_and_fingerprint == bucket.m_dist_and_fingerprint &&
+                    m_equal(key, get_key(m_values[bucket.m_value_idx]))) {
+                    key_found = true;
+                    break;
+                }
+                dist_and_fingerprint = dist_inc(dist_and_fingerprint);
+                bucket_idx = next(bucket_idx);
+            }
+
+            if (key_found) {
+                if (value_idx != static_cast<value_idx_type>(m_values.size() - 1)) {
+                    m_values[value_idx] = std::move(m_values.back());
+                }
+                m_values.pop_back();
+            } else {
+                place_and_shift_up({dist_and_fingerprint, value_idx}, bucket_idx);
+                ++value_idx;
+            }
+        }
+    }
+
+    template <class M, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto insert_or_assign(Key const& key, M&& mapped) -> std::pair<iterator, bool> {
+        return do_insert_or_assign(key, std::forward<M>(mapped));
+    }
+
+    template <class M, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto insert_or_assign(Key&& key, M&& mapped) -> std::pair<iterator, bool> {
+        return do_insert_or_assign(std::move(key), std::forward<M>(mapped));
+    }
+
+    template <typename K,
+              typename M,
+              typename Q = T,
+              typename H = Hash,
+              typename KE = KeyEqual,
+              std::enable_if_t<is_map_v<Q> && is_transparent_v<H, KE>, bool> = true>
+    auto insert_or_assign(K&& key, M&& mapped) -> std::pair<iterator, bool> {
+        return do_insert_or_assign(std::forward<K>(key), std::forward<M>(mapped));
+    }
+
+    template <class M, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto insert_or_assign(const_iterator /*hint*/, Key const& key, M&& mapped) -> iterator {
+        return do_insert_or_assign(key, std::forward<M>(mapped)).first;
+    }
+
+    template <class M, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto insert_or_assign(const_iterator /*hint*/, Key&& key, M&& mapped) -> iterator {
+        return do_insert_or_assign(std::move(key), std::forward<M>(mapped)).first;
+    }
+
+    template <typename K,
+              typename M,
+              typename Q = T,
+              typename H = Hash,
+              typename KE = KeyEqual,
+              std::enable_if_t<is_map_v<Q> && is_transparent_v<H, KE>, bool> = true>
+    auto insert_or_assign(const_iterator /*hint*/, K&& key, M&& mapped) -> iterator {
+        return do_insert_or_assign(std::forward<K>(key), std::forward<M>(mapped)).first;
+    }
+
+    // Single arguments for unordered_set can be used without having to construct the value_type
+    template <class K,
+              typename Q = T,
+              typename H = Hash,
+              typename KE = KeyEqual,
+              std::enable_if_t<!is_map_v<Q> && is_transparent_v<H, KE>, bool> = true>
+    auto emplace(K&& key) -> std::pair<iterator, bool> {
+        auto hash = mixed_hash(key);
+        auto dist_and_fingerprint = dist_and_fingerprint_from_hash(hash);
+        auto bucket_idx = bucket_idx_from_hash(hash);
+
+        while (dist_and_fingerprint <= at(m_buckets, bucket_idx).m_dist_and_fingerprint) {
+            if (dist_and_fingerprint == at(m_buckets, bucket_idx).m_dist_and_fingerprint &&
+                m_equal(key, m_values[at(m_buckets, bucket_idx).m_value_idx])) {
+                // found it, return without ever actually creating anything
+                return {begin() + static_cast<difference_type>(at(m_buckets, bucket_idx).m_value_idx), false};
+            }
+            dist_and_fingerprint = dist_inc(dist_and_fingerprint);
+            bucket_idx = next(bucket_idx);
+        }
+
+        // value is new, insert element first, so when exception happens we are in a valid state
+        return do_place_element(dist_and_fingerprint, bucket_idx, std::forward<K>(key));
+    }
+
+    template <class... Args>
+    auto emplace(Args&&... args) -> std::pair<iterator, bool> {
+        // we have to instantiate the value_type to be able to access the key.
+        // 1. emplace_back the object so it is constructed. 2. If the key is already there, pop it later in the loop.
+        auto& key = get_key(m_values.emplace_back(std::forward<Args>(args)...));
+        auto hash = mixed_hash(key);
+        auto dist_and_fingerprint = dist_and_fingerprint_from_hash(hash);
+        auto bucket_idx = bucket_idx_from_hash(hash);
+
+        while (dist_and_fingerprint <= at(m_buckets, bucket_idx).m_dist_and_fingerprint) {
+            if (dist_and_fingerprint == at(m_buckets, bucket_idx).m_dist_and_fingerprint &&
+                m_equal(key, get_key(m_values[at(m_buckets, bucket_idx).m_value_idx]))) {
+                m_values.pop_back(); // value was already there, so get rid of it
+                return {begin() + static_cast<difference_type>(at(m_buckets, bucket_idx).m_value_idx), false};
+            }
+            dist_and_fingerprint = dist_inc(dist_and_fingerprint);
+            bucket_idx = next(bucket_idx);
+        }
+
+        // value is new, place the bucket and shift up until we find an empty spot
+        auto value_idx = static_cast<value_idx_type>(m_values.size() - 1);
+        if (ANKERL_UNORDERED_DENSE_UNLIKELY(is_full())) {
+            // increase_size just rehashes all the data we have in m_values
+            increase_size();
+        } else {
+            // place element and shift up until we find an empty spot
+            place_and_shift_up({dist_and_fingerprint, value_idx}, bucket_idx);
+        }
+        return {begin() + static_cast<difference_type>(value_idx), true};
+    }
+
+    template <class... Args>
+    auto emplace_hint(const_iterator /*hint*/, Args&&... args) -> iterator {
+        return emplace(std::forward<Args>(args)...).first;
+    }
+
+    template <class... Args, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto try_emplace(Key const& key, Args&&... args) -> std::pair<iterator, bool> {
+        return do_try_emplace(key, std::forward<Args>(args)...);
+    }
+
+    template <class... Args, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto try_emplace(Key&& key, Args&&... args) -> std::pair<iterator, bool> {
+        return do_try_emplace(std::move(key), std::forward<Args>(args)...);
+    }
+
+    template <class... Args, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto try_emplace(const_iterator /*hint*/, Key const& key, Args&&... args) -> iterator {
+        return do_try_emplace(key, std::forward<Args>(args)...).first;
+    }
+
+    template <class... Args, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto try_emplace(const_iterator /*hint*/, Key&& key, Args&&... args) -> iterator {
+        return do_try_emplace(std::move(key), std::forward<Args>(args)...).first;
+    }
+
+    template <
+        typename K,
+        typename... Args,
+        typename Q = T,
+        typename H = Hash,
+        typename KE = KeyEqual,
+        std::enable_if_t<is_map_v<Q> && is_transparent_v<H, KE> && is_neither_convertible_v<K&&, iterator, const_iterator>,
+                         bool> = true>
+    auto try_emplace(K&& key, Args&&... args) -> std::pair<iterator, bool> {
+        return do_try_emplace(std::forward<K>(key), std::forward<Args>(args)...);
+    }
+
+    template <
+        typename K,
+        typename... Args,
+        typename Q = T,
+        typename H = Hash,
+        typename KE = KeyEqual,
+        std::enable_if_t<is_map_v<Q> && is_transparent_v<H, KE> && is_neither_convertible_v<K&&, iterator, const_iterator>,
+                         bool> = true>
+    auto try_emplace(const_iterator /*hint*/, K&& key, Args&&... args) -> iterator {
+        return do_try_emplace(std::forward<K>(key), std::forward<Args>(args)...).first;
+    }
+
+    auto erase(iterator it) -> iterator {
+        auto hash = mixed_hash(get_key(*it));
+        auto bucket_idx = bucket_idx_from_hash(hash);
+
+        auto const value_idx_to_remove = static_cast<value_idx_type>(it - cbegin());
+        while (at(m_buckets, bucket_idx).m_value_idx != value_idx_to_remove) {
+            bucket_idx = next(bucket_idx);
+        }
+
+        do_erase(bucket_idx, [](value_type&& /*unused*/) {
+        });
+        return begin() + static_cast<difference_type>(value_idx_to_remove);
+    }
+
+    auto extract(iterator it) -> value_type {
+        auto hash = mixed_hash(get_key(*it));
+        auto bucket_idx = bucket_idx_from_hash(hash);
+
+        auto const value_idx_to_remove = static_cast<value_idx_type>(it - cbegin());
+        while (at(m_buckets, bucket_idx).m_value_idx != value_idx_to_remove) {
+            bucket_idx = next(bucket_idx);
+        }
+
+        auto tmp = std::optional<value_type>{};
+        do_erase(bucket_idx, [&tmp](value_type&& val) {
+            tmp = std::move(val);
+        });
+        return std::move(tmp).value();
+    }
+
+    template <typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto erase(const_iterator it) -> iterator {
+        return erase(begin() + (it - cbegin()));
+    }
+
+    template <typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto extract(const_iterator it) -> value_type {
+        return extract(begin() + (it - cbegin()));
+    }
+
+    auto erase(const_iterator first, const_iterator last) -> iterator {
+        auto const idx_first = first - cbegin();
+        auto const idx_last = last - cbegin();
+        auto const first_to_last = std::distance(first, last);
+        auto const last_to_end = std::distance(last, cend());
+
+        // remove elements from left to right which moves elements from the end back
+        auto const mid = idx_first + (std::min)(first_to_last, last_to_end);
+        auto idx = idx_first;
+        while (idx != mid) {
+            erase(begin() + idx);
+            ++idx;
+        }
+
+        // all elements from the right are moved, now remove the last element until all done
+        idx = idx_last;
+        while (idx != mid) {
+            --idx;
+            erase(begin() + idx);
+        }
+
+        return begin() + idx_first;
+    }
+
+    auto erase(Key const& key) -> size_t {
+        return do_erase_key(key, [](value_type&& /*unused*/) {
+        });
+    }
+
+    auto extract(Key const& key) -> std::optional<value_type> {
+        auto tmp = std::optional<value_type>{};
+        do_erase_key(key, [&tmp](value_type&& val) {
+            tmp = std::move(val);
+        });
+        return tmp;
+    }
+
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
+    auto erase(K&& key) -> size_t {
+        return do_erase_key(std::forward<K>(key), [](value_type&& /*unused*/) {
+        });
+    }
+
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
+    auto extract(K&& key) -> std::optional<value_type> {
+        auto tmp = std::optional<value_type>{};
+        do_erase_key(std::forward<K>(key), [&tmp](value_type&& val) {
+            tmp = std::move(val);
+        });
+        return tmp;
+    }
+
+    void swap(table& other) noexcept(noexcept(std::is_nothrow_swappable_v<value_container_type> &&
+                                              std::is_nothrow_swappable_v<Hash> && std::is_nothrow_swappable_v<KeyEqual>)) {
+        using std::swap;
+        swap(other, *this);
+    }
+
+    // lookup /////////////////////////////////////////////////////////////////
+
+    template <typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto at(key_type const& key) -> Q& {
+        return do_at(key);
+    }
+
+    template <typename K,
+              typename Q = T,
+              typename H = Hash,
+              typename KE = KeyEqual,
+              std::enable_if_t<is_map_v<Q> && is_transparent_v<H, KE>, bool> = true>
+    auto at(K const& key) -> Q& {
+        return do_at(key);
+    }
+
+    template <typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto at(key_type const& key) const -> Q const& {
+        return do_at(key);
+    }
+
+    template <typename K,
+              typename Q = T,
+              typename H = Hash,
+              typename KE = KeyEqual,
+              std::enable_if_t<is_map_v<Q> && is_transparent_v<H, KE>, bool> = true>
+    auto at(K const& key) const -> Q const& {
+        return do_at(key);
+    }
+
+    template <typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto operator[](Key const& key) -> Q& {
+        return try_emplace(key).first->second;
+    }
+
+    template <typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto operator[](Key&& key) -> Q& {
+        return try_emplace(std::move(key)).first->second;
+    }
+
+    template <typename K,
+              typename Q = T,
+              typename H = Hash,
+              typename KE = KeyEqual,
+              std::enable_if_t<is_map_v<Q> && is_transparent_v<H, KE>, bool> = true>
+    auto operator[](K&& key) -> Q& {
+        return try_emplace(std::forward<K>(key)).first->second;
+    }
+
+    auto count(Key const& key) const -> size_t {
+        return find(key) == end() ? 0 : 1;
+    }
+
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
+    auto count(K const& key) const -> size_t {
+        return find(key) == end() ? 0 : 1;
+    }
+
+    auto find(Key const& key) -> iterator {
+        return do_find(key);
+    }
+
+    auto find(Key const& key) const -> const_iterator {
+        return do_find(key);
+    }
+
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
+    auto find(K const& key) -> iterator {
+        return do_find(key);
+    }
+
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
+    auto find(K const& key) const -> const_iterator {
+        return do_find(key);
+    }
+
+    auto contains(Key const& key) const -> bool {
+        return find(key) != end();
+    }
+
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
+    auto contains(K const& key) const -> bool {
+        return find(key) != end();
+    }
+
+    auto equal_range(Key const& key) -> std::pair<iterator, iterator> {
+        auto it = do_find(key);
+        return {it, it == end() ? end() : it + 1};
+    }
+
+    auto equal_range(const Key& key) const -> std::pair<const_iterator, const_iterator> {
+        auto it = do_find(key);
+        return {it, it == end() ? end() : it + 1};
+    }
+
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
+    auto equal_range(K const& key) -> std::pair<iterator, iterator> {
+        auto it = do_find(key);
+        return {it, it == end() ? end() : it + 1};
+    }
+
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
+    auto equal_range(K const& key) const -> std::pair<const_iterator, const_iterator> {
+        auto it = do_find(key);
+        return {it, it == end() ? end() : it + 1};
+    }
+
+    // bucket interface ///////////////////////////////////////////////////////
+
+    auto bucket_count() const noexcept -> size_t { // NOLINT(modernize-use-nodiscard)
+        return m_num_buckets;
+    }
+
+    static constexpr auto max_bucket_count() noexcept -> size_t { // NOLINT(modernize-use-nodiscard)
+        return max_size();
+    }
+
+    // hash policy ////////////////////////////////////////////////////////////
+
+    [[nodiscard]] auto load_factor() const -> float {
+        return bucket_count() ? static_cast<float>(size()) / static_cast<float>(bucket_count()) : 0.0F;
+    }
+
+    [[nodiscard]] auto max_load_factor() const -> float {
+        return m_max_load_factor;
+    }
+
+    void max_load_factor(float ml) {
+        m_max_load_factor = ml;
+        if (m_num_buckets != max_bucket_count()) {
+            m_max_bucket_capacity = static_cast<value_idx_type>(static_cast<float>(bucket_count()) * max_load_factor());
+        }
+    }
+
+    void rehash(size_t count) {
+        count = (std::min)(count, max_size());
+        auto shifts = calc_shifts_for_size((std::max)(count, size()));
+        if (shifts != m_shifts) {
+            m_shifts = shifts;
+            deallocate_buckets();
+            m_values.shrink_to_fit();
+            allocate_buckets_from_shift();
+            clear_and_fill_buckets_from_values();
+        }
+    }
+
+    void reserve(size_t capa) {
+        capa = (std::min)(capa, max_size());
+        if constexpr (has_reserve<value_container_type>) {
+            // std::deque doesn't have reserve(). Make sure we only call when available
+            m_values.reserve(capa);
+        }
+        auto shifts = calc_shifts_for_size((std::max)(capa, size()));
+        if (0 == m_num_buckets || shifts < m_shifts) {
+            m_shifts = shifts;
+            deallocate_buckets();
+            allocate_buckets_from_shift();
+            clear_and_fill_buckets_from_values();
+        }
+    }
+
+    // observers //////////////////////////////////////////////////////////////
+
+    auto hash_function() const -> hasher {
+        return m_hash;
+    }
+
+    auto key_eq() const -> key_equal {
+        return m_equal;
+    }
+
+    // nonstandard API: expose the underlying values container
+    [[nodiscard]] auto values() const noexcept -> value_container_type const& {
+        return m_values;
+    }
+
+    // non-member functions ///////////////////////////////////////////////////
+
+    friend auto operator==(table const& a, table const& b) -> bool {
+        if (&a == &b) {
+            return true;
+        }
+        if (a.size() != b.size()) {
+            return false;
+        }
+        for (auto const& b_entry : b) {
+            auto it = a.find(get_key(b_entry));
+            if constexpr (is_map_v<T>) {
+                // map: check that key is here, then also check that value is the same
+                if (a.end() == it || !(b_entry.second == it->second)) {
+                    return false;
+                }
+            } else {
+                // set: only check that the key is here
+                if (a.end() == it) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    friend auto operator!=(table const& a, table const& b) -> bool {
+        return !(a == b);
+    }
+};
+
+} // namespace detail
+
+ANKERL_UNORDERED_DENSE_EXPORT template <class Key,
+                                        class T,
+                                        class Hash = hash<Key>,
+                                        class KeyEqual = std::equal_to<Key>,
+                                        class AllocatorOrContainer = std::allocator<std::pair<Key, T>>,
+                                        class Bucket = bucket_type::standard>
+using map = detail::table<Key, T, Hash, KeyEqual, AllocatorOrContainer, Bucket, false>;
+
+ANKERL_UNORDERED_DENSE_EXPORT template <class Key,
+                                        class T,
+                                        class Hash = hash<Key>,
+                                        class KeyEqual = std::equal_to<Key>,
+                                        class AllocatorOrContainer = std::allocator<std::pair<Key, T>>,
+                                        class Bucket = bucket_type::standard>
+using segmented_map = detail::table<Key, T, Hash, KeyEqual, AllocatorOrContainer, Bucket, true>;
+
+ANKERL_UNORDERED_DENSE_EXPORT template <class Key,
+                                        class Hash = hash<Key>,
+                                        class KeyEqual = std::equal_to<Key>,
+                                        class AllocatorOrContainer = std::allocator<Key>,
+                                        class Bucket = bucket_type::standard>
+using set = detail::table<Key, void, Hash, KeyEqual, AllocatorOrContainer, Bucket, false>;
+
+ANKERL_UNORDERED_DENSE_EXPORT template <class Key,
+                                        class Hash = hash<Key>,
+                                        class KeyEqual = std::equal_to<Key>,
+                                        class AllocatorOrContainer = std::allocator<Key>,
+                                        class Bucket = bucket_type::standard>
+using segmented_set = detail::table<Key, void, Hash, KeyEqual, AllocatorOrContainer, Bucket, true>;
+
+#    if defined(ANKERL_UNORDERED_DENSE_PMR)
+
+namespace pmr {
+
+ANKERL_UNORDERED_DENSE_EXPORT template <class Key,
+                                        class T,
+                                        class Hash = hash<Key>,
+                                        class KeyEqual = std::equal_to<Key>,
+                                        class Bucket = bucket_type::standard>
+using map =
+    detail::table<Key, T, Hash, KeyEqual, ANKERL_UNORDERED_DENSE_PMR::polymorphic_allocator<std::pair<Key, T>>, Bucket, false>;
+
+ANKERL_UNORDERED_DENSE_EXPORT template <class Key,
+                                        class T,
+                                        class Hash = hash<Key>,
+                                        class KeyEqual = std::equal_to<Key>,
+                                        class Bucket = bucket_type::standard>
+using segmented_map =
+    detail::table<Key, T, Hash, KeyEqual, ANKERL_UNORDERED_DENSE_PMR::polymorphic_allocator<std::pair<Key, T>>, Bucket, true>;
+
+ANKERL_UNORDERED_DENSE_EXPORT template <class Key,
+                                        class Hash = hash<Key>,
+                                        class KeyEqual = std::equal_to<Key>,
+                                        class Bucket = bucket_type::standard>
+using set = detail::table<Key, void, Hash, KeyEqual, ANKERL_UNORDERED_DENSE_PMR::polymorphic_allocator<Key>, Bucket, false>;
+
+ANKERL_UNORDERED_DENSE_EXPORT template <class Key,
+                                        class Hash = hash<Key>,
+                                        class KeyEqual = std::equal_to<Key>,
+                                        class Bucket = bucket_type::standard>
+using segmented_set =
+    detail::table<Key, void, Hash, KeyEqual, ANKERL_UNORDERED_DENSE_PMR::polymorphic_allocator<Key>, Bucket, true>;
+
+} // namespace pmr
+
+#    endif
+
+// deduction guides ///////////////////////////////////////////////////////////
+
+// deduction guides for alias templates are only possible since C++20
+// see https://en.cppreference.com/w/cpp/language/class_template_argument_deduction
+
+} // namespace ANKERL_UNORDERED_DENSE_NAMESPACE
+} // namespace ankerl::unordered_dense
+
+// std extensions /////////////////////////////////////////////////////////////
+
+namespace std { // NOLINT(cert-dcl58-cpp)
+
+ANKERL_UNORDERED_DENSE_EXPORT template <class Key,
+                                        class T,
+                                        class Hash,
+                                        class KeyEqual,
+                                        class AllocatorOrContainer,
+                                        class Bucket,
+                                        class Pred,
+                                        bool IsSegmented>
+// NOLINTNEXTLINE(cert-dcl58-cpp)
+auto erase_if(ankerl::unordered_dense::detail::table<Key, T, Hash, KeyEqual, AllocatorOrContainer, Bucket, IsSegmented>& map,
+              Pred pred) -> size_t {
+    using map_t = ankerl::unordered_dense::detail::table<Key, T, Hash, KeyEqual, AllocatorOrContainer, Bucket, IsSegmented>;
+
+    // going back to front because erase() invalidates the end iterator
+    auto const old_size = map.size();
+    auto idx = old_size;
+    while (idx) {
+        --idx;
+        auto it = map.begin() + static_cast<typename map_t::difference_type>(idx);
+        if (pred(*it)) {
+            map.erase(it);
+        }
+    }
+
+    return old_size - map.size();
+}
+
+} // namespace std
+
+#endif
+#endif

--- a/include/hipSYCL/glue/kernel_launcher_data.hpp
+++ b/include/hipSYCL/glue/kernel_launcher_data.hpp
@@ -47,6 +47,7 @@ namespace rt {
 class dag_node;
 class kernel_configuration;
 class backend_kernel_launch_capabilities;
+class hcf_kernel_info;
 }
 
 namespace glue {
@@ -80,6 +81,7 @@ struct kernel_launcher_data {
   // compilation flow-specific fields
   unsigned long long sscp_hcf_object_id;
   const char* sscp_kernel_id = nullptr;
+  const rt::hcf_kernel_info* kernel_info = nullptr;
   invoker_function_t sscp_invoker;
 };
 

--- a/include/hipSYCL/glue/llvm-sscp/jit.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/jit.hpp
@@ -55,21 +55,33 @@ namespace jit {
 // into their elements in the kernel function prototype.
 class cxx_argument_mapper {
 public:
+  cxx_argument_mapper() = default;
   cxx_argument_mapper(const rt::hcf_kernel_info &kernel_info, void **args,
                       const std::size_t *arg_sizes, std::size_t num_args) {
+    construct_mapping(kernel_info, args, arg_sizes, num_args);
+  }
+
+  void construct_mapping(const rt::hcf_kernel_info &kernel_info, void **args,
+                         const std::size_t *arg_sizes, std::size_t num_args) {
 
     std::size_t num_params = kernel_info.get_num_parameters();
-    
-    for(int i = 0; i < num_params; ++i) {
+
+    _mapped_data.clear();
+    _mapped_sizes.clear();
+    _mapped_data.reserve(num_params);
+    _mapped_sizes.reserve(num_params);
+
+    for (int i = 0; i < num_params; ++i) {
       std::size_t arg_size = kernel_info.get_argument_size(i);
       std::size_t arg_offset = kernel_info.get_argument_offset(i);
-      std::size_t arg_original_index = kernel_info.get_original_argument_index(i);
+      std::size_t arg_original_index =
+          kernel_info.get_original_argument_index(i);
 
       assert(arg_original_index < num_args);
 
       void *data_ptr = add_offset(args[arg_original_index], arg_offset);
-      
-      if(!data_ptr)
+
+      if (!data_ptr)
         return;
 
       _mapped_data.push_back(data_ptr);

--- a/include/hipSYCL/glue/llvm-sscp/sscp_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/sscp_kernel_launcher.hpp
@@ -49,6 +49,7 @@
 #include "../kernel_launcher_data.hpp"
 
 #include <array>
+#include <atomic>
 #include <string_view>
 
 
@@ -111,6 +112,29 @@ private:
 static static_hcf_registration
     __acpp_register_sscp_hcf_object{get_local_hcf_object()};
 
+
+// This class effectively caches queries into the HCF cache: For each
+// kernel lambda type, a separate object is instantiated which queries the HCF cache.
+// This allows us to not query the cache for every single submission, instead just
+// reusing the pointer here.
+struct kernel_info_retriever {
+  template <class Kernel>
+  static const rt::hcf_kernel_info *get(const Kernel &, rt::hcf_object_id obj,
+                         std::string_view kernel_name) {
+    static kernel_info_retriever retriever;
+
+    const rt::hcf_kernel_info *ptr =
+        retriever._cached_info_ptr.load(std::memory_order_relaxed);
+    if(!ptr) {
+      ptr = rt::hcf_cache::get().get_kernel_info(obj, kernel_name);
+      retriever._cached_info_ptr.store(ptr, std::memory_order_relaxed);
+    }
+    return ptr;
+  }
+
+private:
+  std::atomic<const rt::hcf_kernel_info*> _cached_info_ptr = nullptr;
+};
 
 }
 
@@ -341,11 +365,11 @@ public:
       std::size_t arg_size = launch_config.kernel_args.size();
 
       return invoker->submit_kernel(
-          *kernel_op, launch_config.sscp_hcf_object_id, num_groups, selected_group_size,
-          launch_config.local_mem_size, const_cast<void **>(args.data()), &arg_size,
-          args.size(), launch_config.sscp_kernel_id, kernel_config);
-
-      
+          *kernel_op, launch_config.sscp_hcf_object_id, num_groups,
+          selected_group_size, launch_config.local_mem_size,
+          const_cast<void **>(args.data()), &arg_size, args.size(),
+          launch_config.sscp_kernel_id, launch_config.kernel_info,
+          kernel_config);
     }
   }
 
@@ -375,6 +399,8 @@ private:
     std::memcpy(out.kernel_args.data(), &k, sizeof(Kernel));
 
     out.sscp_kernel_id = generate_kernel(k);
+    out.kernel_info = sscp::kernel_info_retriever::get(
+        k, out.sscp_hcf_object_id, out.sscp_kernel_id);
   }
 
 

--- a/include/hipSYCL/runtime/code_object_invoker.hpp
+++ b/include/hipSYCL/runtime/code_object_invoker.hpp
@@ -62,6 +62,7 @@ public:
                                unsigned local_mem_size, void **args,
                                std::size_t *arg_sizes, std::size_t num_args,
                                std::string_view kernel_name,
+                               const rt::hcf_kernel_info* kernel_info,
                                const kernel_configuration& config) = 0;
 
   virtual rt::range<3> select_group_size(const rt::range<3> &global_range,

--- a/include/hipSYCL/runtime/cuda/cuda_queue.hpp
+++ b/include/hipSYCL/runtime/cuda/cuda_queue.hpp
@@ -34,8 +34,11 @@
 
 #include "cuda_instrumentation.hpp"
 #include "cuda_code_object.hpp"
+#include "hipSYCL/common/spin_lock.hpp"
+#include "hipSYCL/glue/llvm-sscp/jit.hpp"
 #include "hipSYCL/runtime/code_object_invoker.hpp"
 #include "hipSYCL/runtime/cuda/cuda_event.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 
 
 // Forward declare CUstream_st instead of including cuda_runtime_api.h.
@@ -146,6 +149,11 @@ private:
   cuda_backend* _backend;
 
   std::shared_ptr<kernel_cache> _kernel_cache;
+
+  // SSCP submission data
+  common::spin_lock _sscp_submission_spin_lock;
+  glue::jit::cxx_argument_mapper _arg_mapper;
+  kernel_configuration _config;
 };
 
 }

--- a/include/hipSYCL/runtime/cuda/cuda_queue.hpp
+++ b/include/hipSYCL/runtime/cuda/cuda_queue.hpp
@@ -86,6 +86,7 @@ public:
                                unsigned local_mem_size, void **args,
                                std::size_t *arg_sizes, std::size_t num_args,
                                std::string_view kernel_name,
+                               const rt::hcf_kernel_info* kernel_info,
                                const kernel_configuration& config) override;
 private:
   cuda_queue* _queue;
@@ -130,10 +131,10 @@ public:
 
   result submit_sscp_kernel_from_code_object(
       const kernel_operation &op, hcf_object_id hcf_object,
-      std::string_view kernel_name, const rt::range<3> &num_groups,
-      const rt::range<3> &group_size, unsigned local_mem_size, void **args,
-      std::size_t *arg_sizes, std::size_t num_args,
-      const kernel_configuration &config);
+      std::string_view kernel_name, const rt::hcf_kernel_info *kernel_info,
+      const rt::range<3> &num_groups, const rt::range<3> &group_size,
+      unsigned local_mem_size, void **args, std::size_t *arg_sizes,
+      std::size_t num_args, const kernel_configuration &config);
 
   const host_timestamped_event& get_timing_reference() const {
     return _reference_event;

--- a/include/hipSYCL/runtime/hip/hip_queue.hpp
+++ b/include/hipSYCL/runtime/hip/hip_queue.hpp
@@ -78,6 +78,7 @@ public:
                                unsigned local_mem_size, void **args,
                                std::size_t *arg_sizes, std::size_t num_args,
                                std::string_view kernel_name,
+                               const rt::hcf_kernel_info* kernel_info,
                                const kernel_configuration& config) override;
 private:
   hip_queue* _queue;
@@ -121,10 +122,10 @@ public:
 
   result submit_sscp_kernel_from_code_object(
       const kernel_operation &op, hcf_object_id hcf_object,
-      std::string_view kernel_name, const rt::range<3> &num_groups,
-      const rt::range<3> &group_size, unsigned local_mem_size, void **args,
-      std::size_t *arg_sizes, std::size_t num_args,
-      const kernel_configuration &config);
+      std::string_view kernel_name, const rt::hcf_kernel_info *kernel_info,
+      const rt::range<3> &num_groups, const rt::range<3> &group_size,
+      unsigned local_mem_size, void **args, std::size_t *arg_sizes,
+      std::size_t num_args, const kernel_configuration &config);
 
   const host_timestamped_event& get_timing_reference() const {
     return _reference_event;

--- a/include/hipSYCL/runtime/hip/hip_queue.hpp
+++ b/include/hipSYCL/runtime/hip/hip_queue.hpp
@@ -33,6 +33,8 @@
 #include "../generic/host_timestamped_event.hpp"
 #include "../code_object_invoker.hpp"
 
+#include "hipSYCL/common/spin_lock.hpp"
+#include "hipSYCL/glue/llvm-sscp/jit.hpp"
 #include "hip_instrumentation.hpp"
 
 // Avoid including HIP headers to prevent conflicts with CUDA
@@ -137,6 +139,11 @@ private:
   hip_multipass_code_object_invoker _multipass_code_object_invoker;
   hip_sscp_code_object_invoker _sscp_code_object_invoker;
   std::shared_ptr<kernel_cache> _kernel_cache;
+
+  // SSCP submission data
+  common::spin_lock _sscp_submission_spin_lock;
+  glue::jit::cxx_argument_mapper _arg_mapper;
+  kernel_configuration _config;
 };
 
 }

--- a/include/hipSYCL/runtime/inorder_executor.hpp
+++ b/include/hipSYCL/runtime/inorder_executor.hpp
@@ -62,6 +62,8 @@ public:
 
   bool can_execute_on_device(const device_id& dev) const override;
   bool is_submitted_by_me(const dag_node_ptr& node) const override;
+
+  result wait();
 private:
   std::unique_ptr<inorder_queue> _q;
   std::atomic<std::size_t> _num_submitted_operations;

--- a/include/hipSYCL/runtime/kernel_cache.hpp
+++ b/include/hipSYCL/runtime/kernel_cache.hpp
@@ -35,6 +35,7 @@
 #include <array>
 #include "hipSYCL/common/hcf_container.hpp"
 #include "hipSYCL/common/small_map.hpp"
+#include "hipSYCL/common/unordered_dense.hpp"
 #include "hipSYCL/common/stable_running_hash.hpp"
 #include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
@@ -245,15 +246,8 @@ private:
 
   static info_id generate_info_id(hcf_object_id object_id,
                                   std::string_view object_name) {
-    info_id result;
-    result[0] = static_cast<uint64_t>(object_id);
-
-    common::stable_running_hash h;
-    h(object_name.data(), object_name.size());
-
-    result[1] = h.get_current_hash();
-
-    return result;
+    return {ankerl::unordered_dense::hash<hcf_object_id>{}(object_id),
+            ankerl::unordered_dense::hash<std::string_view>{}(object_name)};
   }
 
   struct info_id_hash {
@@ -267,11 +261,9 @@ private:
     }
   };
 
-  std::unordered_map<info_id,
-                     std::unique_ptr<hcf_kernel_info>, info_id_hash>
+  ankerl::unordered_dense::map<info_id, std::unique_ptr<hcf_kernel_info>, info_id_hash>
       _hcf_kernel_info;
-  std::unordered_map<info_id,
-                     std::unique_ptr<hcf_image_info>, info_id_hash>
+  ankerl::unordered_dense::map<info_id, std::unique_ptr<hcf_image_info>, info_id_hash>
       _hcf_image_info;
 
   mutable std::mutex _mutex;
@@ -400,7 +392,7 @@ private:
 
   mutable std::mutex _mutex;
 
-  std::unordered_map<code_object_id, code_object_ptr, rt::kernel_id_hash>
+  ankerl::unordered_dense::map<code_object_id, code_object_ptr, rt::kernel_id_hash>
       _code_objects;
   
   bool _is_first_jit_compilation = true;

--- a/include/hipSYCL/runtime/ocl/ocl_code_object.hpp
+++ b/include/hipSYCL/runtime/ocl/ocl_code_object.hpp
@@ -56,6 +56,7 @@ public:
                                unsigned local_mem_size, void **args,
                                std::size_t *arg_sizes, std::size_t num_args,
                                std::string_view kernel_name,
+                               const rt::hcf_kernel_info* kernel_info,
                                const kernel_configuration& config) override;
 private:
   ocl_queue* _queue;

--- a/include/hipSYCL/runtime/ocl/ocl_queue.hpp
+++ b/include/hipSYCL/runtime/ocl/ocl_queue.hpp
@@ -81,7 +81,8 @@ public:
 
   result submit_sscp_kernel_from_code_object(
       const kernel_operation &op, hcf_object_id hcf_object,
-      const std::string_view kernel_name, const rt::range<3> &num_groups,
+      const std::string_view kernel_name,
+      const rt::hcf_kernel_info *kernel_info, const rt::range<3> &num_groups,
       const rt::range<3> &group_size, unsigned local_mem_size, void **args,
       std::size_t *arg_sizes, std::size_t num_args,
       const kernel_configuration &config);

--- a/include/hipSYCL/runtime/ocl/ocl_queue.hpp
+++ b/include/hipSYCL/runtime/ocl/ocl_queue.hpp
@@ -34,6 +34,8 @@
 #include "../executor.hpp"
 #include "../inorder_queue.hpp"
 
+#include "hipSYCL/common/spin_lock.hpp"
+#include "hipSYCL/glue/llvm-sscp/jit.hpp"
 #include "hipSYCL/runtime/event.hpp"
 #include "hipSYCL/runtime/generic/async_worker.hpp"
 #include "hipSYCL/runtime/ocl/ocl_code_object.hpp"
@@ -116,6 +118,11 @@ private:
   };
 
   protected_state _state;
+
+  // SSCP submission data
+  common::spin_lock _sscp_submission_spin_lock;
+  glue::jit::cxx_argument_mapper _arg_mapper;
+  kernel_configuration _config;
 };
 
 }

--- a/include/hipSYCL/runtime/omp/omp_queue.hpp
+++ b/include/hipSYCL/runtime/omp/omp_queue.hpp
@@ -54,6 +54,7 @@ public:
                                unsigned local_mem_size, void **args,
                                std::size_t *arg_sizes, std::size_t num_args,
                                std::string_view kernel_name,
+                               const rt::hcf_kernel_info* kernel_info,
                                const kernel_configuration& config) override;
   
   virtual rt::range<3> select_group_size(const rt::range<3> &num_groups,
@@ -92,7 +93,8 @@ public:
 
   result submit_sscp_kernel_from_code_object(
       const kernel_operation &op, hcf_object_id hcf_object,
-      const std::string_view kernel_name, const rt::range<3> &num_groups,
+      const std::string_view kernel_name,
+      const rt::hcf_kernel_info *kernel_info, const rt::range<3> &num_groups,
       const rt::range<3> &group_size, unsigned local_mem_size, void **args,
       std::size_t *arg_sizes, std::size_t num_args,
       const kernel_configuration &config);

--- a/include/hipSYCL/runtime/omp/omp_queue.hpp
+++ b/include/hipSYCL/runtime/omp/omp_queue.hpp
@@ -32,6 +32,8 @@
 #include "../executor.hpp"
 #include "../inorder_queue.hpp"
 #include "../device_id.hpp"
+#include "hipSYCL/common/spin_lock.hpp"
+#include "hipSYCL/glue/llvm-sscp/jit.hpp"
 
 namespace hipsycl {
 namespace rt {
@@ -102,6 +104,11 @@ private:
 
   omp_sscp_code_object_invoker _sscp_code_object_invoker;
   std::shared_ptr<kernel_cache> _kernel_cache;
+
+  // SSCP submission data
+  common::spin_lock _sscp_submission_spin_lock;
+  glue::jit::cxx_argument_mapper _arg_mapper;
+  kernel_configuration _config;
 };
 
 }

--- a/include/hipSYCL/runtime/ze/ze_code_object.hpp
+++ b/include/hipSYCL/runtime/ze/ze_code_object.hpp
@@ -57,6 +57,7 @@ public:
                                unsigned local_mem_size, void **args,
                                std::size_t *arg_sizes, std::size_t num_args,
                                std::string_view kernel_name,
+                               const rt::hcf_kernel_info* kernel_info,
                                const kernel_configuration& config) override;
 private:
   ze_queue* _queue;

--- a/include/hipSYCL/runtime/ze/ze_queue.hpp
+++ b/include/hipSYCL/runtime/ze/ze_queue.hpp
@@ -86,10 +86,10 @@ public:
 
   result submit_sscp_kernel_from_code_object(
       const kernel_operation &op, hcf_object_id hcf_object,
-      std::string_view kernel_name, const rt::range<3> &num_groups,
-      const rt::range<3> &group_size, unsigned local_mem_size, void **args,
-      std::size_t *arg_sizes, std::size_t num_args,
-      const kernel_configuration &config);
+      std::string_view kernel_name, const rt::hcf_kernel_info *kernel_info,
+      const rt::range<3> &num_groups, const rt::range<3> &group_size,
+      unsigned local_mem_size, void **args, std::size_t *arg_sizes,
+      std::size_t num_args, const kernel_configuration &config);
 
 private:
   const std::vector<std::shared_ptr<dag_node_event>>&

--- a/include/hipSYCL/runtime/ze/ze_queue.hpp
+++ b/include/hipSYCL/runtime/ze/ze_queue.hpp
@@ -34,6 +34,7 @@
 
 #include "../executor.hpp"
 #include "../inorder_queue.hpp"
+#include "hipSYCL/glue/llvm-sscp/jit.hpp"
 #include "hipSYCL/runtime/code_object_invoker.hpp"
 #include "hipSYCL/runtime/event.hpp"
 #include "hipSYCL/runtime/hints.hpp"
@@ -119,6 +120,10 @@ private:
   // arguably the best strategy to achieve thread-safety is to just have a mutex
   // and lock in every public function.
   std::mutex _mutex;
+
+  // SSCP submission data
+  glue::jit::cxx_argument_mapper _arg_mapper;
+  kernel_configuration _config;  
 };
 
 }

--- a/include/hipSYCL/sycl/queue.hpp
+++ b/include/hipSYCL/sycl/queue.hpp
@@ -29,6 +29,7 @@
 #ifndef HIPSYCL_QUEUE_HPP
 #define HIPSYCL_QUEUE_HPP
 
+#include "hipSYCL/algorithms/util/allocation_cache.hpp"
 #include "hipSYCL/common/debug.hpp"
 #include "hipSYCL/glue/error.hpp"
 #include "hipSYCL/runtime/application.hpp"
@@ -127,6 +128,8 @@ struct AdaptiveCpp_priority : public detail::queue_property {
   int priority;
 };
 
+struct AdaptiveCpp_retargetable : public detail::queue_property {};
+
 // backwards compatibility
 using hipSYCL_coarse_grained_events = AdaptiveCpp_coarse_grained_events;
 using hipSYCL_priority = AdaptiveCpp_priority;
@@ -136,6 +139,39 @@ using hipSYCL_priority = AdaptiveCpp_priority;
 
 class queue : public detail::property_carrying_object
 {
+  struct queue_impl {
+    queue_impl(const context &c, const async_handler &h)
+        : ctx{c}, handler{h}, allocation_cache{
+                                  algorithms::util::allocation_type::device} {}
+
+    rt::runtime_keep_alive_token requires_runtime;  
+    detail::queue_submission_hooks_ptr hooks;
+
+    rt::execution_hints default_hints;
+    context ctx;
+    async_handler handler;
+    bool is_in_order = false;
+    bool is_retargetable = false;
+    // if this is true, in-order queues will be emulated by storing the most recent
+    // event from a submission, and adding that as dependency for the next event.
+    bool needs_in_order_emulation = true;
+    
+
+    // Note: This must not be a weak_ptr, since in the case of instant submissions,
+    // the lifetime of nodes is not guaranteed to exceed task runtime.
+    rt::dag_node_ptr previous_submission = nullptr;
+    std::mutex lock;
+    std::size_t node_group_id = -1;
+    std::shared_ptr<rt::backend_executor> dedicated_inorder_executor = nullptr;
+  
+    // These fields are exclusively hauled around for SYCL 2020 reductions
+    // due to the incredible ingenuity of this API...
+    algorithms::util::allocation_cache allocation_cache;
+    std::weak_ptr<rt::dag_node> most_recent_reduction_kernel;
+
+    // Prevents kernel cache from becoming invalid while we have a queue
+    std::shared_ptr<rt::kernel_cache> kernel_cache;
+  };
 
   template<typename, int, access::mode, access::target>
   friend class detail::automatic_placeholder_requirement_impl;
@@ -145,13 +181,13 @@ public:
       : queue{default_selector_v,
               [](exception_list e) { glue::default_async_handler(e); },
               propList} {
-    assert(_default_hints->has_hint<rt::hints::bind_to_device>());
+    assert(_impl->default_hints.has_hint<rt::hints::bind_to_device>());
   }
 
   explicit queue(const async_handler &asyncHandler,
                  const property_list &propList = {})
       : queue{default_selector_v, asyncHandler, propList} {
-    assert(_default_hints->has_hint<rt::hints::bind_to_device>());
+    assert(_impl->default_hints.has_hint<rt::hints::bind_to_device>());
   }
 
   template <
@@ -225,10 +261,9 @@ public:
                  const std::vector<device> &devices,
                  const async_handler &asyncHandler,
                  const property_list &propList = {})
-      : detail::property_carrying_object{propList}, _ctx{syclContext},
-        _handler{asyncHandler} {
-
-    _default_hints = std::make_shared<rt::execution_hints>();
+      : detail::property_carrying_object{propList} {
+    
+    _impl = std::make_shared<queue_impl>(syclContext, asyncHandler);
 
     if(devices.empty()) {
       throw exception{make_error_code(errc::invalid),
@@ -241,7 +276,7 @@ public:
                         "queue: Device is not in context"};
 
     if(devices.size() == 1){
-      _default_hints->set_hint(rt::hints::bind_to_device{
+      _impl->default_hints.set_hint(rt::hints::bind_to_device{
           detail::extract_rt_device(devices[0])});
     }
     else if(devices.size() > 1) {
@@ -249,7 +284,7 @@ public:
       for(const auto& d : devices) {
         rt_devs.push_back(detail::extract_rt_device(d));
       }
-      _default_hints->set_hint(
+      _impl->default_hints.set_hint(
           rt::hints::bind_to_device_group{rt_devs});
     }
     // Otherwise we are in completely unrestricted scheduling land - don't
@@ -264,13 +299,13 @@ public:
 
 
   context get_context() const {
-    return _ctx;
+    return _impl->ctx;
   }
 
   device get_device() const {
-    if (_default_hints->has_hint<rt::hints::bind_to_device>()) {
+    if (_impl->default_hints.has_hint<rt::hints::bind_to_device>()) {
       rt::device_id id =
-          _default_hints->get_hint<rt::hints::bind_to_device>()->get_device_id();
+          _impl->default_hints.get_hint<rt::hints::bind_to_device>()->get_device_id();
       return device{id};
     } else {
       throw exception{make_error_code(errc::feature_not_supported),
@@ -280,17 +315,17 @@ public:
   }
 
   std::vector<device> get_devices() const {
-    if(_default_hints->has_hint<rt::hints::bind_to_device>()) {
+    if(_impl->default_hints.has_hint<rt::hints::bind_to_device>()) {
 
       rt::device_id id =
-          _default_hints->get_hint<rt::hints::bind_to_device>()->get_device_id();
+          _impl->default_hints.get_hint<rt::hints::bind_to_device>()->get_device_id();
       return std::vector<device>{device{id}};
 
-    } else if(_default_hints->has_hint<rt::hints::bind_to_device_group>()) {
+    } else if(_impl->default_hints.has_hint<rt::hints::bind_to_device_group>()) {
 
       std::vector<device> devs;
       for (const auto &d :
-           _default_hints->get_hint<rt::hints::bind_to_device_group>()
+           _impl->default_hints.get_hint<rt::hints::bind_to_device_group>()
                ->get_devices()) {
         devs.push_back(device{d});
       }
@@ -313,28 +348,38 @@ public:
   }
 
   bool is_in_order() const {
-    return _is_in_order;
+    return _impl->is_in_order;
   }
 
   void wait() {
-    if(_is_in_order) {
-      rt::dag_node_ptr most_recent_event = nullptr;
-      {
-        std::lock_guard<std::mutex> lock{*_lock};
+    if(_impl->is_in_order) {
+      if(_impl->needs_in_order_emulation) {
+        rt::dag_node_ptr most_recent_event = nullptr;
+        {
+          std::lock_guard<std::mutex> lock{_impl->lock};
 
-        most_recent_event = *_previous_submission;
-      }
-      if(most_recent_event) {
-        // Flush DAG for non-submitted events. Note that this does not affect
-        // instant nodes, as they immediately assume the submitted state.
-        if(!most_recent_event->is_submitted())
-          _requires_runtime.get()->dag().flush_sync();
-        
-        most_recent_event->wait();
+          most_recent_event = _impl->previous_submission;
+        }
+        if(most_recent_event) {
+          // Flush DAG for non-submitted events. Note that this does not affect
+          // instant nodes, as they immediately assume the submitted state.
+          if(!most_recent_event->is_submitted())
+            _impl->requires_runtime.get()->dag().flush_sync();
+          
+          most_recent_event->wait();
+        }
+      } else {
+        rt::inorder_executor* exec = AdaptiveCpp_inorder_executor();
+        assert(exec);
+        auto err = exec->wait();
+        if(!err.is_success()) {
+          // We might want to throw a synchronous error here?
+          rt::register_error(err);
+        }
       }
     } else {
-      _requires_runtime.get()->dag().flush_sync();
-      _requires_runtime.get()->dag().wait(_node_group_id);
+      _impl->requires_runtime.get()->dag().flush_sync();
+      _impl->requires_runtime.get()->dag().wait(_impl->node_group_id);
     }
   }
 
@@ -344,7 +389,7 @@ public:
   }
 
   void throw_asynchronous() {
-    glue::throw_asynchronous_errors(_handler);
+    glue::throw_asynchronous_errors(_impl->handler);
   }
 
   template <typename Param>
@@ -353,17 +398,22 @@ public:
 
   template <typename T>
   event submit(const property_list& prop_list, T cgf) {
-    std::lock_guard<std::mutex> lock{*_lock};
+    std::lock_guard<std::mutex> lock{_impl->lock};
 
-    rt::execution_hints hints = *_default_hints;
+    rt::execution_hints hints = _impl->default_hints;
     
     if(prop_list.has_property<property::command_group::AdaptiveCpp_retarget>()) {
+      if(!_impl->is_retargetable)
+        throw exception{make_error_code(errc::invalid),
+                        "queue: Attempted to use AdaptiveCpp_retarget "
+                        "extension with a queue that is not constructed with "
+                        "AdaptiveCpp_retargetable property"};
 
       rt::device_id dev = detail::extract_rt_device(
           prop_list.get_property<property::command_group::AdaptiveCpp_retarget>()
               .dev);
 
-      if(!detail::extract_context_devices(_ctx).contains_device(dev)) {
+      if(!detail::extract_context_devices(_impl->ctx).contains_device(dev)) {
         HIPSYCL_DEBUG_WARNING
             << "queue: Warning: Retargeting operation for a device that is not "
                "part of the queue's context. This can cause terrible problems if the "
@@ -393,11 +443,11 @@ public:
     assert(hints.has_hint<rt::hints::node_group>());
 
     handler cgh{get_context(),
-                _handler,
+                _impl->handler,
                 hints,
-                _requires_runtime.get(),
-                _allocation_cache.get(),
-                _most_recent_reduction_kernel.get()};
+                _impl->requires_runtime.get(),
+                &(_impl->allocation_cache),
+                &(_impl->most_recent_reduction_kernel)};
 
     apply_preferred_group_size<1>(prop_list, cgh);
     apply_preferred_group_size<2>(prop_list, cgh);
@@ -407,7 +457,7 @@ public:
 
     rt::dag_node_ptr node = execute_submission(cgf, cgh);
     
-    return event{node, _handler};
+    return event{node, _impl->handler};
   }
 
 
@@ -426,7 +476,7 @@ public:
 
       event evt = submit(prop_list, cgf);
       // Flush so that we see any errors during submission
-      _requires_runtime.get()->dag().flush_sync();
+      _impl->requires_runtime.get()->dag().flush_sync();
 
       size_t num_errors_end =
           rt::application::errors().num_errors();
@@ -459,18 +509,18 @@ public:
   }
 
   friend bool operator==(const queue& lhs, const queue& rhs)
-  { return lhs._default_hints == rhs._default_hints; }
+  { return lhs._impl == rhs._impl; }
 
   friend bool operator!=(const queue& lhs, const queue& rhs)
   { return !(lhs == rhs); }
 
   std::vector<event> get_wait_list() const {
     if(is_in_order()) {
-      std::lock_guard<std::mutex> lock{*_lock};
+      std::lock_guard<std::mutex> lock{_impl->lock};
 
-      if(auto prev = *_previous_submission){
+      if(auto prev = _impl->previous_submission){
         if(!prev->is_known_complete()) {
-          return std::vector<event>{event{prev, _handler}};
+          return std::vector<event>{event{prev, _impl->handler}};
         }
       }
       // If we don't have a previous event or it's complete,
@@ -480,12 +530,13 @@ public:
     } else {
       // for non-in-order queues we need to ask the runtime for
       // all nodes of this node group
-      _requires_runtime.get()->dag().flush_sync();
-      auto nodes = _requires_runtime.get()->dag().get_group(_node_group_id);
+      _impl->requires_runtime.get()->dag().flush_sync();
+      auto nodes =
+          _impl->requires_runtime.get()->dag().get_group(_impl->node_group_id);
       std::vector<event> evts;
       for(auto node : nodes){
         if(!node->is_known_complete())
-          evts.push_back(event{node, _handler});
+          evts.push_back(event{node, _impl->handler});
       }
 
       return evts;
@@ -955,13 +1006,14 @@ public:
   }
 
   std::size_t AdaptiveCpp_hash_code() const {
-    return _node_group_id;
+    return _impl->node_group_id;
   }
 
   rt::inorder_executor* AdaptiveCpp_inorder_executor() const {
-    if(!_dedicated_inorder_executor)
+    if(!_impl->dedicated_inorder_executor)
       return nullptr;
-    return static_cast<rt::inorder_executor*>(_dedicated_inorder_executor.get());
+    return static_cast<rt::inorder_executor *>(
+        _impl->dedicated_inorder_executor.get());
   }
 
 
@@ -989,17 +1041,17 @@ private:
 
   template <class Cgf>
   rt::dag_node_ptr execute_submission(Cgf cgf, handler &cgh) {
-    if (is_in_order()) {
-      auto previous = *_previous_submission;
+    if (is_in_order() && _impl->needs_in_order_emulation) {
+      auto previous = _impl->previous_submission;
       if(previous)
-        cgh.depends_on(event{previous, _handler});
+        cgh.depends_on(event{previous, _impl->handler});
     }
     
     cgf(cgh);
 
     rt::dag_node_ptr node = this->extract_dag_node(cgh);
-    if (is_in_order()) {
-      *_previous_submission = node;
+    if (is_in_order() && _impl->needs_in_order_emulation) {
+      _impl->previous_submission = node;
     }
     return node;
   }
@@ -1036,36 +1088,36 @@ private:
 
 
   void init() {
+    assert(_impl);
+
     static std::atomic<std::size_t> node_group_id;
-    _node_group_id = ++node_group_id;
+    _impl->node_group_id = ++node_group_id;
     
     HIPSYCL_DEBUG_INFO << "queue: Constructed queue with node group id "
-                       << _node_group_id << std::endl;
+                       << _impl->node_group_id << std::endl;
 
-    _default_hints->set_hint(rt::hints::node_group{_node_group_id});
+    _impl->default_hints.set_hint(rt::hints::node_group{_impl->node_group_id});
 
     if (this->has_property<property::queue::enable_profiling>()) {
-      _default_hints->set_hint(
+      _impl->default_hints.set_hint(
           rt::hints::request_instrumentation_submission_timestamp{});
-      _default_hints->set_hint(
+      _impl->default_hints.set_hint(
               rt::hints::request_instrumentation_start_timestamp{});
-      _default_hints->set_hint(
+      _impl->default_hints.set_hint(
               rt::hints::request_instrumentation_finish_timestamp{});
     }
     if(this->has_property<property::queue::AdaptiveCpp_coarse_grained_events>()){
-      _default_hints->set_hint(
+      _impl->default_hints.set_hint(
           rt::hints::coarse_grained_synchronization{});
     }
 
-    _is_in_order = this->has_property<property::queue::in_order>();
-    _lock = std::make_shared<std::mutex>();
-    _previous_submission = std::make_shared<rt::dag_node_ptr>(nullptr);
-    _allocation_cache = std::make_shared<algorithms::util::allocation_cache>(
-        algorithms::util::allocation_type::device);
-    _most_recent_reduction_kernel =
-        std::make_shared<std::weak_ptr<rt::dag_node>>();
+    if(this->has_property<property::queue::AdaptiveCpp_retargetable>()) {
+      _impl->is_retargetable = true;
+    }
 
-    if(_is_in_order && get_devices().size() == 1) {
+    _impl->is_in_order = this->has_property<property::queue::in_order>();
+
+    if(_impl->is_in_order && get_devices().size() == 1) {
       int priority = 0;
       if(this->has_property<property::queue::AdaptiveCpp_priority>()) {
         priority = this->get_property<property::queue::AdaptiveCpp_priority>().priority;
@@ -1074,46 +1126,35 @@ private:
       rt::device_id rt_dev = detail::extract_rt_device(this->get_device());
       // Dedicated executor may not be supported by all backends,
       // so this might return nullptr.
-      _dedicated_inorder_executor =
-          _requires_runtime.get()
+      _impl->dedicated_inorder_executor =
+          _impl->requires_runtime.get()
               ->backends()
               .get(rt_dev.get_backend())
               ->create_inorder_executor(rt_dev, priority);
       
-      if(_dedicated_inorder_executor) {
-        _default_hints->set_hint(rt::hints::prefer_executor{_dedicated_inorder_executor});
+      if(_impl->dedicated_inorder_executor) {
+        _impl->default_hints.set_hint(
+            rt::hints::prefer_executor{_impl->dedicated_inorder_executor});
       }
     }
 
-    this->_hooks = detail::queue_submission_hooks_ptr{
+    _impl->hooks = detail::queue_submission_hooks_ptr{
           new detail::queue_submission_hooks{}};
+
+    if (_impl->is_in_order && _impl->dedicated_inorder_executor &&
+        !_impl->is_retargetable)
+      _impl->needs_in_order_emulation = false;
+    
+    _impl->kernel_cache = rt::kernel_cache::get();
   }
 
 
   detail::queue_submission_hooks_ptr get_hooks() const
   {
-    return _hooks;
+    return _impl->hooks;
   }
 
-  rt::runtime_keep_alive_token _requires_runtime;  
-  detail::queue_submission_hooks_ptr _hooks;
-
-  std::shared_ptr<rt::execution_hints> _default_hints;
-  context _ctx;
-  async_handler _handler;
-  bool _is_in_order;
-
-  // Note: This must not be a weak_ptr, since in the case of instant submissions,
-  // the lifetime of nodes is not guaranteed to exceed task runtime.
-  std::shared_ptr<rt::dag_node_ptr> _previous_submission;
-  std::shared_ptr<std::mutex> _lock;
-  std::size_t _node_group_id;
-  std::shared_ptr<rt::backend_executor> _dedicated_inorder_executor;
-  
-  // These fields are exclusively hauled around for SYCL 2020 reductions
-  // due to the incredible ingenuity of this API...
-  std::shared_ptr<algorithms::util::allocation_cache> _allocation_cache;
-  std::shared_ptr<std::weak_ptr<rt::dag_node>> _most_recent_reduction_kernel;
+  std::shared_ptr<queue_impl> _impl;
 };
 
 HIPSYCL_SPECIALIZE_GET_INFO(queue, context)
@@ -1133,7 +1174,7 @@ HIPSYCL_SPECIALIZE_GET_INFO(queue, reference_count)
 
 HIPSYCL_SPECIALIZE_GET_INFO(queue, AdaptiveCpp_node_group)
 {
-  return _node_group_id;
+  return _impl->node_group_id;
 }
 
 namespace detail{

--- a/src/runtime/cuda/cuda_queue.cpp
+++ b/src/runtime/cuda/cuda_queue.cpp
@@ -29,6 +29,7 @@
 #include "hipSYCL/common/appdb.hpp"
 #include "hipSYCL/common/filesystem.hpp"
 #include "hipSYCL/common/hcf_container.hpp"
+#include "hipSYCL/common/spin_lock.hpp"
 #include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/runtime/adaptivity_engine.hpp"
 #include "hipSYCL/runtime/application.hpp"
@@ -90,7 +91,7 @@ void host_synchronization_callback(cudaStream_t stream, cudaError_t status,
 class cuda_instrumentation_guard {
 public:
   cuda_instrumentation_guard(cuda_queue *q,
-                             operation &op, dag_node_ptr node) 
+                             operation &op, dag_node* node) 
                              : _queue{q}, _operation{&op}, _node{node} {
     assert(q);
     
@@ -143,7 +144,7 @@ public:
 private:
   cuda_queue* _queue;
   operation* _operation;
-  dag_node_ptr _node;
+  dag_node* _node;
   std::shared_ptr<dag_node_event> _task_start;
 };
 
@@ -307,7 +308,7 @@ result cuda_queue::submit_memcpy(memcpy_operation & op, const dag_node_ptr& node
   assert(dimension >= 1 && dimension <= 3);
 
 
-  cuda_instrumentation_guard instrumentation{this, op, node};
+  cuda_instrumentation_guard instrumentation{this, op, node.get()};
 
   cudaError_t err = cudaSuccess;
   if (dimension == 1) {
@@ -367,7 +368,7 @@ result cuda_queue::submit_kernel(kernel_operation &op, const dag_node_ptr& node)
   cap.provide_multipass_invoker(&_multipass_code_object_invoker);
   cap.provide_sscp_invoker(&_sscp_code_object_invoker);
   
-  cuda_instrumentation_guard instrumentation{this, op, node};
+  cuda_instrumentation_guard instrumentation{this, op, node.get()};
   return op.get_launcher().invoke(backend_id::cuda, this, cap, node.get());
 }
 
@@ -376,7 +377,7 @@ result cuda_queue::submit_prefetch(prefetch_operation& op, const dag_node_ptr& n
   
   cudaError_t err = cudaSuccess;
   
-  cuda_instrumentation_guard instrumentation{this, op, node};
+  cuda_instrumentation_guard instrumentation{this, op, node.get()};
   if (op.get_target().is_host()) {
     err = cudaMemPrefetchAsync(op.get_pointer(), op.get_num_bytes(),
                                         cudaCpuDeviceId, get_stream());
@@ -400,7 +401,7 @@ result cuda_queue::submit_prefetch(prefetch_operation& op, const dag_node_ptr& n
 
 result cuda_queue::submit_memset(memset_operation &op, const dag_node_ptr& node) {
 
-  cuda_instrumentation_guard instrumentation{this, op, node};
+  cuda_instrumentation_guard instrumentation{this, op, node.get()};
   
   cudaError_t err = cudaMemsetAsync(op.get_pointer(), op.get_pattern(),
                                     op.get_num_bytes(), get_stream());
@@ -587,6 +588,8 @@ result cuda_queue::submit_sscp_kernel_from_code_object(
 
   int device = this->_dev.get_id();
 
+  common::spin_lock_guard lock{_sscp_submission_spin_lock};
+
   cuda_hardware_context *ctx = static_cast<cuda_hardware_context *>(
       this->_backend->get_hardware_manager()->get_device(device));
 
@@ -601,10 +604,11 @@ result cuda_queue::submit_sscp_kernel_from_code_object(
             std::string{kernel_name}});
   }
 
+  
+  _arg_mapper.construct_mapping(*kernel_info, args, arg_sizes,
+                                            num_args);
 
-glue::jit::cxx_argument_mapper arg_mapper{*kernel_info, args, arg_sizes,
-                                            num_args};
-  if(!arg_mapper.mapping_available()) {
+  if(!_arg_mapper.mapping_available()) {
     return make_error(
         __acpp_here(),
         error_info{
@@ -612,31 +616,30 @@ glue::jit::cxx_argument_mapper arg_mapper{*kernel_info, args, arg_sizes,
   }
 
   kernel_adaptivity_engine adaptivity_engine{
-      hcf_object, kernel_name, kernel_info, arg_mapper, num_groups,
+      hcf_object, kernel_name, kernel_info, _arg_mapper, num_groups,
       group_size, args,        arg_sizes,   num_args, local_mem_size};
 
-static thread_local kernel_configuration config;
-  config = initial_config;
-  config.append_base_configuration(
+  _config = initial_config;
+  _config.append_base_configuration(
       kernel_base_config_parameter::backend_id, backend_id::cuda);
-  config.append_base_configuration(
+  _config.append_base_configuration(
       kernel_base_config_parameter::compilation_flow,
       compilation_flow::sscp);
-  config.append_base_configuration(
+  _config.append_base_configuration(
       kernel_base_config_parameter::hcf_object_id, hcf_object);
   
   for(const auto& flag : kernel_info->get_compilation_flags())
-    config.set_build_flag(flag);
+    _config.set_build_flag(flag);
   for(const auto& opt : kernel_info->get_compilation_options())
-    config.set_build_option(opt.first, opt.second);
+    _config.set_build_option(opt.first, opt.second);
   // TODO This is incorrect, we should attempt to find a better way to determine
   // the right ptx version
-  config.set_build_option(kernel_build_option::ptx_version,
+  _config.set_build_option(kernel_build_option::ptx_version,
                           compute_capability);
-  config.set_build_option(kernel_build_option::ptx_target_device,
+  _config.set_build_option(kernel_build_option::ptx_target_device,
                           compute_capability);
 
-  auto binary_configuration_id = adaptivity_engine.finalize_binary_configuration(config);
+  auto binary_configuration_id = adaptivity_engine.finalize_binary_configuration(_config);
   auto code_object_configuration_id = binary_configuration_id;
   kernel_configuration::extend_hash(
       code_object_configuration_id,
@@ -660,11 +663,11 @@ static thread_local kernel_configuration config;
     rt::result err;
     if(kernel_names.size() == 1) {
       err = glue::jit::dead_argument_elimination::compile_kernel(
-          translator.get(), hcf_object, selected_image_name, config,
+          translator.get(), hcf_object, selected_image_name, _config,
           binary_configuration_id, compiled_image);
     } else {
       err = glue::jit::compile(translator.get(),
-        hcf_object, selected_image_name, config, compiled_image);
+        hcf_object, selected_image_name, _config, compiled_image);
     }
 
     if(!err.is_success()) {
@@ -682,7 +685,7 @@ static thread_local kernel_configuration config;
     std::string target_arch_name = ctx->get_device_arch();
 
     cuda_sscp_executable_object *exec_obj = new cuda_sscp_executable_object{
-        ptx_image, target_arch_name, hcf_object, kernel_names, device, config};
+        ptx_image, target_arch_name, hcf_object, kernel_names, device, _config};
     result r = exec_obj->get_build_result();
 
     HIPSYCL_DEBUG_INFO
@@ -713,7 +716,7 @@ static thread_local kernel_configuration config;
   }
 
   if(obj->get_jit_output_metadata().kernel_retained_arguments_indices.has_value()) {
-    arg_mapper.apply_dead_argument_elimination_mask(
+    _arg_mapper.apply_dead_argument_elimination_mask(
         obj->get_jit_output_metadata()
             .kernel_retained_arguments_indices.value());
   }
@@ -722,7 +725,7 @@ static thread_local kernel_configuration config;
 
   return launch_kernel_from_module(cumodule, kernel_name, num_groups,
                                    group_size, local_mem_size, _stream,
-                                   arg_mapper.get_mapped_args());
+                                   _arg_mapper.get_mapped_args());
 
 #else
   return make_error(

--- a/src/runtime/cuda/cuda_queue.cpp
+++ b/src/runtime/cuda/cuda_queue.cpp
@@ -575,13 +575,12 @@ result cuda_queue::submit_multipass_kernel_from_code_object(
                                    kernel_args);
 }
 
-
 result cuda_queue::submit_sscp_kernel_from_code_object(
     const kernel_operation &op, hcf_object_id hcf_object,
-    std::string_view kernel_name, const rt::range<3> &num_groups,
-    const rt::range<3> &group_size, unsigned local_mem_size, void **args,
-    std::size_t *arg_sizes, std::size_t num_args,
-    const kernel_configuration &initial_config) {
+    std::string_view kernel_name, const rt::hcf_kernel_info *kernel_info,
+    const rt::range<3> &num_groups, const rt::range<3> &group_size,
+    unsigned local_mem_size, void **args, std::size_t *arg_sizes,
+    std::size_t num_args, const kernel_configuration &initial_config) {
 #ifdef HIPSYCL_WITH_SSCP_COMPILER
 
   this->activate_device();
@@ -595,8 +594,6 @@ result cuda_queue::submit_sscp_kernel_from_code_object(
 
   unsigned compute_capability = ctx->get_compute_capability();
 
-  const hcf_kernel_info *kernel_info =
-      rt::hcf_cache::get().get_kernel_info(hcf_object, kernel_name);
   if(!kernel_info) {
     return make_error(
         __acpp_here(),
@@ -789,13 +786,13 @@ result cuda_sscp_code_object_invoker::submit_kernel(
     const rt::range<3> &num_groups, const rt::range<3> &group_size,
     unsigned local_mem_size, void **args, std::size_t *arg_sizes,
     std::size_t num_args, std::string_view kernel_name,
+    const rt::hcf_kernel_info *kernel_info,
     const kernel_configuration &config) {
 
   return _queue->submit_sscp_kernel_from_code_object(
-      op, hcf_object, kernel_name, num_groups, group_size, local_mem_size, args,
-      arg_sizes, num_args, config);
+      op, hcf_object, kernel_name, kernel_info, num_groups, group_size,
+      local_mem_size, args, arg_sizes, num_args, config);
 }
-
 }
 }
 

--- a/src/runtime/hip/hip_queue.cpp
+++ b/src/runtime/hip/hip_queue.cpp
@@ -581,11 +581,11 @@ result hip_queue::submit_multipass_kernel_from_code_object(
 }
 
 result hip_queue::submit_sscp_kernel_from_code_object(
-      const kernel_operation &op, hcf_object_id hcf_object,
-      std::string_view kernel_name, const rt::range<3> &num_groups,
-      const rt::range<3> &group_size, unsigned local_mem_size, void **args,
-      std::size_t *arg_sizes, std::size_t num_args,
-      const kernel_configuration &initial_config) {
+    const kernel_operation &op, hcf_object_id hcf_object,
+    std::string_view kernel_name, const rt::hcf_kernel_info *kernel_info,
+    const rt::range<3> &num_groups, const rt::range<3> &group_size,
+    unsigned local_mem_size, void **args, std::size_t *arg_sizes,
+    std::size_t num_args, const kernel_configuration &initial_config) {
 #ifdef HIPSYCL_WITH_SSCP_COMPILER
   this->activate_device();
   
@@ -596,8 +596,6 @@ result hip_queue::submit_sscp_kernel_from_code_object(
 
   std::string target_arch_name = ctx->get_device_arch();
 
-  const hcf_kernel_info *kernel_info =
-      rt::hcf_cache::get().get_kernel_info(hcf_object, kernel_name);
   if(!kernel_info) {
     return make_error(
         __acpp_here(),
@@ -766,13 +764,13 @@ result hip_sscp_code_object_invoker::submit_kernel(
     const rt::range<3> &num_groups, const rt::range<3> &group_size,
     unsigned local_mem_size, void **args, std::size_t *arg_sizes,
     std::size_t num_args, std::string_view kernel_name,
+    const rt::hcf_kernel_info *kernel_info,
     const kernel_configuration &config) {
 
   return _queue->submit_sscp_kernel_from_code_object(
-      op, hcf_object, kernel_name, num_groups, group_size, local_mem_size, args,
-      arg_sizes, num_args, config);
+      op, hcf_object, kernel_name, kernel_info, num_groups, group_size,
+      local_mem_size, args, arg_sizes, num_args, config);
 }
-
 }
 }
 

--- a/src/runtime/inorder_executor.cpp
+++ b/src/runtime/inorder_executor.cpp
@@ -216,5 +216,9 @@ bool inorder_executor::is_submitted_by_me(const dag_node_ptr& node) const {
   return node->get_assigned_executor() == this;
 }
 
+result inorder_executor::wait() {
+  return _q->wait();
+}
+
 }
 }

--- a/src/runtime/ocl/ocl_code_object.cpp
+++ b/src/runtime/ocl/ocl_code_object.cpp
@@ -40,13 +40,14 @@ result ocl_sscp_code_object_invoker::submit_kernel(
     const rt::range<3> &num_groups, const rt::range<3> &group_size,
     unsigned int local_mem_size, void **args, std::size_t *arg_sizes,
     std::size_t num_args, std::string_view kernel_name,
+    const rt::hcf_kernel_info *kernel_info,
     const kernel_configuration &config) {
 
   assert(_queue);
 
   return _queue->submit_sscp_kernel_from_code_object(
-      op, hcf_object, kernel_name, num_groups, group_size, local_mem_size, args,
-      arg_sizes, num_args, config);
+      op, hcf_object, kernel_name, kernel_info, num_groups, group_size,
+      local_mem_size, args, arg_sizes, num_args, config);
 }
 
 ocl_executable_object::ocl_executable_object(const cl::Context& ctx, cl::Device& dev,

--- a/src/runtime/ocl/ocl_queue.cpp
+++ b/src/runtime/ocl/ocl_queue.cpp
@@ -393,16 +393,13 @@ ocl_hardware_manager *ocl_queue::get_hardware_manager() const {
 
 result ocl_queue::submit_sscp_kernel_from_code_object(
     const kernel_operation &op, hcf_object_id hcf_object,
-    std::string_view kernel_name, const rt::range<3> &num_groups,
-    const rt::range<3> &group_size, unsigned local_mem_size, void **args,
-    std::size_t *arg_sizes, std::size_t num_args,
-    const kernel_configuration &initial_config) {
-
+    std::string_view kernel_name, const rt::hcf_kernel_info *kernel_info,
+    const rt::range<3> &num_groups, const rt::range<3> &group_size,
+    unsigned local_mem_size, void **args, std::size_t *arg_sizes,
+    std::size_t num_args, const kernel_configuration &initial_config) {
 
 #ifdef HIPSYCL_WITH_SSCP_COMPILER
 
-  const hcf_kernel_info *kernel_info =
-      rt::hcf_cache::get().get_kernel_info(hcf_object, kernel_name);
   if(!kernel_info) {
     return make_error(
         __acpp_here(),
@@ -561,9 +558,7 @@ result ocl_queue::submit_sscp_kernel_from_code_object(
       error_info{"ocl_queue: SSCP kernel launch was requested, but hipSYCL was "
                  "not built with OpenCL SSCP support."});
 #endif
-
 }
-
 
 void ocl_queue::register_submitted_op(cl::Event evt) {
   this->_state.set_most_recent_event(std::make_shared<ocl_node_event>(

--- a/src/runtime/omp/omp_queue.cpp
+++ b/src/runtime/omp/omp_queue.cpp
@@ -398,15 +398,13 @@ result omp_queue::submit_kernel(kernel_operation &op, const dag_node_ptr& node) 
 
 result omp_queue::submit_sscp_kernel_from_code_object(
     const kernel_operation &op, hcf_object_id hcf_object,
-    std::string_view kernel_name, const rt::range<3> &num_groups,
-    const rt::range<3> &group_size, unsigned local_mem_size, void **args,
-    std::size_t *arg_sizes, std::size_t num_args,
-    const kernel_configuration &initial_config) {
+    std::string_view kernel_name, const rt::hcf_kernel_info *kernel_info,
+    const rt::range<3> &num_groups, const rt::range<3> &group_size,
+    unsigned local_mem_size, void **args, std::size_t *arg_sizes,
+    std::size_t num_args, const kernel_configuration &initial_config) {
 #ifdef HIPSYCL_WITH_SSCP_COMPILER
   common::spin_lock_guard lock{_sscp_submission_spin_lock};
 
-  const hcf_kernel_info *kernel_info =
-      rt::hcf_cache::get().get_kernel_info(hcf_object, kernel_name);
   if (!kernel_info) {
     return make_error(
         __acpp_here(),
@@ -610,10 +608,11 @@ result omp_sscp_code_object_invoker::submit_kernel(
     const rt::range<3> &num_groups, const rt::range<3> &group_size,
     unsigned local_mem_size, void **args, std::size_t *arg_sizes,
     std::size_t num_args, std::string_view kernel_name,
+    const rt::hcf_kernel_info *kernel_info,
     const kernel_configuration &config) {
 
   return _queue->submit_sscp_kernel_from_code_object(
-      op, hcf_object, kernel_name, num_groups, group_size,
+      op, hcf_object, kernel_name, kernel_info, num_groups, group_size,
       local_mem_size, args, arg_sizes, num_args, config);
 }
 

--- a/src/runtime/ze/ze_code_object.cpp
+++ b/src/runtime/ze/ze_code_object.cpp
@@ -47,13 +47,14 @@ result ze_sscp_code_object_invoker::submit_kernel(
     const rt::range<3> &num_groups, const rt::range<3> &group_size,
     unsigned int local_mem_size, void **args, std::size_t *arg_sizes,
     std::size_t num_args, std::string_view kernel_name,
+    const rt::hcf_kernel_info *kernel_info,
     const kernel_configuration &config) {
 
   assert(_queue);
 
   return _queue->submit_sscp_kernel_from_code_object(
-      op, hcf_object, kernel_name, num_groups, group_size, local_mem_size, args,
-      arg_sizes, num_args, config);
+      op, hcf_object, kernel_name, kernel_info, num_groups, group_size,
+      local_mem_size, args, arg_sizes, num_args, config);
 }
 
 ze_executable_object::ze_executable_object(ze_context_handle_t ctx,

--- a/src/runtime/ze/ze_queue.cpp
+++ b/src/runtime/ze/ze_queue.cpp
@@ -440,13 +440,12 @@ void ze_queue::register_submitted_op(std::shared_ptr<dag_node_event> evt) {
   _enqueued_synchronization_ops.push_back(evt);
 }
 
-
 result ze_queue::submit_sscp_kernel_from_code_object(
-      const kernel_operation &op, hcf_object_id hcf_object,
-      std::string_view kernel_name, const rt::range<3> &num_groups,
-      const rt::range<3> &group_size, unsigned local_mem_size, void **args,
-      std::size_t *arg_sizes, std::size_t num_args,
-      const kernel_configuration &initial_config) {
+    const kernel_operation &op, hcf_object_id hcf_object,
+    std::string_view kernel_name, const rt::hcf_kernel_info *kernel_info,
+    const rt::range<3> &num_groups, const rt::range<3> &group_size,
+    unsigned local_mem_size, void **args, std::size_t *arg_sizes,
+    std::size_t num_args, const kernel_configuration &initial_config) {
 
 #ifdef HIPSYCL_WITH_SSCP_COMPILER
 
@@ -455,8 +454,6 @@ result ze_queue::submit_sscp_kernel_from_code_object(
   ze_context_handle_t ctx = hw_ctx->get_ze_context();
   ze_device_handle_t dev = hw_ctx->get_ze_device();
 
-  const hcf_kernel_info *kernel_info =
-      rt::hcf_cache::get().get_kernel_info(hcf_object, kernel_name);
   if(!kernel_info) {
     return make_error(
         __acpp_here(),
@@ -612,8 +609,6 @@ result ze_queue::submit_sscp_kernel_from_code_object(
                  "not built with Level Zero SSCP support."});
 #endif
 }
-
-
 }
 }
 

--- a/tests/sycl/extensions.cpp
+++ b/tests/sycl/extensions.cpp
@@ -1104,7 +1104,9 @@ BOOST_AUTO_TEST_CASE(queue_wait_list) {
   using namespace cl;
   sycl::queue out_of_order_q;
   sycl::queue in_order_q{
-      sycl::property_list{sycl::property::queue::in_order{}}};
+      sycl::property_list{sycl::property::queue::in_order{},
+                          // Needed for accurate get_wait_list results
+                          sycl::property::queue::AdaptiveCpp_retargetable{}}};
 
   auto test = [](sycl::queue& q){
     std::vector<sycl::event> evts;

--- a/tests/sycl/extensions.cpp
+++ b/tests/sycl/extensions.cpp
@@ -523,7 +523,10 @@ BOOST_AUTO_TEST_CASE(cg_property_retarget) {
   sycl::device host_device{sycl::detail::get_host_device()};
 
   if(target_devices.size() > 0) {
-    sycl::queue q{target_devices[0], sycl::property_list{sycl::property::queue::in_order{}}};
+    sycl::queue q{
+        target_devices[0],
+        sycl::property_list{sycl::property::queue::in_order{},
+                            sycl::property::queue::AdaptiveCpp_retargetable{}}};
     int* ptr = sycl::malloc_shared<int>(1, q);
     *ptr = 0;
 

--- a/tests/sycl/usm.cpp
+++ b/tests/sycl/usm.cpp
@@ -158,7 +158,11 @@ BOOST_AUTO_TEST_CASE(explicit_queue_dependencies) {
 
 
 BOOST_AUTO_TEST_CASE(in_order_queue) {
-  sycl::queue q{sycl::property_list{sycl::property::queue::in_order{}}};
+  sycl::queue q{sycl::property_list{
+      sycl::property::queue::in_order{},
+      sycl::property::queue::AdaptiveCpp_retargetable{} // Needed for accurate
+                                                        // get_wait_list results
+  }};
 
   BOOST_CHECK(q.is_in_order());
 


### PR DESCRIPTION
This PR introduces more kernel submission latency optimizations. SSCP kernel submission latency is down 20-30% with this PR. The SMCP compilation flows may also benefit, but to a lesser extent.

- If a dedicated in-order executor is used, we no longer add dependencies on the same queue. Those would be removed later on anyway, but that adds a bit of latencies. 
   - This change breaks the `AdaptiveCpp_retarget` extension, which relies on in-order semantics emulation, so this extension now requires that the queue is explicitly constructed with a new `AdaptiveCpp_retargetable` queue property. The queue property again enables adding these in-order events as dependencies.
- We now use an unordered dense hash map instead of `std::unordered_map` in a couple of key places, like kernel cache and HCF cache
- Some optimizations around how things are passed into the `handler` when it is constructed
- A more efficient hash algorithm when constructing the kernel configuration hash. Instead of processing on byte at a time, we now process 64 bit words.
- Replace `thread_local` in the SSCP submission path (this affects kernel configuration and arg mapper) with class members and spin locks, which it turns out is much faster than thread local storage.
- Simplify instrumentation guards so that they don't interfere so much with submissions that ultimately don't request instrumentation
- HCF kernel info is now only queried a single time per kernel instantiation, and then cached. This avoids having to query the hash map for every submission for the kernel info.

@al42and not sure how large the improvements for SMCP are going to be, but this might be worth a try still! Are you still using `get_wait_list`? If so there might be an issue since this PR optimizes away events for the in-order case.