### PR TITLE
Add the preliminary default context KHR extension

### DIFF
--- a/include/hipSYCL/runtime/device_id.hpp
+++ b/include/hipSYCL/runtime/device_id.hpp
@@ -14,6 +14,7 @@
 #include <functional>
 #include <cassert>
 #include <ostream>
+#include <cstdint>
 
 namespace hipsycl {
 namespace rt {
@@ -100,6 +101,12 @@ public:
   friend bool operator!=(const device_id& a, const device_id& b)
   {
     return !(a == b);
+  }
+
+  uint64_t hash_code() const {
+    uint32_t backend = static_cast<uint32_t>(_backend.id);
+    uint32_t id = _device_id;
+    return (static_cast<uint64_t>(backend) << 32) | id;
   }
 private:
   backend_descriptor _backend;

--- a/include/hipSYCL/sycl/extensions.hpp
+++ b/include/hipSYCL/sycl/extensions.hpp
@@ -75,4 +75,8 @@
 #define ACPP_EXT_SPECIALIZED
 #define ACPP_EXT_DYNAMIC_FUNCTIONS
 
+// KHR extensions
+
+#define SYCL_KHR_DEFAULT_CONTEXT 1
+
 #endif

--- a/include/hipSYCL/sycl/platform.hpp
+++ b/include/hipSYCL/sycl/platform.hpp
@@ -126,7 +126,8 @@ public:
     return AdaptiveCpp_hash_code();
   }
 
-
+  
+  context khr_get_default_context() const;
 private:
   rt::platform_id _platform;
   rt::runtime_keep_alive_token _requires_runtime;

--- a/tests/sycl/extensions.cpp
+++ b/tests/sycl/extensions.cpp
@@ -1222,5 +1222,17 @@ BOOST_AUTO_TEST_CASE(sycl_specialized) {
   sycl::free(data, q);
 }
 #endif
+#ifdef SYCL_KHR_DEFAULT_CONTEXT
+BOOST_AUTO_TEST_CASE(khr_default_context) {
+  using namespace cl;
+  sycl::queue q1;
+  sycl::queue q2;
+
+  BOOST_CHECK(q1.get_context() == q2.get_context());
+  BOOST_CHECK(q1.get_device().get_platform().khr_get_default_context() ==
+              q1.get_context());
+  BOOST_CHECK(sycl::context{} != q1.get_context());
+}
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Adds the default context extension, which is currently discussed as a KHR ratified extension: https://github.com/KhronosGroup/SYCL-Docs/pull/624

In AdaptiveCpp, `context` is not really meaningful since backends manage contexts internally. `context` only stores a device list in AdaptiveCpp. So we've never had the performance issues with `queue{}` constructing expensive new backend contexts to begin with.
However, since context for us does not really hold state, implementing this extension was a bit cumbersome since now `get_context()` of a default constructed queue must always compare equal for all default constructed queues on the same platform.
Storing contexts throughout the lifetime of the runtime is even more cumbersome since this complicates lifetime management of the runtime.
So this PR implements things with an ugly hack: Lifetime management of `context` stays as it is, but `context` now stores whether it is a default context. If so, `operator==` and `std::hash` compare the device list of the context by value. Otherwise, the shared pointer is compared that is used to give it the by-reference semantics that SYCL requires. It's ugly, but it works for now.