### PR TITLE
[OpenMP] Improve alignment handling

### DIFF
--- a/include/hipSYCL/glue/llvm-sscp/jit.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/jit.hpp
@@ -241,7 +241,11 @@ inline rt::result compile(compiler::LLVMToBackendTranslator *translator,
   if(translator->getKernels().size() == 1) {
     // Currently we only can specialize kernel arguments for the 
     // single-kernel code object model
+    HIPSYCL_DEBUG_INFO << "jit: Configuring kernel "
+                       << translator->getKernels()[0] << std::endl;
     for(const auto& entry : config.specialized_arguments()) {
+      HIPSYCL_DEBUG_INFO << "jit: Specializing argument " << entry.first
+                         << " = " << entry.second << std::endl;
       translator->specializeKernelArgument(translator->getKernels().front(),
                                           entry.first, &entry.second);
     }
@@ -249,10 +253,14 @@ inline rt::result compile(compiler::LLVMToBackendTranslator *translator,
     int num_param_indices = static_cast<int>(config.get_num_kernel_param_indices());
     for (int i = 0; i < num_param_indices; ++i) {
       if (config.has_kernel_param_flag(i, rt::kernel_param_flag::noalias)) {
+        HIPSYCL_DEBUG_INFO << "jit: Setting argument " << i << " to noalias"
+                           << std::endl;
         translator->setNoAliasKernelParam(translator->getKernels().front(), i);
       }
     }
     for(const auto& entry : config.known_alignments()) {
+      HIPSYCL_DEBUG_INFO << "jit: Setting argument " << entry.first
+                         << " to alignment " << entry.second << std::endl;
       translator->setKnownPtrParamAlignment(translator->getKernels().front(),
                                             entry.first, entry.second);
     }
@@ -260,6 +268,8 @@ inline rt::result compile(compiler::LLVMToBackendTranslator *translator,
   for(const auto& entry : config.function_call_specialization_config()) {
     auto& config = entry.value->function_call_map;
     for(const auto& call_specialization : config) {
+      HIPSYCL_DEBUG_INFO << "jit: Specializing function call to "
+                         << call_specialization.first << std::endl;
       translator->specializeFunctionCalls(call_specialization.first,
                                           call_specialization.second, false);
     }

--- a/src/runtime/adaptivity_engine.cpp
+++ b/src/runtime/adaptivity_engine.cpp
@@ -165,13 +165,13 @@ int determine_ptr_alignment(uint64_t ptrval) {
   // do not support __has_builtin
   #define ACPP_HAS_BUILTIN_CTZ
 #else
-  #if __has_builtin(__builtin_ctz)
+  #if __has_builtin(__builtin_ctzll)
     #define ACPP_HAS_BUILTIN_CTZ
   #endif
 #endif
 
 #ifdef ACPP_HAS_BUILTIN_CTZ
-  uint64_t alignment = 1ull << __builtin_ctz(ptrval);
+  uint64_t alignment = 1ull << __builtin_ctzll(ptrval);
   return alignment >= 32 ? 32 : 0;
 #else
   return 0;
@@ -264,6 +264,7 @@ kernel_adaptivity_engine::finalize_binary_configuration(
         uint64_t buffer = 0;
         std::memcpy(&buffer, _arg_mapper.get_mapped_args()[i],
                     _kernel_info->get_argument_size(i));
+
         int alignment = determine_ptr_alignment(buffer);
         if(alignment > 0) {
           HIPSYCL_DEBUG_INFO

--- a/src/runtime/omp/omp_allocator.cpp
+++ b/src/runtime/omp/omp_allocator.cpp
@@ -22,6 +22,13 @@ omp_allocator::omp_allocator(const device_id &my_device)
     : _my_device{my_device} {}
 
 void *omp_allocator::raw_allocate(size_t min_alignment, size_t size_bytes) {
+  if(min_alignment < 32) {
+    // Enforce alignment by default for performance reasons.
+    // 32 is chosen since this is what is currently needed by the adaptivity
+    // engine to consider an allocation strongly aligned.
+    return raw_allocate(32, size_bytes);
+  }
+
 #if !defined(_WIN32)
   // posix requires alignment to be a multiple of sizeof(void*)
   if (min_alignment < sizeof(void*))
@@ -35,11 +42,12 @@ void *omp_allocator::raw_allocate(size_t min_alignment, size_t size_bytes) {
     min_alignment = 1;
 #endif
 
-  if(size_bytes % min_alignment != 0)
-    return nullptr;
+  if(min_alignment > 0 && size_bytes % min_alignment != 0)
+    return raw_allocate(min_alignment,
+                        next_multiple_of(size_bytes, min_alignment));
 
-  // ToDo: Mac OS CI has a problem with std::aligned_alloc
-  // but it's unclear if it's a Mac, or libc++, or toolchain issue
+    // ToDo: Mac OS CI has a problem with std::aligned_alloc
+    // but it's unclear if it's a Mac, or libc++, or toolchain issue
 #ifdef __APPLE__
   return aligned_alloc(min_alignment, size_bytes);
 #elif !defined(_WIN32)


### PR DESCRIPTION
By default, when JIT-compiling we specialize kernels depending on whether pointer arguments are either strongly aligned or not.
This means that our allocation mechanisms should ensure suitably large alignment by default, so that we avoid JIT-compiling too much.
This is already the case on CUDA or HIP, where every malloc is typically strongly aligned.
On OpenMP this was however not yet the case.

This PR
* fixes a minor issue where the incorrect builtin was called when calculating alignment
* Enforces alignment of at least 32 for all allocation requests
* Adds handling for the case when the allocation size is not a multiple of the alignment, which previously led to an allocation failure
* Adds some diagnostic output for the generated kernel specialization to see more easily how the kernel is really configured at JIT-time.