### PR TITLE
Pass -cl-denorms-are-zero to OpenCL

### DIFF
--- a/src/runtime/ocl/ocl_code_object.cpp
+++ b/src/runtime/ocl/ocl_code_object.cpp
@@ -54,7 +54,7 @@ ocl_executable_object::ocl_executable_object(const cl::Context& ctx, cl::Device&
   std::string options_string="-cl-uniform-work-group-size";
   for(const auto& flag : config.build_flags()) {
     if(flag == kernel_build_flag::fast_math) {
-      options_string += " -cl-fast-relaxed-math";
+      options_string += " -cl-fast-relaxed-math -cl-denorms-are-zero";
     }
   }
 


### PR DESCRIPTION
As mentioned in #1584, denormal numbers can sometimes cause performance degradation.
With `-ffast-math`, denormals should be flushed (similar to enabling `-ffast-math` on regular clang), but this has to be passed as an OpenCL build flag.

This works with Intels OpenCL runtime and PoCL, but I cannot test at the moment whether PoCL is actually affected by this.