### PR TITLE
changed the arch repo add script to do full system upgrade instead of partial system upgrade

### DIFF
--- a/install/scripts/add-hipsycl-repo/archlinux-rolling.sh
+++ b/install/scripts/add-hipsycl-repo/archlinux-rolling.sh
@@ -7,6 +7,6 @@ echo "Server = http://repo.urz.uni-heidelberg.de/sycl${1}/archlinux/x86_64" >> /
 pacman-key --init
 wget -q -O - http://repo.urz.uni-heidelberg.de/sycl/hipsycl.asc | pacman-key --add -
 pacman-key --lsign-key E967BA09716F870320089583E68CC4B9B2B75080
-pacman -Sy
+pacman -Syu
 
 


### PR DESCRIPTION
The shell script to add the repo on arch contains 'pacman -Sy', which is an unsupported partial upgrade (see https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported).
This pr changes that command to 'pacman -Syu', which is a supprted full system upgrade.