### PR TITLE
Set CMake policy CMP0167 to suppress FindBoost removal warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,8 @@ if(POLICY CMP0074) # Since CMake 3.12
 endif()
 if(POLICY CMP0167) # Since CMake 3.30
     # Suppress warning: "Policy CMP0167 is not set: The FindBoost module is removed."
-    cmake_policy(SET CMP0167 NEW)
+    # Set CMP0167 to OLD to avoid breakage in the Windows & macOS CI tests.
+    cmake_policy(SET CMP0167 OLD)
 endif()
 
 
@@ -57,16 +58,16 @@ if(NOT ACPP_VERSION_SUFFIX)
       RESULT_VARIABLE GIT_LOCAL_CHANGES_RETURN_CODE
       OUTPUT_STRIP_TRAILING_WHITESPACE
     )
-  
-    if (GIT_HASH_RETURN_CODE EQUAL 0 AND GIT_BRANCH_RETURN_CODE EQUAL 0 AND 
+
+    if (GIT_HASH_RETURN_CODE EQUAL 0 AND GIT_BRANCH_RETURN_CODE EQUAL 0 AND
         GIT_DATE_RETURN_CODE EQUAL 0 AND GIT_LOCAL_CHANGES_RETURN_CODE EQUAL 0)
-    
+
       if(NOT "${ACPP_LOCAL_CHANGES}" STREQUAL "")
         set(DIRTY_STR ".dirty")
       else()
         set(DIRTY_STR "")
       endif()
-  
+
       set(ACPP_VERSION_SUFFIX "+git.${ACPP_GIT_COMMIT_HASH}.${ACPP_GIT_DATE}.branch.${ACPP_GIT_BRANCH}${DIRTY_STR}")
     endif()
   endif()
@@ -153,13 +154,13 @@ elseif(ACPP_COMPILER_FEATURE_PROFILE STREQUAL "custom-deprecated")
   if(DEFINED WITH_ACCELERATED_CPU)
     set(ACPP_CUSTOM_PROFILE_WITH_ACCELERATED_CPU ${WITH_ACCELERATED_CPU} CACHE INTERNAL "(deprecated) custom profile")
   endif()
-  
+
   # Ensure that these argument do not enter cache, otherwise the if(defined) checks above
   # will no longer work.
   unset(WITH_SSCP_COMPILER CACHE)
   unset(WITH_STDPAR_COMPILER CACHE)
   unset(WITH_ACCELERATED_CPU CACHE)
-  
+
   set(WITH_SSCP_COMPILER ${ACPP_CUSTOM_PROFILE_WITH_SSCP_COMPILER})
   set(WITH_STDPAR_COMPILER ${ACPP_CUSTOM_PROFILE_WITH_STDPAR_COMPILER})
   set(WITH_ACCELERATED_CPU ${ACPP_CUSTOM_PROFILE_WITH_ACCELERATED_CPU})
@@ -205,7 +206,7 @@ endif()
 if(WITH_ROCM_BACKEND)
   if(NOT ROCM_FOUND)
     #  message(SEND_ERROR "hipcc was not found")
-  
+
     # User has requested ROCm, but we could not find hipcc.
     # this is not necessarily a reason to abort,
     # since we only need libhip_hcc, the HIP includes,
@@ -303,7 +304,7 @@ if(BUILD_CLANG_PLUGIN)
   get_filename_component(LLVM_BIN_DIR "${CLANG_EXECUTABLE_PATH}" DIRECTORY)
   get_filename_component(LLVM_PREFIX_DIR "${LLVM_BIN_DIR}" DIRECTORY)
   # The path to the internal clang includes is currently required on ROCm
-  # to let acpp fix a wrong order of system includes (clang's internal 
+  # to let acpp fix a wrong order of system includes (clang's internal
   # includes are not of high enough priority in the include path search order).
   # We identify this path as the one containing __clang_cuda_runtime_wrapper.h,
   # which is a clang-specific header file.
@@ -323,7 +324,7 @@ if(BUILD_CLANG_PLUGIN)
     # Required for newer ROCm versions
     set(CLANG_INCLUDE_PATH ${FOUND_CLANG_INCLUDE_PATH}/..)
   endif()
-  
+
   if(NOT EXISTS ${CLANG_INCLUDE_PATH})
     message(SEND_ERROR "clang include path ${CLANG_INCLUDE_PATH} does not exist. Please provide clang's internal include path manually: Find the directory where __clang_cuda_runtime_wrapper.h is. Provide this directory for older ROCm versions and the parent directory for newer ones.")
   endif()
@@ -339,7 +340,7 @@ if(BUILD_CLANG_PLUGIN)
       message(STATUS "AMD clang version: ${ROCM_VERSION_MAJOR}.${ROCM_VERSION_MINOR}.${ROCM_VERSION_PATCH}")
     endif()
   endif()
-  
+
   if(${LLVM_VERSION_MAJOR} LESS 14)
     if(${WITH_ACCELERATED_CPU} OR ${WITH_SSCP_COMPILER} OR ${WITH_STDPAR_COMPILER})
       message(WARNING "clang version too old (${LLVM_VERSION_MAJOR} < 14) to be used with advanced AdaptiveCpp compiler features, disabling WITH_STDPAR_COMPILER, WITH_ACCELERATED_CPU, WITH_SSCP_COMPILER")
@@ -350,8 +351,8 @@ if(BUILD_CLANG_PLUGIN)
     endif()
   endif()
   message(STATUS "Using clang include directory: ${CLANG_INCLUDE_PATH}")
-  
-# Check if building on Windows and LLVM_LIBS is set, if not, use LLVM_AVAILABLE_LIBS 
+
+# Check if building on Windows and LLVM_LIBS is set, if not, use LLVM_AVAILABLE_LIBS
   if(WIN32 AND NOT LLVM_LIBS AND LLVM_AVAILABLE_LIBS)
     llvm_map_components_to_libnames(LLVM_LIBS analysis core support passes)
   endif()
@@ -367,7 +368,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(ACPP_CONFIG_FILE_PATH "${PROJECT_BINARY_DIR}")
-set(ACPP_CONFIG_FILE_GLOBAL_INSTALLATION false CACHE BOOL 
+set(ACPP_CONFIG_FILE_GLOBAL_INSTALLATION false CACHE BOOL
   "Whether to install the AdaptiveCpp configuration files into a global directory (typically, /etc/AdaptiveCpp). This is generally not recommended.")
 
 if(ACPP_CONFIG_FILE_GLOBAL_INSTALLATION)
@@ -391,7 +392,7 @@ endif()
 
 if(APPLE)
   set(DEFAULT_OMP_FLAG "-Xclang -fopenmp")
-  
+
   if(Boost_FIBER_LIBRARY_DEBUG)
     set(DEFAULT_BOOST_LIBRARIES "${Boost_CONTEXT_LIBRARY_DEBUG} ${Boost_FIBER_LIBRARY_DEBUG} -Wl,-rpath ${Boost_LIBRARY_DIR}")
   else()
@@ -456,7 +457,7 @@ if(WIN32)
   if(NOT OMP_LINK_LINE)
     set(OMP_LINK_LINE ${DEFAULT_WIN32_OMP_LINK_LINE} CACHE STRING "Arguments passed to compiler to link OpenMP libraries to SYCL applications")
   endif()
-  if(NOT SEQUENTIAL_LINK_LINE) 
+  if(NOT SEQUENTIAL_LINK_LINE)
     set(SEQUENTIAL_LINK_LINE ${DEFAULT_WIN32_SEQUENTIAL_LINK_LINE} CACHE STRING "Arguments passed to compiler to link host libraries to SYCL applications")
   endif()
 elseif(APPLE)
@@ -466,7 +467,7 @@ elseif(APPLE)
   if(NOT OMP_LINK_LINE)
     set(OMP_LINK_LINE ${DEFAULT_APPLE_OMP_LINK_LINE} CACHE STRING "Arguments passed to compiler to link OpenMP libraries to SYCL applications")
   endif()
-  if(NOT SEQUENTIAL_LINK_LINE) 
+  if(NOT SEQUENTIAL_LINK_LINE)
     set(SEQUENTIAL_LINK_LINE ${DEFAULT_APPLE_SEQUENTIAL_LINK_LINE} CACHE STRING "Arguments passed to compiler to link host libraries to SYCL applications")
   endif()
 else()
@@ -476,33 +477,33 @@ else()
   if(NOT OMP_LINK_LINE)
     set(OMP_LINK_LINE ${DEFAULT_OMP_LINK_LINE} CACHE STRING "Arguments passed to compiler to link OpenMP libraries to SYCL applications")
   endif()
-  if(NOT SEQUENTIAL_LINK_LINE) 
+  if(NOT SEQUENTIAL_LINK_LINE)
     set(SEQUENTIAL_LINK_LINE ${DEFAULT_SEQUENTIAL_LINK_LINE} CACHE STRING "Arguments passed to compiler to link host libraries to SYCL applications")
   endif()
 endif()
 
 # If no compile flags given, set to default.
 if(NOT ROCM_CXX_FLAGS)
-  # clang erroneously sets feature detection flags for 
+  # clang erroneously sets feature detection flags for
   # __float128 even though it is not supported for CUDA / HIP,
   # see https://bugs.llvm.org/show_bug.cgi?id=47559.
 
   set(ROCM_CXX_FLAGS "-isystem $HIPSYCL_PATH/include/AdaptiveCpp/hipSYCL/std/hiplike -isystem ${CLANG_INCLUDE_PATH} -U__FLOAT128__ -U__SIZEOF_FLOAT128__ -I$HIPSYCL_ROCM_PATH/include -I$HIPSYCL_ROCM_PATH/include --rocm-device-lib-path=$HIPSYCL_ROCM_PATH/amdgcn/bitcode --rocm-path=$HIPSYCL_ROCM_PATH -fhip-new-launch-api -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -D__HIP_ROCclr__" CACHE STRING "Arguments passed to compiler to compile SYCL applications with ROCm")
 endif()
 
-if(NOT CUDA_CXX_FLAGS)	
-  # clang erroneously sets feature detection flags for 
+if(NOT CUDA_CXX_FLAGS)
+  # clang erroneously sets feature detection flags for
   # __float128 even though it is not supported for CUDA / HIP,
   # see https://bugs.llvm.org/show_bug.cgi?id=47559.
   set(CUDA_CXX_FLAGS "-U__FLOAT128__ -U__SIZEOF_FLOAT128__ -isystem $HIPSYCL_PATH/include/AdaptiveCpp/hipSYCL/std/hiplike" CACHE STRING "Arguments passed to compiler to compile SYCL applications with CUDA")
 endif()
 
 # always need -D_ENABLE_EXTENDED_ALIGNED_STORAGE to allow correctly aligned local memory on CPU
-if(NOT OMP_CXX_FLAGS) 
+if(NOT OMP_CXX_FLAGS)
   set(OMP_CXX_FLAGS "-I${Boost_INCLUDE_DIR} ${DEFAULT_OMP_FLAG} -D_ENABLE_EXTENDED_ALIGNED_STORAGE" CACHE STRING "Arguments passed to compiler to compile SYCL applications with OpenMP")
 endif()
 
-if(NOT SEQUENTIAL_CXX_FLAGS) 
+if(NOT SEQUENTIAL_CXX_FLAGS)
   set(SEQUENTIAL_CXX_FLAGS "-I${Boost_INCLUDE_DIR} -D_ENABLE_EXTENDED_ALIGNED_STORAGE" CACHE STRING "Arguments passed to compiler to compile SYCL applications on host")
 endif()
 
@@ -516,13 +517,13 @@ set(DEFAULT_GPU_ARCH "" CACHE STRING "(Deprecated, use DEFAULT_TARGETS instead) 
 set(DEFAULT_TARGETS "" CACHE STRING "Default targets to compile for")
 
 if(NOT DEFAULT_TARGETS)
-  if(DEFAULT_PLATFORM)  
+  if(DEFAULT_PLATFORM)
     message(DEPRECATION "DEFAULT_PLATFORM is deprecated; use DEFAULT_TARGETS instead.")
-    
+
     if(DEFAULT_PLATFORM STREQUAL "cpu")
       set(DEFAULT_TARGETS "omp")
     endif()
-    
+
     if(DEFAULT_GPU_ARCH)
       message(DEPRECATION "DEFAULT_GPU_ARCH is deprecated; use DEFAULT_TARGETS instead.")
 
@@ -533,7 +534,7 @@ if(NOT DEFAULT_TARGETS)
       else()
         message(SEND_ERROR "Invalid value for DEFAULT_PLATFORM: \"${DEFAULT_PLATFORM}\". When DEFAULT_GPU_ARCH is specified, only \"cuda\" and \"rocm\" are supported.")
       endif()
-      
+
     endif()
   elseif(DEFAULT_GPU_ARCH)
     message(DEPRECATION "DEFAULT_GPU_ARCH is deprecated; use DEFAULT_TARGETS instead.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.10)
-if(NOT CMAKE_VERSION VERSION_LESS 3.12)
+
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
   cmake_policy(SET CMP0074 NEW) # Don't complain about using BOOST_ROOT...
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.30)
+    # Suppress warning: "Policy CMP0167 is not set: The FindBoost module is removed."
+    cmake_policy(SET CMP0167 NEW)
+  endif()
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 3.10)
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
+if(POLICY CMP0074) # Since CMake 3.12
   cmake_policy(SET CMP0074 NEW) # Don't complain about using BOOST_ROOT...
-  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.30)
+endif()
+if(POLICY CMP0167) # Since CMake 3.30
     # Suppress warning: "Policy CMP0167 is not set: The FindBoost module is removed."
     cmake_policy(SET CMP0167 NEW)
-  endif()
 endif()
 
 


### PR DESCRIPTION
CMake 3.30 [officially removes the FindBoost module](https://cmake.org/cmake/help/latest/release/3.30.html#deprecated-and-removed-features), which causes warnings of the form:

```
CMake Warning (dev) at CMakeLists.txt:96 (find_package):
  Policy CMP0167 is not set: The FindBoost module is removed.  Run "cmake
  --help-policy CMP0167" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.
```

However, setting `CMP0167` to `NEW`, which apparently makes CMake search directly for the upstream BoostConfig.cmake file, appears sufficient to make CMake find Boost without warning (while preserving AdaptiveCpp's ability to be compiled). Hence, I have added this setting to the CMakeLists.txt.

I have currently only enabled this new behaviour for CMake versions new enough such that they are affected by the above-described warning (using the logic that people who run CMake `>= 3.30`  will also use a Boost version new enough (`>= 1.70`) such that it provides a valid BoostConfig.cmake).

I have also replaced the `NOT CMAKE_VERSION VERSION_LESS` conditions with `CMAKE_VERSION VERSION_GREATER_EQUAL`, as `VERSION_GREATER_EQUAL` [was added in CMake 3.7](https://cmake.org/cmake/help/v3.7/release/3.7.html#commands), which is below the currently required minimum CMake version (3.10).