### PR TITLE
Remove the warning when no_init/discard was not used

### DIFF
--- a/src/runtime/dag_direct_scheduler.cpp
+++ b/src/runtime/dag_direct_scheduler.cpp
@@ -311,13 +311,6 @@ result submit_requirement(runtime* rt, dag_node_ptr req) {
           req->assign_to_device(original_device);
         }
       });
-    } else {
-      HIPSYCL_DEBUG_WARNING
-          << "dag_direct_scheduler: Detected a requirement that is neither of "
-             "discard access mode (SYCL 1.2.1) nor no_init property (SYCL 2020) "
-             "that accesses uninitialized data. Consider changing to "
-             "discard/no_init. Optimizing potential data transfers away."
-          << std::endl;
     }
   }
   if (!res.is_success())


### PR DESCRIPTION
Currently we are emitting a warning when a buffer is used for the first time without the `no_init` property. This warning has proven to not be particularly useful:

- Users tend to misinterpret it as a reason for concern, when it is actually only a mild optimization hint that does not even affect AdaptiveCpp
- There is source location associated with the warning, which makes it difficult to find out where even the problem comes from
- In complex code, when exactly the buffer is used for the first time might depend on non-trivial conditions, making it difficult to correctly place `no_init` at all the right accessors.