### PR TITLE
Print JIT compile time, cleanup kernel_cache.hpp

### DIFF
--- a/include/hipSYCL/runtime/kernel_cache.hpp
+++ b/include/hipSYCL/runtime/kernel_cache.hpp
@@ -318,9 +318,19 @@ public:
     // TODO: We might want to allow JIT compilation in parallel at some point
     std::lock_guard<std::mutex> lock{_mutex};
 
-    if(!persistent_cache_lookup(id_of_binary, compiled_binary)){
+    if(!persistent_cache_lookup(id_of_binary, compiled_binary)) {
+      HIPSYCL_DEBUG_INFO << "kernel_cache: JIT-compiling binary for id "
+                         << kernel_configuration::to_string(id_of_binary)
+                         << "\n";
+
+      const auto start_time = std::chrono::high_resolution_clock::now();
       if(!jit_compile(compiled_binary))
         return nullptr;
+      const auto elapsed_time = std::chrono::high_resolution_clock::now() - start_time;
+
+      HIPSYCL_DEBUG_INFO << "kernel_cache: JIT compilation took "
+                         << std::chrono::duration_cast<std::chrono::milliseconds>(elapsed_time).count()
+                         << "ms\n";
 
       if(_is_first_jit_compilation) {
         _is_first_jit_compilation = false;

--- a/include/hipSYCL/runtime/kernel_cache.hpp
+++ b/include/hipSYCL/runtime/kernel_cache.hpp
@@ -299,27 +299,30 @@ public:
     return get_or_construct_code_object_impl(id, c);
   }
 
-  /// Obtain or construct code objects. This is for code objects
+  /// \brief Obtain or construct code objects. This is for code objects
   /// which rely on AdaptiveCpp-handled JIT compilation.
-  /// In order to implement optimizations such as persistent on-disk kernel cache,
-  /// we need to have explicit access to the JIT-compiled binary and distinguish
-  /// the act of JIT compilation from constructing the backend code objects (e.g. CUmodule).
+  ///
+  /// In order to implement optimizations such as persistent on-disk kernel
+  /// cache, we need to have explicit access to the JIT-compiled binary and
+  /// distinguish the act of JIT compilation from constructing the backend code
+  /// objects (e.g. CUmodule).
   ///
   /// This is why this function has two factory function arguments, and two ids:
-  /// \c id_of_binary: A unique id of the binary. This value should only include configuration
-  /// that is relevant for the jit-compiled code. It should not depend on any values
-  /// that might vary between application runs (e.g. cl_context), because the binary
-  /// might be persistently cached on-disk.
-  /// \c id_of_code_object: The full id of the backend code object that the user wants to obtain.
-  /// This id may depend on values which vary between application runs, such as cl_context.
-  /// \c j Has signature bool(std::string&). Will be invoked when JIT compilation is triggered, and
-  /// is expected to carry out JIT compilation.
-  /// Should return true if the compilation was successful. The binary output of JIT compilation
-  /// should be stored in the string reference.
-  /// \c c Is expected to turn the JIT-compiled binary into a code_object*. Has signature
-  /// code_object*(const std::string&). It is expected to return nullptr on error. The JIT-compiled
-  /// binary will be passed in as string reference.
-  template <class CodeObjectConstructor, class JitCompiler>
+  /// \param id_of_binary: A unique id of the binary. This value should only include
+  /// configuration that is relevant for the jit-compiled code. It should not
+  /// depend on any values that might vary between application runs (e.g.
+  /// cl_context), because the binary might be persistently cached on-disk.
+  /// \param id_of_code_object: The full id of the backend code object that the user
+  /// wants to obtain. This id may depend on values which vary between
+  /// application runs, such as cl_context.
+  /// \param jit_compile Has signature bool(std::string&). Will be invoked when JIT
+  /// compilation is triggered, and is expected to carry out JIT compilation.
+  /// Should return true if the compilation was successful. The binary output of
+  /// JIT compilation should be stored in the string reference.
+  /// \param c Is expected to turn the JIT-compiled binary into a code_object*. Has
+  /// signature code_object*(const std::string&). It is expected to return
+  /// nullptr on error. The JIT-compiled binary will be passed in as string
+  /// reference.
   template <class CodeObjectConstructor, class JitCompiler,
             typename = std::enable_if_t<is_valid_jit_compiler_v<JitCompiler>>,
             typename = std::enable_if_t<is_valid_code_object_constructor_v<CodeObjectConstructor>>>

--- a/include/hipSYCL/runtime/kernel_cache.hpp
+++ b/include/hipSYCL/runtime/kernel_cache.hpp
@@ -252,6 +252,24 @@ private:
 };
 
 class kernel_cache {
+  // Alias for the return type of jit_compiler (expects bool(std::string&))
+  template <typename Callable>
+  using jit_compiler_ret_type_t = std::invoke_result_t<Callable, std::string &>;
+
+  // Alias for the return type of CodeObjectConstructor (expects
+  // code_object*(code_object_id))
+  template <typename Callable>
+  using code_obj_ret_type_t = std::invoke_result_t<Callable, std::string &>;
+
+  // Traits to validate callable types
+  template <typename Callable>
+  constexpr static bool is_valid_jit_compiler_v =
+      std::is_same_v<jit_compiler_ret_type_t<Callable>, bool>;
+
+  template <typename Callable>
+  constexpr static bool is_valid_code_object_constructor_v =
+      std::is_same_v<code_obj_ret_type_t<Callable>, code_object *>;
+
 public:
   using code_object_id = kernel_configuration::id_type;
   using code_object_ptr = std::unique_ptr<const code_object>;
@@ -302,6 +320,9 @@ public:
   /// code_object*(const std::string&). It is expected to return nullptr on error. The JIT-compiled
   /// binary will be passed in as string reference.
   template <class CodeObjectConstructor, class JitCompiler>
+  template <class CodeObjectConstructor, class JitCompiler,
+            typename = std::enable_if_t<is_valid_jit_compiler_v<JitCompiler>>,
+            typename = std::enable_if_t<is_valid_code_object_constructor_v<CodeObjectConstructor>>>
   const code_object *get_or_construct_jit_code_object(code_object_id id_of_code_object,
                                                       code_object_id id_of_binary,
                                                       JitCompiler &&jit_compile,

--- a/include/hipSYCL/runtime/kernel_cache.hpp
+++ b/include/hipSYCL/runtime/kernel_cache.hpp
@@ -8,6 +8,9 @@
  * See file LICENSE in the project root for full license details.
  */
 // SPDX-License-Identifier: BSD-2-Clause
+#ifndef HIPSYCL_RT_KERNEL_CACHE_HPP
+#define HIPSYCL_RT_KERNEL_CACHE_HPP
+
 #include <cstdint>
 #include <string>
 #include <unordered_map>
@@ -23,9 +26,6 @@
 #include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
 #include "hipSYCL/runtime/error.hpp"
-
-#ifndef HIPSYCL_RT_KERNEL_CACHE_HPP
-#define HIPSYCL_RT_KERNEL_CACHE_HPP
 
 namespace hipsycl {
 namespace rt {

--- a/include/hipSYCL/runtime/kernel_cache.hpp
+++ b/include/hipSYCL/runtime/kernel_cache.hpp
@@ -25,8 +25,7 @@
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/kernel_configuration.hpp"
 
-namespace hipsycl {
-namespace rt {
+namespace hipsycl::rt {
 
 enum class compilation_flow {
   integrated_multipass,
@@ -398,8 +397,6 @@ kernel_registrator<KernelT> static_kernel_registration<KernelT>::init = {};
 
 } // detail
 
-
-}
-}
+} // namespace hipsycl::rt
 
 #endif

--- a/include/hipSYCL/runtime/kernel_cache.hpp
+++ b/include/hipSYCL/runtime/kernel_cache.hpp
@@ -122,8 +122,8 @@ public:
   const std::vector<std::string> &get_images_containing_kernel() const;
   hcf_object_id get_hcf_object_id() const;
 
-  const std::vector<rt::kernel_build_flag>& get_compilation_flags() const;
-  const std::vector<std::pair<rt::kernel_build_option, std::string>> &
+  const std::vector<kernel_build_flag>& get_compilation_flags() const;
+  const std::vector<std::pair<kernel_build_option, std::string>> &
   get_compilation_options() const;
 
 private:
@@ -137,8 +137,8 @@ private:
 
   std::vector<std::string> _image_providers;
   
-  std::vector<rt::kernel_build_flag> _compilation_flags;
-  std::vector<std::pair<rt::kernel_build_option, std::string>>
+  std::vector<kernel_build_flag> _compilation_flags;
+  std::vector<std::pair<kernel_build_option, std::string>>
       _compilation_options;
 
   hcf_object_id _id;
@@ -374,7 +374,7 @@ private:
 
   mutable std::mutex _mutex;
 
-  ankerl::unordered_dense::map<code_object_id, code_object_ptr, rt::kernel_id_hash>
+  ankerl::unordered_dense::map<code_object_id, code_object_ptr, kernel_id_hash>
       _code_objects;
   
   bool _is_first_jit_compilation = true;

--- a/include/hipSYCL/runtime/kernel_cache.hpp
+++ b/include/hipSYCL/runtime/kernel_cache.hpp
@@ -11,21 +11,19 @@
 #ifndef HIPSYCL_RT_KERNEL_CACHE_HPP
 #define HIPSYCL_RT_KERNEL_CACHE_HPP
 
+#include <array>
 #include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
 #include <string>
 #include <unordered_map>
-#include <mutex>
-#include <cassert>
-#include <memory>
-#include <optional>
-#include <array>
+
 #include "hipSYCL/common/hcf_container.hpp"
-#include "hipSYCL/common/small_map.hpp"
 #include "hipSYCL/common/unordered_dense.hpp"
-#include "hipSYCL/common/stable_running_hash.hpp"
-#include "hipSYCL/runtime/kernel_configuration.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
 #include "hipSYCL/runtime/error.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
 
 namespace hipsycl {
 namespace rt {


### PR DESCRIPTION
- Put `#include` after header guard
- Collapse namespaces
- Remove unneeded namespace specification (rt::)
- Add debug log with JIT timing
- [Use SFINAE for get_or_construct_jit_code_object](https://github.com/AdaptiveCpp/AdaptiveCpp/pull/1648/commits/62772c94e6a2aaaddf5b280db7944b6ae7a8b057)