### PR TITLE
[llvm-to-amdgpu] Improve bitcode handling for ROCm versions defaulting to code object version 5

### DIFF
--- a/include/hipSYCL/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.hpp
@@ -40,6 +40,7 @@ private:
   std::string RocmDeviceLibsPath;
   std::string RocmPath = ACPP_ROCM_PATH;
   std::string TargetDevice = "gfx900";
+  int CodeObjectModelVersion = -1;
 
   bool hiprtcJitLink(const std::string& Bitcode, std::string& Output);
   bool clangJitLink(llvm::Module& FlavoredModule, std::string& Output);


### PR DESCRIPTION
Currently we ask `hipcc` to provide the list of amdgcn builtin bitcode libraries to link. This can cause issues when our own bitcode libraries are built with a clang that defaults to a different code object version compared to `hipcc`.

This PR provides a hotfix: It checks if the `amdgpu_code_object_version` LLVM module flag is set. If so, we override whatever `hipcc` returns and link with the `oclc_abi_version_<version>.bc` corresponding to the code object model version from the LLVM module flag.

This improves compatibility with ROCm 6+. @sbalint98, for me this fixes the subgroup issue that you have found, provided that LLVM generates the `amdgpu_code_object_version` metadata. This seems to happen reliably for my LLVM 17.

This is just a temporary fix; post 24.06 release we should reimplement the way bitcode libraries are discovered and do the selection of bitcode libraries ourselves rather than to delegate it to `hipcc`.