### PR TITLE
Rework index.md

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -13,7 +13,7 @@ Welcome to the documentation of AdaptiveCpp!
 
     [:octicons-arrow-right-24: Installation](./installing.md)
 
--   :fontawesome-solid-gears:{ .lg .middle } __Can run on most hardware__
+-   :fontawesome-solid-gears:{ .lg .middle } __Can run on hardware from all major vendors__
 
     ---
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,7 +1,7 @@
 #
-![The Rust Logo](img/logo/logo-color.png)
+![The AdaptiveCpp Logo](img/logo/logo-color.png)
 
-Welcome to the documentation of the AdaptiveCpp !
+Welcome to the documentation of AdaptiveCpp!
 
 <div class="grid cards" markdown>
 
@@ -9,16 +9,15 @@ Welcome to the documentation of the AdaptiveCpp !
 
     ---
 
-    Configure and install AdaptiveCpp
+    Configure and install AdaptiveCpp.
 
     [:octicons-arrow-right-24: Installation](./installing.md)
 
--   :fontawesome-solid-gears:{ .lg .middle } __Can run on any hardware__
+-   :fontawesome-solid-gears:{ .lg .middle } __Can run on most hardware__
 
     ---
 
-    We support CPUs, GPUs, from all vendors, either through multipass compilation.
-    Or through our single pass SSCP compiler
+    We support CPUs and GPUs from all major vendors, either through multipass compilation or through our single-pass SSCP compiler.
 
     [:octicons-arrow-right-24: Usage](./using-hipsycl.md)
 
@@ -27,4 +26,4 @@ Welcome to the documentation of the AdaptiveCpp !
 
 !!! note
 
-    This documentation webpage is WIP.
+    This documentation webpage is still work-in-progress.


### PR DESCRIPTION
This pull request reworks the [landing page for the MkDocs-based documentation pages](https://adaptivecpp.github.io/AdaptiveCpp/).

In particular, it includes fixes which address a copy/paste error (unless I missed the Rust logo advertised by the Markdown source), some dubious punctuation, and some potentially false advertising (claiming AdaptiveCpp can run on \"any\", i.e. all, hardware seems a bit much, eh? 😉).