### PR TITLE
properly handle LLVM_DEFINITIONS with assigned values

### DIFF
--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -102,8 +102,11 @@ function(configure_target)
     ${CMAKE_BINARY_DIR}/include)
   target_include_directories(${target} SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS})
 
+  separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
   target_compile_definitions(${target} PRIVATE
-    ${LLVM_DEFINITIONS} -DHIPSYCL_COMPILER_COMPONENT)
+    ${LLVM_DEFINITIONS_LIST})
+  target_compile_definitions(${target} PRIVATE
+    -DHIPSYCL_COMPILER_COMPONENT)
 
   if(ROCM_VERSION_MAJOR)
     target_compile_definitions(${target} PRIVATE -DROCM_CLANG_VERSION_MAJOR=${ROCM_VERSION_MAJOR} -DROCM_CLANG_VERSION_MINOR=${ROCM_VERSION_MINOR} -DROCM_CLANG_VERSION_PATCH=${ROCM_VERSION_PATCH})

--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -26,8 +26,11 @@ function(create_llvm_based_library)
   target_include_directories(${target} PRIVATE
     ${LLVM_TO_BACKEND_INCLUDE_DIRS})
   target_include_directories(${target} SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS})
-  
-  target_compile_definitions(${target} PRIVATE ${LLVM_DEFINITIONS} -DHIPSYCL_COMPILER_COMPONENT)
+
+  separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
+  target_compile_definitions(${target} PRIVATE
+    ${LLVM_DEFINITIONS_LIST})
+  target_compile_definitions(${target} PRIVATE -DHIPSYCL_COMPILER_COMPONENT)
   find_library(LLVM_LIBRARY NAMES LLVM LLVM-${LLVM_VERSION_MAJOR} HINTS ${LLVM_LIBRARY_DIRS} NO_DEFAULT_PATH)
   if(NOT LLVM_LIBRARY)
     message(FATAL_ERROR "LLVM at ${LLVM_DIR} does not have libLLVM.so. Please disable SSCP and related backends (-DWITH_SSCP_COMPILER=OFF -DWITH_OPENCL_BACKEND=OFF -DWITH_LEVEL_ZERO_BACKEND=OFF) or choose another LLVM installation")
@@ -76,8 +79,11 @@ function(create_llvm_to_backend_tool)
   target_include_directories(${target}-tool PRIVATE
     ${LLVM_TO_BACKEND_INCLUDE_DIRS})
   target_include_directories(${target}-tool SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS})
-  
-  target_compile_definitions(${target}-tool PRIVATE ${LLVM_DEFINITIONS} -DHIPSYCL_TOOL_COMPONENT)
+
+  separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
+  target_compile_definitions(${target}-tool PRIVATE
+    ${LLVM_DEFINITIONS_LIST})
+  target_compile_definitions(${target}-tool PRIVATE -DHIPSYCL_TOOL_COMPONENT)
   target_link_libraries(${target}-tool PRIVATE ${target})
 
   install(TARGETS ${target}-tool DESTINATION lib/hipSYCL/llvm-to-backend)


### PR DESCRIPTION
I found this issue by incorrectly pointing LLVM_DIR at a 32 bit version. nonetheless, we would like to have more robust CMAKE when possible.

the presenting issue during build was:
```
make[2]: Entering directory '/home/wolfwood/repos/AdaptiveCpp/build17'
[  2%] Building CXX object src/compiler/CMakeFiles/acpp-clang-cbs.dir/cbs/LoopSplitterInlining.cpp.o
cd /home/wolfwood/repos/AdaptiveCpp/build17/src/compiler && /usr/bin/c++ -DHIPSYCL_COMPILER_COMPONENT -DHIPSYCL_DEBUG_LEVEL=2 -DHIPSYCL_WITH_ACCELERATED_CPU -DHIPSYCL_WITH_REFLECTION_BUILTINS -DHIPSYCL_WITH_SSCP_COMPILER -DHIPSYCL_WITH_STDPAR_COMPILER -D_GNU_SOURCE -D_FILE_OFFSET_BITS="64 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS" -I/home/wolfwood/repos/AdaptiveCpp/src/compiler/../../include -I/home/wolfwood/repos/AdaptiveCpp/src/compiler -I/home/wolfwood/repos/AdaptiveCpp/build17/include -isystem /usr/lib/llvm/17/include -O3 -DNDEBUG -std=c++17 -fPIC -MD -MT src/compiler/CMakeFiles/acpp-clang-cbs.dir/cbs/LoopSplitterInlining.cpp.o -MF CMakeFiles/acpp-clang-cbs.dir/cbs/LoopSplitterInlining.cpp.o.d -o CMakeFiles/acpp-clang-cbs.dir/cbs/LoopSplitterInlining.cpp.o -c /home/wolfwood/repos/AdaptiveCpp/src/compiler/cbs/LoopSplitterInlining.cpp
<command-line>: error: token "=" is not valid in preprocessor expressions
```
note that the first `-D_FILE_OFFSET_BITS=64` was mangled to wrap the following defines in quotes.

these CMAKE incantations, provided by @al42and, treat the defines as a proper list and avoid any attempt to quote assignments.