### PR TITLE
Fix non-instant tasks not interfacing correctly with instant tasks for non-emulated in-order queue

### DIFF
--- a/include/hipSYCL/sycl/handler.hpp
+++ b/include/hipSYCL/sycl/handler.hpp
@@ -1112,6 +1112,10 @@ private:
   const rt::node_list_t& get_cg_nodes() const
   { return _command_group_nodes; }
 
+  bool contains_non_instant_nodes() const {
+    return _contains_non_instant_nodes;
+  }
+
   
   handler(const context &ctx, async_handler handler,
           const rt::execution_hints &hints, rt::runtime* rt,
@@ -1182,6 +1186,8 @@ private:
         op->is_requirement()) {
       // traditional submission
       rt::dag_build_guard build{_rt->dag()};
+      _contains_non_instant_nodes = true;
+      
       return build.builder()->add_command_group(std::move(op), requirements, hints);
     } else {
 
@@ -1220,6 +1226,7 @@ private:
   rt::runtime* _rt;
 
   bool _operation_uses_reductions = false;
+  bool _contains_non_instant_nodes = false;
 
   algorithms::util::allocation_cache* _allocation_cache;
 


### PR DESCRIPTION
When submitting non-instant tasks to a non-emulated in-order queue and instant submission is enabled, we need to `flush_sync` so that subsequent instant tasks synchronize correctly.

This is not ideal, as it can have negative performance impact when `ACPP_ALLOW_INSTANT_SUBMISSION` is set to 1, but occasionally non-instant tasks (e.g. using a buffer) are submitted.
So we should look into whether there is a better approach in the future.

Fixes #1525 

CC @fknorr 