### PR TITLE
Buffer reduction: Clone requirement instead of reusing existing one to avoid debug assertions/hangs

### DIFF
--- a/include/hipSYCL/runtime/operations.hpp
+++ b/include/hipSYCL/runtime/operations.hpp
@@ -101,6 +101,9 @@ public:
     return make_success();
   }
 
+  virtual std::unique_ptr<requirement>
+  clone_requirement(bool bind_to_same_id) const = 0;
+
   virtual ~requirement(){}
 };
 
@@ -278,6 +281,17 @@ public:
   }
   
   void dump(std::ostream & ostr, int indentation=0) const override;
+
+  virtual std::unique_ptr<requirement>
+  clone_requirement(bool bind_to_same_id) const final override {
+    auto new_req = std::make_unique<buffer_memory_requirement>(
+        _mem_region, _offset, _range, _mode, _target);
+    
+    if(bind_to_same_id)
+      new_req->bind(_bound_embedded_ptr_id);
+
+    return new_req;
+  }
 
 private:
   bool page_ranges_intersect(buffer_data_region::page_range other) const{

--- a/include/hipSYCL/sycl/handler.hpp
+++ b/include/hipSYCL/sycl/handler.hpp
@@ -808,8 +808,16 @@ private:
       // buffers for buffer-accessor reductions
       for(const rt::dag_node_ptr& req : _requirements.get()) {
         auto* op = req->get_operation();
-        if(op->is_requirement())
-          req_list.add_node_requirement(req);
+        if(op->is_requirement()) {
+          auto cloned_op =
+              static_cast<rt::requirement *>(op)->clone_requirement(true);
+
+          req_list.add_requirement(std::move(cloned_op));
+        } else {
+          // Other dependencies that are not requirements should be
+          // covered by the dependency to the previous node that we add
+          // before this for loop.
+        }
       }
       
       previous_event =


### PR DESCRIPTION
when a buffer reduction submits multiple kernels, we need to add the original buffer requirements (accessors) to all reduction kernels, so that they all participate in dependency calculation among each other and subsequent kernels.

Previously, we have done this by adding existing requirement as dependencies. I don't know where or why exactly this broke things, but it does violate AdaptiveCpp's buffer-accessor model where requirement nodes are supposed to act as unique dependency edges between other nodes.

This PR changes reductions so that requirements are cloned instead of directly reused. In my testing, this
- fixes #1476
- fixes #1496 