### PR TITLE
removed depracated `startswith`

### DIFF
--- a/src/compiler/stdpar/SyncElision.cpp
+++ b/src/compiler/stdpar/SyncElision.cpp
@@ -82,7 +82,7 @@ void identifyStoresPotentiallyForStdparArgHandling(
                 if (StdparFunctions.contains(CB->getCalledFunction())) {
                   Users.push_back(Current);
                   return true;
-                } else if(CB->getCalledFunction()->getName().startswith("llvm.lifetime")) {
+                } else if(CB->getCalledFunction()->getName().starts_with("llvm.lifetime")) {
                   return true;
                 }
               }
@@ -134,7 +134,7 @@ bool functionDoesNotAccessMemory(llvm::Function* F){
   if(!F)
     return true;
   if(F->isIntrinsic()) {
-    if(F->getName().startswith("llvm.lifetime")){
+    if(F->getName().starts_with("llvm.lifetime")){
       return true;
     }
   }


### PR DESCRIPTION
I have updated the usage of `inline bool llvm::StringRef::startswith(llvm::StringRef Prefix) const` with `inline bool llvm::StringRef::starts_with(llvm::StringRef Prefix) const` as `llvm-18/llvm/ADT/StringRef.h` has marked `startswith` as deprecated.

Please let me know if you have any questions or if this pull request violates any contribution rules.