### PR TITLE
[Doc] fix indentation issue in markdown

### DIFF
--- a/doc/compilation.md
+++ b/doc/compilation.md
@@ -3,18 +3,18 @@
 AdaptiveCpp supports multiple types of compilation flows:
 
 1. **A generic, single-pass compiler infrastructure that compiles kernels to a unified code representation** that is then lowered at runtime to target devices, providing a high degree of portability, low compilation times, flexibility and extensibility. **AdaptiveCpp is the only major SYCL implementation that supports a single-pass compiler design, where the code is only parsed once for both host and target devices**. Support includes:
-   1. NVIDIA CUDA GPUs through PTX;
-   2. AMD ROCm GPUs through amdgcn code;
-   3. Intel GPUs through SPIR-V (Level Zero);
-   4. SPIR-V compatible OpenCL devices supporting Intel USM extensions or fine-grained system SVM (such as Intel's OpenCL implementation for CPUs or GPUs);
-   5. The host CPU through LLVM
+    1. NVIDIA CUDA GPUs through PTX;
+    2. AMD ROCm GPUs through amdgcn code;
+    3. Intel GPUs through SPIR-V (Level Zero);
+    4. SPIR-V compatible OpenCL devices supporting Intel USM extensions or fine-grained system SVM (such as Intel's OpenCL implementation for CPUs or GPUs);
+    5. The host CPU through LLVM
 2. Interoperability-focused multipass compilation flows. **AdaptiveCpp can aggregate existing clang toolchains and augment them with support for SYCL constructs**. This allows for a high degree of interoperability between SYCL and other models such as CUDA or HIP. For example, in this mode, the AdaptiveCpp CUDA and ROCm backends rely on the clang CUDA/HIP frontends that have been augmented by AdaptiveCpp to *additionally* also understand other models like SYCL. This means that the AdaptiveCpp compiler can not only compile SYCL code, but also CUDA/HIP code *even if they are mixed in the same source file*, making all CUDA/HIP features - such as the latest device intrinsics - also available from SYCL code ([details](hip-source-interop.md)). Additionally, vendor-optimized template libraries such as rocPRIM or CUB can also be used with AdaptiveCpp. This allows for highly optimized code paths in SYCL code for specific devices. Support includes:
-   1. Any LLVM-supported CPU (including e.g. x86, arm, power etc) through the regular clang host toolchain with dedicated compiler transformation to accelerate SYCL constructs;
-   2. NVIDIA CUDA GPUs through the clang CUDA toolchain;
-   3. AMD ROCm GPUs through the clang HIP toolchain
+    1. Any LLVM-supported CPU (including e.g. x86, arm, power etc) through the regular clang host toolchain with dedicated compiler transformation to accelerate SYCL constructs;
+    2. NVIDIA CUDA GPUs through the clang CUDA toolchain;
+    3. AMD ROCm GPUs through the clang HIP toolchain
 3. Or **AdaptiveCpp can be used in library-only compilation flows**. In these compilation flows, AdaptiveCpp acts as a C++ library for third-party compilers. This can have portability advantages or simplify deployment. This includes support for:
-   1. Any CPU supported by any OpenMP compilers;
-   2. NVIDIA GPUs through CUDA and the NVIDIA nvc++ compiler, bringing NVIDIA vendor support and day 1 hardware support to the SYCL ecosystem
+    1. Any CPU supported by any OpenMP compilers;
+    2. NVIDIA GPUs through CUDA and the NVIDIA nvc++ compiler, bringing NVIDIA vendor support and day 1 hardware support to the SYCL ecosystem
 
 The following illustration shows the complete stack and its capabilities to target hardware:
 ![Compiler stack](img/stack.png)
@@ -68,14 +68,14 @@ AdaptiveCpp allows using backend-specific language extensions (e.g. CUDA/HIP C++
 
 * If a backend runs on a compiler that provides a unified, single compilation pass for both host and device, backend-specific language extensions are always available. Currently this only affects the CUDA-nvc++ backend.
 * If the compiler relies on separate compilation passes for host and device:
-  * In device compilation passes, backend-specific language extensions are always available.
-  * In host compilation passes, the following applies:
-    * If the backend runs in integrated multipass mode, backend-specific language extensions are available.
-    * If the backend runs in explicit multipass mode:
-      * For SPIR-V, language extensions are always available
-      * For CUDA and HIP: Language extensions from *one* of them are available in the host pass.
-        * If one of them runs in integrated multipass and one in explicit multipass, language extensions from the one in integrated multipass are available
-        * If both are in explicit multipass, `acpp` will currently automatically pick one that will have language extensions enabled in the host pass.
+    * In device compilation passes, backend-specific language extensions are always available.
+    * In host compilation passes, the following applies:
+        * If the backend runs in integrated multipass mode, backend-specific language extensions are available.
+        * If the backend runs in explicit multipass mode:
+            * For SPIR-V, language extensions are always available
+            * For CUDA and HIP: Language extensions from *one* of them are available in the host pass.
+                * If one of them runs in integrated multipass and one in explicit multipass, language extensions from the one in integrated multipass are available
+                * If both are in explicit multipass, `acpp` will currently automatically pick one that will have language extensions enabled in the host pass.
 
 
 ## Summary of supported compilation targets

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -14,8 +14,8 @@ In order to successfully build and install AdaptiveCpp, the following dependenci
 * python 3 (for the `acpp` compiler driver)
 * `cmake`
 * the Boost C++ libraries (in particular `boost.fiber`, `boost.context` and for the unit tests `boost.test`)
-  * it may be helpful to set the `BOOST_ROOT` `cmake` variable to the path to the root directory of Boost you wish to use if `cmake` does not find it automatically
-  * **Note for boost 1.78 users:** There seems to be a bug in the build system for boost 1.78, causing the compiled fiber and context libraries not to be copied to the installation directory. You will have to copy these libraries manually to the installation directory. In binary packages from some distribution repositories this issue is fixed. You might be only affected when building boost manually from source.
+    * it may be helpful to set the `BOOST_ROOT` `cmake` variable to the path to the root directory of Boost you wish to use if `cmake` does not find it automatically
+    * **Note for boost 1.78 users:** There seems to be a bug in the build system for boost 1.78, causing the compiled fiber and context libraries not to be copied to the installation directory. You will have to copy these libraries manually to the installation directory. In binary packages from some distribution repositories this issue is fixed. You might be only affected when building boost manually from source.
 
 In addition, the various supported [compilation flows](compilation.md) and programming models have additional requirements:
 
@@ -106,9 +106,9 @@ The default installation prefix is `/usr/local`. Change this to your liking.
 ###### General
 *  `-DCMAKE_CXX_COMPILER` should be pointed to the C++ compiler to compile AdaptiveCpp with. Note that this also sets the default C++ compiler for the CPU backend when using acpp once AdaptiveCpp is installed. This can however also be modified later using `HIPSYCL_CPU_CXX`.
 * `-DACPP_COMPILER_FEATURE_PROFILE` can be used to configure the desired degree of compiler support. Supported values:
-  * `full` (default and recommended): Enables all AdaptiveCpp features, requires a compatible LLVM installation as described [here](install-llvm.md). This is recommended for both functionality and performance.
-  * `minimal`: Only enables the older interoperability-focused compilation flows for CUDA and HIP (`--acpp-targets=cuda` and `--acpp-targets=hip`). No OpenCL or Level Zero support, no C++ standard parallelism offloading support, no generic JIT compiler (`generic` target), no compiler acceleration for SYCL constructs on CPU device. **Should only be selected in specific circumstances.**
-  * `none`: Disables all compiler support and dependencies on LLVM. In addition to `minimal`, also disables the support for `--acpp-targets=cuda` and `--acpp-targets=hip`. In this mode, AdaptiveCpp operates purely as a library for third-party compilers. **Should only be selected in specific circumstances.**
+    * `full` (default and recommended): Enables all AdaptiveCpp features, requires a compatible LLVM installation as described [here](install-llvm.md). This is recommended for both functionality and performance.
+    * `minimal`: Only enables the older interoperability-focused compilation flows for CUDA and HIP (`--acpp-targets=cuda` and `--acpp-targets=hip`). No OpenCL or Level Zero support, no C++ standard parallelism offloading support, no generic JIT compiler (`generic` target), no compiler acceleration for SYCL constructs on CPU device. **Should only be selected in specific circumstances.**
+    * `none`: Disables all compiler support and dependencies on LLVM. In addition to `minimal`, also disables the support for `--acpp-targets=cuda` and `--acpp-targets=hip`. In this mode, AdaptiveCpp operates purely as a library for third-party compilers. **Should only be selected in specific circumstances.**
 
 ###### generic
 

--- a/doc/using-hipsycl.md
+++ b/doc/using-hipsycl.md
@@ -26,35 +26,39 @@ and can be passed either as `acpp` command line argument (`--acpp-targets=...`),
 Whether a compilation flow needs to be followed by a target list or not varies between the available flows and is described below.
 
 For the following compilation flows, targets cannot be specified:
+
 * `omp.*`
 * `generic`
 
 For the following compilation flows, targets can optionally be specified:
+
 * `cuda-nvcxx` - Targets take the format of `ccXY` where `XY` stands for the compute capability of the device.
 
 For the following compilation flows, targets must be specified:
+
 * `cuda.*` - The target format is defined by clang and takes the format of `sm_XY`. For example:
-  * `sm_52`: NVIDIA Maxwell GPUs
-  * `sm_60`: NVIDIA Pascal GPUs
-  * `sm_70`: NVIDIA Volta GPUs
+    * `sm_52`: NVIDIA Maxwell GPUs
+    * `sm_60`: NVIDIA Pascal GPUs
+    * `sm_70`: NVIDIA Volta GPUs
 * `hip.*` - The target format is defined by clang and takes the format of `gfxXYZ`. For example:
-  * `gfx900`: AMD Vega 10 GPUs (e.g. Radeon Vega 56, Vega 64)
-  * `gfx906`: AMD Vega 20 GPUs (e.g. Radeon VII, Instinct MI50)
-  * `gfx908`: AMD CDNA GPUs (e.g Instinct MI100)
+    * `gfx900`: AMD Vega 10 GPUs (e.g. Radeon Vega 56, Vega 64)
+    * `gfx906`: AMD Vega 20 GPUs (e.g. Radeon VII, Instinct MI50)
+    * `gfx908`: AMD CDNA GPUs (e.g Instinct MI100)
 
 ### Abbreviations
 
 For some compilation flows, abbreviations exist that will be resolved by AdaptiveCpp to one of the available compilation flows:
+
 * `omp` will be translated 
-  * into `omp.accelerated` 
-     * if AdaptiveCpp has been built with support for accelerated CPU and the host compiler is the clang that AdaptiveCpp has been built with or
-     * if `--acpp-use-accelerated-cpu` is set. If the accelerated CPU compilation flow is not available (e.g. AdaptiveCpp has been compiled without support for it), compilation will abort with an error.
-  * into `omp.library-only` otherwise
+    * into `omp.accelerated` 
+        * if AdaptiveCpp has been built with support for accelerated CPU and the host compiler is the clang that AdaptiveCpp has been built with or
+        * if `--acpp-use-accelerated-cpu` is set. If the accelerated CPU compilation flow is not available (e.g. AdaptiveCpp has been compiled without support for it), compilation will abort with an error.
+    * into `omp.library-only` otherwise
 * `cuda` will be translated
-  * into `cuda.explicit-multipass`
-    * if another integrated multipass has been requested, or another backend that would conflict with `cuda.integrated-multipass`. AdaptiveCpp will emit a warning in this case, since switching to explicit multipass can change interoperability guarantees (see the [compilation](compilation.md) documentation).
-    * if `--acpp-explicit-multipass` is set explicitly
-  * into `cuda.integrated-multipass` otherwise
+    * into `cuda.explicit-multipass`
+        * if another integrated multipass has been requested, or another backend that would conflict with `cuda.integrated-multipass`. AdaptiveCpp will emit a warning in this case, since switching to explicit multipass can change interoperability guarantees (see the [compilation](compilation.md) documentation).
+        * if `--acpp-explicit-multipass` is set explicitly
+    * into `cuda.integrated-multipass` otherwise
 * `hip` will be translated into `hip.integrated-multipass`
 
 Of course, the desired flows can also always be specified explicitly.


### PR DESCRIPTION
- Use 4 space indentation to ensure proper rendering of nested bullet points/enumeration. 
- Fix missing line breaks before enumeration/bullet points (without them they are not rendered outside of github flavored markdown)