### PR TITLE
Fix legacy multi_ptr ctor

### DIFF
--- a/include/hipSYCL/sycl/libkernel/multi_ptr.hpp
+++ b/include/hipSYCL/sycl/libkernel/multi_ptr.hpp
@@ -689,7 +689,7 @@ public:
   multi_ptr(multi_ptr &&) = default;
 
   ACPP_UNIVERSAL_TARGET
-  explicit multi_ptr(ElementType *ptr) : _ptr{ptr} {}
+  multi_ptr(ElementType *ptr) : _ptr{ptr} {}
 
   ACPP_UNIVERSAL_TARGET
   multi_ptr(std::nullptr_t) : _ptr{nullptr} {}


### PR DESCRIPTION
In SYCL2020, the legacy interface for `multi_ptr<ElementType, Space, access::decorated::legacy` has non-explicit constructor from a raw pointer.

See the listing below Table 92 in SYCL2020 spec rev. 8