### PR TITLE
[renaming] migrate clang plugin flags from -hipsycl-* to -acpp-*

### DIFF
--- a/bin/acpp
+++ b/bin/acpp
@@ -1520,7 +1520,7 @@ class llvm_sscp_invocation:
 
   def get_cxx_flags(self):
     flags = ["-D__ACPP_ENABLE_LLVM_SSCP_TARGET__",
-            "-Xclang", "-disable-O0-optnone", "-mllvm", "-hipsycl-sscp"]
+            "-Xclang", "-disable-O0-optnone", "-mllvm", "-acpp-sscp"]
 
     sscp_compile_opts = []
     if ("-Ofast" in self._config.forwarded_compiler_arguments or 
@@ -1528,7 +1528,7 @@ class llvm_sscp_invocation:
       sscp_compile_opts.append("fast-math")
 
     if len(sscp_compile_opts) > 0:
-      flags += ["-mllvm", "-hipsycl-sscp-kernel-opts="+ ",".join(sscp_compile_opts)]
+      flags += ["-mllvm", "-acpp-sscp-kernel-opts="+ ",".join(sscp_compile_opts)]
 
     if not sys.platform.startswith("win32"):
       flags += [
@@ -1755,12 +1755,12 @@ class compiler:
         "-D__OPENSYCL_STDPAR__", "-D__HIPSYCL_STDPAR__", "-D__ADAPTIVECPP_STDPAR__", "-D__ACPP_STDPAR__",
         "-DACPP_ALLOW_INSTANT_SUBMISSION=1",
         # TODO We should find a way to only emit this argument if the clang plugin is used.
-        "-mllvm", "-hipsycl-stdpar",
+        "-mllvm", "-acpp-stdpar",
         "-include", os.path.join(stdpar_include_path, "detail", "sycl_glue.hpp")
       ]
       
       if self._is_stdpar_system_usm:
-        args += ["-mllvm", "-hipsycl-stdpar-no-malloc-to-usm", "-D__ACPP_STDPAR_ASSUME_SYSTEM_USM__"]
+        args += ["-mllvm", "-acpp-stdpar-no-malloc-to-usm", "-D__ACPP_STDPAR_ASSUME_SYSTEM_USM__"]
       if self._is_stdpar_unconditional_offload:
         args += ["-D__ACPP_STDPAR_UNCONDITIONAL_OFFLOAD__"]
       

--- a/src/compiler/AdaptiveCppClangPlugin.cpp
+++ b/src/compiler/AdaptiveCppClangPlugin.cpp
@@ -50,20 +50,20 @@ namespace hipsycl {
 namespace compiler {
 
 static llvm::cl::opt<bool> EnableLLVMSSCP{
-    "hipsycl-sscp", llvm::cl::init(false),
+    "acpp-sscp", llvm::cl::init(false),
     llvm::cl::desc{"Enable AdaptiveCpp LLVM SSCP compilation flow"}};
 
 static llvm::cl::opt<std::string> LLVMSSCPKernelOpts{
-    "hipsycl-sscp-kernel-opts", llvm::cl::init(""),
+    "acpp-sscp-kernel-opts", llvm::cl::init(""),
     llvm::cl::desc{
         "Specify compilation options to use when JIT-compiling AdaptiveCpp SSCP kernels"}};
 
 static llvm::cl::opt<bool> EnableStdPar{
-    "hipsycl-stdpar", llvm::cl::init(false),
+    "acpp-stdpar", llvm::cl::init(false),
     llvm::cl::desc{"Enable hipSYCL C++ standard parallelism support"}};
 
 static llvm::cl::opt<bool> StdparNoMallocToUSM{
-    "hipsycl-stdpar-no-malloc-to-usm", llvm::cl::init(false),
+    "acpp-stdpar-no-malloc-to-usm", llvm::cl::init(false),
     llvm::cl::desc{"Disable hipSYCL C++ standard parallelism malloc-to-usm compiler-side support"}};
 
 // Register and activate passes

--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -81,7 +81,7 @@ using optional_t = std::optional<T>;
 bool getCommandOutput(const std::string &Program, const llvm::SmallVector<std::string> &Invocation,
                       std::string &Out) {
 
-  auto OutputFile = llvm::sys::fs::TempFile::create("hipsycl-sscp-query-%%%%%%.txt");
+  auto OutputFile = llvm::sys::fs::TempFile::create("acpp-sscp-query-%%%%%%.txt");
 
   std::string OutputFilename = OutputFile->TmpName;
 
@@ -395,9 +395,9 @@ bool LLVMToAmdgpuTranslator::clangJitLink(llvm::Module& FlavoredModule, std::str
   for(const auto& BC : DeviceLibs)
     addBitcodeFile(BC);
 
-  auto InputFile = llvm::sys::fs::TempFile::create("hipsycl-sscp-amdgpu-%%%%%%.bc");
-  auto OutputFile = llvm::sys::fs::TempFile::create("hipsycl-sscp-amdgpu-%%%%%%.hipfb");
-  auto DummyFile = llvm::sys::fs::TempFile::create("hipsycl-sscp-amdgpu-dummy-%%%%%%.cpp");
+  auto InputFile = llvm::sys::fs::TempFile::create("acpp-sscp-amdgpu-%%%%%%.bc");
+  auto OutputFile = llvm::sys::fs::TempFile::create("acpp-sscp-amdgpu-%%%%%%.hipfb");
+  auto DummyFile = llvm::sys::fs::TempFile::create("acpp-sscp-amdgpu-dummy-%%%%%%.cpp");
 
   std::string OutputFilename = OutputFile->TmpName;
 

--- a/src/compiler/llvm-to-backend/host/LLVMToHost.cpp
+++ b/src/compiler/llvm-to-backend/host/LLVMToHost.cpp
@@ -110,8 +110,8 @@ bool LLVMToHostTranslator::toBackendFlavor(llvm::Module &M, PassHandler &PH) {
 
 bool LLVMToHostTranslator::translateToBackendFormat(llvm::Module &FlavoredModule,
                                                     std::string &out) {
-  auto InputFile = llvm::sys::fs::TempFile::create("hipsycl-sscp-host-%%%%%%.bc");
-  auto OutputFile = llvm::sys::fs::TempFile::create("hipsycl-sscp-host-%%%%%%.so");
+  auto InputFile = llvm::sys::fs::TempFile::create("acpp-sscp-host-%%%%%%.bc");
+  auto OutputFile = llvm::sys::fs::TempFile::create("acpp-sscp-host-%%%%%%.so");
 
   if (auto E = InputFile.takeError()) {
     this->registerError("LLVMToHost: Could not create temp file: " + InputFile->TmpName);

--- a/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
+++ b/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
@@ -227,8 +227,8 @@ bool LLVMToPtxTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
 
 bool LLVMToPtxTranslator::translateToBackendFormat(llvm::Module &FlavoredModule, std::string &out) {
 
-  auto InputFile = llvm::sys::fs::TempFile::create("hipsycl-sscp-ptx-%%%%%%.bc");
-  auto OutputFile = llvm::sys::fs::TempFile::create("hipsycl-sscp-ptx-%%%%%%.s");
+  auto InputFile = llvm::sys::fs::TempFile::create("acpp-sscp-ptx-%%%%%%.bc");
+  auto OutputFile = llvm::sys::fs::TempFile::create("acpp-sscp-ptx-%%%%%%.s");
   
   std::string OutputFilename = OutputFile->TmpName;
   

--- a/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
+++ b/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
@@ -218,8 +218,8 @@ bool LLVMToSpirvTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
 
 bool LLVMToSpirvTranslator::translateToBackendFormat(llvm::Module &FlavoredModule, std::string &out) {
 
-  auto InputFile = llvm::sys::fs::TempFile::create("hipsycl-sscp-spirv-%%%%%%.bc");
-  auto OutputFile = llvm::sys::fs::TempFile::create("hipsycl-sscp-spirv-%%%%%%.spv");
+  auto InputFile = llvm::sys::fs::TempFile::create("acpp-sscp-spirv-%%%%%%.bc");
+  auto OutputFile = llvm::sys::fs::TempFile::create("acpp-sscp-spirv-%%%%%%.spv");
   
   std::string OutputFilename = OutputFile->TmpName;
   

--- a/src/compiler/sscp/TargetSeparationPass.cpp
+++ b/src/compiler/sscp/TargetSeparationPass.cpp
@@ -97,11 +97,11 @@ public:
 };
 
 static llvm::cl::opt<bool> SSCPEmitHcf{
-    "hipsycl-sscp-emit-hcf", llvm::cl::init(false),
+    "acpp-sscp-emit-hcf", llvm::cl::init(false),
     llvm::cl::desc{"Emit HCF from hipSYCL LLVM SSCP compilation flow"}};
 
 static llvm::cl::opt<bool> PreoptimizeSSCPKernels{
-    "hipsycl-sscp-preoptimize", llvm::cl::init(false),
+    "acpp-sscp-preoptimize", llvm::cl::init(false),
     llvm::cl::desc{
         "Preoptimize SYCL kernels in LLVM IR instead of embedding unoptimized kernels and relying "
         "on optimization at runtime. This is mainly for hipSYCL developers and NOT supported!"}};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -122,7 +122,7 @@ target_link_libraries(rt_tests PRIVATE Threads::Threads)
 add_sycl_to_target(TARGET rt_tests)
 
 # We cannot enable building them unconditionally at the moment,
-# because --hipsycl-stdpar is not compatible with all --hipsycl-targets
+# because --acpp-stdpar is not compatible with all --acpp-targets
 # values. Enabling them in all cases would break some existing test flows.
 if(WITH_PSTL_TESTS)
   add_executable(pstl_tests 


### PR DESCRIPTION
Migrates flags for our clang plugin (as well as some filenames used internally during JIT) to `acpp-*` naming schemes. These flags are not currently publicly documented, so I don't think we need backwards compatibility here.