### PR TITLE
Fix pointer to a temporary returned from kernel_configuration::data_ptr

### DIFF
--- a/include/hipSYCL/runtime/kernel_configuration.hpp
+++ b/include/hipSYCL/runtime/kernel_configuration.hpp
@@ -256,7 +256,7 @@ public:
 
 private:
   static const void* data_ptr(const char* data) {
-    return data_ptr(std::string{data});
+    return data_ptr(data);
   }
 
   static const void* data_ptr(const std::string& data) {
@@ -278,7 +278,7 @@ private:
   }
 
   static std::size_t data_size(const char* data) {
-    return data_size(std::string{data});
+    return data_size(std::string_view{data});
   }
 
   static std::size_t data_size(const std::string& data) {


### PR DESCRIPTION
`kernel_configuration::data_ptr` was creating a temporary string and returning a pointer to it.

The change to `data_size` is unrelated, just avoiding extra copies there.