### PR TITLE
[SSCP] Ensure sycl_tests by default succeed with SSCP

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -108,7 +108,7 @@ jobs:
       if: matrix.clang >= 14
       run: |
         cd ${GITHUB_WORKSPACE}/build/tests-sscp
-        ACPP_VISIBILITY_MASK="omp" LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ./sycl_tests -t '!group_functions_tests/*' -t '!extension_tests/*' -t '!kernel_invocation_tests/hierarchical*'
+        ACPP_VISIBILITY_MASK="omp" LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ./sycl_tests
     - name: run PSTL tests on CPU
       if: matrix.clang >= 14
       run: |

--- a/include/hipSYCL/runtime/kernel_launcher.hpp
+++ b/include/hipSYCL/runtime/kernel_launcher.hpp
@@ -109,7 +109,8 @@ public:
       }
     }
 
-    if(cap.get_sscp_invoker().has_value() && _static_data.sscp_kernel_id) {
+    if (cap.get_sscp_invoker().has_value() &&
+        (_static_data.sscp_kernel_id || _static_data.custom_op)) {
       return _static_data.sscp_invoker(_static_data, node, _kernel_config,
                                        cap, params);
     }

--- a/src/libkernel/sscp/spirv/subgroup.cpp
+++ b/src/libkernel/sscp/spirv/subgroup.cpp
@@ -10,30 +10,31 @@
 // SPDX-License-Identifier: BSD-2-Clause
 #include "hipSYCL/sycl/libkernel/sscp/builtins/subgroup.hpp"
 
-extern "C" __acpp_uint32 __spirv_BuiltInSubgroupLocalInvocationId();
-extern "C" __acpp_uint32 __spirv_BuiltInSubgroupSize();
-extern "C" __acpp_uint32 __spirv_BuiltInSubgroupMaxSize();
-extern "C" __acpp_uint32 __spirv_BuiltInSubgroupId();
-extern "C" __acpp_uint32 __spirv_BuiltInNumSubgroups();
+extern "C" __acpp_uint32 __spirv_BuiltInSubgroupLocalInvocationId;
+extern "C" __acpp_uint32 __spirv_BuiltInSubgroupSize;
+extern "C" __acpp_uint32 __spirv_BuiltInSubgroupMaxSize;
+extern "C" __acpp_uint32 __spirv_BuiltInSubgroupId;
+extern "C" __acpp_uint32 __spirv_BuiltInNumSubgroups;
+
 
 HIPSYCL_SSCP_BUILTIN __acpp_uint32 __acpp_sscp_get_subgroup_local_id() {
-  return __spirv_BuiltInSubgroupLocalInvocationId();
+  return __spirv_BuiltInSubgroupLocalInvocationId;
 }
 
 HIPSYCL_SSCP_BUILTIN __acpp_uint32 __acpp_sscp_get_subgroup_size() {
-  return __spirv_BuiltInSubgroupSize();
+  return __spirv_BuiltInSubgroupSize;
 }
 
 HIPSYCL_SSCP_BUILTIN __acpp_uint32 __acpp_sscp_get_subgroup_max_size() {
-  return __spirv_BuiltInSubgroupMaxSize();
+  return __spirv_BuiltInSubgroupMaxSize;
 }
 
 HIPSYCL_SSCP_BUILTIN __acpp_uint32 __acpp_sscp_get_subgroup_id() {
-  return __spirv_BuiltInSubgroupId();
+  return __spirv_BuiltInSubgroupId;
 }
 
 HIPSYCL_SSCP_BUILTIN __acpp_uint32 __acpp_sscp_get_num_subgroups() {
-  return __spirv_BuiltInNumSubgroups();
+  return __spirv_BuiltInNumSubgroups;
 }
 
 

--- a/src/runtime/ocl/ocl_hardware_manager.cpp
+++ b/src/runtime/ocl/ocl_hardware_manager.cpp
@@ -266,7 +266,7 @@ bool ocl_hardware_context::has(device_support_aspect aspect) const {
     return this->_usm_provider->has_usm_system_allocations();
     break;
   case device_support_aspect::execution_timestamps:
-    return true;
+    return false;
     break;
   case device_support_aspect::sscp_kernels:
 #ifdef HIPSYCL_WITH_SSCP_COMPILER

--- a/src/runtime/ocl/ocl_hardware_manager.cpp
+++ b/src/runtime/ocl/ocl_hardware_manager.cpp
@@ -476,13 +476,29 @@ ocl_hardware_context::get_property(device_uint_list_property prop) const {
   switch (prop) {
   case device_uint_list_property::sub_group_sizes:
     // TODO - there does not seem to be a direct query for this.
-    // The current implementation is a hack and might not return
-    // all possible subgroup sizes.
+    // So we return all power of two values between 1 and
+    // the max workgroup size. The latter corresponds to the case when there is
+    // only a single subgroup for the whole work group.
+    // Unfortunately there does not seem to be a good way to get a min bound.
+    //
+    // This is a heuristic that returns all possible subgroup sizes, but may
+    // also return values that are not actually possible as subgroups.
     std::size_t max_num_sub_groups =
         get_property(device_uint_property::max_num_sub_groups);
-    return std::vector<std::size_t>{
-        get_property(device_uint_property::max_group_size) /
-        max_num_sub_groups};
+    std::size_t max_group_size =
+        get_property(device_uint_property::max_group_size);
+    
+    auto min_bound = 1;
+    auto max_bound = std::max(max_num_sub_groups, max_group_size);
+
+    std::vector<std::size_t> result;
+
+    for(std::size_t i = 1; i < max_bound; i *= 2) {
+      if(i >= min_bound)
+        result.push_back(i);
+    }
+
+    return result;
     break;
   }
   assert(false && "Invalid device property");

--- a/src/runtime/ocl/ocl_usm.cpp
+++ b/src/runtime/ocl/ocl_usm.cpp
@@ -161,6 +161,7 @@ public:
 
     out.is_from_host_backend = false;
     out.is_optimized_host = false;
+    out.is_usm = false;
 
     if(err != CL_SUCCESS)
       return err;

--- a/tests/sycl/extensions.cpp
+++ b/tests/sycl/extensions.cpp
@@ -86,7 +86,8 @@ BOOST_AUTO_TEST_CASE(auto_placeholder_require_extension) {
   }
 }
 #endif
-#ifdef ACPP_EXT_CUSTOM_PFWI_SYNCHRONIZATION
+#if defined(ACPP_EXT_CUSTOM_PFWI_SYNCHRONIZATION) &&                           \
+    !defined(__ACPP_ENABLE_LLVM_SSCP_TARGET__)
 BOOST_AUTO_TEST_CASE(custom_pfwi_synchronization_extension) {
   namespace sync = cl::sycl::vendor::hipsycl::synchronization;
 
@@ -154,8 +155,11 @@ BOOST_AUTO_TEST_CASE(custom_pfwi_synchronization_extension) {
   }
 }
 #endif
-#if defined(ACPP_EXT_SCOPED_PARALLELISM_V2) &&                              \
-    !defined(ACPP_LIBKERNEL_CUDA_NVCXX) // nvc++ currently crashed with sp code
+
+#if defined(ACPP_EXT_SCOPED_PARALLELISM_V2) &&                                 \
+    !defined(                                                                  \
+        ACPP_LIBKERNEL_CUDA_NVCXX) && /*nvc++ currently crashed with sp code*/ \
+    !defined(__ACPP_ENABLE_LLVM_SSCP_TARGET__)
 
 template<class KernelName, int N>
 class enumerated_kernel_name;

--- a/tests/sycl/group_functions/group_functions.hpp
+++ b/tests/sycl/group_functions/group_functions.hpp
@@ -25,8 +25,9 @@
 
 using namespace cl;
 
-
+#ifndef __ACPP_ENABLE_LLVM_SSCP_TARGET__
 #define HIPSYCL_ENABLE_GROUP_ALGORITHM_TESTS
+#endif
 
 
 #ifdef TESTS_GROUPFUNCTION_FULL

--- a/tests/sycl/kernel_invocation.cpp
+++ b/tests/sycl/kernel_invocation.cpp
@@ -86,6 +86,7 @@ BOOST_AUTO_TEST_CASE(basic_parallel_for_nd) {
   }
 }
 
+#if !defined(__ACPP_ENABLE_LLVM_SSCP_TARGET__)
 BOOST_AUTO_TEST_CASE(hierarchical_dispatch) {
   constexpr size_t local_size = 256;
   constexpr size_t global_size = 1024;
@@ -164,7 +165,8 @@ BOOST_AUTO_TEST_CASE(hierarchical_private_memory) {
   for (int i = 0; i < global_size; ++i)
     BOOST_TEST(host_acc[i] == i);
 }
-#endif
+#endif // ACPP_LIBKERNEL_CUDA_NVCXX
+#endif // __ACPP_ENABLE_LLVM_SSCP_TARGET__
 
 BOOST_AUTO_TEST_SUITE_END() // NOTE: Make sure not to add anything below this
                             // line

--- a/tests/sycl/profiler.cpp
+++ b/tests/sycl/profiler.cpp
@@ -14,6 +14,11 @@
 
 BOOST_FIXTURE_TEST_SUITE(profiler_tests, reset_device_fixture)
 
+bool default_device_supports_profiling() {
+  cl::sycl::queue q;
+  return q.get_device().get_info<cl::sycl::info::device::queue_profiling>();
+}
+
 BOOST_AUTO_TEST_CASE(queue_no_profiling_exception)
 {
   const auto is_invalid = [](const cl::sycl::exception &e) {
@@ -74,117 +79,139 @@ BOOST_AUTO_TEST_CASE(queue_no_profiling_exception)
 
 BOOST_AUTO_TEST_CASE(queue_profiling)
 {
-  cl::sycl::queue queue{cl::sycl::property::queue::enable_profiling{}};
-  constexpr size_t n = 4;
-  cl::sycl::buffer<int, 1> buf1{cl::sycl::range<1>(n)};
+  if(default_device_supports_profiling()) {
+    cl::sycl::queue queue{cl::sycl::property::queue::enable_profiling{}};
+    constexpr size_t n = 4;
+    cl::sycl::buffer<int, 1> buf1{cl::sycl::range<1>(n)};
 
-  auto evt1 = queue.submit([&](cl::sycl::handler &cgh) {
-    auto acc = buf1.get_access<cl::sycl::access::mode::discard_write>(cgh);
-    cgh.single_task<class profile_single_task>([=]() {
-      acc[0] = 42;
+    auto evt1 = queue.submit([&](cl::sycl::handler &cgh) {
+      auto acc = buf1.get_access<cl::sycl::access::mode::discard_write>(cgh);
+      cgh.single_task<class profile_single_task>([=]() { acc[0] = 42; });
     });
-  });
 
-  auto t12 = evt1.get_profiling_info<cl::sycl::info::event_profiling::command_start>();
-  auto t11 = evt1.get_profiling_info<cl::sycl::info::event_profiling::command_submit>();
-  auto t13 = evt1.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
-  BOOST_CHECK(t11 <= t12 && t12 <= t13);
-  
-  auto evt2 = queue.submit([&](cl::sycl::handler &cgh) {
-    auto acc = buf1.get_access<cl::sycl::access::mode::discard_write>(cgh);
-    cgh.parallel_for<class profile_parallel_for>(buf1.get_range(), [=](cl::sycl::item<1> item) {
-      acc[item] = item.get_id()[0];
+    auto t12 = evt1.get_profiling_info<
+        cl::sycl::info::event_profiling::command_start>();
+    auto t11 = evt1.get_profiling_info<
+        cl::sycl::info::event_profiling::command_submit>();
+    auto t13 =
+        evt1.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
+    BOOST_CHECK(t11 <= t12 && t12 <= t13);
+
+    auto evt2 = queue.submit([&](cl::sycl::handler &cgh) {
+      auto acc = buf1.get_access<cl::sycl::access::mode::discard_write>(cgh);
+      cgh.parallel_for<class profile_parallel_for>(
+          buf1.get_range(),
+          [=](cl::sycl::item<1> item) { acc[item] = item.get_id()[0]; });
     });
-  });
 
-  cl::sycl::buffer<int, 1> buf2{buf1.get_range()};
-  auto evt3 = queue.submit([&](cl::sycl::handler &cgh) {
-    cgh.copy(buf1.get_access<cl::sycl::access::mode::read>(cgh),
-             buf2.get_access<cl::sycl::access::mode::discard_write>(cgh));
-  });
+    cl::sycl::buffer<int, 1> buf2{buf1.get_range()};
+    auto evt3 = queue.submit([&](cl::sycl::handler &cgh) {
+      cgh.copy(buf1.get_access<cl::sycl::access::mode::read>(cgh),
+               buf2.get_access<cl::sycl::access::mode::discard_write>(cgh));
+    });
 
-  auto t21 = evt2.get_profiling_info<cl::sycl::info::event_profiling::command_submit>();
-  auto t22 = evt2.get_profiling_info<cl::sycl::info::event_profiling::command_start>();
-  auto t23 = evt2.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
-  BOOST_CHECK(t21 <= t22 && t22 <= t23);
+    auto t21 = evt2.get_profiling_info<
+        cl::sycl::info::event_profiling::command_submit>();
+    auto t22 = evt2.get_profiling_info<
+        cl::sycl::info::event_profiling::command_start>();
+    auto t23 =
+        evt2.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
+    BOOST_CHECK(t21 <= t22 && t22 <= t23);
 
-  auto t31 = evt3.get_profiling_info<cl::sycl::info::event_profiling::command_submit>();
-  auto t32 = evt3.get_profiling_info<cl::sycl::info::event_profiling::command_start>();
-  auto t33 = evt3.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
-  BOOST_CHECK(t31 <= t32 && t32 <= t33);
-  BOOST_CHECK(t21 <= t31 && t23 <= t32);
+    auto t31 = evt3.get_profiling_info<
+        cl::sycl::info::event_profiling::command_submit>();
+    auto t32 = evt3.get_profiling_info<
+        cl::sycl::info::event_profiling::command_start>();
+    auto t33 =
+        evt3.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
+    BOOST_CHECK(t31 <= t32 && t32 <= t33);
+    BOOST_CHECK(t21 <= t31 && t23 <= t32);
 
-  auto evt4 = queue.submit([&](cl::sycl::handler &cgh) {
-    cgh.fill(buf1.get_access<cl::sycl::access::mode::discard_write>(cgh), 1);
-  });
+    auto evt4 = queue.submit([&](cl::sycl::handler &cgh) {
+      cgh.fill(buf1.get_access<cl::sycl::access::mode::discard_write>(cgh), 1);
+    });
 
-  int host_array[n];
-  auto evt5 = queue.submit([&](cl::sycl::handler &cgh) {
-    // copy to pointer
-    cgh.copy(buf2.get_access<cl::sycl::access::mode::read>(cgh), host_array);
-  });
+    int host_array[n];
+    auto evt5 = queue.submit([&](cl::sycl::handler &cgh) {
+      // copy to pointer
+      cgh.copy(buf2.get_access<cl::sycl::access::mode::read>(cgh), host_array);
+    });
 
-  auto t51 = evt5.get_profiling_info<cl::sycl::info::event_profiling::command_submit>();
-  auto t52 = evt5.get_profiling_info<cl::sycl::info::event_profiling::command_start>();
-  auto t53 = evt5.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
-  BOOST_CHECK(t51 <= t52 && t52 <= t53);
+    auto t51 = evt5.get_profiling_info<
+        cl::sycl::info::event_profiling::command_submit>();
+    auto t52 = evt5.get_profiling_info<
+        cl::sycl::info::event_profiling::command_start>();
+    auto t53 =
+        evt5.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
+    BOOST_CHECK(t51 <= t52 && t52 <= t53);
 
-  // re-ordered
-  auto t41 = evt4.get_profiling_info<cl::sycl::info::event_profiling::command_submit>();
-  auto t42 = evt4.get_profiling_info<cl::sycl::info::event_profiling::command_start>();
-  auto t43 = evt4.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
-  BOOST_CHECK(t41 <= t42 && t42 <= t43);
+    // re-ordered
+    auto t41 = evt4.get_profiling_info<
+        cl::sycl::info::event_profiling::command_submit>();
+    auto t42 = evt4.get_profiling_info<
+        cl::sycl::info::event_profiling::command_start>();
+    auto t43 =
+        evt4.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
+    BOOST_CHECK(t41 <= t42 && t42 <= t43);
 
-  // usm
-  auto *src = cl::sycl::malloc_shared<int>(n, queue);
-  auto *dest = cl::sycl::malloc_shared<int>(n, queue);
-  auto evt6 = queue.submit([&](cl::sycl::handler &cgh) {
-    cgh.memset(src, 0, sizeof src);
-  });
+    // usm
+    auto *src = cl::sycl::malloc_shared<int>(n, queue);
+    auto *dest = cl::sycl::malloc_shared<int>(n, queue);
+    auto evt6 = queue.submit(
+        [&](cl::sycl::handler &cgh) { cgh.memset(src, 0, sizeof src); });
 
-  auto t61 = evt6.get_profiling_info<cl::sycl::info::event_profiling::command_submit>();
-  auto t62 = evt6.get_profiling_info<cl::sycl::info::event_profiling::command_start>();
-  auto t63 = evt6.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
-  BOOST_CHECK(t61 <= t62 && t62 <= t63);
+    auto t61 = evt6.get_profiling_info<
+        cl::sycl::info::event_profiling::command_submit>();
+    auto t62 = evt6.get_profiling_info<
+        cl::sycl::info::event_profiling::command_start>();
+    auto t63 =
+        evt6.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
+    BOOST_CHECK(t61 <= t62 && t62 <= t63);
 
-  auto evt7 = queue.submit([&](cl::sycl::handler &cgh) {
-    cgh.memcpy(dest, src, sizeof src);
-  });
-  auto t71 = evt7.get_profiling_info<cl::sycl::info::event_profiling::command_submit>();
-  auto t72 = evt7.get_profiling_info<cl::sycl::info::event_profiling::command_start>();
-  auto t73 = evt7.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
-  BOOST_CHECK(t71 <= t72 && t72 <= t73);
+    auto evt7 = queue.submit(
+        [&](cl::sycl::handler &cgh) { cgh.memcpy(dest, src, sizeof src); });
+    auto t71 = evt7.get_profiling_info<
+        cl::sycl::info::event_profiling::command_submit>();
+    auto t72 = evt7.get_profiling_info<
+        cl::sycl::info::event_profiling::command_start>();
+    auto t73 =
+        evt7.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
+    BOOST_CHECK(t71 <= t72 && t72 <= t73);
 
-  auto evt8 = queue.submit([&](cl::sycl::handler &cgh) {
-    cgh.prefetch(dest, sizeof src);
-  });
-  auto t81 = evt8.get_profiling_info<cl::sycl::info::event_profiling::command_submit>();
-  auto t82 = evt8.get_profiling_info<cl::sycl::info::event_profiling::command_start>();
-  auto t83 = evt8.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
-  // run time may be zero if prefetching is a no-op
-  BOOST_CHECK(t81 <= t82 && t82 <= t83);
+    auto evt8 = queue.submit(
+        [&](cl::sycl::handler &cgh) { cgh.prefetch(dest, sizeof src); });
+    auto t81 = evt8.get_profiling_info<
+        cl::sycl::info::event_profiling::command_submit>();
+    auto t82 = evt8.get_profiling_info<
+        cl::sycl::info::event_profiling::command_start>();
+    auto t83 =
+        evt8.get_profiling_info<cl::sycl::info::event_profiling::command_end>();
+    // run time may be zero if prefetching is a no-op
+    BOOST_CHECK(t81 <= t82 && t82 <= t83);
 
-  cl::sycl::free(src, queue);
-  cl::sycl::free(dest, queue);
+    cl::sycl::free(src, queue);
+    cl::sycl::free(dest, queue);
+  }
 }
 
 // update_host is an explicit operation, but implemented as a requirement and thus not profiled.
 // remove the warning and merge this test into queue_profiling if that is ever resolved.
 BOOST_AUTO_TEST_CASE(queue_profiling_update_host_supported)
 {
-  cl::sycl::queue queue{cl::sycl::property::queue::enable_profiling{}};
-  int i = 1337;
-  cl::sycl::buffer<int, 1> buf{&i, cl::sycl::range<1>(1)};
-  queue.submit([&](cl::sycl::handler &cgh) {
-    auto acc = buf.get_access<cl::sycl::access::mode::discard_write>(cgh);
-    cgh.single_task<class basic_single_task>([=]() {
-      acc[0] = 42;
+  if(default_device_supports_profiling()) {
+    cl::sycl::queue queue{cl::sycl::property::queue::enable_profiling{}};
+    int i = 1337;
+    cl::sycl::buffer<int, 1> buf{&i, cl::sycl::range<1>(1)};
+    queue.submit([&](cl::sycl::handler &cgh) {
+      auto acc = buf.get_access<cl::sycl::access::mode::discard_write>(cgh);
+      cgh.single_task<class basic_single_task>([=]() { acc[0] = 42; });
     });
-  });
-  auto evt = queue.submit([&](cl::sycl::handler &cgh) {
-    cgh.update_host(buf.get_access<cl::sycl::access::mode::read>(cgh));
-  });
-  BOOST_WARN_NO_THROW(evt.get_profiling_info<cl::sycl::info::event_profiling::command_start>());
+    auto evt = queue.submit([&](cl::sycl::handler &cgh) {
+      cgh.update_host(buf.get_access<cl::sycl::access::mode::read>(cgh));
+    });
+    BOOST_WARN_NO_THROW(evt.get_profiling_info<
+                        cl::sycl::info::event_profiling::command_start>());
+  }
 }
 
 


### PR DESCRIPTION
This PR
* disables test cases not supported in the SSCP compilation flow, so we can just run `sycl_tests` to test with SSCP.
* fixes a minor regression I had discovered around this in the `AdaptiveCpp_enqueue_custom_operation` extension.
* fixes a couple of issues in the OpenCL backend, allowing `sycl_tests` to run cleanly with the OpenCL backend.