### PR TITLE
[SSCP][llvm-to-host] Support internal local memory for group algorithms

### DIFF
--- a/include/hipSYCL/compiler/cbs/IRUtils.hpp
+++ b/include/hipSYCL/compiler/cbs/IRUtils.hpp
@@ -59,6 +59,7 @@ static const std::array<const char *, 3> NumGroupsGlobalNames{
     NumGroupsGlobalNameX, NumGroupsGlobalNameY, NumGroupsGlobalNameZ};
 
 static constexpr const char SscpDynamicLocalMemoryPtrName[] = "__acpp_cbs_sscp_dynamic_local_memory";
+static constexpr const char SscpInternalLocalMemoryPtrName[] = "__acpp_cbs_sscp_internal_local_memory";
 } // namespace cbs
 
 static constexpr const char SscpAnnotationsName[] = "hipsycl.sscp.annotations";

--- a/include/hipSYCL/runtime/omp/omp_code_object.hpp
+++ b/include/hipSYCL/runtime/omp/omp_code_object.hpp
@@ -29,14 +29,17 @@ public:
   // The kernel argument struct providing work-group information.
   struct work_group_info {
     work_group_info(rt::range<3> num_groups, rt::id<3> group_id,
-                    rt::range<3> local_size, void* local_memory)
+                    rt::range<3> local_size, void *local_memory,
+                    void *internal_local_memory)
         : _num_groups(num_groups), _group_id(group_id), _local_size(local_size),
-          _local_memory(local_memory) {}
+          _local_memory(local_memory),
+          _internal_local_memory(internal_local_memory) {}
 
     rt::range<3> _num_groups;
     rt::range<3> _group_id;
     rt::range<3> _local_size;
     void* _local_memory;
+    void* _internal_local_memory;
   };
 
   using omp_sscp_kernel = void(const work_group_info *, void **);

--- a/src/libkernel/sscp/host/localmem.cpp
+++ b/src/libkernel/sscp/host/localmem.cpp
@@ -11,7 +11,9 @@
 #include "hipSYCL/sycl/libkernel/sscp/builtins/localmem.hpp"
 
 extern "C" void* __acpp_cbs_sscp_dynamic_local_memory;
+extern "C" void* __acpp_cbs_sscp_internal_local_memory;
 
+HIPSYCL_SSCP_BUILTIN
 __attribute__((address_space(3))) void* __acpp_sscp_get_dynamic_local_memory() {
 
   // We rely on the host side allocating page-aligned memory. On all relevant
@@ -19,4 +21,11 @@ __attribute__((address_space(3))) void* __acpp_sscp_get_dynamic_local_memory() {
   // conservative minimum alignment seems safe.
   return (__attribute__((address_space(3))) void *)(__builtin_assume_aligned(
       __acpp_cbs_sscp_dynamic_local_memory, 512));
+}
+
+
+HIPSYCL_SSCP_BUILTIN
+void* __acpp_sscp_host_get_internal_local_memory() {
+  return (void *)(__builtin_assume_aligned(
+      __acpp_cbs_sscp_internal_local_memory, 512));
 }


### PR DESCRIPTION
This PR adds support for an additional section of dedicated local memory to be passed into the kernel for internal use, particularly for the implementation of group algorithms.

It turned out to not be possible to allocate local memory as `thread_local` memory inside the bitcode libraries due to TLS limitations.

While it might have been possible to use the existing local memory and set aside some part of that allocation for group algorithms, this would have introduced some additional, potentially undesired, offset calculations when accessing local memory.

Therefore, this PR solves this at the compiler level with an additional local memory builtin for internal use.

