### PR TITLE
Fix clang parser hang when kernel is not provided to parallel_for call

### DIFF
--- a/include/hipSYCL/sycl/detail/util.hpp
+++ b/include/hipSYCL/sycl/detail/util.hpp
@@ -62,21 +62,26 @@ extract_tuple(Tuple&& tuple, std::index_sequence<Ints...>) {
 template<class F, typename... Args>
 void separate_last_argument_and_apply(F&& f, Args&& ... args) {
   
-  static_assert(
-      sizeof...(args) > 0,
-      "Cannot extract last argument from template pack for empty pack");
-  
-  constexpr std::size_t last_index = sizeof...(args) - 1;
+  if constexpr(sizeof...(args) > 0) {
+    
+    constexpr std::size_t last_index = sizeof...(args) - 1;
 
-  auto last_element =
-      std::get<last_index>(std::forward_as_tuple(std::forward<Args>(args)...));
+    auto last_element =
+        std::get<last_index>(std::forward_as_tuple(std::forward<Args>(args)...));
 
-  auto preceding_elements =
-      extract_tuple(std::forward_as_tuple(std::forward<Args>(args)...),
-                    std::make_index_sequence<last_index>());
+    auto preceding_elements =
+        extract_tuple(std::forward_as_tuple(std::forward<Args>(args)...),
+                      std::make_index_sequence<last_index>());
 
-  std::apply(f,
-             std::tuple_cat(std::make_tuple(last_element), preceding_elements));
+    std::apply(f,
+              std::tuple_cat(std::make_tuple(last_element), preceding_elements));
+  } else {
+    // We still need the if constexpr, because otherwise parsing may
+    // not terminate in case of an empty argument pack, and the
+    // static_assert is never evaluated.
+    static_assert(sizeof...(args) > 0,
+                  "Invalid call with empty argument list");
+  }
 }
 
 


### PR DESCRIPTION
Due to the insanity of the SYCL 2020 reduction API, we need to pass in kernel arguments and reductions as a combined variadic template pack. This opens the door to invoking `parallel_for` without kernel argument, since packs can be empty.

In that case, clang seems to hang while executing our template metaprogramming algorithm to extract the last argument (the kernel) from the pack. Turns out there was a `static_assert` to catch this case, however, the parser already seems to hang before the `static_assert` is evaluated.

This PR fixes this by surrounding the code with an additional `if constexpr` to prevent it from attempting to extract the last element of the pack if the pack is empty.

Fixes #1526 