### PR TITLE
[SSCP][libkernel][llvm-to-host] Assume that local memory is always aligned to 512 byte boundaries

### DIFF
--- a/src/libkernel/sscp/host/localmem.cpp
+++ b/src/libkernel/sscp/host/localmem.cpp
@@ -13,5 +13,10 @@
 extern "C" void* __acpp_cbs_sscp_dynamic_local_memory;
 
 __attribute__((address_space(3))) void* __acpp_sscp_get_dynamic_local_memory() {
-  return (__attribute__((address_space(3))) void*)(__acpp_cbs_sscp_dynamic_local_memory);
+
+  // We rely on the host side allocating page-aligned memory. On all relevant
+  // systems, the page size is larger than 512 bytes, so using this as a
+  // conservative minimum alignment seems safe.
+  return (__attribute__((address_space(3))) void *)(__builtin_assume_aligned(
+      __acpp_cbs_sscp_dynamic_local_memory, 512));
 }


### PR DESCRIPTION
The local memory pointer for the host is constructed to be aligned to page sizes in `omp_queue.cpp`. So far we haven't exploited this.
This PR asserts to the optimizer that the local memory segment on host is at least aligned to 512 bytes, which seems a safe assumption given that the page size is larger on all relevant systems.