### PR TITLE
[llvm-to-amdgpu] Approximate sqrt when -ffast-math is enabled

### DIFF
--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -146,8 +146,10 @@ public:
       "--hip-link",
       "-###"
     };
-    if(IsFastMath)
+    if(IsFastMath) {
       Invocation.push_back("-ffast-math");
+      Invocation.push_back("-fno-hip-fp32-correctly-rounded-divide-sqrt");
+    }
     
     if(!llvm::StringRef{ClangPath}.endswith("hipcc")) {
       // Normally we try to use hipcc. However, when that fails,


### PR DESCRIPTION
Currently we ask `hipcc` for the correct set of bitcode libraries to link when `-ffast-math` is specified. Turns out that even with `-ffast-math` hipcc does round sqrt correctly. I think in the `-ffast-math` case we can relax this. This PR approximates sqrt when JIT compiling for amdgpu target and `-ffast-math` is given.

This also makes comparisons with oneAPI DPC++ easier, which never rounds sqrt correctly (even with `-fno-fast-math`), which is probably the most frequent comparison target for AdaptiveCpp.
With this PR, at least in the `-ffast-math` case they will be roughly similar.