### PR TITLE
[stdpar] Enable offloading of std::execution::par for devices supporting it

### DIFF
--- a/doc/stdpar.md
+++ b/doc/stdpar.md
@@ -17,6 +17,7 @@ AdaptiveCpp by default uses some experimental heuristics to determine if a probl
 
 Currently, the following execution policies qualify for offloading:
 * `par_unseq`
+* `par` (experimental; will only be offloaded on hardware that provides independent work item forward progress guarantees such as recent NVIDIA GPUs)
 
 Offloading is implemented for the following STL algorithms:
 
@@ -112,3 +113,5 @@ If you are on a system that supports system-level USM, i.e. a system where every
 The functionality supported in device code aligns with the kernel restrictions from SYCL. This means that no exceptions, dynamic polymorphism, dynamic memory management, or calls to external shared libraries are allowed. Note that this functionality might already be prohibited in the C++ `par_unseq` model anyway.
 
 The `std::` math functions are supported in device code in an experimental state when using the generic SSCP compilation flow (`--acpp-targets=generic`). This is accomplished using a dedicated compiler pass that maps standard functions to our SSCP builtins.
+
+When using the `par` execution policy, `std::atomic` and `std::atomic_ref` support in device code is available when using the generic SSCP compilation flow (`--acpp-targets=generic`), but experimental.

--- a/include/hipSYCL/runtime/hardware.hpp
+++ b/include/hipSYCL/runtime/hardware.hpp
@@ -35,7 +35,8 @@ enum class device_support_aspect {
   usm_atomic_shared_allocations,
   usm_system_allocations,
   execution_timestamps,
-  sscp_kernels
+  sscp_kernels,
+  work_item_independent_forward_progress
 };
 
 enum class device_uint_property {

--- a/include/hipSYCL/std/stdpar/detail/execution_fwd.hpp
+++ b/include/hipSYCL/std/stdpar/detail/execution_fwd.hpp
@@ -18,15 +18,28 @@ namespace hipsycl::stdpar {
 using par_unseq =
     __pstl::execution::parallel_unsequenced_policy;
 
+using par =
+    __pstl::execution::parallel_policy;
+
 struct par_unseq_host_fallback_policy
     : public __pstl::execution::parallel_unsequenced_policy {};
+
+struct par_host_fallback_policy
+    : public __pstl::execution::parallel_policy {};
+
 inline constexpr par_unseq_host_fallback_policy par_unseq_host_fallback {};
+inline constexpr par_host_fallback_policy par_host_fallback {};
 }
 
 namespace __pstl::execution {
 template <>
 struct is_execution_policy<hipsycl::stdpar::par_unseq_host_fallback_policy>
     : std::true_type {};
+
+template <>
+struct is_execution_policy<hipsycl::stdpar::par_host_fallback_policy>
+    : std::true_type {};
+
 }
 
 

--- a/include/hipSYCL/std/stdpar/detail/offload.hpp
+++ b/include/hipSYCL/std/stdpar/detail/offload.hpp
@@ -383,6 +383,12 @@ private:
 
 template <class AlgorithmType, class Size, typename... Args>
 bool should_offload(AlgorithmType type, Size n, const Args &...args) {
+  if constexpr (std::is_same_v<typename AlgorithmType::execution_policy,
+                               hipsycl::stdpar::par>) {
+    if (!detail::stdpar_tls_runtime::get()
+             .device_has_work_item_independent_forward_progress())
+      return false;
+  }
   // If we have system USM, no need to validate pointers as all
   // will be automatically valid.
 #if !defined(__ACPP_STDPAR_ASSUME_SYSTEM_USM__)

--- a/include/hipSYCL/std/stdpar/detail/offload_heuristic_db.hpp
+++ b/include/hipSYCL/std/stdpar/detail/offload_heuristic_db.hpp
@@ -29,7 +29,7 @@
 
 namespace hipsycl::stdpar {
 
-namespace algorithm_type {
+namespace algorithm_category {
 struct for_each {};
 struct for_each_n {};
 struct transform {};
@@ -54,6 +54,14 @@ struct none_of {};
 struct transform_reduce {};
 struct reduce {};
 } // namespace algorithm_type
+
+template<class AlgorithmCategory, class ExecPolicy>
+struct algorithm {
+  using algorithm_category = AlgorithmCategory;
+  using execution_policy = ExecPolicy;
+
+  algorithm(const AlgorithmCategory&, ExecPolicy&&) {}
+};
 
 
 namespace detail {

--- a/include/hipSYCL/std/stdpar/pstl-impl/algorithm.hpp
+++ b/include/hipSYCL/std/stdpar/pstl-impl/algorithm.hpp
@@ -20,8 +20,12 @@
 #include "../detail/stdpar_defs.hpp"
 #include "../detail/offload.hpp"
 #include "hipSYCL/algorithms/algorithm.hpp"
+#include "hipSYCL/std/stdpar/detail/offload_heuristic_db.hpp"
 
 namespace std {
+
+
+////////////////// par_unseq policy
 
 template <class ForwardIt, class UnaryFunction2>
 HIPSYCL_STDPAR_ENTRYPOINT void for_each(hipsycl::stdpar::par_unseq, ForwardIt first,
@@ -34,9 +38,12 @@ HIPSYCL_STDPAR_ENTRYPOINT void for_each(hipsycl::stdpar::par_unseq, ForwardIt fi
     std::for_each(hipsycl::stdpar::par_unseq_host_fallback, first, last, f);
   };
 
-  HIPSYCL_STDPAR_OFFLOAD_NORET(hipsycl::stdpar::algorithm_type::for_each{},
-                               std::distance(first, last), offloader, fallback,
-                               first, HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), f);
+  HIPSYCL_STDPAR_OFFLOAD_NORET(
+      hipsycl::stdpar::algorithm(
+          hipsycl::stdpar::algorithm_category::for_each{},
+          hipsycl::stdpar::par_unseq{}),
+      std::distance(first, last), offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), f);
 }
 
 template<class ForwardIt, class Size, class UnaryFunction2>
@@ -55,8 +62,11 @@ ForwardIt for_each_n(hipsycl::stdpar::par_unseq,
                            f);
   };
 
-  HIPSYCL_STDPAR_OFFLOAD(hipsycl::stdpar::algorithm_type::for_each_n{}, n,
-                         ForwardIt, offloader, fallback, first, n, f);
+  HIPSYCL_STDPAR_OFFLOAD(
+      hipsycl::stdpar::algorithm(
+          hipsycl::stdpar::algorithm_category::for_each_n{},
+          hipsycl::stdpar::par_unseq{}),
+      n, ForwardIt, offloader, fallback, first, n, f);
 }
 
 template <class ForwardIt1, class ForwardIt2, class UnaryOperation>
@@ -78,7 +88,9 @@ ForwardIt2 transform(hipsycl::stdpar::par_unseq,
   };
 
   HIPSYCL_STDPAR_OFFLOAD(
-      hipsycl::stdpar::algorithm_type::transform{},
+      hipsycl::stdpar::algorithm(
+          hipsycl::stdpar::algorithm_category::transform{},
+          hipsycl::stdpar::par_unseq{}),
       std::distance(first1, last1), ForwardIt2, offloader, fallback, first1,
       HIPSYCL_STDPAR_NO_PTR_VALIDATION(last1), d_first, unary_op);
 }
@@ -104,7 +116,9 @@ ForwardIt3 transform(hipsycl::stdpar::par_unseq,
   };
 
   HIPSYCL_STDPAR_OFFLOAD(
-      hipsycl::stdpar::algorithm_type::transform{},
+      hipsycl::stdpar::algorithm(
+          hipsycl::stdpar::algorithm_category::transform{},
+          hipsycl::stdpar::par_unseq{}),
       std::distance(first1, last1), ForwardIt3, offloader, fallback, first1,
       HIPSYCL_STDPAR_NO_PTR_VALIDATION(last1), first2, d_first, binary_op);
 }
@@ -125,10 +139,11 @@ HIPSYCL_STDPAR_ENTRYPOINT ForwardIt2 copy(const hipsycl::stdpar::par_unseq,
                      d_first);
   };
 
-  HIPSYCL_STDPAR_OFFLOAD(hipsycl::stdpar::algorithm_type::copy{},
-                         std::distance(first, last), ForwardIt2, offloader,
-                         fallback, first,
-                         HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), d_first);
+  HIPSYCL_STDPAR_OFFLOAD(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::copy{},
+                                 hipsycl::stdpar::par_unseq{}),
+      std::distance(first, last), ForwardIt2, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), d_first);
 }
 
 template<class ForwardIt1, class ForwardIt2, class UnaryPredicate >
@@ -149,10 +164,11 @@ ForwardIt2 copy_if(hipsycl::stdpar::par_unseq,
                         d_first, pred);
   };
 
-  HIPSYCL_STDPAR_OFFLOAD(hipsycl::stdpar::algorithm_type::copy_if{},
-                         std::distance(first, last), ForwardIt2, offloader,
-                         fallback, first,
-                         HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), d_first, pred);
+  HIPSYCL_STDPAR_OFFLOAD(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::copy_if{},
+                                 hipsycl::stdpar::par_unseq{}),
+      std::distance(first, last), ForwardIt2, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), d_first, pred);
 }
 
 template<class ForwardIt1, class Size, class ForwardIt2 >
@@ -172,8 +188,10 @@ ForwardIt2 copy_n(hipsycl::stdpar::par_unseq,
                        result);
   };
 
-  HIPSYCL_STDPAR_OFFLOAD(hipsycl::stdpar::algorithm_type::copy_n{}, count,
-                         ForwardIt2, offloader, fallback, first, count, result);
+  HIPSYCL_STDPAR_OFFLOAD(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::copy_n{},
+                                 hipsycl::stdpar::par_unseq{}),
+      count, ForwardIt2, offloader, fallback, first, count, result);
 }
 
 template<class ForwardIt, class T >
@@ -188,10 +206,11 @@ void fill(hipsycl::stdpar::par_unseq,
     std::fill(hipsycl::stdpar::par_unseq_host_fallback, first, last, value);
   };
 
-  HIPSYCL_STDPAR_OFFLOAD_NORET(hipsycl::stdpar::algorithm_type::fill{},
-                               std::distance(first, last), offloader, fallback,
-                               first, HIPSYCL_STDPAR_NO_PTR_VALIDATION(last),
-                               value);
+  HIPSYCL_STDPAR_OFFLOAD_NORET(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::fill{},
+                                 hipsycl::stdpar::par_unseq{}),
+      std::distance(first, last), offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), value);
 }
 
 template <class ForwardIt, class Size, class T>
@@ -210,8 +229,10 @@ HIPSYCL_STDPAR_ENTRYPOINT ForwardIt fill_n(hipsycl::stdpar::par_unseq, ForwardIt
                        value);
   };
 
-  HIPSYCL_STDPAR_OFFLOAD(hipsycl::stdpar::algorithm_type::fill_n{}, count,
-                         ForwardIt, offloader, fallback, first, count, value);
+  HIPSYCL_STDPAR_OFFLOAD(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::fill_n{},
+                                 hipsycl::stdpar::par_unseq{}),
+      count, ForwardIt, offloader, fallback, first, count, value);
 }
 
 template <class ForwardIt, class Generator>
@@ -226,8 +247,11 @@ HIPSYCL_STDPAR_ENTRYPOINT void generate(hipsycl::stdpar::par_unseq, ForwardIt fi
   };
 
   HIPSYCL_STDPAR_OFFLOAD_NORET(
-      hipsycl::stdpar::algorithm_type::generate{}, std::distance(first, last),
-      offloader, fallback, first, HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), g);
+      hipsycl::stdpar::algorithm(
+          hipsycl::stdpar::algorithm_category::generate{},
+          hipsycl::stdpar::par_unseq{}),
+      std::distance(first, last), offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), g);
 }
 
 template <class ForwardIt, class Size, class Generator>
@@ -246,8 +270,11 @@ HIPSYCL_STDPAR_ENTRYPOINT ForwardIt generate_n(hipsycl::stdpar::par_unseq,
                            count, g);
   };
 
-  HIPSYCL_STDPAR_OFFLOAD(hipsycl::stdpar::algorithm_type::generate_n{}, count,
-                         ForwardIt, offloader, fallback, first, count, g);
+  HIPSYCL_STDPAR_OFFLOAD(hipsycl::stdpar::algorithm(
+                             hipsycl::stdpar::algorithm_category::generate_n{},
+                             hipsycl::stdpar::par_unseq{}),
+                         count, ForwardIt, offloader, fallback, first, count,
+                         g);
 }
 
 template <class ForwardIt, class T>
@@ -262,10 +289,11 @@ void replace(hipsycl::stdpar::par_unseq, ForwardIt first, ForwardIt last,
                  old_value, new_value);
   };
 
-  HIPSYCL_STDPAR_OFFLOAD_NORET(hipsycl::stdpar::algorithm_type::replace{},
-                               std::distance(first, last), offloader, fallback,
-                               first, HIPSYCL_STDPAR_NO_PTR_VALIDATION(last),
-                               old_value, new_value);
+  HIPSYCL_STDPAR_OFFLOAD_NORET(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::replace{},
+                                 hipsycl::stdpar::par_unseq{}),
+      std::distance(first, last), offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), old_value, new_value);
 }
 
 template <class ForwardIt, class UnaryPredicate, class T>
@@ -281,10 +309,12 @@ void replace_if(hipsycl::stdpar::par_unseq, ForwardIt first, ForwardIt last,
                     new_value);
   };
 
-  HIPSYCL_STDPAR_OFFLOAD_NORET(hipsycl::stdpar::algorithm_type::replace_if{},
-                               std::distance(first, last), offloader, fallback,
-                               first, HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), p,
-                               new_value);
+  HIPSYCL_STDPAR_OFFLOAD_NORET(
+      hipsycl::stdpar::algorithm(
+          hipsycl::stdpar::algorithm_category::replace_if{},
+          hipsycl::stdpar::par_unseq{}),
+      std::distance(first, last), offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), p, new_value);
 }
 
 template <class ForwardIt1, class ForwardIt2, class T>
@@ -306,7 +336,9 @@ replace_copy(hipsycl::stdpar::par_unseq, ForwardIt1 first, ForwardIt1 last,
   };
 
   HIPSYCL_STDPAR_OFFLOAD(
-      hipsycl::stdpar::algorithm_type::replace_copy{},
+      hipsycl::stdpar::algorithm(
+          hipsycl::stdpar::algorithm_category::replace_copy{},
+          hipsycl::stdpar::par_unseq{}),
       std::distance(first, last), ForwardIt2, offloader, fallback, first,
       HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), d_first, old_value, new_value);
 }
@@ -330,7 +362,9 @@ HIPSYCL_STDPAR_ENTRYPOINT ForwardIt2 replace_copy_if(
   };
 
   HIPSYCL_STDPAR_OFFLOAD(
-      hipsycl::stdpar::algorithm_type::replace_copy_if{},
+      hipsycl::stdpar::algorithm(
+                             hipsycl::stdpar::algorithm_category::replace_copy_if{},
+                             hipsycl::stdpar::par_unseq{}),
       std::distance(first, last), ForwardIt2, offloader, fallback, first,
       HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), d_first, p, new_value);
 }
@@ -377,10 +411,11 @@ bool all_of(hipsycl::stdpar::par_unseq, ForwardIt first, ForwardIt last,
     return std::all_of(hipsycl::stdpar::par_unseq_host_fallback, first, last, p);
   };
 
-  HIPSYCL_STDPAR_BLOCKING_OFFLOAD(hipsycl::stdpar::algorithm_type::all_of{},
-                                  std::distance(first, last), bool, offloader,
-                                  fallback, first,
-                                  HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), p);
+  HIPSYCL_STDPAR_BLOCKING_OFFLOAD(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::all_of{},
+                                 hipsycl::stdpar::par_unseq{}),
+      std::distance(first, last), bool, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), p);
 }
 
 template<class ForwardIt, class UnaryPredicate>
@@ -409,10 +444,11 @@ bool any_of(hipsycl::stdpar::par_unseq, ForwardIt first, ForwardIt last,
     return std::any_of(hipsycl::stdpar::par_unseq_host_fallback, first, last, p);
   };
 
-  HIPSYCL_STDPAR_BLOCKING_OFFLOAD(hipsycl::stdpar::algorithm_type::any_of{},
-                                  std::distance(first, last), bool, offloader,
-                                  fallback, first,
-                                  HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), p);
+  HIPSYCL_STDPAR_BLOCKING_OFFLOAD(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::any_of{},
+                                 hipsycl::stdpar::par_unseq{}),
+      std::distance(first, last), bool, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), p);
 }
 
 template<class ForwardIt, class UnaryPredicate>
@@ -441,11 +477,481 @@ bool none_of(hipsycl::stdpar::par_unseq, ForwardIt first, ForwardIt last,
     return std::none_of(hipsycl::stdpar::par_unseq_host_fallback, first, last, p);
   };
 
-  HIPSYCL_STDPAR_BLOCKING_OFFLOAD(hipsycl::stdpar::algorithm_type::none_of{},
-                                  std::distance(first, last), bool, offloader,
-                                  fallback, first,
-                                  HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), p);
+  HIPSYCL_STDPAR_BLOCKING_OFFLOAD(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::none_of{},
+                                 hipsycl::stdpar::par_unseq{}),
+      std::distance(first, last), bool, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), p);
 }
+
+
+
+
+
+
+//////////////////// par policy  /////////////////////////////////////
+
+
+template <class ForwardIt, class UnaryFunction2>
+HIPSYCL_STDPAR_ENTRYPOINT void for_each(hipsycl::stdpar::par, ForwardIt first,
+                                        ForwardIt last, UnaryFunction2 f) {
+  auto offloader = [&](auto& queue) {
+    hipsycl::algorithms::for_each(queue, first, last, f);
+  };
+
+  auto fallback = [&](){
+    std::for_each(hipsycl::stdpar::par_host_fallback, first, last, f);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD_NORET(
+      hipsycl::stdpar::algorithm(
+          hipsycl::stdpar::algorithm_category::for_each{},
+          hipsycl::stdpar::par{}),
+      std::distance(first, last), offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), f);
+}
+
+template<class ForwardIt, class Size, class UnaryFunction2>
+HIPSYCL_STDPAR_ENTRYPOINT
+ForwardIt for_each_n(hipsycl::stdpar::par,
+                    ForwardIt first, Size n, UnaryFunction2 f) {
+  auto offloader = [&](auto& queue) {
+    ForwardIt last = first;
+    std::advance(last, std::max(n, Size{0}));
+    hipsycl::algorithms::for_each_n(queue, first, n, f);
+    return last;
+  };
+
+  auto fallback = [&]() {
+    return std::for_each_n(hipsycl::stdpar::par_host_fallback, first, n,
+                           f);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD(
+      hipsycl::stdpar::algorithm(
+          hipsycl::stdpar::algorithm_category::for_each_n{},
+          hipsycl::stdpar::par{}),
+      n, ForwardIt, offloader, fallback, first, n, f);
+}
+
+template <class ForwardIt1, class ForwardIt2, class UnaryOperation>
+HIPSYCL_STDPAR_ENTRYPOINT
+ForwardIt2 transform(hipsycl::stdpar::par,
+                     ForwardIt1 first1, ForwardIt1 last1, ForwardIt2 d_first,
+                     UnaryOperation unary_op) {
+  
+  auto offloader = [&](auto& queue){
+    ForwardIt2 last = d_first;
+    std::advance(last, std::distance(first1, last1));
+    hipsycl::algorithms::transform(queue, first1, last1, d_first, unary_op);
+    return last;
+  };
+
+  auto fallback = [&]() {
+    return std::transform(hipsycl::stdpar::par_host_fallback, first1,
+                          last1, d_first, unary_op);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD(
+      hipsycl::stdpar::algorithm(
+          hipsycl::stdpar::algorithm_category::transform{},
+          hipsycl::stdpar::par{}),
+      std::distance(first1, last1), ForwardIt2, offloader, fallback, first1,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last1), d_first, unary_op);
+}
+
+template <class ForwardIt1, class ForwardIt2, class ForwardIt3,
+          class BinaryOperation>
+HIPSYCL_STDPAR_ENTRYPOINT
+ForwardIt3 transform(hipsycl::stdpar::par,
+                     ForwardIt1 first1, ForwardIt1 last1, ForwardIt2 first2,
+                     ForwardIt3 d_first, BinaryOperation binary_op) {
+
+  auto offloader = [&](auto &queue) {
+    ForwardIt3 last = d_first;
+    std::advance(last, std::distance(first1, last1));
+    hipsycl::algorithms::transform(queue, first1, last1, first2, d_first,
+                                   binary_op);
+    return last;
+  };
+
+  auto fallback = [&]() {
+    return std::transform(hipsycl::stdpar::par_host_fallback, first1,
+                          last1, first2, d_first, binary_op);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD(
+      hipsycl::stdpar::algorithm(
+          hipsycl::stdpar::algorithm_category::transform{},
+          hipsycl::stdpar::par{}),
+      std::distance(first1, last1), ForwardIt3, offloader, fallback, first1,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last1), first2, d_first, binary_op);
+}
+
+template <class ForwardIt1, class ForwardIt2>
+HIPSYCL_STDPAR_ENTRYPOINT ForwardIt2 copy(const hipsycl::stdpar::par,
+                                          ForwardIt1 first, ForwardIt1 last,
+                                          ForwardIt2 d_first) {
+  auto offloader = [&](auto& queue){
+    ForwardIt2 d_last = d_first;
+    std::advance(d_last, std::distance(first, last));
+    hipsycl::algorithms::copy(queue, first, last, d_first);
+    return d_last;
+  };
+
+  auto fallback = [&]() {
+    return std::copy(hipsycl::stdpar::par_host_fallback, first, last,
+                     d_first);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::copy{},
+                                 hipsycl::stdpar::par{}),
+      std::distance(first, last), ForwardIt2, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), d_first);
+}
+
+template<class ForwardIt1, class ForwardIt2, class UnaryPredicate >
+HIPSYCL_STDPAR_ENTRYPOINT
+ForwardIt2 copy_if(hipsycl::stdpar::par,
+                   ForwardIt1 first, ForwardIt1 last,
+                   ForwardIt2 d_first,
+                   UnaryPredicate pred) {
+  auto offloader = [&](auto& queue){
+    ForwardIt2 d_last = d_first;
+    std::advance(d_last, std::distance(first, last));
+    hipsycl::algorithms::copy_if(queue, first, last, d_first, pred);
+    return d_last;
+  };
+
+  auto fallback = [&]() {
+    return std::copy_if(hipsycl::stdpar::par_host_fallback, first, last,
+                        d_first, pred);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::copy_if{},
+                                 hipsycl::stdpar::par{}),
+      std::distance(first, last), ForwardIt2, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), d_first, pred);
+}
+
+template<class ForwardIt1, class Size, class ForwardIt2 >
+HIPSYCL_STDPAR_ENTRYPOINT
+ForwardIt2 copy_n(hipsycl::stdpar::par,
+                   ForwardIt1 first, Size count, ForwardIt2 result ) {
+
+  auto offloader = [&](auto& queue){
+    ForwardIt2 last = result;
+    std::advance(last, std::max(count, Size{0}));
+    hipsycl::algorithms::copy_n(queue, first, count, result);
+    return last;
+  };
+
+  auto fallback = [&]() {
+    return std::copy_n(hipsycl::stdpar::par_host_fallback, first, count,
+                       result);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::copy_n{},
+                                 hipsycl::stdpar::par{}),
+      count, ForwardIt2, offloader, fallback, first, count, result);
+}
+
+template<class ForwardIt, class T >
+HIPSYCL_STDPAR_ENTRYPOINT
+void fill(hipsycl::stdpar::par,
+          ForwardIt first, ForwardIt last, const T& value) {
+  auto offloader = [&](auto& queue){
+    hipsycl::algorithms::fill(queue, first, last, value);
+  };
+
+  auto fallback = [&]() {
+    std::fill(hipsycl::stdpar::par_host_fallback, first, last, value);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD_NORET(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::fill{},
+                                 hipsycl::stdpar::par{}),
+      std::distance(first, last), offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), value);
+}
+
+template <class ForwardIt, class Size, class T>
+HIPSYCL_STDPAR_ENTRYPOINT ForwardIt fill_n(hipsycl::stdpar::par, ForwardIt first,
+                                           Size count, const T &value) {
+ 
+  auto offloader = [&](auto& queue){
+    ForwardIt last = first;
+    std::advance(last, std::max(count, Size{0}));
+    hipsycl::algorithms::fill_n(queue, first, count, value);
+    return last;
+  };
+
+  auto fallback = [&]() {
+    return std::fill_n(hipsycl::stdpar::par_host_fallback, first, count,
+                       value);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::fill_n{},
+                                 hipsycl::stdpar::par{}),
+      count, ForwardIt, offloader, fallback, first, count, value);
+}
+
+template <class ForwardIt, class Generator>
+HIPSYCL_STDPAR_ENTRYPOINT void generate(hipsycl::stdpar::par, ForwardIt first,
+                                        ForwardIt last, Generator g) {
+  auto offloader = [&](auto &queue) {
+    hipsycl::algorithms::generate(queue, first, last, g);
+  };
+
+  auto fallback = [&]() {
+    std::generate(hipsycl::stdpar::par_host_fallback, first, last, g);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD_NORET(
+      hipsycl::stdpar::algorithm(
+          hipsycl::stdpar::algorithm_category::generate{},
+          hipsycl::stdpar::par{}),
+      std::distance(first, last), offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), g);
+}
+
+template <class ForwardIt, class Size, class Generator>
+HIPSYCL_STDPAR_ENTRYPOINT ForwardIt generate_n(hipsycl::stdpar::par,
+                                               ForwardIt first, Size count,
+                                               Generator g) {
+  auto offloader = [&](auto& queue){
+    ForwardIt last = first;
+    std::advance(last, std::max(count, Size{0}));
+    hipsycl::algorithms::generate_n(queue, first, count, g);
+    return last;
+  };
+
+  auto fallback = [&]() {
+    return std::generate_n(hipsycl::stdpar::par_host_fallback, first,
+                           count, g);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD(hipsycl::stdpar::algorithm(
+                             hipsycl::stdpar::algorithm_category::generate_n{},
+                             hipsycl::stdpar::par{}),
+                         count, ForwardIt, offloader, fallback, first, count,
+                         g);
+}
+
+template <class ForwardIt, class T>
+void replace(hipsycl::stdpar::par, ForwardIt first, ForwardIt last,
+             const T &old_value, const T &new_value) {
+  auto offloader = [&](auto &queue) {
+    hipsycl::algorithms::replace(queue, first, last, old_value, new_value);
+  };
+
+  auto fallback = [&]() {
+    std::replace(hipsycl::stdpar::par_host_fallback, first, last,
+                 old_value, new_value);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD_NORET(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::replace{},
+                                 hipsycl::stdpar::par{}),
+      std::distance(first, last), offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), old_value, new_value);
+}
+
+template <class ForwardIt, class UnaryPredicate, class T>
+void replace_if(hipsycl::stdpar::par, ForwardIt first, ForwardIt last,
+                UnaryPredicate p, const T &new_value) {
+  
+  auto offloader = [&](auto& queue){
+    hipsycl::algorithms::replace_if(queue, first, last, p, new_value);
+  };
+
+  auto fallback = [&]() {
+    std::replace_if(hipsycl::stdpar::par_host_fallback, first, last, p,
+                    new_value);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD_NORET(
+      hipsycl::stdpar::algorithm(
+          hipsycl::stdpar::algorithm_category::replace_if{},
+          hipsycl::stdpar::par{}),
+      std::distance(first, last), offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), p, new_value);
+}
+
+template <class ForwardIt1, class ForwardIt2, class T>
+HIPSYCL_STDPAR_ENTRYPOINT ForwardIt2
+replace_copy(hipsycl::stdpar::par, ForwardIt1 first, ForwardIt1 last,
+             ForwardIt2 d_first, const T &old_value, const T &new_value) {
+
+  auto offloader = [&](auto &queue) {
+    ForwardIt2 d_last = d_first;
+    std::advance(d_last, std::distance(first, last));
+    hipsycl::algorithms::replace_copy(queue, first, last, d_first, old_value,
+                                      new_value);
+    return d_last;
+  };
+
+  auto fallback = [&]() {
+    return std::replace_copy(hipsycl::stdpar::par_host_fallback, first,
+                             last, d_first, old_value, new_value);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD(
+      hipsycl::stdpar::algorithm(
+          hipsycl::stdpar::algorithm_category::replace_copy{},
+          hipsycl::stdpar::par{}),
+      std::distance(first, last), ForwardIt2, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), d_first, old_value, new_value);
+}
+
+template <class ForwardIt1, class ForwardIt2, class UnaryPredicate, class T>
+HIPSYCL_STDPAR_ENTRYPOINT ForwardIt2 replace_copy_if(
+    hipsycl::stdpar::par, ForwardIt1 first,
+    ForwardIt1 last, ForwardIt2 d_first, UnaryPredicate p, const T &new_value) {
+
+  auto offloader = [&](auto &queue) {
+    ForwardIt2 d_last = d_first;
+    std::advance(d_last, std::distance(first, last));
+    hipsycl::algorithms::replace_copy_if(queue, first, last, d_first, p,
+                                         new_value);
+    return d_last;
+  };
+
+  auto fallback = [&]() {
+    return std::replace_copy_if(hipsycl::stdpar::par_host_fallback, first,
+                                last, d_first, p, new_value);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD(
+      hipsycl::stdpar::algorithm(
+                             hipsycl::stdpar::algorithm_category::replace_copy_if{},
+                             hipsycl::stdpar::par{}),
+      std::distance(first, last), ForwardIt2, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), d_first, p, new_value);
+}
+
+/*
+template <class ForwardIt, class T>
+HIPSYCL_STDPAR_ENTRYPOINT ForwardIt find(const hipsycl::stdpar::par, ForwardIt first,
+                                         ForwardIt last, const T &value);
+
+template <class ForwardIt, class UnaryPredicate>
+HIPSYCL_STDPAR_ENTRYPOINT ForwardIt find_if(const hipsycl::stdpar::par,
+                                            ForwardIt first, ForwardIt last,
+                                            UnaryPredicate p);
+
+template <class ForwardIt, class UnaryPredicate>
+HIPSYCL_STDPAR_ENTRYPOINT ForwardIt find_if_not(const hipsycl::stdpar::par,
+                                                ForwardIt first, ForwardIt last,
+                                                UnaryPredicate q); */
+
+
+template<class ForwardIt, class UnaryPredicate>
+HIPSYCL_STDPAR_ENTRYPOINT
+bool all_of(hipsycl::stdpar::par, ForwardIt first, ForwardIt last,
+            UnaryPredicate p ) {
+
+  auto offloader = [&](auto& queue){
+    
+    if(std::distance(first, last) == 0)
+      return true;
+    
+    auto output_scratch_group =
+        hipsycl::stdpar::detail::stdpar_tls_runtime::get()
+            .make_scratch_group<
+                hipsycl::algorithms::util::allocation_type::host>();
+
+    auto *output = output_scratch_group
+                      .obtain<hipsycl::algorithms::detail::early_exit_flag_t>(1);
+    hipsycl::algorithms::all_of(queue, first, last, output, p);
+    queue.wait();
+    return static_cast<bool>(*output);
+  };
+
+  auto fallback = [&](){
+    return std::all_of(hipsycl::stdpar::par_host_fallback, first, last, p);
+  };
+
+  HIPSYCL_STDPAR_BLOCKING_OFFLOAD(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::all_of{},
+                                 hipsycl::stdpar::par{}),
+      std::distance(first, last), bool, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), p);
+}
+
+template<class ForwardIt, class UnaryPredicate>
+HIPSYCL_STDPAR_ENTRYPOINT
+bool any_of(hipsycl::stdpar::par, ForwardIt first, ForwardIt last,
+            UnaryPredicate p ) {
+  
+  auto offloader = [&](auto& queue){
+
+    if(std::distance(first, last) == 0)
+      return false;
+
+    auto output_scratch_group =
+        hipsycl::stdpar::detail::stdpar_tls_runtime::get()
+            .make_scratch_group<
+                hipsycl::algorithms::util::allocation_type::host>();
+
+    auto *output = output_scratch_group
+                      .obtain<hipsycl::algorithms::detail::early_exit_flag_t>(1);
+    hipsycl::algorithms::any_of(queue, first, last, output, p);
+    queue.wait();
+    return static_cast<bool>(*output);
+  };
+
+  auto fallback = [&](){
+    return std::any_of(hipsycl::stdpar::par_host_fallback, first, last, p);
+  };
+
+  HIPSYCL_STDPAR_BLOCKING_OFFLOAD(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::any_of{},
+                                 hipsycl::stdpar::par{}),
+      std::distance(first, last), bool, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), p);
+}
+
+template<class ForwardIt, class UnaryPredicate>
+HIPSYCL_STDPAR_ENTRYPOINT
+bool none_of(hipsycl::stdpar::par, ForwardIt first, ForwardIt last,
+            UnaryPredicate p ) {
+  
+  auto offloader = [&](auto& queue){
+
+    if(std::distance(first, last) == 0)
+      return true;
+
+    auto output_scratch_group =
+        hipsycl::stdpar::detail::stdpar_tls_runtime::get()
+            .make_scratch_group<
+                hipsycl::algorithms::util::allocation_type::host>();
+
+    auto *output = output_scratch_group
+                      .obtain<hipsycl::algorithms::detail::early_exit_flag_t>(1);
+    hipsycl::algorithms::none_of(queue, first, last, output, p);
+    queue.wait();
+    return static_cast<bool>(*output);
+  };
+
+  auto fallback = [&](){
+    return std::none_of(hipsycl::stdpar::par_host_fallback, first, last, p);
+  };
+
+  HIPSYCL_STDPAR_BLOCKING_OFFLOAD(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::none_of{},
+                                 hipsycl::stdpar::par{}),
+      std::distance(first, last), bool, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), p);
+}
+
+
+
+
 
 }
 

--- a/include/hipSYCL/std/stdpar/pstl-impl/numeric.hpp
+++ b/include/hipSYCL/std/stdpar/pstl-impl/numeric.hpp
@@ -12,6 +12,7 @@
 #define HIPSYCL_PSTL_NUMERIC_DEFINITION_HPP
 
 #include "hipSYCL/std/stdpar/detail/execution_fwd.hpp"
+#include "hipSYCL/std/stdpar/detail/offload_heuristic_db.hpp"
 #include "hipSYCL/std/stdpar/numeric"
 
 #include "../detail/sycl_glue.hpp"
@@ -67,7 +68,9 @@ T transform_reduce(hipsycl::stdpar::par_unseq,
   };
 
   HIPSYCL_STDPAR_BLOCKING_OFFLOAD(
-      hipsycl::stdpar::algorithm_type::transform_reduce{},
+      hipsycl::stdpar::algorithm(
+          hipsycl::stdpar::algorithm_category::transform_reduce{},
+          hipsycl::stdpar::par_unseq{}),
       std::distance(first1, last1), T, offloader, fallback, first1,
       HIPSYCL_STDPAR_NO_PTR_VALIDATION(last1), first2, init);
 }
@@ -112,7 +115,9 @@ T transform_reduce(hipsycl::stdpar::par_unseq,
   };
 
   HIPSYCL_STDPAR_BLOCKING_OFFLOAD(
-      hipsycl::stdpar::algorithm_type::transform_reduce{},
+      hipsycl::stdpar::algorithm(
+                             hipsycl::stdpar::algorithm_category::transform_reduce{},
+                             hipsycl::stdpar::par_unseq{}),
       std::distance(first1, last1), T, offloader, fallback, first1,
       HIPSYCL_STDPAR_NO_PTR_VALIDATION(last1), first2, init, reduce, transform);
 }
@@ -155,7 +160,9 @@ T transform_reduce(hipsycl::stdpar::par_unseq,
   };
 
   HIPSYCL_STDPAR_BLOCKING_OFFLOAD(
-      hipsycl::stdpar::algorithm_type::transform_reduce{},
+      hipsycl::stdpar::algorithm(
+          hipsycl::stdpar::algorithm_category::transform_reduce{},
+          hipsycl::stdpar::par_unseq{}),
       std::distance(first, last), T, offloader, fallback, first,
       HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), init, reduce, transform);
 }
@@ -195,10 +202,11 @@ reduce(hipsycl::stdpar::par_unseq, ForwardIt first,
     return std::reduce(hipsycl::stdpar::par_unseq_host_fallback, first, last);
   };
 
-  HIPSYCL_STDPAR_BLOCKING_OFFLOAD(hipsycl::stdpar::algorithm_type::reduce{},
-                                  std::distance(first, last), result_type,
-                                  offloader, fallback, first,
-                                  HIPSYCL_STDPAR_NO_PTR_VALIDATION(last));
+  HIPSYCL_STDPAR_BLOCKING_OFFLOAD(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::reduce{},
+                                 hipsycl::stdpar::par_unseq{}),
+      std::distance(first, last), result_type, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last));
 }
 
 template <class ForwardIt, class T>
@@ -236,8 +244,10 @@ T reduce(hipsycl::stdpar::par_unseq, ForwardIt first,
   };
 
   HIPSYCL_STDPAR_BLOCKING_OFFLOAD(
-      hipsycl::stdpar::algorithm_type::reduce{}, std::distance(first, last), T,
-      offloader, fallback, first, HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), init);
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::reduce{},
+                                 hipsycl::stdpar::par_unseq{}),
+      std::distance(first, last), T, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), init);
 }
 
 template <class ForwardIt, class T, class BinaryOp>
@@ -274,10 +284,282 @@ T reduce(hipsycl::stdpar::par_unseq, ForwardIt first,
   };
 
   HIPSYCL_STDPAR_BLOCKING_OFFLOAD(
-      hipsycl::stdpar::algorithm_type::reduce{}, std::distance(first, last), T,
-      offloader, fallback, first, HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), init,
-      binary_op);
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::reduce{},
+                                 hipsycl::stdpar::par_unseq{}),
+      std::distance(first, last), T, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), init, binary_op);
 }
+
+
+//////////////////// par policy /////////////////////////////////////
+
+
+template<class ForwardIt1, class ForwardIt2, class T >
+HIPSYCL_STDPAR_ENTRYPOINT
+T transform_reduce(hipsycl::stdpar::par,
+                    ForwardIt1 first1, ForwardIt1 last1,
+                    ForwardIt2 first2,
+                    T init) {
+  
+  auto offloader = [&](auto& queue) {
+    // Note: Using a scratch allocation_group that expires at the end of the scope
+    // is safe because
+    // a) We synchronize before the end, so the allocation_group also lives until
+    // the kernels are complete;
+    // b) We have one allocation cache per thread-local in-order queue. So, subsequent operations
+    // fed from the same cache would wait for us anyway due to using the same in-order queue.
+    // These conditions ensure that no other operations can get access to the 
+    // cached scratch memory while we are using it.
+    auto output_scratch_group =
+        hipsycl::stdpar::detail::stdpar_tls_runtime::get()
+            .make_scratch_group<
+                hipsycl::algorithms::util::allocation_type::host>();
+    auto reduction_scratch_group =
+        hipsycl::stdpar::detail::stdpar_tls_runtime::get()
+            .make_scratch_group<
+                hipsycl::algorithms::util::allocation_type::device>();
+    
+    T* output = output_scratch_group.obtain<T>(1);
+    hipsycl::algorithms::transform_reduce(queue, reduction_scratch_group, first1,
+                                            last1, first2, output, init);
+    // We need to wait in any case here, so cannot elide synchronization
+    queue.wait();
+    
+    if(first1 == last1)
+      return init;
+    else
+      return *output;
+  };
+
+  auto fallback = [&]() {
+    return std::transform_reduce(hipsycl::stdpar::par_host_fallback,
+                                 first1, last1, first2, init);
+  };
+
+  HIPSYCL_STDPAR_BLOCKING_OFFLOAD(
+      hipsycl::stdpar::algorithm(
+          hipsycl::stdpar::algorithm_category::transform_reduce{},
+          hipsycl::stdpar::par{}),
+      std::distance(first1, last1), T, offloader, fallback, first1,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last1), first2, init);
+}
+
+template<class ForwardIt1, class ForwardIt2, class T,
+          class BinaryReductionOp,
+          class BinaryTransformOp >
+HIPSYCL_STDPAR_ENTRYPOINT
+T transform_reduce(hipsycl::stdpar::par,
+                    ForwardIt1 first1, ForwardIt1 last1,
+                    ForwardIt2 first2,
+                    T init,
+                    BinaryReductionOp reduce,
+                    BinaryTransformOp transform ) {
+  auto offloader = [&](auto& queue){
+    auto output_scratch_group =
+        hipsycl::stdpar::detail::stdpar_tls_runtime::get()
+            .make_scratch_group<
+                hipsycl::algorithms::util::allocation_type::host>();
+    auto reduction_scratch_group =
+        hipsycl::stdpar::detail::stdpar_tls_runtime::get()
+            .make_scratch_group<
+                hipsycl::algorithms::util::allocation_type::device>();
+    
+    T* output = output_scratch_group.obtain<T>(1);
+    hipsycl::algorithms::transform_reduce(queue, reduction_scratch_group, first1,
+                                          last1, first2, output, init, reduce,
+                                          transform);
+    // We need to wait in any case here, so cannot elide synchronization
+    queue.wait();
+    
+    if(first1 == last1)
+      return init;
+    else
+      return *output;
+  };
+
+  auto fallback = [&]() {
+    return std::transform_reduce(hipsycl::stdpar::par_host_fallback,
+                                 first1, last1, first2, init, reduce,
+                                 transform);
+  };
+
+  HIPSYCL_STDPAR_BLOCKING_OFFLOAD(
+      hipsycl::stdpar::algorithm(
+                             hipsycl::stdpar::algorithm_category::transform_reduce{},
+                             hipsycl::stdpar::par{}),
+      std::distance(first1, last1), T, offloader, fallback, first1,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last1), first2, init, reduce, transform);
+}
+
+template<class ForwardIt, class T,
+          class BinaryReductionOp,
+          class UnaryTransformOp >
+HIPSYCL_STDPAR_ENTRYPOINT
+T transform_reduce(hipsycl::stdpar::par,
+                    ForwardIt first, ForwardIt last,
+                    T init,
+                    BinaryReductionOp reduce,
+                    UnaryTransformOp transform ) {
+
+  auto offloader = [&](auto& queue) {
+    auto output_scratch_group =
+        hipsycl::stdpar::detail::stdpar_tls_runtime::get()
+            .make_scratch_group<
+                hipsycl::algorithms::util::allocation_type::host>();
+    auto reduction_scratch_group =
+        hipsycl::stdpar::detail::stdpar_tls_runtime::get()
+            .make_scratch_group<
+                hipsycl::algorithms::util::allocation_type::device>();
+    
+    T* output = output_scratch_group.obtain<T>(1);
+    hipsycl::algorithms::transform_reduce(queue, reduction_scratch_group, first, last,
+                                          output, init, reduce, transform);
+    // We need to wait in any case here, so cannot elide synchronization
+    queue.wait();
+    
+    if(first == last)
+      return init;
+    else
+      return *output;
+  };
+
+  auto fallback = [&]() {
+    return std::transform_reduce(hipsycl::stdpar::par_host_fallback,
+                                 first, last, init, reduce, transform);
+  };
+
+  HIPSYCL_STDPAR_BLOCKING_OFFLOAD(
+      hipsycl::stdpar::algorithm(
+          hipsycl::stdpar::algorithm_category::transform_reduce{},
+          hipsycl::stdpar::par{}),
+      std::distance(first, last), T, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), init, reduce, transform);
+}
+
+template <class ForwardIt>
+HIPSYCL_STDPAR_ENTRYPOINT
+typename std::iterator_traits<ForwardIt>::value_type
+reduce(hipsycl::stdpar::par, ForwardIt first,
+       ForwardIt last) {
+
+  using result_type = typename std::iterator_traits<ForwardIt>::value_type;
+
+  auto offloader = [&](auto &queue) {
+
+    auto output_scratch_group =
+        hipsycl::stdpar::detail::stdpar_tls_runtime::get()
+            .make_scratch_group<
+                hipsycl::algorithms::util::allocation_type::host>();
+    auto reduction_scratch_group =
+        hipsycl::stdpar::detail::stdpar_tls_runtime::get()
+            .make_scratch_group<
+                hipsycl::algorithms::util::allocation_type::device>();
+
+    result_type *output = output_scratch_group.obtain<result_type>(1);
+    hipsycl::algorithms::reduce(queue, reduction_scratch_group, first, last,
+                                output);
+    // We need to wait in any case here, so cannot elide synchronization
+    queue.wait();
+
+    if (first == last)
+      return result_type{};
+    else
+      return *output;
+  };
+
+  auto fallback = [&](){
+    return std::reduce(hipsycl::stdpar::par_host_fallback, first, last);
+  };
+
+  HIPSYCL_STDPAR_BLOCKING_OFFLOAD(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::reduce{},
+                                 hipsycl::stdpar::par{}),
+      std::distance(first, last), result_type, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last));
+}
+
+template <class ForwardIt, class T>
+HIPSYCL_STDPAR_ENTRYPOINT
+T reduce(hipsycl::stdpar::par, ForwardIt first,
+         ForwardIt last, T init) {
+
+  auto offloader = [&](auto& queue){
+      
+    auto output_scratch_group =
+        hipsycl::stdpar::detail::stdpar_tls_runtime::get()
+            .make_scratch_group<
+                hipsycl::algorithms::util::allocation_type::host>();
+    auto reduction_scratch_group =
+        hipsycl::stdpar::detail::stdpar_tls_runtime::get()
+            .make_scratch_group<
+                hipsycl::algorithms::util::allocation_type::device>();
+    
+    T* output = output_scratch_group.obtain<T>(1);
+    hipsycl::algorithms::reduce(queue, reduction_scratch_group, first, last,
+                                output, init);
+    // We need to wait in any case here, so cannot elide synchronization
+    queue.wait();
+    
+    if(first == last)
+      return init;
+    else
+      return *output;
+
+  };
+
+  auto fallback = [&]() {
+    return std::reduce(hipsycl::stdpar::par_host_fallback, first, last,
+                       init);
+  };
+
+  HIPSYCL_STDPAR_BLOCKING_OFFLOAD(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::reduce{},
+                                 hipsycl::stdpar::par{}),
+      std::distance(first, last), T, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), init);
+}
+
+template <class ForwardIt, class T, class BinaryOp>
+HIPSYCL_STDPAR_ENTRYPOINT
+T reduce(hipsycl::stdpar::par, ForwardIt first,
+         ForwardIt last, T init, BinaryOp binary_op) {
+
+  auto offloader = [&](auto& queue){
+      
+    auto output_scratch_group =
+        hipsycl::stdpar::detail::stdpar_tls_runtime::get()
+            .make_scratch_group<
+                hipsycl::algorithms::util::allocation_type::host>();
+    auto reduction_scratch_group =
+        hipsycl::stdpar::detail::stdpar_tls_runtime::get()
+            .make_scratch_group<
+                hipsycl::algorithms::util::allocation_type::device>();
+    
+    T* output = output_scratch_group.obtain<T>(1);
+    hipsycl::algorithms::reduce(queue, reduction_scratch_group, first, last, output,
+                                init, binary_op);
+    // We need to wait in any case here, so cannot elide synchronization
+    queue.wait();
+    
+    if(first == last)
+      return init;
+    else
+      return *output;
+  };
+
+  auto fallback = [&]() {
+    return std::reduce(hipsycl::stdpar::par_host_fallback, first, last,
+                       init, binary_op);
+  };
+
+  HIPSYCL_STDPAR_BLOCKING_OFFLOAD(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::reduce{},
+                                 hipsycl::stdpar::par{}),
+      std::distance(first, last), T, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), init, binary_op);
+}
+
+
 
 }
 

--- a/src/runtime/cuda/cuda_hardware_manager.cpp
+++ b/src/runtime/cuda/cuda_hardware_manager.cpp
@@ -201,6 +201,9 @@ bool cuda_hardware_context::has(device_support_aspect aspect) const {
     return false;
 #endif
     break;
+  case device_support_aspect::work_item_independent_forward_progress:
+    return _properties->major >= 7;
+    break;
   }
   assert(false && "Unknown device aspect");
   std::terminate();

--- a/src/runtime/hip/hip_hardware_manager.cpp
+++ b/src/runtime/hip/hip_hardware_manager.cpp
@@ -208,6 +208,9 @@ bool hip_hardware_context::has(device_support_aspect aspect) const {
     return false;
 #endif
     break;
+  case device_support_aspect::work_item_independent_forward_progress:
+    return false;
+    break;
   }
   assert(false && "Unknown device aspect");
   std::terminate();

--- a/src/runtime/ocl/ocl_hardware_manager.cpp
+++ b/src/runtime/ocl/ocl_hardware_manager.cpp
@@ -276,6 +276,9 @@ bool ocl_hardware_context::has(device_support_aspect aspect) const {
     return false;
 #endif
     break;
+  case device_support_aspect::work_item_independent_forward_progress:
+    return false;
+    break;
   }
   assert(false && "Unknown device aspect");
   std::terminate();

--- a/src/runtime/omp/omp_hardware_manager.cpp
+++ b/src/runtime/omp/omp_hardware_manager.cpp
@@ -110,6 +110,9 @@ bool omp_hardware_context::has(device_support_aspect aspect) const {
     return false;
 #endif
     break;
+  case device_support_aspect::work_item_independent_forward_progress:
+    return false;
+    break;
   }
   assert(false && "Unknown device aspect");
   return false;

--- a/src/runtime/ze/ze_hardware_manager.cpp
+++ b/src/runtime/ze/ze_hardware_manager.cpp
@@ -288,6 +288,9 @@ bool ze_hardware_context::has(device_support_aspect aspect) const {
     return false;
 #endif
     break;
+  case device_support_aspect::work_item_independent_forward_progress:
+    return false;
+    break;
   }
   assert(false && "Unknown device aspect");
   std::terminate();

--- a/tests/pstl/any_of.cpp
+++ b/tests/pstl/any_of.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <execution>
+#include <pstl/glue_execution_defs.h>
 #include <utility>
 #include <vector>
 
@@ -20,38 +21,64 @@
 
 BOOST_FIXTURE_TEST_SUITE(pstl_any_of, enable_unified_shared_memory)
 
-template <class Generator, class Predicate>
-void test_any_of(std::size_t problem_size, Generator gen, Predicate p) {
+template <class Policy, class Generator, class Predicate>
+void test_any_of(Policy&& pol, std::size_t problem_size, Generator gen, Predicate p) {
   std::vector<int> data(problem_size);
   for(int i = 0; i < problem_size; ++i)
     data[i] = gen(i);
 
   auto ret =
-      std::any_of(std::execution::par_unseq, data.begin(), data.end(), p);
+      std::any_of(pol, data.begin(), data.end(), p);
   auto ret_host =
       std::any_of(data.begin(), data.end(), p);
 
   BOOST_CHECK(ret == ret_host);
 }
 
+template<class Policy>
+void empty_tests(Policy&& pol) {
+  test_any_of(pol, 0, [](int i){return i;}, [](int x){ return x > 0;});
+}
+
+template<class Policy>
+void single_element_tests(Policy&& pol) {
+  test_any_of(pol, 1, [](int i){return i;}, [](int x){ return x < 0;});
+  test_any_of(pol, 1, [](int i){return i;}, [](int x){ return x > 0;});
+  test_any_of(pol, 1, [](int i){return i;}, [](int x){ return x >= 0;});
+  test_any_of(pol, 1, [](int i){return i;}, [](int x){ return x % 2 == 0;});
+}
+
+template<class Policy>
+void medium_size_tests(Policy&& pol) {
+  test_any_of(pol, 1000, [](int i){return i;}, [](int x){ return x < 0;});
+  test_any_of(pol, 1000, [](int i){return i;}, [](int x){ return x > 0;});
+  test_any_of(pol, 1000, [](int i){return i;}, [](int x){ return x >= 0;});
+  test_any_of(pol, 1000, [](int i){return i;}, [](int x){ return x % 2 == 0;});
+}
+
 BOOST_AUTO_TEST_CASE(par_unseq_empty) {
-  test_any_of(0, [](int i){return i;}, [](int x){ return x > 0;});
+  empty_tests(std::execution::par_unseq);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_single_element) {
-  test_any_of(1, [](int i){return i;}, [](int x){ return x < 0;});
-  test_any_of(1, [](int i){return i;}, [](int x){ return x > 0;});
-  test_any_of(1, [](int i){return i;}, [](int x){ return x >= 0;});
-  test_any_of(1, [](int i){return i;}, [](int x){ return x % 2 == 0;});
+  single_element_tests(std::execution::par_unseq);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_medium_size) {
-  test_any_of(1000, [](int i){return i;}, [](int x){ return x < 0;});
-  test_any_of(1000, [](int i){return i;}, [](int x){ return x > 0;});
-  test_any_of(1000, [](int i){return i;}, [](int x){ return x >= 0;});
-  test_any_of(1000, [](int i){return i;}, [](int x){ return x % 2 == 0;});
+  medium_size_tests(std::execution::par_unseq);
 }
 
 
+BOOST_AUTO_TEST_CASE(par_empty) {
+  empty_tests(std::execution::par_unseq);
+}
+
+BOOST_AUTO_TEST_CASE(par_single_element) {
+  single_element_tests(std::execution::par_unseq);
+}
+
+BOOST_AUTO_TEST_CASE(par_medium_size) {
+  medium_size_tests(std::execution::par_unseq);
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pstl/copy.cpp
+++ b/tests/pstl/copy.cpp
@@ -22,8 +22,8 @@
 BOOST_FIXTURE_TEST_SUITE(pstl_copy, enable_unified_shared_memory)
 
 
-template<class T>
-void test_copy(std::size_t problem_size) {
+template<class T, class Policy>
+void test_copy(Policy&& pol, std::size_t problem_size) {
   std::vector<T> data(problem_size);
   for(int i = 0; i < problem_size; ++i) {
     data[i] = T{i};
@@ -32,7 +32,7 @@ void test_copy(std::size_t problem_size) {
   std::vector<T> dest_device(problem_size);
   std::vector<T> dest_host(problem_size);
 
-  auto ret = std::copy(std::execution::par_unseq, data.begin(), data.end(),
+  auto ret = std::copy(pol, data.begin(), data.end(),
                        dest_device.begin());
   std::copy(data.begin(), data.end(), dest_host.begin());
 
@@ -42,17 +42,28 @@ void test_copy(std::size_t problem_size) {
 
 using types = boost::mpl::list<int, non_trivial_copy>;
 BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_empty, T, types::type) {
-  test_copy<T>(0);
+  test_copy<T>(std::execution::par_unseq, 0);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_single_element, T, types::type) {
-  test_copy<T>(1);
+  test_copy<T>(std::execution::par_unseq, 1);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_medium_size, T, types::type) {
-  test_copy<T>(1000);
+  test_copy<T>(std::execution::par_unseq, 1000);
 }
 
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_empty, T, types::type) {
+  test_copy<T>(std::execution::par, 0);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_single_element, T, types::type) {
+  test_copy<T>(std::execution::par, 1);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_medium_size, T, types::type) {
+  test_copy<T>(std::execution::par, 1000);
+}
 
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pstl/copy_n.cpp
+++ b/tests/pstl/copy_n.cpp
@@ -21,8 +21,8 @@
 
 BOOST_FIXTURE_TEST_SUITE(pstl_copy_n, enable_unified_shared_memory)
 
-template<class T>
-void test_copy_n(std::size_t problem_size) {
+template<class T, class Policy>
+void test_copy_n(Policy&& pol, std::size_t problem_size) {
   std::vector<T> data(problem_size);
   for(int i = 0; i < problem_size; ++i) {
     data[i] = T{i};
@@ -31,7 +31,7 @@ void test_copy_n(std::size_t problem_size) {
   std::vector<T> dest_device(problem_size);
   std::vector<T> dest_host(problem_size);
 
-  auto ret = std::copy_n(std::execution::par_unseq, data.begin(), data.size(),
+  auto ret = std::copy_n(pol, data.begin(), data.size(),
                          dest_device.begin());
   std::copy_n(data.begin(), data.size(), dest_host.begin());
 
@@ -50,17 +50,29 @@ BOOST_AUTO_TEST_CASE(par_unseq_negative) {
 
 using types = boost::mpl::list<int, non_trivial_copy>;
 BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_empty, T, types::type) {
-  test_copy_n<T>(0);
+  test_copy_n<T>(std::execution::par_unseq, 0);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_single_element, T, types::type) {
-  test_copy_n<T>(1);
+  test_copy_n<T>(std::execution::par_unseq, 1);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_medium_size, T, types::type) {
-  test_copy_n<T>(1000);
+  test_copy_n<T>(std::execution::par_unseq, 1000);
 }
 
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_empty, T, types::type) {
+  test_copy_n<T>(std::execution::par, 0);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_single_element, T, types::type) {
+  test_copy_n<T>(std::execution::par, 1);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_medium_size, T, types::type) {
+  test_copy_n<T>(std::execution::par, 1000);
+}
 
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pstl/fill.cpp
+++ b/tests/pstl/fill.cpp
@@ -22,8 +22,8 @@
 BOOST_FIXTURE_TEST_SUITE(pstl_fill, enable_unified_shared_memory)
 
 
-template<class T>
-void test_fill(std::size_t problem_size) {
+template<class T, class Policy>
+void test_fill(Policy&& pol, std::size_t problem_size) {
   std::vector<T> data(problem_size);
   for(int i = 0; i < problem_size; ++i) {
     data[i] = T{i};
@@ -43,15 +43,28 @@ void test_fill(std::size_t problem_size) {
 
 using types = boost::mpl::list<int, non_trivial_copy>;
 BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_empty, T, types::type) {
-  test_fill<T>(0);
+  test_fill<T>(std::execution::par_unseq, 0);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_single_element, T, types::type) {
-  test_fill<T>(1);
+  test_fill<T>(std::execution::par_unseq, 1);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_medium_size, T, types::type) {
-  test_fill<T>(1000);
+  test_fill<T>(std::execution::par_unseq, 1000);
+}
+
+using types = boost::mpl::list<int, non_trivial_copy>;
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_empty, T, types::type) {
+  test_fill<T>(std::execution::par, 0);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_single_element, T, types::type) {
+  test_fill<T>(std::execution::par, 1);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_medium_size, T, types::type) {
+  test_fill<T>(std::execution::par, 1000);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pstl/fill_n.cpp
+++ b/tests/pstl/fill_n.cpp
@@ -22,15 +22,15 @@
 BOOST_FIXTURE_TEST_SUITE(pstl_fill_n, enable_unified_shared_memory)
 
 
-template<class T>
-void test_fill_n(std::size_t problem_size) {
+template<class T, class Policy>
+void test_fill_n(Policy&& pol, std::size_t problem_size) {
   std::vector<T> data(problem_size);
   for(int i = 0; i < problem_size; ++i) {
     data[i] = T{i};
   }
 
   auto ret =
-      std::fill_n(std::execution::par_unseq, data.begin(), data.size(), T(42));
+      std::fill_n(pol, data.begin(), data.size(), T(42));
 
   BOOST_CHECK(ret == data.begin() + problem_size);
 
@@ -54,15 +54,37 @@ BOOST_AUTO_TEST_CASE(par_unseq_negative) {
 
 using types = boost::mpl::list<int, non_trivial_copy>;
 BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_empty, T, types::type) {
-  test_fill_n<T>(0);
+  test_fill_n<T>(std::execution::par_unseq, 0);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_single_element, T, types::type) {
-  test_fill_n<T>(1);
+  test_fill_n<T>(std::execution::par_unseq, 1);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_medium_size, T, types::type) {
-  test_fill_n<T>(1000);
+  test_fill_n<T>(std::execution::par_unseq, 1000);
+}
+
+
+BOOST_AUTO_TEST_CASE(par_negative) {
+  std::vector<int> empty;
+
+  auto ret =
+      std::fill_n(std::execution::par_unseq, empty.begin(), -1, 42);
+  BOOST_CHECK(ret == empty.begin());
+}
+
+using types = boost::mpl::list<int, non_trivial_copy>;
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_empty, T, types::type) {
+  test_fill_n<T>(std::execution::par_unseq, 0);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_single_element, T, types::type) {
+  test_fill_n<T>(std::execution::par_unseq, 1);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_medium_size, T, types::type) {
+  test_fill_n<T>(std::execution::par_unseq, 1000);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pstl/for_each.cpp
+++ b/tests/pstl/for_each.cpp
@@ -38,4 +38,23 @@ BOOST_AUTO_TEST_CASE(par_unseq_incomplete_work_group) {
   }
 }
 
+
+BOOST_AUTO_TEST_CASE(par_zero_size) {
+  std::vector<int> data{24};
+  std::for_each(std::execution::par, data.begin(), data.begin(),
+                [=](auto &x) { x = 12; });
+  BOOST_CHECK(data[0] == 24);
+}
+
+BOOST_AUTO_TEST_CASE(par_incomplete_work_group) {
+  std::vector<int> data(1000);
+  for(int i = 0; i < data.size(); ++i)
+    data[i] = i;
+  std::for_each(std::execution::par, data.begin(), data.end(),
+                [=](auto &x) { x *= 2; });
+  for(int i = 0; i < data.size(); ++i) {
+    BOOST_CHECK(data[i] == 2*i);
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pstl/for_each_n.cpp
+++ b/tests/pstl/for_each_n.cpp
@@ -19,34 +19,43 @@
 
 BOOST_FIXTURE_TEST_SUITE(pstl_for_each_n, enable_unified_shared_memory)
 
-
-BOOST_AUTO_TEST_CASE(par_unseq_zero_size) {
+template<class Policy>
+void test_zero_size(Policy&& pol) {
   std::vector<int> data{24};
-  auto res = std::for_each_n(std::execution::par_unseq, data.begin(), 0,
+  auto res = std::for_each_n(pol, data.begin(), 0,
                              [=](auto &x) { x = 12; });
   BOOST_CHECK(data[0] == 24);
   BOOST_CHECK(res == data.begin());
 }
 
-BOOST_AUTO_TEST_CASE(par_unseq_negative_size) {
-  std::vector<int> data{24};
-  auto res = std::for_each_n(std::execution::par_unseq, data.begin(), -1,
-                             [=](auto &x) { x = 12; });
-  BOOST_CHECK(data[0] == 24);
-  BOOST_CHECK(res == data.begin());
-}
-
-
-BOOST_AUTO_TEST_CASE(par_unseq_incomplete_work_group) {
+template<class Policy>
+void test_incomplete_work_group(Policy&& pol) {
   std::vector<int> data(1000);
   for(int i = 0; i < data.size(); ++i)
     data[i] = i;
-  auto res = std::for_each_n(std::execution::par_unseq, data.begin(),
+  auto res = std::for_each_n(pol, data.begin(),
                              data.size(), [=](auto &x) { x *= 2; });
   for(int i = 0; i < data.size(); ++i) {
     BOOST_CHECK(data[i] == 2*i);
   }
   BOOST_CHECK(res == data.end());
+}
+
+BOOST_AUTO_TEST_CASE(par_unseq_zero_size) {
+  test_zero_size(std::execution::par_unseq);
+}
+
+BOOST_AUTO_TEST_CASE(par_unseq_incomplete_work_group) {
+  test_incomplete_work_group(std::execution::par_unseq);
+}
+
+
+BOOST_AUTO_TEST_CASE(par_zero_size) {
+  test_zero_size(std::execution::par);
+}
+
+BOOST_AUTO_TEST_CASE(par_incomplete_work_group) {
+  test_incomplete_work_group(std::execution::par);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pstl/generate.cpp
+++ b/tests/pstl/generate.cpp
@@ -21,8 +21,8 @@
 
 BOOST_FIXTURE_TEST_SUITE(pstl_generate, enable_unified_shared_memory)
 
-
-void test_generate(std::size_t problem_size) {
+template<class Policy>
+void test_generate(Policy&& pol, std::size_t problem_size) {
   std::vector<int> data(problem_size);
 
   std::generate(std::execution::par_unseq, data.begin(), data.end(),
@@ -30,24 +30,36 @@ void test_generate(std::size_t problem_size) {
 
   std::vector<int> data_host(problem_size);
 
-  std::generate(data_host.begin(), data_host.end(),
+  std::generate(pol, data_host.begin(), data_host.end(),
                 []() { return 42; });
 
   BOOST_CHECK(data == data_host);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_empty) {
-  test_generate(0);
+  test_generate(std::execution::par_unseq, 0);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_single_element) {
-  test_generate(1);
+  test_generate(std::execution::par_unseq, 1);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_medium_size) {
-  test_generate(1000);
+  test_generate(std::execution::par_unseq, 1000);
 }
 
+
+BOOST_AUTO_TEST_CASE(par_empty) {
+  test_generate(std::execution::par, 0);
+}
+
+BOOST_AUTO_TEST_CASE(par_single_element) {
+  test_generate(std::execution::par, 1);
+}
+
+BOOST_AUTO_TEST_CASE(par_medium_size) {
+  test_generate(std::execution::par, 1000);
+}
 
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pstl/generate_n.cpp
+++ b/tests/pstl/generate_n.cpp
@@ -21,11 +21,11 @@
 
 BOOST_FIXTURE_TEST_SUITE(pstl_generate_n, enable_unified_shared_memory)
 
-
-void test_generate_n(std::size_t problem_size) {
+template<class Policy>
+void test_generate_n(Policy&& pol, std::size_t problem_size) {
   std::vector<int> data(problem_size);
 
-  auto ret = std::generate_n(std::execution::par_unseq, data.begin(), data.size(),
+  auto ret = std::generate_n(pol, data.begin(), data.size(),
                 []() { return 42; });
   BOOST_CHECK(ret == data.begin() + problem_size);
 
@@ -46,17 +46,28 @@ BOOST_AUTO_TEST_CASE(par_unseq_negative) {
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_empty) {
-  test_generate_n(0);
+  test_generate_n(std::execution::par_unseq, 0);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_single_element) {
-  test_generate_n(1);
+  test_generate_n(std::execution::par_unseq, 1);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_medium_size) {
-  test_generate_n(1000);
+  test_generate_n(std::execution::par_unseq, 1000);
 }
 
 
+BOOST_AUTO_TEST_CASE(par_empty) {
+  test_generate_n(std::execution::par, 0);
+}
+
+BOOST_AUTO_TEST_CASE(par_single_element) {
+  test_generate_n(std::execution::par_unseq, 1);
+}
+
+BOOST_AUTO_TEST_CASE(par_medium_size) {
+  test_generate_n(std::execution::par, 1000);
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pstl/none_of.cpp
+++ b/tests/pstl/none_of.cpp
@@ -20,8 +20,9 @@
 
 BOOST_FIXTURE_TEST_SUITE(pstl_none_of, enable_unified_shared_memory)
 
-template <class Generator, class Predicate>
-void test_none_of(std::size_t problem_size, Generator gen, Predicate p) {
+template <class Policy, class Generator, class Predicate>
+void test_none_of(Policy &&pol, std::size_t problem_size, Generator gen,
+                  Predicate p) {
   std::vector<int> data(problem_size);
   for(int i = 0; i < problem_size; ++i)
     data[i] = gen(i);
@@ -34,24 +35,50 @@ void test_none_of(std::size_t problem_size, Generator gen, Predicate p) {
   BOOST_CHECK(ret == ret_host);
 }
 
+template<class Policy>
+void test_empty(Policy&& pol) {
+  test_none_of(pol, 0, [](int i){return i;}, [](int x){ return x > 0;});
+}
+
+template<class Policy>
+void test_single_element(Policy&& pol) {
+  test_none_of(pol, 1, [](int i){return i;}, [](int x){ return x < 0;});
+  test_none_of(pol, 1, [](int i){return i;}, [](int x){ return x > 0;});
+  test_none_of(pol, 1, [](int i){return i;}, [](int x){ return x >= 0;});
+  test_none_of(pol, 1, [](int i){return i;}, [](int x){ return x % 2 == 0;});
+}
+
+template<class Policy>
+void test_medium_size(Policy&& pol) {
+  test_none_of(pol, 1000, [](int i){return i;}, [](int x){ return x < 0;});
+  test_none_of(pol, 1000, [](int i){return i;}, [](int x){ return x > 0;});
+  test_none_of(pol, 1000, [](int i){return i;}, [](int x){ return x >= 0;});
+  test_none_of(pol, 1000, [](int i){return i;}, [](int x){ return x % 2 == 0;});
+}
+
 BOOST_AUTO_TEST_CASE(par_unseq_empty) {
-  test_none_of(0, [](int i){return i;}, [](int x){ return x > 0;});
+  test_empty(std::execution::par_unseq);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_single_element) {
-  test_none_of(1, [](int i){return i;}, [](int x){ return x < 0;});
-  test_none_of(1, [](int i){return i;}, [](int x){ return x > 0;});
-  test_none_of(1, [](int i){return i;}, [](int x){ return x >= 0;});
-  test_none_of(1, [](int i){return i;}, [](int x){ return x % 2 == 0;});
+  test_single_element(std::execution::par_unseq);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_medium_size) {
-  test_none_of(1000, [](int i){return i;}, [](int x){ return x < 0;});
-  test_none_of(1000, [](int i){return i;}, [](int x){ return x > 0;});
-  test_none_of(1000, [](int i){return i;}, [](int x){ return x >= 0;});
-  test_none_of(1000, [](int i){return i;}, [](int x){ return x % 2 == 0;});
+  test_medium_size(std::execution::par_unseq);
 }
 
 
+BOOST_AUTO_TEST_CASE(par_empty) {
+  test_empty(std::execution::par);
+}
+
+BOOST_AUTO_TEST_CASE(par_single_element) {
+  test_single_element(std::execution::par);
+}
+
+BOOST_AUTO_TEST_CASE(par_medium_size) {
+  test_medium_size(std::execution::par);
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pstl/reduce.cpp
+++ b/tests/pstl/reduce.cpp
@@ -21,47 +21,69 @@
 
 BOOST_FIXTURE_TEST_SUITE(pstl_reduce, enable_unified_shared_memory)
 
-template<class T>
-void test_basic_reduction(T init, std::size_t size) {
+template<class T, class Policy>
+void test_basic_reduction(Policy&& pol, T init, std::size_t size) {
   std::vector<T> data(size);
   for(std::size_t i = 0; i < data.size(); ++i)
     data[i] = static_cast<T>(i);
 
   T reference_result = std::reduce(
       data.begin(), data.end(), init, std::plus<>{});
-  T res = std::reduce(std::execution::par_unseq,
+  T res = std::reduce(pol,
       data.begin(), data.end(), init, std::plus<>{});
   BOOST_CHECK(res == reference_result);
 
-  T res2 = std::reduce(std::execution::par_unseq,
+  T res2 = std::reduce(pol,
       data.begin(), data.end(), init);
   BOOST_CHECK(res2 == res);
 
   T reference_result2 = std::reduce(
       data.begin(), data.end());
-  T res3 = std::reduce(std::execution::par_unseq,
-      data.begin(), data.end());
+  T res3 = std::reduce(pol, data.begin(), data.end());
   BOOST_CHECK(reference_result2 == res3);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_empty_offset) {
-  test_basic_reduction(10, 0);
+  test_basic_reduction(std::execution::par_unseq, 10, 0);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_single_element_offset) {
-  test_basic_reduction(10, 1);
+  test_basic_reduction(std::execution::par_unseq, 10, 1);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_incomplete_single_work_group_offset) {
-  test_basic_reduction(10, 127);
+  test_basic_reduction(std::execution::par_unseq, 10, 127);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_medium_size) {
-  test_basic_reduction(0, 1000);
+  test_basic_reduction(std::execution::par_unseq, 0, 1000);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_large_size) {
-  test_basic_reduction(0ll, 1000*1000);
+  test_basic_reduction(std::execution::par_unseq, 0ll, 1000*1000);
 }
+
+
+
+BOOST_AUTO_TEST_CASE(par_empty_offset) {
+  test_basic_reduction(std::execution::par, 10, 0);
+}
+
+BOOST_AUTO_TEST_CASE(par_single_element_offset) {
+  test_basic_reduction(std::execution::par, 10, 1);
+}
+
+BOOST_AUTO_TEST_CASE(par_incomplete_single_work_group_offset) {
+  test_basic_reduction(std::execution::par, 10, 127);
+}
+
+BOOST_AUTO_TEST_CASE(par_medium_size) {
+  test_basic_reduction(std::execution::par, 0, 1000);
+}
+
+BOOST_AUTO_TEST_CASE(par_large_size) {
+  test_basic_reduction(std::execution::par, 0ll, 1000*1000);
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pstl/replace.cpp
+++ b/tests/pstl/replace.cpp
@@ -21,15 +21,15 @@
 
 BOOST_FIXTURE_TEST_SUITE(pstl_replace, enable_unified_shared_memory)
 
-template <class Generator>
-void test_replace(std::size_t problem_size, Generator gen, int old_val,
+template <class Policy, class Generator>
+void test_replace(Policy&& pol, std::size_t problem_size, Generator gen, int old_val,
                   int new_val) {
   std::vector<int> data(problem_size);
   for(int i = 0; i < problem_size; ++i)
     data[i] = gen(i);
   std::vector<int> host_data = data;
 
-  std::replace(std::execution::par_unseq, data.begin(), data.end(), old_val,
+  std::replace(pol, data.begin(), data.end(), old_val,
                new_val);
   std::replace(host_data.begin(), host_data.end(), old_val,
                new_val);               
@@ -38,19 +38,32 @@ void test_replace(std::size_t problem_size, Generator gen, int old_val,
 
 
 BOOST_AUTO_TEST_CASE(par_unseq_empty) {
-  test_replace(0, [](int i){return i;}, 3, 2);
+  test_replace(std::execution::par_unseq, 0, [](int i){return i;}, 3, 2);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_single_element) {
-  test_replace(1, [](int i){return 42;}, 42, 4);
-  test_replace(1, [](int i){return 42;}, 2, 4);
+  test_replace(std::execution::par_unseq, 1, [](int i){return 42;}, 42, 4);
+  test_replace(std::execution::par_unseq, 1, [](int i){return 42;}, 2, 4);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_medium_size) {
-  test_replace(1000, [](int i){return i%10+3;}, 20, 4);
-  test_replace(1000, [](int i){return i%10+3;}, -2, 4);
+  test_replace(std::execution::par_unseq, 1000, [](int i){return i%10+3;}, 20, 4);
+  test_replace(std::execution::par_unseq, 1000, [](int i){return i%10+3;}, -2, 4);
 }
 
 
+BOOST_AUTO_TEST_CASE(par_empty) {
+  test_replace(std::execution::par, 0, [](int i){return i;}, 3, 2);
+}
+
+BOOST_AUTO_TEST_CASE(par_single_element) {
+  test_replace(std::execution::par, 1, [](int i){return 42;}, 42, 4);
+  test_replace(std::execution::par, 1, [](int i){return 42;}, 2, 4);
+}
+
+BOOST_AUTO_TEST_CASE(par_medium_size) {
+  test_replace(std::execution::par, 1000, [](int i){return i%10+3;}, 20, 4);
+  test_replace(std::execution::par, 1000, [](int i){return i%10+3;}, -2, 4);
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pstl/replace_copy.cpp
+++ b/tests/pstl/replace_copy.cpp
@@ -21,9 +21,9 @@
 
 BOOST_FIXTURE_TEST_SUITE(pstl_replace_copy, enable_unified_shared_memory)
 
-template <class Generator>
-void test_replace_copy(std::size_t problem_size, Generator gen, int old_val,
-                       int new_val) {
+template <class Policy, class Generator>
+void test_replace_copy(Policy &&pol, std::size_t problem_size, Generator gen,
+                       int old_val, int new_val) {
   std::vector<int> data(problem_size);
   for(int i = 0; i < problem_size; ++i)
     data[i] = gen(i);
@@ -31,8 +31,8 @@ void test_replace_copy(std::size_t problem_size, Generator gen, int old_val,
   std::vector<int> dest(problem_size);
   std::vector<int> host_dest(problem_size);
 
-  auto ret = std::replace_copy(std::execution::par_unseq, data.begin(),
-                               data.end(), dest.begin(), old_val, new_val);
+  auto ret = std::replace_copy(pol, data.begin(), data.end(), dest.begin(),
+                               old_val, new_val);
   std::replace_copy(data.begin(), data.end(), host_dest.begin(), old_val,
                     new_val);
   BOOST_CHECK(ret == dest.begin() + problem_size);
@@ -40,19 +40,33 @@ void test_replace_copy(std::size_t problem_size, Generator gen, int old_val,
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_empty) {
-  test_replace_copy(0, [](int i){return i;}, 3, 2);
+  test_replace_copy(std::execution::par_unseq, 0, [](int i){return i;}, 3, 2);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_single_element) {
-  test_replace_copy(1, [](int i){return 42;}, 42, 4);
-  test_replace_copy(1, [](int i){return 42;}, 2, 4);
+  test_replace_copy(std::execution::par_unseq, 1, [](int i){return 42;}, 42, 4);
+  test_replace_copy(std::execution::par_unseq, 1, [](int i){return 42;}, 2, 4);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_medium_size) {
-  test_replace_copy(1000, [](int i){return i%10+3;}, 20, 4);
-  test_replace_copy(1000, [](int i){return i%10+3;}, -2, 4);
+  test_replace_copy(std::execution::par_unseq, 1000, [](int i){return i%10+3;}, 20, 4);
+  test_replace_copy(std::execution::par_unseq, 1000, [](int i){return i%10+3;}, -2, 4);
 }
 
+
+BOOST_AUTO_TEST_CASE(par_empty) {
+  test_replace_copy(std::execution::par, 0, [](int i){return i;}, 3, 2);
+}
+
+BOOST_AUTO_TEST_CASE(par_single_element) {
+  test_replace_copy(std::execution::par, 1, [](int i){return 42;}, 42, 4);
+  test_replace_copy(std::execution::par, 1, [](int i){return 42;}, 2, 4);
+}
+
+BOOST_AUTO_TEST_CASE(par_medium_size) {
+  test_replace_copy(std::execution::par, 1000, [](int i){return i%10+3;}, 20, 4);
+  test_replace_copy(std::execution::par, 1000, [](int i){return i%10+3;}, -2, 4);
+}
 
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pstl/replace_if.cpp
+++ b/tests/pstl/replace_if.cpp
@@ -21,39 +21,58 @@
 
 BOOST_FIXTURE_TEST_SUITE(pstl_replace_if, enable_unified_shared_memory)
 
-template <class Generator, class Pred>
-void test_replace_if(std::size_t problem_size, Generator gen, Pred p, int new_val) {
+template <class Policy, class Generator, class Pred>
+void test_replace_if(Policy &&pol, std::size_t problem_size, Generator gen,
+                     Pred p, int new_val) {
   std::vector<int> data(problem_size);
   for(int i = 0; i < problem_size; ++i)
     data[i] = gen(i);
   std::vector<int> host_data = data;
 
-  std::replace_if(std::execution::par_unseq, data.begin(), data.end(), p,
+  std::replace_if(pol, data.begin(), data.end(), p,
                   new_val);
   std::replace_if(host_data.begin(), host_data.end(), p, new_val);
   BOOST_CHECK(data == host_data);
 }
 
-
 BOOST_AUTO_TEST_CASE(par_unseq_empty) {
-  test_replace_if(
+  test_replace_if(std::execution::par_unseq,
       0, [](int i) { return i; }, [](int x) { return x % 2 == 0; }, 4);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_single_element) {
-  test_replace_if(
+  test_replace_if(std::execution::par_unseq,
       1, [](int i) { return 42; }, [](int x) { return x == 42; }, 4);
-  test_replace_if(
+  test_replace_if(std::execution::par_unseq,
       1, [](int i) { return 2; }, [](int x) { return x == 42; }, 4);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_medium_size) {
-  test_replace_if(
+  test_replace_if(std::execution::par_unseq,
       1000, [](int i) { return i%10+3; }, [](int x) { return x == 20; }, 4);
-  test_replace_if(
+  test_replace_if(std::execution::par_unseq,
       1000, [](int i) { return i%10+3; }, [](int x) { return x == -2; }, 4);
 }
 
+
+BOOST_AUTO_TEST_CASE(par_empty) {
+  test_replace_if(std::execution::par,
+      0, [](int i) { return i; }, [](int x) { return x % 2 == 0; }, 4);
+}
+
+BOOST_AUTO_TEST_CASE(par_single_element) {
+  test_replace_if(std::execution::par,
+      1, [](int i) { return 42; }, [](int x) { return x == 42; }, 4);
+  test_replace_if(std::execution::par,
+      1, [](int i) { return 2; }, [](int x) { return x == 42; }, 4);
+}
+
+BOOST_AUTO_TEST_CASE(par_medium_size) {
+  test_replace_if(std::execution::par,
+      1000, [](int i) { return i%10+3; }, [](int x) { return x == 20; }, 4);
+  test_replace_if(std::execution::par,
+      1000, [](int i) { return i%10+3; }, [](int x) { return x == -2; }, 4);
+}
 
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pstl/transform_reduce.cpp
+++ b/tests/pstl/transform_reduce.cpp
@@ -20,38 +20,60 @@
 
 BOOST_FIXTURE_TEST_SUITE(pstl_transform_reduce, enable_unified_shared_memory)
 
-template<class T>
-void test_basic_reduction(T init, std::size_t size) {
+template<class Policy, class T>
+void test_basic_reduction(Policy&& pol, T init, std::size_t size) {
   std::vector<T> data(size);
   for(std::size_t i = 0; i < data.size(); ++i)
     data[i] = static_cast<T>(i);
 
   T reference_result = std::transform_reduce(
       data.begin(), data.end(), init, std::plus<>{}, [](auto x) { return x; });
-  T res = std::transform_reduce(std::execution::par_unseq,
+  T res = std::transform_reduce(pol,
       data.begin(), data.end(), init, std::plus<>{}, [](auto x) { return x; });
   
   BOOST_CHECK(res == reference_result);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_empty) {
-  test_basic_reduction(10, 0);
+  test_basic_reduction(std::execution::par_unseq, 10, 0);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_single_element) {
-  test_basic_reduction(10, 1);
+  test_basic_reduction(std::execution::par_unseq, 10, 1);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_incomplete_single_work_group) {
-  test_basic_reduction(10, 127);
+  test_basic_reduction(std::execution::par_unseq, 10, 127);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_int_plus) {
-  test_basic_reduction(0, 1000);
+  test_basic_reduction(std::execution::par_unseq, 0, 1000);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_int_plus_large) {
-  test_basic_reduction(0ll, 1000*1000);
+  test_basic_reduction(std::execution::par_unseq, 0ll, 1000*1000);
+}
+
+
+
+BOOST_AUTO_TEST_CASE(par_empty) {
+  test_basic_reduction(std::execution::par, 10, 0);
+}
+
+BOOST_AUTO_TEST_CASE(par_single_element) {
+  test_basic_reduction(std::execution::par, 10, 1);
+}
+
+BOOST_AUTO_TEST_CASE(par_incomplete_single_work_group) {
+  test_basic_reduction(std::execution::par, 10, 127);
+}
+
+BOOST_AUTO_TEST_CASE(par_int_plus) {
+  test_basic_reduction(std::execution::par, 0, 1000);
+}
+
+BOOST_AUTO_TEST_CASE(par_int_plus_large) {
+  test_basic_reduction(std::execution::par, 0ll, 1000*1000);
 }
 
 BOOST_AUTO_TEST_CASE(par_unseq_int_unknown_identity) {


### PR DESCRIPTION
Currently we only offload `std::execution::par_unseq`. This PR enables offloading of `std::execution::par`. Currently, this is limited to recent NVIDIA GPUs due to the necessary forward progress guarantees.