### PR TITLE
[msgpack] Fix incorrect deserialization for uint64 types

### DIFF
--- a/include/hipSYCL/common/appdb.hpp
+++ b/include/hipSYCL/common/appdb.hpp
@@ -113,7 +113,7 @@ class appdb  {
 public:
   // DO NOT FORGET TO INCREMENT THIS WHEN ADDING/REMOVING
   // FIELDS OR OTHERWISE CHANGING THE DATA LAYOUT!
-  static const uint64_t format_version = 3;
+  static const uint64_t format_version = 4;
 
   appdb(const std::string& db_path);
   ~appdb();

--- a/include/hipSYCL/common/msgpack/msgpack.hpp
+++ b/include/hipSYCL/common/msgpack/msgpack.hpp
@@ -863,7 +863,6 @@ void Unpacker::unpack_type(uint64_t &value) {
       value += uint64_t(safe_data()) << 8 * (i - 1);
       safe_increment();
     }
-    data_pointer++;
   } else if (safe_data() == uint16) {
     safe_increment();
     for (auto i = sizeof(uint16_t); i > 0; --i) {


### PR DESCRIPTION
Turns out there was a bug in the msgpack library that we use around the deserialization of `uint64` types. We use those types massively, and incorrectly reading them can have catastrophic consequences, including retrieving the wrong kernels from the cache. This PR fixes the issue.

I'm also increasing the appdb format version to avoid possibly corrupt appdbs being read.