### PR TITLE
[SSCP][stdpar] Improve builtin remapping when -ffast-math is used

### DIFF
--- a/include/hipSYCL/sycl/libkernel/sscp/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins.hpp
@@ -204,7 +204,7 @@ HIPSYCL_BUILTIN float __acpp_pown(float x, IntType y) noexcept {
 
 template<class IntType>
 HIPSYCL_BUILTIN double __acpp_pown(double x, IntType y) noexcept {
-  return __acpp_sscp_pown_f64(x, static_cast<__acpp_int64>(y));
+  return __acpp_sscp_pown_f64(x, static_cast<__acpp_int32>(y));
 }
 
 HIPSYCL_DEFINE_SSCP_GENFLOAT_MATH_BUILTIN2(remainder)

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/math.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/math.hpp
@@ -165,7 +165,7 @@ HIPSYCL_SSCP_BUILTIN float __acpp_sscp_powr_f32(float, float);
 HIPSYCL_SSCP_BUILTIN double __acpp_sscp_powr_f64(double, double);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_pown_f32(float, __acpp_int32);
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_pown_f64(double, __acpp_int64);
+HIPSYCL_SSCP_BUILTIN double __acpp_sscp_pown_f64(double, __acpp_int32);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_remainder_f32(float, float);
 HIPSYCL_SSCP_BUILTIN double __acpp_sscp_remainder_f64(double, double);

--- a/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
+++ b/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
@@ -35,6 +35,7 @@
 #include <string>
 #include <system_error>
 #include <vector>
+#include <array>
 
 namespace hipsycl {
 namespace compiler {
@@ -109,6 +110,48 @@ void setPrecSqrt(llvm::Module& M, int Mode) {
   setNVVMReflectParameter(M, "prec-sqrt", Mode);
 }
 
+
+using IntrinsicMapping = std::array<const char*, 2>;
+// These intrinsics seem to not be handled correctly by NVPTX backend,
+// so replace them with our own builtins.
+static constexpr std::array IntrinsicReplacementMap = {
+  IntrinsicMapping{"llvm.pow.f32", "__acpp_sscp_pow_f32"},
+  IntrinsicMapping{"llvm.pow.f64", "__acpp_sscp_pow_f64"},
+  IntrinsicMapping{"llvm.exp.f32", "__acpp_sscp_exp_f32"},
+  IntrinsicMapping{"llvm.exp.f64", "__acpp_sscp_exp_f64"},
+  IntrinsicMapping{"llvm.exp2.f32", "__acpp_sscp_exp2_f32"},
+  IntrinsicMapping{"llvm.exp2.f64", "__acpp_sscp_exp2_f64"},
+  IntrinsicMapping{"llvm.exp10.f32", "__acpp_sscp_exp10_f32"},
+  IntrinsicMapping{"llvm.exp10.f64", "__acpp_sscp_exp10_f64"},
+  IntrinsicMapping{"llvm.cos.f32", "__acpp_sscp_cos_f32"},
+  IntrinsicMapping{"llvm.cos.f64", "__acpp_sscp_cos_f64"},
+  IntrinsicMapping{"llvm.sin.f32", "__acpp_sscp_sin_f32"},
+  IntrinsicMapping{"llvm.sin.f64", "__acpp_sscp_sin_f64"},
+  // tan seems fine
+  IntrinsicMapping{"llvm.log.f32", "__acpp_sscp_log_f32"},
+  IntrinsicMapping{"llvm.log.f64", "__acpp_sscp_log_f64"},
+  IntrinsicMapping{"llvm.log2.f32", "__acpp_sscp_log2_f32"},
+  IntrinsicMapping{"llvm.log2.f64", "__acpp_sscp_log2_f64"},
+  IntrinsicMapping{"llvm.log10.f32", "__acpp_sscp_log10_f32"},
+  IntrinsicMapping{"llvm.log10.f64", "__acpp_sscp_log10_f64"},
+  // asin seems fine (presumably acos and atan as well)
+  // sqrt seems fine
+};
+
+void replaceBrokenLLVMIntrinsics(llvm::Module& M) {
+  for(auto& RM : IntrinsicReplacementMap) {
+    if(auto* F = M.getFunction(RM[0])) {
+      llvm::Function* Replacement = M.getFunction(RM[1]);
+
+      if(!Replacement) {
+        Replacement = llvm::Function::Create(F->getFunctionType(),
+                                             llvm::GlobalValue::ExternalLinkage, RM[1], M);
+        F->replaceAllUsesWith(Replacement);
+      }
+    }
+  }
+}
+
 }
 
 LLVMToPtxTranslator::LLVMToPtxTranslator(const std::vector<std::string> &KN)
@@ -153,6 +196,8 @@ bool LLVMToPtxTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
       applyKernelProperties(F);
     }
   }
+
+  replaceBrokenLLVMIntrinsics(M);
 
   std::string BuiltinBitcodeFile = 
     common::filesystem::join_path(common::filesystem::get_install_directory(),

--- a/src/libkernel/sscp/amdgpu/math.cpp
+++ b/src/libkernel/sscp/amdgpu/math.cpp
@@ -189,8 +189,8 @@ HIPSYCL_SSCP_MAP_OCML_FLOAT_BUILTIN2(powr, __ocml_powr)
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_pown_f32(float x, __acpp_int32 y) {
   return __ocml_pown_f32(x, y);
 }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_pown_f64(double x, __acpp_int64 y) {
-  return __ocml_pown_f64(x, static_cast<__acpp_int32>(y));
+HIPSYCL_SSCP_BUILTIN double __acpp_sscp_pown_f64(double x, __acpp_int32 y) {
+  return __ocml_pown_f64(x, y);
 }
 
 HIPSYCL_SSCP_MAP_OCML_FLOAT_BUILTIN2(remainder, __ocml_remainder)

--- a/src/libkernel/sscp/host/math.cpp
+++ b/src/libkernel/sscp/host/math.cpp
@@ -215,7 +215,7 @@ HIPSYCL_SSCP_BUILTIN float __acpp_sscp_pown_f32(float x, __acpp_int32 y) {
   return __acpp_sscp_pow_f32(x, (float)y);
 }
 HIPSYCL_SSCP_BUILTIN double __acpp_sscp_pown_f64(double x,
-                                                    __acpp_int64 y) {
+                                                    __acpp_int32 y) {
   return __acpp_sscp_pow_f64(x, (double)y);
 }
 

--- a/src/libkernel/sscp/ptx/math.cpp
+++ b/src/libkernel/sscp/ptx/math.cpp
@@ -184,8 +184,8 @@ HIPSYCL_SSCP_BUILTIN float __acpp_sscp_pown_f32(float x, __acpp_int32 y) {
   return __nv_powif(x, y);
 }
 HIPSYCL_SSCP_BUILTIN double __acpp_sscp_pown_f64(double x,
-                                                    __acpp_int64 y) {
-  return __nv_powi(x, static_cast<__acpp_int32>(y));
+                                                    __acpp_int32 y) {
+  return __nv_powi(x, y);
 }
 
 HIPSYCL_SSCP_MAP_PTX_FLOAT_BUILTIN2(remainder, __nv_remainderf, __nv_remainder)

--- a/src/libkernel/sscp/spirv/math.cpp
+++ b/src/libkernel/sscp/spirv/math.cpp
@@ -169,8 +169,8 @@ float __spirv_ocl_pown(float, __acpp_int32);
 double __spirv_ocl_pown(double, __acpp_int32);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_pown_f32(float x, __acpp_int32 y) { return __spirv_ocl_pown(x, y); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_pown_f64(double x, __acpp_int64 y)
-{return __spirv_ocl_pown(x, static_cast<__acpp_int32>(y)); }
+HIPSYCL_SSCP_BUILTIN double __acpp_sscp_pown_f64(double x, __acpp_int32 y)
+{return __spirv_ocl_pown(x, y); }
 
 HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN2(remainder)
 HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN(rint)

--- a/tests/compiler/sscp/builtin_remapping.cpp
+++ b/tests/compiler/sscp/builtin_remapping.cpp
@@ -1,0 +1,73 @@
+
+// RUN: %acpp %s -o %t --acpp-targets=generic
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s -o %t --acpp-targets=generic -O3
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s -o %t --acpp-targets=generic -O3 -ffast-math
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s -o %t --acpp-targets=generic -g
+// RUN: %t | FileCheck %s
+
+#include <iostream>
+#include <cmath>
+#include <sycl/sycl.hpp>
+#include "common.hpp"
+
+bool check_with_tolerance(double a, double b) {
+  return std::abs(a - b) / std::abs(a) < 0.0001;
+}
+
+
+template<class T>
+void test() {
+  sycl::queue q = get_queue();
+
+  int num_functions = 10;
+
+  double init = 0.75;
+
+  T* data = sycl::malloc_shared<T>(num_functions, q);
+  for(int i = 0; i < num_functions; ++i)
+    data[i] = static_cast<T>(init);
+
+  q.single_task([=](){
+    data[0] = std::sin(data[0]);
+    data[1] = std::cos(data[1]);
+    data[2] = std::pow(data[2], init);
+    data[3] = std::pow(data[3], 3);
+    data[4] = std::exp(data[4]);
+    data[5] = std::sqrt(data[5]);
+    data[6] = std::tan(data[6]);
+    data[7] = std::exp2(data[7]);
+    data[8] = std::log(data[8]);
+    data[9] = std::asin(data[9]);
+  }).wait();
+
+  // CHECK: 1
+  std::cout << check_with_tolerance(data[0], std::sin(init)) << std::endl;
+  // CHECK: 1
+  std::cout << check_with_tolerance(data[1], std::cos(init)) << std::endl;
+  // CHECK: 1
+  std::cout << check_with_tolerance(data[2], std::pow(init, init)) << std::endl;
+  // CHECK: 1
+  std::cout << check_with_tolerance(data[3], std::pow(init, 3)) << std::endl;
+  // CHECK: 1
+  std::cout << check_with_tolerance(data[4], std::exp(init)) << std::endl;
+  // CHECK: 1
+  std::cout << check_with_tolerance(data[5], std::sqrt(init)) << std::endl;
+  // CHECK: 1
+  std::cout << check_with_tolerance(data[6], std::tan(init)) << std::endl;
+  // CHECK: 1
+  std::cout << check_with_tolerance(data[7], std::exp2(init)) << std::endl;
+  // CHECK: 1
+  std::cout << check_with_tolerance(data[8], std::log(init)) << std::endl;
+  // CHECK: 1
+  std::cout << check_with_tolerance(data[9], std::asin(init)) << std::endl;
+
+  sycl::free(data, q);
+}
+
+int main() {
+  test<float>();
+  test<double>();
+}


### PR DESCRIPTION
When `-ffast-math` is used, our stdpar builtin remapping might sometimes fail.

There are actually two separate but similar issues:
* clang might emit calls to the gnu soft-float library in some cases. The only known case so far are the `__powisf2` and `__powidf2 ` builtins. This PR remaps those to AdaptiveCpp builtins.
* For math functions, `-ffast-math`  causes clang to sometimes directly emit LLVM intrinsics. It turns out that the LLVM NVPTX backend in particular does not seem to handle those well: I have seen cases of backend errors, as well as calls to undefined functions being generated by the LLVM NVPTX backend. This PR therefore also remaps calls to problematic intrinsics for the PTX backend at JIT time. Other backends seem fine. While I have not tried every single intrinsic, I tried most math intrinsics, especially the common ones. There does not seem to be a clear rule of what works and what doesn't. We may have to fix issues on a case by case basis should additional problems be reported. Ultimately this is probably an LLVM issue. There might be a relation to what is supported in NVVM: https://docs.nvidia.com/cuda/nvvm-ir-spec/index.html#standard-c-library-intrinsics but there also seem to be some LLVM intrinsics which are fine even though not listed as supported by NVVM.

I've also added a LIT test that tests the `-ffast-math` path.

Fixes #1435
CC @breyerml 