### PR TITLE
Builtin remapping: Also remap finite builtins

### DIFF
--- a/src/compiler/sscp/StdBuiltinRemapperPass.cpp
+++ b/src/compiler/sscp/StdBuiltinRemapperPass.cpp
@@ -13,6 +13,10 @@
 #include <unordered_set>
 #include <unordered_map>
 
+#define STRINGIFY2(x) #x
+#define STRINGIFY(x) STRINGIFY2(x)
+
+
 namespace hipsycl {
 namespace compiler {
 
@@ -54,7 +58,34 @@ using builtin_mapping = std::array<const char*, 2>;
 static constexpr std::array explicitly_mapped_builtins = {
   // clang sometimes (e.g. -ffast-math) these builtins
   builtin_mapping{"__powisf2", "__acpp_sscp_pown_f32"},
-  builtin_mapping{"__powidf2", "__acpp_sscp_pown_f64"}
+  builtin_mapping{"__powidf2", "__acpp_sscp_pown_f64"},
+
+#define ACPP_DECLARE_FINITE_BUILTIN_MAPPING(name) \
+  builtin_mapping{STRINGIFY(__ ## name ## f_finite), STRINGIFY(__acpp_sscp_ ## name ## _f32)}, \
+  builtin_mapping{STRINGIFY(__ ## name ## _finite), STRINGIFY(__acpp_sscp_ ## name ## _f64)}
+
+  ACPP_DECLARE_FINITE_BUILTIN_MAPPING(acos),
+  ACPP_DECLARE_FINITE_BUILTIN_MAPPING(acosh),
+  ACPP_DECLARE_FINITE_BUILTIN_MAPPING(asin),
+  ACPP_DECLARE_FINITE_BUILTIN_MAPPING(asinh),
+  ACPP_DECLARE_FINITE_BUILTIN_MAPPING(atan2),
+  ACPP_DECLARE_FINITE_BUILTIN_MAPPING(atanh),
+  ACPP_DECLARE_FINITE_BUILTIN_MAPPING(cosh),
+  ACPP_DECLARE_FINITE_BUILTIN_MAPPING(cos),
+  ACPP_DECLARE_FINITE_BUILTIN_MAPPING(exp10),
+  ACPP_DECLARE_FINITE_BUILTIN_MAPPING(exp2),
+  ACPP_DECLARE_FINITE_BUILTIN_MAPPING(exp),
+  ACPP_DECLARE_FINITE_BUILTIN_MAPPING(fmod),
+  ACPP_DECLARE_FINITE_BUILTIN_MAPPING(log10),
+  ACPP_DECLARE_FINITE_BUILTIN_MAPPING(log2),
+  ACPP_DECLARE_FINITE_BUILTIN_MAPPING(log),
+  ACPP_DECLARE_FINITE_BUILTIN_MAPPING(hypot),
+  ACPP_DECLARE_FINITE_BUILTIN_MAPPING(pow),
+  ACPP_DECLARE_FINITE_BUILTIN_MAPPING(remainder),
+  ACPP_DECLARE_FINITE_BUILTIN_MAPPING(sinh),
+  ACPP_DECLARE_FINITE_BUILTIN_MAPPING(sin),
+  ACPP_DECLARE_FINITE_BUILTIN_MAPPING(sqrt),
+  ACPP_DECLARE_FINITE_BUILTIN_MAPPING(tan)
 };
 
 llvm::PreservedAnalyses StdBuiltinRemapperPass::run(llvm::Module &M,


### PR DESCRIPTION
On some libc versions, clang might emit `__<builtin>_finite` calls in case `-ffast-math` is active. So we also need to remap those in device code. This is implemented in this PR.