### PR TITLE
Add missing llvm/IR/Module.h header in KnownPtrParamAlignmentOptPass.cpp

### DIFF
--- a/src/compiler/llvm-to-backend/KnownPtrParamAlignmentOptPass.cpp
+++ b/src/compiler/llvm-to-backend/KnownPtrParamAlignmentOptPass.cpp
@@ -15,6 +15,7 @@
 #include <llvm/IR/Instruction.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Intrinsics.h>
+#include <llvm/IR/Module.h>
 #include <llvm/IR/PassManager.h>
 
 namespace hipsycl {


### PR DESCRIPTION
Didn't build on my machine without it.

LLVM/Clang 19