### PR TITLE
[SSCP][Adaptivity] Specialize local memory accessor content at adaptivity level >= 1

### DIFF
--- a/include/hipSYCL/runtime/kernel_configuration.hpp
+++ b/include/hipSYCL/runtime/kernel_configuration.hpp
@@ -160,6 +160,12 @@ public:
   }
 
   void set_specialized_kernel_argument(int param_index, uint64_t buffer_value) {
+    for(int i = 0; i < _specialized_kernel_args.size(); ++i) {
+      if(_specialized_kernel_args[i].first == param_index) {
+        _specialized_kernel_args[i] = std::make_pair(param_index, buffer_value);
+        return;
+      }
+    }
     _specialized_kernel_args.push_back(
         std::make_pair(param_index, buffer_value));
   }

--- a/include/hipSYCL/sycl/libkernel/accessor.hpp
+++ b/include/hipSYCL/sycl/libkernel/accessor.hpp
@@ -44,6 +44,7 @@
 #include "item.hpp"
 #include "multi_ptr.hpp"
 #include "atomic.hpp"
+#include "../specialized.hpp"
 #include "detail/local_memory_allocator.hpp"
 #include "detail/mobile_shared_ptr.hpp"
 
@@ -2148,8 +2149,8 @@ private:
     : _addr{addr}, _num_elements{r}
   {}
 
-  address _addr{};
-  range<dimensions> _num_elements;
+  specialized<address> _addr;
+  specialized<range<dimensions>> _num_elements;
 };
 
 namespace detail::accessor {


### PR DESCRIPTION
Turns out some of the gains (particularly miniBUDE) observed using IADS optimization at adaptivity level 2 were due to specialization of internal local accessor offset and dimensions.
Since local accessor offset and dimensions are typically only tied to work group size and we already specialize for work group size at adaptivity level 1, it makes sense to do this optimization for local accessors at AL1.

This PR implements this, and thus brings miniBUDE AL2 performance to AL1 configurations. This is a ~17% perf boost.