### PR TITLE
[SSCP] Provide `sycl::buffer` device pointers to custom operations

### DIFF
--- a/include/hipSYCL/glue/kernel_launcher_data.hpp
+++ b/include/hipSYCL/glue/kernel_launcher_data.hpp
@@ -31,6 +31,7 @@ class dag_node;
 class kernel_configuration;
 class backend_kernel_launch_capabilities;
 class hcf_kernel_info;
+class kernel_operation;
 }
 
 namespace glue {
@@ -53,7 +54,7 @@ struct kernel_launcher_data {
   rt::range<3> group_size; // <- indices must be flipped
   unsigned local_mem_size;
   // In case the launch is a custom operation
-  std::function<void(sycl::interop_handle&)> custom_op;
+  std::function<void(rt::kernel_operation*, sycl::interop_handle&)> custom_op;
 
   using invoker_function_t = rt::result (*)(
       const kernel_launcher_data &launch_config, rt::dag_node *node,


### PR DESCRIPTION
If a kernel passed to `AdaptiveCpp_enqueue_custom_operation` makes use of (i.e. captures) a `sycl::buffer`, then the captured buffer's internal pointer must point to its associated device memory, in order for the custom kernel to extract the pointer and provide to e.g. `cudaMemcpyAsync`.

The transformation from host pointer to device pointer is done at kernel launch time by rewriting the bytes of the kernel's captured variables using an `initialize_embedded_pointers` function. However, this function was not being called for custom operations enqueued using `AdaptiveCpp_enqueue_custom_operation`.

So decorate the custom kernel with a call to `initialize_embedded_pointers`, before calling the kernel itself.

This is required for e.g. oneMKL, which makes use of `AdaptiveCpp_enqueue_custom_operation` (well, `hipSYCL_enqueue_custom_operation`) to call cuBLAS functions, with the device memory pointer coming from a `sycl::buffer` (via `sycl::interop_handle::get_native_mem<...>(...)`

There is a unit test of `AdaptiveCpp_enqueue_custom_operation` (`custom_enqueue`) checking this case. However, I found that it was being skipped when running the suite locally. It seems there is a logic flaw in the macros that conditionally compile the test. After tweaking the macros and running the test, it does indeed fail without the above fix.

Unfortunately I'm currently limited in local testing to NVIDIA and to SSCP. Setting the target to either `cuda` or `cuda.explicit-multipass` causes compiler crashes (hopefully just a local config issue). 

This means I don't actually know whether the `custom_enqueue` test runs using other CUDA targets; and whether my changes to the CMake/macro config makes sense for other CUDA targets; and whether similar changes are needed for ROCM/HIP targets...



