### PR TITLE
Expose different OpenCL platforms as different SYCL platforms

### DIFF
--- a/include/hipSYCL/runtime/cuda/cuda_hardware_manager.hpp
+++ b/include/hipSYCL/runtime/cuda/cuda_hardware_manager.hpp
@@ -52,6 +52,8 @@ public:
   virtual std::string get_driver_version() const override;
   virtual std::string get_profile() const override;
 
+  virtual std::size_t get_platform_index() const override;
+
   virtual ~cuda_hardware_context();
 
   cuda_allocator* get_allocator() const;
@@ -73,6 +75,8 @@ public:
   virtual std::size_t get_num_devices() const override;
   virtual hardware_context *get_device(std::size_t index) override;
   virtual device_id get_device_id(std::size_t index) const override;
+
+  virtual std::size_t get_num_platforms() const override;
 
   virtual ~cuda_hardware_manager() {}
   

--- a/include/hipSYCL/runtime/hardware.hpp
+++ b/include/hipSYCL/runtime/hardware.hpp
@@ -127,6 +127,8 @@ public:
 
   virtual std::string get_driver_version() const = 0;
   virtual std::string get_profile() const = 0;
+
+  virtual std::size_t get_platform_index() const= 0;
   
   virtual ~hardware_context(){}
 };
@@ -135,6 +137,8 @@ class backend_hardware_manager
 {
 public:
   virtual std::size_t get_num_devices() const = 0;
+  virtual std::size_t get_num_platforms() const = 0;
+
   virtual hardware_context *get_device(std::size_t index) = 0;
   virtual device_id get_device_id(std::size_t index) const = 0;
 

--- a/include/hipSYCL/runtime/hip/hip_hardware_manager.hpp
+++ b/include/hipSYCL/runtime/hip/hip_hardware_manager.hpp
@@ -53,6 +53,8 @@ public:
   virtual std::string get_driver_version() const override;
   virtual std::string get_profile() const override;
 
+  virtual std::size_t get_platform_index() const override;
+
   virtual ~hip_hardware_context() {}
 
   hip_allocator* get_allocator() const;
@@ -75,6 +77,7 @@ public:
   virtual std::size_t get_num_devices() const override;
   virtual hardware_context *get_device(std::size_t index) override;
   virtual device_id get_device_id(std::size_t index) const override;
+  virtual std::size_t get_num_platforms() const override;
 
   virtual ~hip_hardware_manager() {}
   

--- a/include/hipSYCL/runtime/ocl/ocl_hardware_manager.hpp
+++ b/include/hipSYCL/runtime/ocl/ocl_hardware_manager.hpp
@@ -57,6 +57,8 @@ public:
 
   virtual ~ocl_hardware_context();
 
+  virtual std::size_t get_platform_index() const override;
+
   ocl_allocator* get_allocator();
   ocl_usm* get_usm_provider();
 
@@ -86,6 +88,7 @@ public:
   virtual std::size_t get_num_devices() const override;
   virtual hardware_context *get_device(std::size_t index) override;
   virtual device_id get_device_id(std::size_t index) const override;
+  virtual std::size_t get_num_platforms() const override;
 
   virtual ~ocl_hardware_manager() {}
   

--- a/include/hipSYCL/runtime/omp/omp_hardware_manager.hpp
+++ b/include/hipSYCL/runtime/omp/omp_hardware_manager.hpp
@@ -40,6 +40,8 @@ public:
   virtual std::string get_driver_version() const override;
   virtual std::string get_profile() const override;
 
+  virtual std::size_t get_platform_index() const override;
+
   virtual ~omp_hardware_context() {}
 };
 
@@ -49,6 +51,7 @@ public:
   virtual std::size_t get_num_devices() const override;
   virtual hardware_context *get_device(std::size_t index) override;
   virtual device_id get_device_id(std::size_t index) const override;
+  virtual std::size_t get_num_platforms() const override;
 
   virtual ~omp_hardware_manager(){}
 private:

--- a/include/hipSYCL/runtime/ze/ze_hardware_manager.hpp
+++ b/include/hipSYCL/runtime/ze/ze_hardware_manager.hpp
@@ -88,6 +88,8 @@ public:
   virtual std::string get_driver_version() const override;
   virtual std::string get_profile() const override;
 
+  virtual std::size_t get_platform_index() const override;
+
   virtual ~ze_hardware_context();
 
   ze_driver_handle_t get_ze_driver() const
@@ -119,6 +121,7 @@ public:
   virtual std::size_t get_num_devices() const override;
   virtual hardware_context *get_device(std::size_t index) override;
   virtual device_id get_device_id(std::size_t index) const override;
+  virtual std::size_t get_num_platforms() const override;
 
   virtual ~ze_hardware_manager() {}
   

--- a/include/hipSYCL/sycl/platform.hpp
+++ b/include/hipSYCL/sycl/platform.hpp
@@ -172,6 +172,7 @@ HIPSYCL_SPECIALIZE_GET_INFO(platform, name)
       _requires_runtime.get()->backends().get(b)->get_name();
   platform_name +=
       " (platform " + std::to_string(_platform.get_platform()) + ")";
+      return platform_name;
 }
 
 HIPSYCL_SPECIALIZE_GET_INFO(platform, vendor)

--- a/src/runtime/cuda/cuda_hardware_manager.cpp
+++ b/src/runtime/cuda/cuda_hardware_manager.cpp
@@ -85,6 +85,13 @@ device_id cuda_hardware_manager::get_device_id(std::size_t index) const {
                    static_cast<int>(index)};
 }
 
+std::size_t cuda_hardware_manager::get_num_platforms() const {
+  return 1;
+}
+
+std::size_t cuda_hardware_context::get_platform_index() const {
+  return 0;
+}
 
 cuda_hardware_context::cuda_hardware_context(int dev) 
   : _dev{dev} {

--- a/src/runtime/hip/hip_hardware_manager.cpp
+++ b/src/runtime/hip/hip_hardware_manager.cpp
@@ -108,6 +108,13 @@ device_id hip_hardware_manager::get_device_id(std::size_t index) const {
                    static_cast<int>(index)};
 }
 
+std::size_t hip_hardware_manager::get_num_platforms() const {
+  return 1;
+}
+
+std::size_t hip_hardware_context::get_platform_index() const {
+  return 0;
+}
 
 hip_hardware_context::hip_hardware_context(int dev) : _dev{dev} {
   _properties = std::make_unique<hipDeviceProp_t>();

--- a/src/runtime/ocl/ocl_hardware_manager.cpp
+++ b/src/runtime/ocl/ocl_hardware_manager.cpp
@@ -574,6 +574,14 @@ void ocl_hardware_context::init_allocator(ocl_hardware_manager *mgr) {
   _alloc = ocl_allocator{dev, _usm_provider.get()};
 }
 
+std::size_t ocl_hardware_context::get_platform_index() const {
+  return static_cast<std::size_t>(_platform_id);
+}
+
+std::size_t ocl_hardware_manager::get_num_platforms() const {
+  return _platforms.size();
+}
+
 ocl_hardware_manager::ocl_hardware_manager()
 : _hw_platform{hardware_platform::ocl} {
   const auto visibility_mask =

--- a/src/runtime/omp/omp_hardware_manager.cpp
+++ b/src/runtime/omp/omp_hardware_manager.cpp
@@ -294,6 +294,16 @@ std::string omp_hardware_context::get_profile() const {
   return "FULL_PROFILE";
 }
 
+std::size_t omp_hardware_context::get_platform_index() const {
+  return 0;
+}
+
+std::size_t omp_hardware_manager::get_num_platforms() const {
+  return 1;
+}
+
+
+
 std::size_t omp_hardware_manager::get_num_devices() const { return 1; }
 
 

--- a/src/runtime/ze/ze_hardware_manager.cpp
+++ b/src/runtime/ze/ze_hardware_manager.cpp
@@ -512,6 +512,15 @@ uint32_t ze_hardware_context::get_ze_global_memory_ordinal() const {
   return result;
 }
 
+std::size_t ze_hardware_context::get_platform_index() const {
+  return 0;
+}
+
+std::size_t ze_hardware_manager::get_num_platforms() const {
+  return 1;
+}
+
+
 ze_hardware_manager::ze_hardware_manager() {
 
   if (has_device_visibility_mask(

--- a/src/tools/acpp-info/acpp-info.cpp
+++ b/src/tools/acpp-info/acpp-info.cpp
@@ -70,6 +70,11 @@ void list_device_details(rt::device_id dev, rt::backend *b,
   std::cout << " General device information:" << std::endl;
   print_info("Name", hw->get_device_name(), 2);
   print_info("Backend", b->get_name(), 2);
+  print_info("Platform",
+             "Backend " +
+                 std::to_string(static_cast<int>(b->get_unique_backend_id())) +
+                 " / Platform " + std::to_string(hw->get_platform_index()),
+             2);
   print_info("Vendor", hw->get_vendor_name(), 2);
   print_info("Arch", hw->get_device_arch(), 2);
   print_info("Driver version", hw->get_driver_version(), 2);


### PR DESCRIPTION
PR #1590 has changed semantics of the default-constructed queue, in that it now constructs a context of all of the devices in the queue device's platform.
This causes a problem in OpenCL, since it then can happen that we generate SYCL contexts (by default!) that span multiple OpenCL platforms, which is then renders substantial parts of the SYCL API dysfunctional.

This PR attempts to address this by putting different OpenCL platforms in different SYCL platforms.

Hopefully fixes #1631 

@al42and Can you give this a try?

Draft because I've only done very limited testing.