### PR TITLE
Build Clang plugin as module

### DIFF
--- a/bin/acpp
+++ b/bin/acpp
@@ -745,8 +745,6 @@ class acpp_config:
   def acpp_plugin_path(self):
     if sys.platform.startswith('win32'):
       return os.path.join(self.acpp_installation_path, "bin", "acpp-clang.dll")
-    elif sys.platform == "darwin":
-      return os.path.join(self.acpp_installation_path, "lib", "libacpp-clang.dylib")
     else:
       return os.path.join(self.acpp_installation_path, "lib", "libacpp-clang.so")
 
@@ -1531,7 +1529,7 @@ class llvm_sscp_invocation:
   def get_cxx_flags(self):
     flags = ["-D__ACPP_ENABLE_LLVM_SSCP_TARGET__",
             "-Xclang", "-disable-O0-optnone", "-mllvm", "-acpp-sscp"]
-    
+
     if self._config.is_export_all:
       flags += ["-mllvm","-acpp-sscp-export-all"]
 

--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -36,13 +36,13 @@ if(WITH_ACCELERATED_CPU OR WITH_SSCP_COMPILER)
   add_library(acpp-clang-cbs OBJECT
     ${CBS_PLUGIN}
   )
-  
+
   set_property(TARGET acpp-clang-cbs PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
 
 if(WITH_SSCP_COMPILER)
   set(WITH_REFLECTION_BUILTINS ON)
-  set(SSCP_COMPILER 
+  set(SSCP_COMPILER
     sscp/KernelOutliningPass.cpp
     sscp/IRConstantReplacer.cpp
     sscp/DynamicFunctionSupport.cpp
@@ -75,7 +75,7 @@ else()
   set(REFLECTION_BUILTINS "")
 endif()
 
-add_library(acpp-clang SHARED
+add_library(acpp-clang MODULE
   AdaptiveCppClangPlugin.cpp
   GlobalsPruningPass.cpp
   ${SSCP_COMPILER}


### PR DESCRIPTION
Otherwise `-Wl,--no-undefined` will make the build fail

## To test

From `develop` do
```shell
cmake -B build -DCMAKE_CXX_FLAGS=-Wl,--no-undefined
cmake --build build -j8
```
