### PR TITLE
[CI] Temporarily disable multi-device queue extension tests

### DIFF
--- a/tests/sycl/extensions.cpp
+++ b/tests/sycl/extensions.cpp
@@ -1114,7 +1114,7 @@ BOOST_AUTO_TEST_CASE(queue_wait_list) {
 }
 
 #endif
-#ifdef ACPP_EXT_MULTI_DEVICE_QUEUE
+#if defined(ACPP_EXT_MULTI_DEVICE_QUEUE) && defined(ACPP_TEST_MULTI_DEVICE_QUEUE)
 
 BOOST_AUTO_TEST_CASE(multi_device_queue) {
   using namespace cl;


### PR DESCRIPTION
Temporarily disable multi-device queue extension tests, which causes spurious CI failures. For quite some time this did not seem to be a priority/interesting for anybody, so this PR disables the test until somebody has the time to look into this problem.