### PR TITLE
default selector: Prefer OpenCL CPU over OpenMP CPU device

### DIFF
--- a/include/hipSYCL/sycl/device_selector.hpp
+++ b/include/hipSYCL/sycl/device_selector.hpp
@@ -108,7 +108,14 @@ inline int select_default(const device& dev) {
   } else if(dev.is_cpu()) {
     // Prefer CPU over GPUs that don't have compiled kernels
     // and cannot run kernels.
-    return 1;
+
+    // Prefer non-OpenMP CPU device since the OpenMP backend cannot be disabled,
+    // so there would be no way to select e.g. an OpenCL CPU device
+    // using ACPP_VISIBILITY_MASK otherwise.
+    if(dev.get_backend() != sycl::backend::omp)
+      return 1;
+    else
+      return 0;
   } else {
     // Never select GPUs without compiled kernels
     return -1;


### PR DESCRIPTION
Currently, we treat all CPU devices equally in the device selector. Depending on backend load order, this can cause OpenMP CPU to be picked over OpenCL CPU device. This is a problem, since in that case, there is no way to use `ACPP_VISIBILITY_MASK` to force execution through OpenCL because the `omp` backend cannot be unloaded.
Being able to force execution through any backend through `ACPP_VISIBILITY_MASK` is something we would however want, e.g. for CI.

This PR addresses this by changing the default selector such that OpenCL CPU devices are preferred over OpenMP CPU devices.
This means one can set
* `ACPP_VISIBILITY_MASK=omp` - guaranteed execution through OpenCL
* `ACPP_VISIBILITY_MASK="omp;ocl"` - guaranteed execution through OpenCL, unless there is no OpenCL device.
