### PR TITLE
[stdpar] Add simple std::sort implementation using bitonic sort

### DIFF
--- a/doc/stdpar.md
+++ b/doc/stdpar.md
@@ -42,6 +42,7 @@ Offloading is implemented for the following STL algorithms:
 |`any_of` | |
 |`all_of` | |
 |`none_of` | |
+|`sort` | |
 
 
 For all other execution policies or algorithms, the algorithm will compile and execute correctly, however the regular host implementation of the algorithm provided by the C++ standard library implementation will be invoked and no offloading takes place.

--- a/include/hipSYCL/algorithms/algorithm.hpp
+++ b/include/hipSYCL/algorithms/algorithm.hpp
@@ -24,6 +24,7 @@
 #include "util/traits.hpp"
 #include "hipSYCL/algorithms/util/allocation_cache.hpp"
 #include "hipSYCL/algorithms/util/memory_streaming.hpp"
+#include "hipSYCL/algorithms/sort/bitonic_sort.hpp"
 
 namespace hipsycl::algorithms {
 
@@ -452,6 +453,15 @@ sycl::event none_of(sycl::queue &q,
   });
 }
 
+template <class RandomIt, class Compare>
+void sort(sycl::queue &q, RandomIt first, RandomIt last,
+          Compare comp = std::less<>{}) {
+  std::size_t problem_size = std::distance(first, last);
+  if(problem_size == 0)
+    return sycl::event{};
+  
+  return sorting::bitonic_sort(q, first, last, comp);
+}
 }
 
 #endif

--- a/include/hipSYCL/algorithms/sort/bitonic_sort.hpp
+++ b/include/hipSYCL/algorithms/sort/bitonic_sort.hpp
@@ -13,116 +13,70 @@
 #define ACPP_ALGORITHMS_BITONIC_SORT
 
 #include <iterator>
+#include <cstdint>
 #include "hipSYCL/sycl/queue.hpp"
 
 namespace hipsycl::algorithms::sorting {
 
+namespace detail{
 
-// This function is based on the code from SyclParallelSTL, and subject
-// to the following copyright and license:
-/*
-Copyright (c) 2015-2018 The Khronos Group Inc.
 
-   Permission is hereby granted, free of charge, to any person obtaining a
-   copy of this software and/or associated documentation files (the
-   "Materials"), to deal in the Materials without restriction, including
-   without limitation the rights to use, copy, modify, merge, publish,
-   distribute, sublicense, and/or sell copies of the Materials, and to
-   permit persons to whom the Materials are furnished to do so, subject to
-   the following conditions:
+template<class RandomIt, class Size>
+RandomIt advance_to(RandomIt first, Size i) {
+  std::advance(first, i);
+  return first;
+}
 
-   The above copyright notice and this permission notice shall be included
-   in all copies or substantial portions of the Materials.
+inline bool can_compare(std::size_t left_id, std::size_t right_id,
+                        std::size_t problem_size) {
 
-   MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS
-   KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS
-   SPECIFICATIONS AND HEADER INFORMATION ARE LOCATED AT
-    https://www.khronos.org/registry/
+  return (left_id < right_id) && (left_id < problem_size) &&
+         (right_id < problem_size);
+}
 
-  THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-  MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
-  */
-/* bitonic_sort.
- * Performs a bitonic sort on the given buffer
- */
+
+} //detail
+
+
 template <class RandomIt, class Comparator>
 sycl::event bitonic_sort(sycl::queue &q, RandomIt first, RandomIt last,
                          Comparator comp) {
 
-  std::size_t num_elements = std::distance(first, last);
+  std::size_t problem_size = std::distance(first, last);
+  sycl::event most_recent_event;
+  bool is_first_kernel = true;
 
-  int num_stages = 0;
-  // 2^numStages should be equal to length
-  // i.e number of times you halve the lenght to get 1 should be numStages
-  for (int tmp = num_elements; tmp > 1; tmp >>= 1) {
-    ++num_stages;
+  auto launch_kernel = [&](std::size_t j){
+
+    auto k = [=](sycl::id<1> idx) {
+      std::size_t a_id = idx.get(0);
+      std::size_t b_id = a_id ^ j;
+      if(detail::can_compare(a_id, b_id, problem_size)) {
+        auto a = *detail::advance_to(first, a_id);
+        auto b = *detail::advance_to(first, b_id);
+        if(comp(b, a)) {
+          *detail::advance_to(first, a_id) = b;
+          *detail::advance_to(first, b_id) = a;
+        }
+      }
+    };
+    if(is_first_kernel || q.is_in_order())
+      most_recent_event = q.parallel_for(problem_size, k);
+    else
+      most_recent_event = q.parallel_for(problem_size, most_recent_event, k);
+  };
+
+  for (std::size_t k = 2; (k >> 1) < problem_size; k *= 2) {
+    launch_kernel(k-1);
+
+    for (std::size_t j = k >> 1; j > 0; j >>= 1) {
+      launch_kernel(j);
+    }
   }
 
-  sycl::event most_recent_event;
-  sycl::range<1> r{num_elements / 2};
-
-  using T = typename std::iterator_traits<RandomIt>::value_type;
-
-  for (int stage = 0; stage < num_stages; ++stage) {
-    // Every stage has stage + 1 passes
-    for (int pass = 0; pass < stage + 1; ++pass) {
-
-      auto advance_to = [](RandomIt first, auto i) -> RandomIt {
-        std::advance(first, i);
-        return first;
-      };
-
-      auto kernel = [=](sycl::id<1> idx) {
-
-        int sort_increasing = 1;
-        
-        std::size_t gid = idx.get(0);
-
-        int pair_distance = 1 << (stage - pass);
-        int block_width = 2 * pair_distance;
-
-        std::size_t left_id =
-            (gid % pair_distance) + (gid / pair_distance) * block_width;
-        std::size_t right_id = left_id + pair_distance;
-
-        T left_element = *advance_to(first, left_id);
-        T right_element = *advance_to(first, right_id);
-
-        std::size_t same_direction_block_width = 1 << stage;
-
-        if ((gid / same_direction_block_width) % 2 == 1) {
-          sort_increasing = 1 - sort_increasing;
-        }
-
-        T greater = left_element;
-        T lesser = right_element;
-
-        if (comp(left_element, right_element)) {
-          greater = right_element;
-          lesser = left_element;
-        } else {
-          greater = left_element;
-          lesser = right_element;
-        }
-
-        *advance_to(first, left_id) = sort_increasing ? lesser : greater;
-        *advance_to(first, right_id) = sort_increasing ? greater : lesser;
-      };
-
-      if((stage == 0 && pass == 0) || q.is_in_order())
-        most_recent_event = q.parallel_for(r, kernel);
-      else
-        most_recent_event = q.parallel_for(r, most_recent_event, kernel);
-
-    } // pass_stage
-  }   // stage
   return most_recent_event;
 } // bitonic_sort
+
 }
 
 #endif

--- a/include/hipSYCL/algorithms/sort/bitonic_sort.hpp
+++ b/include/hipSYCL/algorithms/sort/bitonic_sort.hpp
@@ -1,0 +1,128 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+#ifndef ACPP_ALGORITHMS_BITONIC_SORT
+#define ACPP_ALGORITHMS_BITONIC_SORT
+
+#include <iterator>
+#include "hipSYCL/sycl/queue.hpp"
+
+namespace hipsycl::algorithms::sorting {
+
+
+// This function is based on the code from SyclParallelSTL, and subject
+// to the following copyright and license:
+/*
+Copyright (c) 2015-2018 The Khronos Group Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining a
+   copy of this software and/or associated documentation files (the
+   "Materials"), to deal in the Materials without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Materials, and to
+   permit persons to whom the Materials are furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Materials.
+
+   MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS
+   KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS
+   SPECIFICATIONS AND HEADER INFORMATION ARE LOCATED AT
+    https://www.khronos.org/registry/
+
+  THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+  */
+/* bitonic_sort.
+ * Performs a bitonic sort on the given buffer
+ */
+template <class RandomIt, class Comparator>
+sycl::event bitonic_sort(sycl::queue &q, RandomIt first, RandomIt last,
+                         Comparator comp) {
+
+  std::size_t num_elements = std::distance(first, last);
+
+  int num_stages = 0;
+  // 2^numStages should be equal to length
+  // i.e number of times you halve the lenght to get 1 should be numStages
+  for (int tmp = num_elements; tmp > 1; tmp >>= 1) {
+    ++num_stages;
+  }
+
+  sycl::event most_recent_event;
+  sycl::range<1> r{num_elements / 2};
+
+  using T = typename std::iterator_traits<RandomIt>::value_type;
+
+  for (int stage = 0; stage < num_stages; ++stage) {
+    // Every stage has stage + 1 passes
+    for (int pass = 0; pass < stage + 1; ++pass) {
+
+      auto advance_to = [](RandomIt first, auto i) -> RandomIt {
+        std::advance(first, i);
+        return first;
+      };
+
+      auto kernel = [=](sycl::id<1> idx) {
+
+        int sort_increasing = 1;
+        
+        std::size_t gid = idx.get(0);
+
+        int pair_distance = 1 << (stage - pass);
+        int block_width = 2 * pair_distance;
+
+        std::size_t left_id =
+            (gid % pair_distance) + (gid / pair_distance) * block_width;
+        std::size_t right_id = left_id + pair_distance;
+
+        T left_element = *advance_to(first, left_id);
+        T right_element = *advance_to(first, right_id);
+
+        std::size_t same_direction_block_width = 1 << stage;
+
+        if ((gid / same_direction_block_width) % 2 == 1) {
+          sort_increasing = 1 - sort_increasing;
+        }
+
+        T greater = left_element;
+        T lesser = right_element;
+
+        if (comp(left_element, right_element)) {
+          greater = right_element;
+          lesser = left_element;
+        } else {
+          greater = left_element;
+          lesser = right_element;
+        }
+
+        *advance_to(first, left_id) = sort_increasing ? lesser : greater;
+        *advance_to(first, right_id) = sort_increasing ? greater : lesser;
+      };
+
+      if((stage == 0 && pass == 0) || q.is_in_order())
+        most_recent_event = q.parallel_for(r, kernel);
+      else
+        most_recent_event = q.parallel_for(r, most_recent_event, kernel);
+
+    } // pass_stage
+  }   // stage
+  return most_recent_event;
+} // bitonic_sort
+}
+
+#endif

--- a/include/hipSYCL/std/stdpar/detail/offload_heuristic_db.hpp
+++ b/include/hipSYCL/std/stdpar/detail/offload_heuristic_db.hpp
@@ -50,6 +50,8 @@ struct find_if_not {};
 struct all_of {};
 struct any_of {};
 struct none_of {};
+struct sort {};
+
 
 struct transform_reduce {};
 struct reduce {};

--- a/include/hipSYCL/std/stdpar/pstl-impl/algorithm.hpp
+++ b/include/hipSYCL/std/stdpar/pstl-impl/algorithm.hpp
@@ -487,6 +487,45 @@ bool none_of(hipsycl::stdpar::par_unseq, ForwardIt first, ForwardIt last,
 
 
 
+template <class RandomIt>
+HIPSYCL_STDPAR_ENTRYPOINT void sort(hipsycl::stdpar::par_unseq, RandomIt first,
+                                        RandomIt last) {
+  auto offloader = [&](auto& queue) {
+    hipsycl::algorithms::sort(queue, first, last);
+  };
+
+  auto fallback = [&](){
+    std::sort(hipsycl::stdpar::par_unseq_host_fallback, first, last);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD_NORET(
+      hipsycl::stdpar::algorithm(
+          hipsycl::stdpar::algorithm_category::sort{},
+          hipsycl::stdpar::par_unseq{}),
+      std::distance(first, last), offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last));
+}
+
+
+template <class RandomIt, class Compare>
+HIPSYCL_STDPAR_ENTRYPOINT void sort(hipsycl::stdpar::par_unseq, RandomIt first,
+                                        RandomIt last, Compare comp) {
+  auto offloader = [&](auto& queue) {
+    hipsycl::algorithms::sort(queue, first, last, comp);
+  };
+
+  auto fallback = [&]() {
+    std::sort(hipsycl::stdpar::par_unseq_host_fallback, first, last, comp);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD_NORET(
+      hipsycl::stdpar::algorithm(
+          hipsycl::stdpar::algorithm_category::sort{},
+          hipsycl::stdpar::par_unseq{}),
+      std::distance(first, last), offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), comp);
+}
+
 
 
 //////////////////// par policy  /////////////////////////////////////
@@ -951,10 +990,43 @@ bool none_of(hipsycl::stdpar::par, ForwardIt first, ForwardIt last,
       HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), p);
 }
 
+template <class RandomIt>
+HIPSYCL_STDPAR_ENTRYPOINT void sort(hipsycl::stdpar::par, RandomIt first,
+                                        RandomIt last) {
+  auto offloader = [&](auto& queue) {
+    hipsycl::algorithms::sort(queue, first, last);
+  };
 
+  auto fallback = [&](){
+    std::sort(hipsycl::stdpar::par_host_fallback, first, last);
+  };
 
+  HIPSYCL_STDPAR_OFFLOAD_NORET(
+      hipsycl::stdpar::algorithm(
+          hipsycl::stdpar::algorithm_category::sort{},
+          hipsycl::stdpar::par{}),
+      std::distance(first, last), offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last));
+}
 
+template <class RandomIt, class Compare>
+HIPSYCL_STDPAR_ENTRYPOINT void sort(hipsycl::stdpar::par, RandomIt first,
+                                    RandomIt last, Compare comp) {
+  auto offloader = [&](auto& queue) {
+    hipsycl::algorithms::sort(queue, first, last, comp);
+  };
 
+  auto fallback = [&]() {
+    std::sort(hipsycl::stdpar::par_host_fallback, first, last, comp);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD_NORET(
+      hipsycl::stdpar::algorithm(
+          hipsycl::stdpar::algorithm_category::sort{},
+          hipsycl::stdpar::par{}),
+      std::distance(first, last), offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), comp);
+}
 }
 
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -147,6 +147,7 @@ if(WITH_PSTL_TESTS)
     pstl/replace_if.cpp
     pstl/replace_copy.cpp
     pstl/replace_copy_if.cpp
+    pstl/sort.cpp
     pstl/transform.cpp
     pstl/transform_reduce.cpp
     pstl/pointer_validation.cpp

--- a/tests/pstl/sort.cpp
+++ b/tests/pstl/sort.cpp
@@ -54,4 +54,12 @@ BOOST_AUTO_TEST_CASE(par_unseq_pow2_ascending) {
   test_sort(std::execution::par_unseq, 1024, [](int i){return i;});
 }
 
+BOOST_AUTO_TEST_CASE(par_unseq_non_pow2_descending) {
+  test_sort(std::execution::par_unseq, 1000, [](int i){return -i;});
+}
+
+BOOST_AUTO_TEST_CASE(par_unseq_non_pow2_ascending) {
+  test_sort(std::execution::par_unseq, 1000, [](int i){return i;});
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pstl/sort.cpp
+++ b/tests/pstl/sort.cpp
@@ -1,0 +1,57 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <algorithm>
+#include <execution>
+#include <utility>
+#include <vector>
+#include <functional>
+
+#include <boost/test/unit_test.hpp>
+#include <boost/mpl/list.hpp>
+
+#include "pstl_test_suite.hpp"
+
+BOOST_FIXTURE_TEST_SUITE(pstl_sort, enable_unified_shared_memory)
+
+template <class Policy, class Generator, class Comp = std::less<>>
+void test_sort(Policy &&pol, std::size_t problem_size, Generator gen,
+               Comp comp = {}) {
+  std::vector<int> data(problem_size);
+  for(int i = 0; i < problem_size; ++i)
+    data[i] = gen(i);
+  std::vector<int> host_data = data;
+
+  std::sort(pol, data.begin(), data.end(), comp);
+  
+  BOOST_CHECK(std::is_sorted(data.begin(), data.end(), comp));
+  std::sort(host_data.begin(), host_data.end(), comp);
+  BOOST_CHECK(host_data == data);
+}
+
+BOOST_AUTO_TEST_CASE(par_unseq_empty) {
+  test_sort(std::execution::par_unseq, 0, [](int i){return 0;});
+}
+
+BOOST_AUTO_TEST_CASE(par_unseq_single_element) {
+  test_sort(std::execution::par_unseq, 1, [](int i){return i;});
+}
+
+
+BOOST_AUTO_TEST_CASE(par_unseq_pow2_descending) {
+  test_sort(std::execution::par_unseq, 1024, [](int i){return -i;});
+}
+
+BOOST_AUTO_TEST_CASE(par_unseq_pow2_ascending) {
+  test_sort(std::execution::par_unseq, 1024, [](int i){return i;});
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add a simple `std::sort` implementation using bitonic sort. It's not going to deliver the best performance, but it's very general as the implementation works for any problem size, data type or comparator. More optimized algorithms for special cases can be added later on.
In the meantime, this might be sufficient for use cases where the sort is not the most performance-critical part of the code.