### PR TITLE
Add experimental --acpp-export-all feature to make SYCL_EXTERNAL unnecessary

### DIFF
--- a/bin/acpp
+++ b/bin/acpp
@@ -363,7 +363,10 @@ class acpp_config:
       'stdpar-unconditional-offload' : option("--acpp-stdpar-unconditional-offload", "ACPP_STDPAR_UNCONDITIONAL_OFFLOAD", "default-is-stdpar-unconditional-offload",
 """  Normally, heuristics are employed to determine whether algorithms should be offloaded.
   This particularly affects small problem sizes. If this flag is set, supported parallel STL
-  algorithms will be offloaded unconditionally.""")
+  algorithms will be offloaded unconditionally."""),
+      'is-export-all' : option("--acpp-export-all", "ACPP_EXPORT_ALL", "default-export-all",
+"""  (Experimental) Treat all functions implicitly as SYCL_EXTERNAL. Only supported with generic target.
+  This currently only works with translation units that include the sycl.hpp header.""")
     }
 
 
@@ -809,6 +812,13 @@ class acpp_config:
   def is_explicit_multipass(self):
     try:
       return self._is_flag_set("is-explicit-multipass")
+    except OptionNotSet:
+      return False
+
+  @property
+  def is_export_all(self):
+    try:
+      return self._is_flag_set("is-export-all")
     except OptionNotSet:
       return False
 
@@ -1521,6 +1531,9 @@ class llvm_sscp_invocation:
   def get_cxx_flags(self):
     flags = ["-D__ACPP_ENABLE_LLVM_SSCP_TARGET__",
             "-Xclang", "-disable-O0-optnone", "-mllvm", "-acpp-sscp"]
+    
+    if self._config.is_export_all:
+      flags += ["-mllvm","-acpp-sscp-export-all"]
 
     sscp_compile_opts = []
     if ("-Ofast" in self._config.forwarded_compiler_arguments or

--- a/include/hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp
@@ -232,9 +232,13 @@ private:
   int S2IRConstantBackendId;
   
   std::vector<std::string> OutliningEntrypoints;
+  // function call specializations might result in additional outlining entrypoints
+  // that we need to consider early on
+  std::vector<std::string> FunctionCallSpecializationOutliningEntrypoints;
   std::vector<std::string> Kernels;
 
   std::vector<std::string> Errors;
+  
   std::unordered_map<std::string, std::function<void(llvm::Module &)>> SpecializationApplicators;
   ExternalSymbolResolver SymbolResolver;
   bool HasExternalSymbolResolver = false;

--- a/include/hipSYCL/compiler/llvm-to-backend/Utils.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/Utils.hpp
@@ -70,7 +70,7 @@ inline llvm::Error loadModuleFromString(const std::string &LLVMIR, llvm::LLVMCon
 }
 
 template<class F>
-inline void constructPassBuilder(F&& handler) {
+inline auto withPassBuilder(F&& handler) {
   llvm::LoopAnalysisManager LAM;
   llvm::FunctionAnalysisManager FAM;
   llvm::CGSCCAnalysisManager CGAM;
@@ -82,11 +82,11 @@ inline void constructPassBuilder(F&& handler) {
   PB.registerLoopAnalyses(LAM);
   PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
 
-  handler(PB, LAM, FAM, CGAM, MAM);
+  return handler(PB, LAM, FAM, CGAM, MAM);
 }
 
 template<class F>
-inline void constructPassBuilderAndMAM(F&& handler) {
+inline auto withPassBuilderAndMAM(F&& handler) {
   llvm::LoopAnalysisManager LAM;
   llvm::FunctionAnalysisManager FAM;
   llvm::CGSCCAnalysisManager CGAM;
@@ -98,7 +98,7 @@ inline void constructPassBuilderAndMAM(F&& handler) {
   PB.registerLoopAnalyses(LAM);
   PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
 
-  handler(PB, MAM);
+  return handler(PB, MAM);
 }
 
 

--- a/include/hipSYCL/compiler/sscp/KernelOutliningPass.hpp
+++ b/include/hipSYCL/compiler/sscp/KernelOutliningPass.hpp
@@ -20,6 +20,8 @@ namespace compiler {
 
 class EntrypointPreparationPass : public llvm::PassInfoMixin<EntrypointPreparationPass> {
 public:
+  EntrypointPreparationPass(bool ExportByDefault = false);
+
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
 
   const std::vector<std::string>& getKernelNames() const {
@@ -38,6 +40,7 @@ private:
   std::vector<std::string> KernelNames;
   std::vector<std::string> OutliningEntrypoints;
   std::vector<std::string> NonKernelOutliningEntrypoints;
+  bool ExportAll;
 };
 
 //  Removes all code not belonging to kernels

--- a/src/compiler/llvm-to-backend/LLVMToBackend.cpp
+++ b/src/compiler/llvm-to-backend/LLVMToBackend.cpp
@@ -218,32 +218,35 @@ bool LLVMToBackendTranslator::fullTransformation(const std::string &LLVMIR, std:
 }
 
 bool LLVMToBackendTranslator::prepareIR(llvm::Module &M) {
+
   HIPSYCL_DEBUG_INFO << "LLVMToBackend: Preparing backend flavoring...\n";
 
-  if(!this->prepareBackendFlavor(M))
-    return false;
-
-  // We need to resolve symbols now instead of after optimization, because we
-  // may have to reuotline if the code that is linked in after symbol resolution
-  // depends on IR constants.
-  // This also means that we cannot error yet if we cannot resolve all symbols :(
-  resolveExternalSymbols(M);
-
-  HIPSYCL_DEBUG_INFO << "LLVMToBackend: Applying specializations and S2 IR constants...\n";
-  for(auto& A : SpecializationApplicators) {
-    HIPSYCL_DEBUG_INFO << "LLVMToBackend: Processing specialization " << A.first << "\n";
-    A.second(M);
-  }
-  // Return error in case applying specializations has caused error list to be populated
-  if(!Errors.empty())
-    return false;
-
-  bool ContainsUnsetIRConstants = false;
-  bool FlavoringSuccessful = false;
-  bool OptimizationSuccessful = false;
-
-  constructPassBuilderAndMAM([&](llvm::PassBuilder &PB, llvm::ModuleAnalysisManager &MAM) {
+  return withPassBuilderAndMAM([&](llvm::PassBuilder &PB, llvm::ModuleAnalysisManager &MAM) {
     PassHandler PH {&PB, &MAM};
+
+    // Do an initial outlining to simplify the code, particularly to reduce
+    // linking complexity if --acpp-export-all is used
+    HIPSYCL_DEBUG_INFO << "LLVMToBackend: Reoutlining kernels...\n";
+    KernelOutliningPass InitialOutlining{OutliningEntrypoints};
+    InitialOutlining.run(M, MAM);
+    
+    // We need to resolve symbols now instead of after optimization, because we
+    // may have to reuotline if the code that is linked in after symbol resolution
+    // depends on IR constants.
+    // This also means that we cannot error yet if we cannot resolve all symbols :(
+    resolveExternalSymbols(M);
+
+    if(!this->prepareBackendFlavor(M))
+      return false;
+
+    HIPSYCL_DEBUG_INFO << "LLVMToBackend: Applying specializations and S2 IR constants...\n";
+    for(auto& A : SpecializationApplicators) {
+      HIPSYCL_DEBUG_INFO << "LLVMToBackend: Processing specialization " << A.first << "\n";
+      A.second(M);
+    }
+    // Return error in case applying specializations has caused error list to be populated
+    if(!Errors.empty())
+      return false;
 
     // Optimize away unnecessary branches due to backend-specific S2IR constants
     // This is what allows us to specialize code for different backends.
@@ -281,55 +284,56 @@ bool LLVMToBackendTranslator::prepareIR(llvm::Module &M) {
     ICP.run(M, MAM);
 
     HIPSYCL_DEBUG_INFO << "LLVMToBackend: Adding backend-specific flavor to IR...\n";
-    FlavoringSuccessful = this->toBackendFlavor(M, PH);
+    if(!this->toBackendFlavor(M, PH)) {
+      HIPSYCL_DEBUG_INFO << "LLVMToBackend: Flavoring failed\n";
+      return false;
+    }
+
     // Inline again to handle builtin definitions pulled in by backend flavors
     InliningPass.run(M, MAM);
 
-    if(FlavoringSuccessful) {
-      // Run optimizations
-      HIPSYCL_DEBUG_INFO << "LLVMToBackend: Optimizing flavored IR...\n";
+    // Run optimizations
+    HIPSYCL_DEBUG_INFO << "LLVMToBackend: Optimizing flavored IR...\n";
 
-      if(IsFastMath)
-        setFastMathFunctionAttribs(M);
+    if(IsFastMath)
+      setFastMathFunctionAttribs(M);
 
-      // Remove argument_used hints, which are no longer needed once we enter optimization stage.
-      // This is primarily needed for dynamic functions.
-      utils::ProcessFunctionAnnotationPass PFA({"argument_used"});
-      PFA.run(M, MAM);
+    // Remove argument_used hints, which are no longer needed once we enter optimization stage.
+    // This is primarily needed for dynamic functions.
+    utils::ProcessFunctionAnnotationPass PFA({"argument_used"});
+    PFA.run(M, MAM);
 
-      MAM.clear();
+    MAM.clear(); 
 
-      OptimizationSuccessful = optimizeFlavoredIR(M, PH);
-
-      if(!OptimizationSuccessful) {
-        this->registerError("LLVMToBackend: Optimization failed");
-      }
-
-      for(const auto& Entry : FunctionsForDeadArgumentElimination) {
-        if(auto* F = M.getFunction(Entry.first)) {
-          if(isKernelAfterFlavoring(*F)) {
-            runKernelDeadArgumentElimination(M, F, PH, *Entry.second);
-          }
-        }
-      }
-      llvm::AlwaysInlinerPass AIP;
-      AIP.run(M, MAM);
-
-      S2IRConstant::forEachS2IRConstant(M, [&](S2IRConstant C) {
-        if (C.isValid()) {
-          if (!C.isInitialized()) {
-            ContainsUnsetIRConstants = true;
-            this->registerError("LLVMToBackend: AdaptiveCpp S2IR constant was not set: " +
-                                C.getGlobalVariable()->getName().str());
-          }
-        }
-      });
-    } else {
-      HIPSYCL_DEBUG_INFO << "LLVMToBackend: Flavoring failed\n";
+    if(!optimizeFlavoredIR(M, PH)) {
+      this->registerError("LLVMToBackend: Optimization failed");
+      return false;
     }
-  });
 
-  return FlavoringSuccessful && OptimizationSuccessful && !ContainsUnsetIRConstants;
+    for(const auto& Entry : FunctionsForDeadArgumentElimination) {
+      if(auto* F = M.getFunction(Entry.first)) {
+        if(isKernelAfterFlavoring(*F)) {
+          runKernelDeadArgumentElimination(M, F, PH, *Entry.second);
+        }
+      }
+    }
+    llvm::AlwaysInlinerPass{}.run(M, MAM);
+
+    bool ContainsUnsetIRConstants = false;
+    S2IRConstant::forEachS2IRConstant(M, [&](S2IRConstant C) {
+      if (C.isValid()) {
+        if (!C.isInitialized()) {
+          ContainsUnsetIRConstants = true;
+          this->registerError("LLVMToBackend: AdaptiveCpp S2IR constant was not set: " +
+                              C.getGlobalVariable()->getName().str());
+        }
+      }
+    });
+    if(ContainsUnsetIRConstants)
+      return false;
+
+    return true;
+  });
 }
 
 bool LLVMToBackendTranslator::translatePreparedIR(llvm::Module &FlavoredModule, std::string &out) {

--- a/src/compiler/sscp/TargetSeparationPass.cpp
+++ b/src/compiler/sscp/TargetSeparationPass.cpp
@@ -99,13 +99,18 @@ public:
 
 static llvm::cl::opt<bool> SSCPEmitHcf{
     "acpp-sscp-emit-hcf", llvm::cl::init(false),
-    llvm::cl::desc{"Emit HCF from hipSYCL LLVM SSCP compilation flow"}};
+    llvm::cl::desc{"Emit HCF from AdaptiveCpp LLVM SSCP compilation flow"}};
 
 static llvm::cl::opt<bool> PreoptimizeSSCPKernels{
     "acpp-sscp-preoptimize", llvm::cl::init(false),
     llvm::cl::desc{
         "Preoptimize SYCL kernels in LLVM IR instead of embedding unoptimized kernels and relying "
-        "on optimization at runtime. This is mainly for hipSYCL developers and NOT supported!"}};
+        "on optimization at runtime. This is mainly for AdaptiveCpp developers and NOT supported!"}};
+
+static llvm::cl::opt<bool> ExportAllSymbols{
+    "acpp-sscp-export-all", llvm::cl::init(false),
+    llvm::cl::desc{
+        "(experimental) export all functions for JIT-time linking"}};
 
 static const char *SscpIsHostIdentifier = "__acpp_sscp_is_host";
 static const char *SscpIsDeviceIdentifier = "__acpp_sscp_is_device";
@@ -279,7 +284,7 @@ std::unique_ptr<llvm::Module> generateDeviceIR(llvm::Module &M,
     }
   }
 
-  EntrypointPreparationPass EPP;
+  EntrypointPreparationPass EPP{ExportAllSymbols};
   EPP.run(*DeviceModule, DeviceMAM);
   
   ExportedSymbolsOutput = EPP.getNonKernelOutliningEntrypoints();

--- a/tests/compiler/sscp/export-all/export_all.cpp
+++ b/tests/compiler/sscp/export-all/export_all.cpp
@@ -1,0 +1,26 @@
+// RUN: %acpp %s %S/second_tu.cpp -o %t --acpp-targets=generic --acpp-export-all
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s %S/second_tu.cpp -o %t --acpp-targets=generic -O3 --acpp-export-all
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s %S/second_tu.cpp -o %t --acpp-targets=generic -g --acpp-export-all
+// RUN: %t | FileCheck %s
+
+#include <iostream>
+#include <sycl/sycl.hpp>
+#include "../common.hpp"
+
+// defined in second_tu.cpp
+int increment(int x);
+
+int main() {
+  sycl::queue q = get_queue();
+  int* data = sycl::malloc_shared<int>(1, q);
+  q.single_task([=](){
+    *data = increment(123);
+  });
+  q.wait();
+
+  // CHECK: 124
+  std::cout << *data << std::endl;
+  sycl::free(data, q);
+}

--- a/tests/compiler/sscp/export-all/lit.local.cfg
+++ b/tests/compiler/sscp/export-all/lit.local.cfg
@@ -1,0 +1,1 @@
+config.excludes = ["second_tu.cpp"]

--- a/tests/compiler/sscp/export-all/second_tu.cpp
+++ b/tests/compiler/sscp/export-all/second_tu.cpp
@@ -1,0 +1,5 @@
+#include <sycl/sycl.hpp>
+
+int increment(int x) {
+  return x+1;
+}


### PR DESCRIPTION
This adds support for a new *experimental* `--acpp-export-all` flag, which causes the generic JIT compiler to treat all functions implicitly as `SYCL_EXTERNAL`.

This allows normal C++ code without `SYCL_EXTERNAL` to link "as expected".

This is experimental; current known limitations are
* the `sycl/sycl.hpp` header must be included in files that are supposed to be callable from kernels. This is because the header contains our HCF registration stub which handles registration of the device code with the runtime. In the future we could look into integrating this portion of the code automatically. *Note:* In the stdpar case, the relevant headers are always implicitly included and no additional includes or `-include` flags are needed to get this feature to work.
* The kernel cache is currently unaware of dependent TUs that get linked into the kernel; so if you have a TU with a kernel into which device code from another TU is linked, and you modify the second TU no recompilation of the kernel is triggered.
* Warnings may occur during compile-time during kernel outlining indicating that some code could not be stripped. These warnings can be ignored and the warning behavior should probably be changed in the future.