### PR TITLE
Avoid global config usage in `omp_accelerated_invocation`

### DIFF
--- a/bin/acpp
+++ b/bin/acpp
@@ -1414,6 +1414,7 @@ class omp_accelerated_invocation:
   def __init__(self, config, targets):
     self._linker_args = config.omp_link_line
     self._cxx_flags = config.omp_cxx_flags
+    self._acpp_plugin_path = config.acpp_plugin_path
 
     if len(targets) != 0:
       raise RuntimeError("OpenMP backend does not support specifiying target architecture")
@@ -1437,8 +1438,8 @@ class omp_accelerated_invocation:
     flags = ["-D__ACPP_ENABLE_OMPHOST_TARGET__"]
     if not sys.platform.startswith("win32"):
       flags += [
-        "-fplugin=" + config.acpp_plugin_path
-        , "-fpass-plugin=" + config.acpp_plugin_path
+        "-fplugin=" + self._acpp_plugin_path
+        , "-fpass-plugin=" + self._acpp_plugin_path
         , "-D__ACPP_USE_ACCELERATED_CPU__"
       ]
     flags += self._cxx_flags


### PR DESCRIPTION
Updates the flag generation logic to use the instance variable instead of accessing the global `config`
