### PR TITLE
[clang-tidy] Add missing include to memory_streaming.hpp

### DIFF
--- a/include/hipSYCL/algorithms/util/memory_streaming.hpp
+++ b/include/hipSYCL/algorithms/util/memory_streaming.hpp
@@ -15,6 +15,7 @@
 #include "hipSYCL/sycl/device.hpp"
 #include "hipSYCL/sycl/libkernel/nd_item.hpp"
 #include "hipSYCL/sycl/info/device.hpp"
+#include "hipSYCL/sycl/jit.hpp"
 #include <cstddef>
 
 


### PR DESCRIPTION
Fixes #1605 