### PR TITLE
Add Unified Runtime backend

### DIFF
--- a/include/hipSYCL/runtime/device_id.hpp
+++ b/include/hipSYCL/runtime/device_id.hpp
@@ -24,6 +24,7 @@ enum class hardware_platform
   rocm,
   cuda,
   level_zero,
+  unified_runtime,
   ocl,
   cpu
 };
@@ -32,6 +33,7 @@ enum class api_platform {
   cuda,
   hip,
   level_zero,
+  unified_runtime,
   ocl,
   omp
 };
@@ -41,7 +43,8 @@ enum class backend_id {
   hip,
   level_zero,
   ocl,
-  omp
+  omp,
+  unified_runtime
 };
 
 struct backend_descriptor
@@ -67,6 +70,9 @@ struct backend_descriptor
       id = backend_id::level_zero;
     else if (hw_plat == hardware_platform::ocl && sw_plat == api_platform::ocl)
       id = backend_id::ocl;
+    else if (hw_plat == hardware_platform::unified_runtime &&
+             sw_plat == api_platform::unified_runtime)
+      id = backend_id::unified_runtime;
     else
       assert(false && "Invalid combination of hardware/software platform for "
                       "backend descriptor.");
@@ -83,18 +89,18 @@ class device_id
 public:
   device_id() = default;
   device_id(backend_descriptor b, int id);
-  
+
   bool is_host() const;
   backend_id get_backend() const;
   backend_descriptor get_full_backend_descriptor() const;
-  
+
   int get_id() const;
 
   void dump(std::ostream& ostr) const;
 
   friend bool operator==(const device_id& a, const device_id& b)
   {
-    return a._backend == b._backend && 
+    return a._backend == b._backend &&
            a._device_id == b._device_id;
   }
 
@@ -149,7 +155,7 @@ struct hash<hipsycl::rt::device_id>
 {
   std::size_t operator()(const hipsycl::rt::device_id& k) const
   {
-    return hash<int>()(static_cast<int>(k.get_backend())) ^ 
+    return hash<int>()(static_cast<int>(k.get_backend())) ^
           (hash<int>()(k.get_id()) << 8);
   }
 };
@@ -159,7 +165,7 @@ struct hash<hipsycl::rt::platform_id>
 {
   std::size_t operator()(const hipsycl::rt::platform_id& p) const
   {
-    return hash<int>()(static_cast<int>(p.get_backend())) ^ 
+    return hash<int>()(static_cast<int>(p.get_backend())) ^
           (hash<int>()(p.get_platform()) << 8);
   }
 };

--- a/include/hipSYCL/runtime/ur/ur_allocator.hpp
+++ b/include/hipSYCL/runtime/ur/ur_allocator.hpp
@@ -1,0 +1,54 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#ifndef HIPSYCL_UR_ALLOCATOR_HPP
+#define HIPSYCL_UR_ALLOCATOR_HPP
+
+#include "hipSYCL/runtime/allocator.hpp"
+#include "hipSYCL/runtime/device_id.hpp"
+
+#include <ur_api.h>
+
+namespace hipsycl::rt {
+
+class ur_hardware_context;
+class ur_hardware_manager;
+
+class ur_allocator final : public backend_allocator {
+public:
+  ur_allocator(ur_device_handle_t dev, ur_context_handle_t ctx,
+               std::size_t device_index);
+
+  [[nodiscard]] void *raw_allocate(size_t min_alignment, size_t bytes) override;
+  [[nodiscard]] void *raw_allocate_optimized_host(size_t min_alignment,
+                                                  size_t bytes) override;
+  [[nodiscard]] void *raw_allocate_usm(size_t bytes) override;
+  void raw_free(void *mem) override;
+
+  [[nodiscard]] bool
+  is_usm_accessible_from(backend_descriptor b) const override;
+
+  result query_pointer(const void *ptr, pointer_info &out) const override;
+
+  result mem_advise(const void *addr, std::size_t num_bytes,
+                    int advise) const override;
+
+  [[nodiscard]] device_id get_device() const override;
+
+private:
+  ur_device_handle_t _dev;
+  ur_context_handle_t _ctx;
+
+  device_id _dev_id;
+};
+
+} // namespace hipsycl::rt
+
+#endif

--- a/include/hipSYCL/runtime/ur/ur_backend.hpp
+++ b/include/hipSYCL/runtime/ur/ur_backend.hpp
@@ -1,0 +1,47 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#ifndef HIPSYCL_UR_BACKEND_HPP
+#define HIPSYCL_UR_BACKEND_HPP
+
+#include "hipSYCL/runtime/backend.hpp"
+#include "hipSYCL/runtime/multi_queue_executor.hpp"
+#include "hipSYCL/runtime/ur/ur_hardware_manager.hpp"
+
+#include <memory>
+
+namespace hipsycl::rt {
+
+class ur_backend final : public backend {
+public:
+  ur_backend();
+  ~ur_backend() override;
+
+  [[nodiscard]] api_platform get_api_platform() const override;
+  [[nodiscard]] hardware_platform get_hardware_platform() const override;
+  [[nodiscard]] backend_id get_unique_backend_id() const override;
+
+  [[nodiscard]] backend_executor *get_executor(device_id dev) const override;
+  [[nodiscard]] ur_hardware_manager *get_hardware_manager() const override;
+  [[nodiscard]] ur_allocator *get_allocator(device_id dev) const override;
+
+  [[nodiscard]] std::string get_name() const override;
+
+  std::unique_ptr<backend_executor>
+  create_inorder_executor(device_id dev, int priority) override;
+
+private:
+  std::unique_ptr<ur_hardware_manager> _hw_manager;
+  std::unique_ptr<lazily_constructed_executor<multi_queue_executor>> _executor;
+};
+
+} // namespace hipsycl::rt
+
+#endif

--- a/include/hipSYCL/runtime/ur/ur_code_object.hpp
+++ b/include/hipSYCL/runtime/ur/ur_code_object.hpp
@@ -1,0 +1,102 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#ifndef HIPSYCL_UR_CODE_OBJECT_HPP
+#define HIPSYCL_UR_CODE_OBJECT_HPP
+
+#include "hipSYCL/runtime/code_object_invoker.hpp"
+#include "hipSYCL/runtime/error.hpp"
+#include "hipSYCL/runtime/kernel_cache.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
+
+#include <string>
+#include <ur_api.h>
+
+namespace hipsycl::rt {
+
+class ur_queue;
+
+class ur_sscp_code_object_invoker final : public sscp_code_object_invoker {
+public:
+  explicit ur_sscp_code_object_invoker(ur_queue &queue) : _queue{queue} {}
+  ~ur_sscp_code_object_invoker() override = default;
+
+  result submit_kernel(const kernel_operation &op, hcf_object_id hcf_object,
+                       const range<3> &num_groups, const range<3> &group_size,
+                       unsigned local_mem_size, void **args,
+                       std::size_t *arg_sizes, std::size_t num_args,
+                       std::string_view kernel_name,
+                       const hcf_kernel_info *kernel_info,
+                       const kernel_configuration &config) override;
+
+private:
+  ur_queue &_queue;
+};
+
+enum class ur_source_format { spirv, native };
+
+class ur_executable_object : public code_object {
+public:
+  ur_executable_object(ur_context_handle_t ctx, ur_device_handle_t dev,
+                       hcf_object_id source, const std::string &code_image,
+                       const kernel_configuration &config);
+  ~ur_executable_object() override = default;
+
+  code_object_state state() const override;
+  code_format format() const override;
+  backend_id managing_backend() const override;
+  hcf_object_id hcf_source() const override;
+  std::string target_arch() const override;
+  compilation_flow source_compilation_flow() const override;
+
+  std::vector<std::string> supported_backend_kernel_names() const override;
+  bool contains(const std::string &backend_kernel_name) const override;
+
+  result get_build_result() const;
+
+  result get_kernel(const std::string_view &name,
+                    ur_kernel_handle_t &out) const;
+
+private:
+  hcf_object_id _source;
+  code_format _format;
+  code_object_state _state;
+  result _build_status;
+
+  ur_context_handle_t _ctx;
+  ur_device_handle_t _dev;
+  ur_program_handle_t _program;
+
+  std::vector<std::string> _kernels;
+  std::unordered_map<std::string_view, ur_kernel_handle_t> _kernel_handles;
+
+  void load_kernel_handles();
+
+  kernel_configuration::id_type _id;
+};
+
+class ur_sscp_executable_object final : public ur_executable_object {
+public:
+  ur_sscp_executable_object(ur_context_handle_t ctx, ur_device_handle_t dev,
+                            hcf_object_id source,
+                            const std::string &spirv_image,
+                            const kernel_configuration &config);
+  ~ur_sscp_executable_object() override = default;
+
+  compilation_flow source_compilation_flow() const override;
+  kernel_configuration::id_type configuration_id() const override;
+
+private:
+  kernel_configuration::id_type _id;
+};
+
+} // namespace hipsycl::rt
+
+#endif

--- a/include/hipSYCL/runtime/ur/ur_event.hpp
+++ b/include/hipSYCL/runtime/ur/ur_event.hpp
@@ -1,0 +1,39 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#ifndef HIPSYCL_UR_EVENT_HPP
+#define HIPSYCL_UR_EVENT_HPP
+
+#include "hipSYCL/runtime/inorder_queue_event.hpp"
+
+#include <ur_api.h>
+
+namespace hipsycl::rt {
+
+class ur_node_event final : public inorder_queue_event<ur_event_handle_t> {
+public:
+  /// Takes ownership of supplied ze_event_handle_t
+  explicit ur_node_event(ur_event_handle_t evt);
+  ~ur_node_event() override;
+
+  void wait() override;
+
+  [[nodiscard]] bool is_complete() const override;
+  [[nodiscard]] ur_event_handle_t request_backend_event() override;
+
+  [[nodiscard]] ur_event_handle_t get_event_handle() const;
+
+private:
+  ur_event_handle_t _evt;
+};
+
+} // namespace hipsycl::rt
+
+#endif

--- a/include/hipSYCL/runtime/ur/ur_hardware_manager.hpp
+++ b/include/hipSYCL/runtime/ur/ur_hardware_manager.hpp
@@ -1,0 +1,106 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#ifndef HIPSYCL_UR_HARDWARE_MANAGER_HPP
+#define HIPSYCL_UR_HARDWARE_MANAGER_HPP
+
+#include "hipSYCL/runtime/error.hpp"
+#include "hipSYCL/runtime/hardware.hpp"
+#include "hipSYCL/runtime/ur/ur_allocator.hpp"
+
+#include <memory>
+#include <ur_api.h>
+#include <vector>
+
+namespace hipsycl::rt {
+
+/// A wrapper around an ur_context_handle_t that manages the lifetime of the
+/// context and can be shared among multiple ur_hardware_context instances.
+class ur_context_manager {
+public:
+  explicit ur_context_manager(ur_context_handle_t ctx);
+  ~ur_context_manager();
+
+  // No copying or moving
+
+  ur_context_manager(const ur_context_manager &) = delete;
+  ur_context_manager(ur_context_manager &&) = delete;
+  ur_context_manager &operator=(const ur_context_manager &) = delete;
+  ur_context_manager &operator=(ur_context_manager &&) = delete;
+
+  [[nodiscard]] ur_context_handle_t get() const { return _context; }
+
+private:
+  ur_context_handle_t _context;
+};
+
+/// Represents a Unified Runtime device handle.
+class ur_hardware_context final : public hardware_context {
+public:
+  ur_hardware_context(ur_device_handle_t device,
+                      const std::shared_ptr<ur_context_manager> &ctx,
+                      size_t platform_idx);
+  ~ur_hardware_context() override;
+
+  [[nodiscard]] bool is_cpu() const override;
+  [[nodiscard]] bool is_gpu() const override;
+
+  [[nodiscard]] std::size_t get_max_kernel_concurrency() const override;
+  [[nodiscard]] std::size_t get_max_memcpy_concurrency() const override;
+
+  [[nodiscard]] std::string get_device_name() const override;
+  [[nodiscard]] std::string get_vendor_name() const override;
+  [[nodiscard]] std::string get_device_arch() const override;
+
+  [[nodiscard]] bool has(device_support_aspect aspect) const override;
+  [[nodiscard]] std::size_t
+  get_property(device_uint_property prop) const override;
+  [[nodiscard]] std::vector<std::size_t>
+  get_property(device_uint_list_property prop) const override;
+
+  [[nodiscard]] std::string get_driver_version() const override;
+  [[nodiscard]] std::string get_profile() const override;
+  [[nodiscard]] std::size_t get_platform_index() const override;
+
+  [[nodiscard]] ur_context_handle_t get_ur_context() const;
+  [[nodiscard]] ur_device_handle_t get_ur_device() const;
+
+  [[nodiscard]] ur_allocator *get_allocator();
+
+private:
+  ur_allocator _allocator;
+  std::shared_ptr<ur_context_manager> _context;
+
+  size_t _platform_idx;
+  ur_device_handle_t _device;
+};
+
+class ur_hardware_manager final : public backend_hardware_manager {
+public:
+  ur_hardware_manager();
+  ~ur_hardware_manager() override;
+
+  [[nodiscard]] std::size_t get_num_devices() const override;
+  [[nodiscard]] hardware_context *get_device(std::size_t index) override;
+  [[nodiscard]] device_id get_device_id(std::size_t index) const override;
+  [[nodiscard]] std::size_t get_num_platforms() const override;
+
+  result device_handle_to_device_id(ur_device_handle_t d, device_id &out) const;
+
+private:
+  std::vector<ur_adapter_handle_t> _adapters{};
+  std::vector<ur_platform_handle_t> _platforms{};
+
+  std::vector<ur_hardware_context> _contexts{};
+};
+
+} // namespace hipsycl::rt
+
+#endif

--- a/include/hipSYCL/runtime/ur/ur_queue.hpp
+++ b/include/hipSYCL/runtime/ur/ur_queue.hpp
@@ -1,0 +1,107 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#ifndef HIPSYCL_UR_QUEUE_HPP
+#define HIPSYCL_UR_QUEUE_HPP
+
+#include "hipSYCL/common/spin_lock.hpp"
+#include "hipSYCL/glue/llvm-sscp/jit-reflection/reflection_map.hpp"
+#include "hipSYCL/glue/llvm-sscp/jit.hpp"
+#include "hipSYCL/runtime/event.hpp"
+#include "hipSYCL/runtime/hints.hpp"
+#include "hipSYCL/runtime/inorder_queue.hpp"
+#include "hipSYCL/runtime/ur/ur_code_object.hpp"
+
+#include <future>
+
+namespace hipsycl::rt {
+
+class ur_hardware_manager;
+class ur_queue;
+
+class ur_queue final : public inorder_queue {
+public:
+  ur_queue(ur_hardware_manager *hw_manager, int device_index);
+  ~ur_queue() override;
+
+  /// Inserts an event into the stream
+  std::shared_ptr<dag_node_event> insert_event() override;
+  std::shared_ptr<dag_node_event> create_queue_completion_event() override;
+
+  result submit_kernel(kernel_operation &, const dag_node_ptr &) override;
+  result submit_memcpy(memcpy_operation &, const dag_node_ptr &) override;
+  result submit_prefetch(prefetch_operation &, const dag_node_ptr &) override;
+  result submit_memset(memset_operation &, const dag_node_ptr &) override;
+
+  /// Causes the queue to wait until an event on another queue has occured.
+  /// the other queue must be from the same backend
+  result submit_queue_wait_for(const dag_node_ptr &evt) override;
+  result submit_external_wait_for(const dag_node_ptr &node) override;
+
+  result wait() override;
+
+  device_id get_device() const override;
+  /// Return native type if supported, nullptr otherwise
+  void *get_native_type() const override;
+
+  result query_status(inorder_queue_status &status) override;
+
+  [[nodiscard]] ur_queue_handle_t get_ur_queue() const;
+  [[nodiscard]] ur_hardware_manager *get_hardware_manager() const;
+
+  result submit_sscp_kernel_from_code_object(
+      const kernel_operation &op, hcf_object_id hcf_object,
+      std::string_view kernel_name, const hcf_kernel_info *kernel_info,
+      const range<3> &num_groups, const range<3> &group_size,
+      unsigned local_mem_size, void **args, std::size_t *arg_sizes,
+      std::size_t num_args, const kernel_configuration &config);
+
+private:
+  void register_submitted_op(ur_event_handle_t evt);
+
+  // Non-thread safe state should go here
+  struct protected_state {
+    auto get_most_recent_event() const {
+      std::lock_guard lock{_mutex};
+      return _most_recent_event;
+    }
+
+    template <class T> void set_most_recent_event(const T &x) {
+      std::lock_guard lock{_mutex};
+      _most_recent_event = x;
+    }
+
+  private:
+    std::shared_ptr<dag_node_event> _most_recent_event = nullptr;
+    mutable std::mutex _mutex;
+  };
+
+  protected_state _state;
+
+  const int _device_index;
+  ur_queue_handle_t _queue{};
+  ur_hardware_manager *_hw_manager;
+  ur_sscp_code_object_invoker _sscp_code_object_invoker;
+  std::shared_ptr<dag_node_event> _last_submitted_op_event;
+  std::vector<std::shared_ptr<dag_node_event>> _enqueued_synchronization_ops;
+  std::vector<std::future<void>> _external_waits;
+  std::shared_ptr<kernel_cache> _kernel_cache;
+
+  // SSCP submission data
+  glue::jit::cxx_argument_mapper _arg_mapper;
+  kernel_configuration _config;
+  glue::jit::reflection_map _reflection_map;
+
+  common::spin_lock _sscp_submission_spin_lock;
+};
+
+} // namespace hipsycl::rt
+
+#endif

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -117,7 +117,7 @@ if(WITH_CUDA_BACKEND)
   target_include_directories(rt-backend-cuda PRIVATE
     ${HIPSYCL_SOURCE_DIR}/include
     ${CUDA_TOOLKIT_ROOT_DIR}/include)
-  
+
   target_link_libraries(rt-backend-cuda PRIVATE acpp-rt ${CUDA_LIBS})
 
   target_compile_options(rt-backend-cuda PRIVATE ${HIPSYCL_RT_EXTRA_CXX_FLAGS})
@@ -192,7 +192,7 @@ if(WITH_LEVEL_ZERO_BACKEND)
     ze/ze_event.cpp
     ze/ze_queue.cpp
     ze/ze_code_object.cpp)
-  
+
   target_include_directories(rt-backend-ze PRIVATE ${HIPSYCL_SOURCE_DIR}/include)
   target_link_libraries(rt-backend-ze PRIVATE acpp-rt -lze_loader)
 
@@ -228,7 +228,7 @@ if(WITH_OPENCL_BACKEND)
   endif()
   add_library(ocl-headers INTERFACE)
   target_include_directories(ocl-headers INTERFACE ${ocl-headers_SOURCE_DIR})
-  
+
   FetchContent_Declare(ocl-cxx-headers
     GIT_REPOSITORY https://github.com/KhronosGroup/OpenCL-CLHPP
     GIT_TAG 0bdbbfe5ecda42cff50c96cc5e33527f42fcbd45
@@ -250,7 +250,9 @@ if(WITH_OPENCL_BACKEND)
     ocl/ocl_allocator.cpp
     ocl/ocl_usm.cpp
     ocl/ocl_event.cpp
-    ocl/ocl_queue.cpp)
+    ocl/ocl_queue.cpp
+
+  )
 
   target_include_directories(rt-backend-ocl PRIVATE ${HIPSYCL_SOURCE_DIR}/include)
   target_link_libraries(rt-backend-ocl PRIVATE acpp-rt ${OpenCL_LIBRARIES} ocl-headers ocl-cxx-headers)
@@ -273,6 +275,33 @@ if(WITH_OPENCL_BACKEND)
         ARCHIVE DESTINATION lib/hipSYCL)
 endif()
 
+if (WITH_UNIFIED_RUNTIME_BACKEND)
+    add_library(rt-backend-ur SHARED
+            ur/ur_utils.hpp
+            ur/ur_backend.cpp
+            ur/ur_allocator.cpp
+            ur/ur_queue.cpp
+            ur/ur_event.cpp
+            ur/ur_hardware_manager.cpp
+            ur/ur_code_object.cpp
+    )
+
+    target_include_directories(rt-backend-ur PRIVATE ${HIPSYCL_SOURCE_DIR}/include)
+
+    find_package(unified-runtime REQUIRED)
+    target_link_libraries(rt-backend-ur PRIVATE acpp-rt unified-runtime::ur_headers unified-runtime::ur_loader)
+
+    if (WITH_SSCP_COMPILER)
+        target_compile_definitions(rt-backend-ur PRIVATE -DHIPSYCL_WITH_SSCP_COMPILER)
+        target_link_libraries(rt-backend-ur PRIVATE llvm-to-spirv)
+    endif ()
+
+    install(TARGETS rt-backend-ur
+            LIBRARY DESTINATION lib/hipSYCL
+            ARCHIVE DESTINATION lib/hipSYCL)
+
+endif ()
+
 if(WITH_CPU_BACKEND)
   add_library(rt-backend-omp SHARED
     omp/omp_allocator.cpp
@@ -285,7 +314,7 @@ if(WITH_CPU_BACKEND)
     if (APPLE)
       if (NOT DEFINED OpenMP_ROOT AND NOT DEFINED OMP_ROOT)
         execute_process(COMMAND brew list libomp
-        COMMAND grep libomp.a 
+        COMMAND grep libomp.a
         COMMAND sed -E "s/\\/lib\\/.*//"
         OUTPUT_VARIABLE DefaultOMP_ROOT
         OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -297,9 +326,9 @@ if(WITH_CPU_BACKEND)
     endif()
 
     find_package(OpenMP REQUIRED)
-    
+
     target_include_directories(rt-backend-omp PRIVATE
-      ${HIPSYCL_SOURCE_DIR}/include 
+      ${HIPSYCL_SOURCE_DIR}/include
       ${PROJECT_BINARY_DIR}/include)
 
     if(WITH_SSCP_COMPILER)
@@ -316,7 +345,7 @@ if(WITH_CPU_BACKEND)
       string(JOIN " " hipSYCL_OpenMP_CXX_LIBRARIES ${OpenMP_CXX_LIBRARIES})
       set(hipSYCL_OpenMP_CXX_LIBRARIES ${hipSYCL_OpenMP_CXX_LIBRARIES} PARENT_SCOPE)
     endif()
-  
+
   list(LENGTH OpenMP_CXX_LIBRARIES OpenMP_CXX_LIBRARIES_LENGTH)
   if(WIN32 AND ${OpenMP_CXX_LIBRARIES_LENGTH} EQUAL 0)
     # FindOpenMP does a bad job here, finding any library.. so add some more hints..

--- a/src/runtime/ur/ur_allocator.cpp
+++ b/src/runtime/ur/ur_allocator.cpp
@@ -1,0 +1,118 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#include "hipSYCL/runtime/ur/ur_allocator.hpp"
+
+#include "hipSYCL/runtime/ur/ur_hardware_manager.hpp"
+#include "ur_utils.hpp"
+
+#include <ur_api.h>
+
+using namespace hipsycl::rt;
+
+namespace {} // namespace
+
+ur_allocator::ur_allocator(ur_device_handle_t dev, ur_context_handle_t ctx,
+                           const std::size_t device_index)
+    : _dev(dev), _ctx(ctx),
+      _dev_id{device_id{backend_descriptor{hardware_platform::unified_runtime,
+                                           api_platform::unified_runtime},
+                        static_cast<int>(device_index)}} {}
+
+void *ur_allocator::raw_allocate(size_t, const size_t bytes) {
+  void *out = nullptr;
+  const ur_result_t res =
+      urUSMDeviceAlloc(_ctx, _dev, nullptr, nullptr, bytes, &out);
+
+  if (res != UR_RESULT_SUCCESS) {
+    register_error(make_error(
+        __acpp_here(), ur_error_info("urUSMDeviceAlloc() failed", res,
+                                     error_type::memory_allocation_error)));
+    return nullptr;
+  }
+
+  return out;
+}
+
+void *ur_allocator::raw_allocate_optimized_host(size_t, const size_t bytes) {
+  void *out = nullptr;
+  const ur_result_t res = urUSMHostAlloc(_ctx, nullptr, nullptr, bytes, &out);
+
+  if (res != UR_RESULT_SUCCESS) {
+    register_error(make_error(__acpp_here(),
+                              ur_error_info("urUSMHostAlloc() failed", res)));
+    return nullptr;
+  }
+
+  return out;
+}
+void *ur_allocator::raw_allocate_usm(const size_t bytes) {
+  void *out = nullptr;
+
+  const ur_result_t res =
+      urUSMSharedAlloc(_ctx, _dev, nullptr, nullptr, bytes, &out);
+  if (res != UR_RESULT_SUCCESS) {
+    register_error(make_error(
+        __acpp_here(), ur_error_info("urUSMSharedAlloc() failed", res,
+                                     error_type::memory_allocation_error)));
+    return nullptr;
+  }
+
+  return out;
+}
+
+void ur_allocator::raw_free(void *mem) {
+  const ur_result_t res = urUSMFree(_ctx, mem);
+  if (res != UR_RESULT_SUCCESS) {
+    register_error(
+        make_error(__acpp_here(), ur_error_info("urUSMFree() failed", res)));
+  }
+}
+
+bool ur_allocator::is_usm_accessible_from(const backend_descriptor b) const {
+  return b.hw_platform == hardware_platform::cpu ||
+         b.hw_platform == hardware_platform::unified_runtime;
+}
+
+result ur_allocator::query_pointer(const void *ptr, pointer_info &out) const {
+
+  ur_usm_type_t type;
+
+  const ur_result_t res = urUSMGetMemAllocInfo(
+      _ctx, ptr, UR_USM_ALLOC_INFO_TYPE, sizeof(type), &type, nullptr);
+
+  if (res != UR_RESULT_SUCCESS) {
+    return make_error(__acpp_here(),
+                      ur_error_info("urUSMGetMemAllocInfo() failed", res));
+  }
+
+  if (type == UR_USM_TYPE_UNKNOWN) {
+    return make_error(
+        __acpp_here(),
+        ur_error_info("urUSMGetMemAllocInfo() returned unknown type",
+                      UR_RESULT_ERROR_INVALID_VALUE));
+  }
+
+  out.is_optimized_host = type == UR_USM_TYPE_HOST;
+  out.is_usm = type == UR_USM_TYPE_SHARED;
+  out.is_from_host_backend = false;
+  out.dev = _dev_id;
+
+  return make_success();
+}
+result ur_allocator::mem_advise(const void *addr, std::size_t num_bytes,
+                                int advise) const {
+  // TODO: Implement this
+  // urEnqueueUSMAdvise()
+
+  return make_success();
+}
+
+device_id ur_allocator::get_device() const { return _dev_id; }

--- a/src/runtime/ur/ur_backend.cpp
+++ b/src/runtime/ur/ur_backend.cpp
@@ -1,0 +1,109 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#include "hipSYCL/runtime/ur/ur_backend.hpp"
+
+#include "hipSYCL/runtime/ur/ur_queue.hpp"
+#include "ur_utils.hpp"
+
+HIPSYCL_PLUGIN_API_EXPORT
+hipsycl::rt::backend *hipsycl_backend_plugin_create() {
+  return new hipsycl::rt::ur_backend();
+}
+
+HIPSYCL_PLUGIN_API_EXPORT
+const char *hipsycl_backend_plugin_get_name() { return "ur"; }
+
+using namespace hipsycl::rt;
+
+namespace {
+std::unique_ptr<multi_queue_executor>
+create_multi_queue_executor(ur_backend *backend, ur_hardware_manager *hw_mgr) {
+
+  auto queue_factory = [hw_mgr](const device_id dev) {
+    return std::make_unique<ur_queue>(hw_mgr,
+                                      static_cast<std::size_t>(dev.get_id()));
+  };
+
+  return std::make_unique<multi_queue_executor>(*backend, queue_factory);
+}
+
+bool is_device_id_valid(const device_id dev) {
+  return dev.get_backend() == backend_id::unified_runtime;
+}
+
+} // namespace
+
+ur_backend::ur_backend() {
+  _hw_manager = std::make_unique<ur_hardware_manager>();
+  _executor =
+      std::make_unique<lazily_constructed_executor<multi_queue_executor>>(
+          [this] {
+            return create_multi_queue_executor(this, _hw_manager.get());
+          });
+}
+ur_backend::~ur_backend() = default;
+
+std::string ur_backend::get_name() const { return "Unified Runtime"; }
+
+api_platform ur_backend::get_api_platform() const {
+  return api_platform::unified_runtime;
+}
+
+backend_id ur_backend::get_unique_backend_id() const {
+  return backend_id::unified_runtime;
+}
+
+hardware_platform ur_backend::get_hardware_platform() const {
+  return hardware_platform::unified_runtime;
+}
+
+ur_hardware_manager *ur_backend::get_hardware_manager() const {
+  return _hw_manager.get();
+}
+
+backend_executor *ur_backend::get_executor(const device_id dev) const {
+  if (!is_device_id_valid(dev)) {
+    register_error(
+        __acpp_here(),
+        error_info{"passed device_id does not belong to this backend"});
+    return nullptr;
+  }
+
+  return _executor->get();
+}
+
+std::unique_ptr<backend_executor>
+ur_backend::create_inorder_executor(const device_id dev, int priority) {
+  if (!is_device_id_valid(dev)) {
+    register_error(
+        __acpp_here(),
+        error_info{"passed device_id does not belong to this backend"});
+    return nullptr;
+  }
+
+  std::unique_ptr<inorder_queue> q =
+      std::make_unique<ur_queue>(_hw_manager.get(), dev.get_id());
+
+  return std::make_unique<inorder_executor>(std::move(q));
+}
+
+ur_allocator *ur_backend::get_allocator(const device_id dev) const {
+  if (!is_device_id_valid(dev)) {
+    register_error(
+        __acpp_here(),
+        error_info{"passed device_id does not belong to this backend"});
+    return nullptr;
+  }
+
+  const auto dev_ctx = dynamic_cast<ur_hardware_context *>(
+      _hw_manager->get_device(dev.get_id()));
+  return dev_ctx->get_allocator();
+}

--- a/src/runtime/ur/ur_code_object.cpp
+++ b/src/runtime/ur/ur_code_object.cpp
@@ -1,0 +1,133 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#include "hipSYCL/runtime/ur/ur_code_object.hpp"
+
+#include "hipSYCL/runtime/ur/ur_queue.hpp"
+#include "ur_utils.hpp"
+
+using namespace hipsycl::rt;
+
+result ur_sscp_code_object_invoker::submit_kernel(
+    const kernel_operation &op, const hcf_object_id hcf_object,
+    const range<3> &num_groups, const range<3> &group_size,
+    const unsigned int local_mem_size, void **args, std::size_t *arg_sizes,
+    const std::size_t num_args, const std::string_view kernel_name,
+    const hcf_kernel_info *kernel_info, const kernel_configuration &config) {
+
+  return _queue.submit_sscp_kernel_from_code_object(
+      op, hcf_object, kernel_name, kernel_info, num_groups, group_size,
+      local_mem_size, args, arg_sizes, num_args, config);
+}
+
+ur_executable_object::ur_executable_object(const ur_context_handle_t ctx,
+                                           ur_device_handle_t dev,
+                                           const hcf_object_id source,
+                                           const std::string &code_image,
+                                           const kernel_configuration &config)
+    : _source{source}, _ctx{ctx}, _dev{dev}, _id{config.generate_id()} {
+
+  std::vector<char> ir(code_image.size());
+  std::memcpy(ir.data(), code_image.data(), code_image.size());
+
+  {
+    const auto err =
+        urProgramCreateWithIL(_ctx, ir.data(), ir.size(), nullptr, &_program);
+    if (err != UR_RESULT_SUCCESS) {
+      _build_status = register_error(
+          __acpp_here(),
+          ur_error_info("Construction of UR program failed", err));
+      return;
+    }
+  }
+
+  {
+    const auto err = urProgramBuild(_ctx, _program, nullptr);
+    if (err != UR_RESULT_SUCCESS) {
+      _build_status = register_error(
+          __acpp_here(), ur_error_info("Building of UR program failed", err));
+      return;
+    }
+  }
+
+  // TODO: This is a placeholder. We need to add support for build options.
+  throw std::runtime_error{"ur_executable_object: not implemented"}; // TODO
+}
+result ur_executable_object::get_build_result() const { return _build_status; }
+hcf_object_id ur_executable_object::hcf_source() const { return _source; }
+backend_id ur_executable_object::managing_backend() const {
+  return backend_id::unified_runtime;
+}
+
+code_format ur_executable_object::format() const {
+  throw std::runtime_error{
+      "ur_executable_object::format() not implemented"}; // TODO
+}
+std::string ur_executable_object::target_arch() const {
+  throw std::runtime_error{
+      "ur_executable_object::target_arch() not implemented"}; // TODO
+}
+
+code_object_state ur_executable_object::state() const {
+  return _build_status.is_success() ? code_object_state::executable
+                                    : code_object_state::invalid;
+}
+
+compilation_flow ur_executable_object::source_compilation_flow() const {
+  throw std::runtime_error{"ur_executable_object::source_compilation_flow() "
+                           "not implemented"}; // TODO
+}
+
+std::vector<std::string>
+ur_executable_object::supported_backend_kernel_names() const {
+  throw std::runtime_error{"ur_executable_object::supported_backend_kernel_"
+                           "names() not implemented"}; // TODO
+}
+bool ur_executable_object::contains(
+    const std::string &backend_kernel_name) const {
+  throw std::runtime_error{
+      "ur_executable_object::contains() not implemented"}; // TODO
+}
+
+void ur_executable_object::load_kernel_handles() {
+  throw std::runtime_error{
+      "ur_executable_object::load_kernel_handles() not implemented"}; // TODO
+}
+
+ur_sscp_executable_object::ur_sscp_executable_object(
+    ur_context_handle_t ctx, ur_device_handle_t dev, hcf_object_id source,
+    const std::string &spirv_image, const kernel_configuration &config)
+    : ur_executable_object{ctx, dev, source, spirv_image, config} {
+  // TODO: Implement this
+}
+
+compilation_flow ur_sscp_executable_object::source_compilation_flow() const {
+  return compilation_flow::sscp;
+}
+
+kernel_configuration::id_type
+ur_sscp_executable_object::configuration_id() const {
+  return _id;
+}
+
+result ur_executable_object::get_kernel(const std::string_view &name,
+                                        ur_kernel_handle_t &out) const {
+  if (!_build_status.is_success()) {
+    return _build_status;
+  }
+
+  const auto k_handle = _kernel_handles.find(name);
+  if (k_handle == _kernel_handles.end()) {
+    return make_error(__acpp_here(), error_info{"Unknown kernel name"});
+  }
+
+  out = k_handle->second;
+  return make_success();
+}

--- a/src/runtime/ur/ur_event.cpp
+++ b/src/runtime/ur/ur_event.cpp
@@ -1,0 +1,49 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#include "hipSYCL/runtime/ur/ur_event.hpp"
+
+#include "ur_utils.hpp"
+
+using namespace hipsycl::rt;
+
+ur_node_event::ur_node_event(const ur_event_handle_t evt) : _evt(evt) {}
+ur_node_event::~ur_node_event() = default;
+
+ur_event_handle_t ur_node_event::get_event_handle() const { return _evt; }
+ur_event_handle_t ur_node_event::request_backend_event() {
+  return get_event_handle();
+}
+
+bool ur_node_event::is_complete() const {
+  ur_event_status_t status;
+  const ur_result_t err =
+      urEventGetInfo(_evt, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS,
+                     sizeof(status), &status, nullptr);
+  if (err != UR_RESULT_SUCCESS) {
+    register_error(make_error(
+        __acpp_here(),
+        ur_error_info("ur_node_event: urEventGetInfo() failed", err)));
+
+    return false;
+  }
+
+  return status == UR_EVENT_STATUS_COMPLETE || status == UR_EVENT_STATUS_ERROR;
+}
+
+void ur_node_event::wait() {
+  const auto events = std::vector{_evt};
+  const auto err = urEventWait(events.size(), events.data());
+  if (err != UR_RESULT_SUCCESS) {
+    register_error(
+        make_error(__acpp_here(),
+                   ur_error_info("ur_node_event: urEventWait() failed", err)));
+  }
+}

--- a/src/runtime/ur/ur_hardware_manager.cpp
+++ b/src/runtime/ur/ur_hardware_manager.cpp
@@ -1,0 +1,348 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#include "hipSYCL/runtime/ur/ur_hardware_manager.hpp"
+
+#include "hipSYCL/runtime/error.hpp"
+#include "hipSYCL/runtime/settings.hpp"
+#include "ur_utils.hpp"
+
+#include <cstddef>
+
+using namespace hipsycl::rt;
+
+ur_hardware_manager::ur_hardware_manager() {
+  {
+    const auto err = urLoaderInit(0, nullptr);
+    if (err != UR_RESULT_SUCCESS) {
+      print_warning(
+          __acpp_here(),
+          ur_error_info("ur_hardware_manager: Could not initialize UR loader",
+                        err));
+      return;
+    }
+  }
+
+  uint32_t num_adapters = 0;
+  {
+    const auto err = urAdapterGet(0, nullptr, &num_adapters);
+    if (err != UR_RESULT_SUCCESS) {
+      print_warning(__acpp_here(),
+                    ur_error_info("Could not get number of adapters", err));
+      return;
+    }
+  }
+
+  HIPSYCL_DEBUG_INFO << "ur_hardware_manager: Found " << num_adapters
+                     << " adapters" << std::endl;
+  _adapters = std::vector<ur_adapter_handle_t>(num_adapters);
+
+  {
+    const auto err =
+        urAdapterGet(num_adapters, _adapters.data(), &num_adapters);
+    if (err != UR_RESULT_SUCCESS) {
+      print_warning(__acpp_here(),
+                    ur_error_info("Could not list adapters", err));
+      return;
+    }
+  }
+
+  uint32_t num_platforms = 0;
+  {
+    const auto err = urPlatformGet(_adapters.data(), num_adapters, 1, nullptr,
+                                   &num_platforms);
+    if (err != UR_RESULT_SUCCESS) {
+      print_warning(__acpp_here(),
+                    ur_error_info("Could not get number of platforms", err));
+      return;
+    }
+  }
+
+  HIPSYCL_DEBUG_INFO << "ur_hardware_manager: Found " << num_platforms
+                     << " platforms" << std::endl;
+  _platforms = std::vector<ur_platform_handle_t>(num_platforms);
+
+  {
+    const auto err = urPlatformGet(_adapters.data(), num_adapters,
+                                   num_platforms, _platforms.data(), nullptr);
+    if (err != UR_RESULT_SUCCESS) {
+      print_warning(__acpp_here(),
+                    ur_error_info("Could not list platforms", err));
+      return;
+    }
+  }
+
+  // for each platform, try to create a context with all devices
+  for (std::size_t platform_idx = 0; platform_idx < _platforms.size();
+       ++platform_idx) {
+
+    const auto platform = _platforms[platform_idx];
+
+    uint32_t num_devices = 0;
+    {
+      const auto err =
+          urDeviceGet(platform, UR_DEVICE_TYPE_ALL, 0, nullptr, &num_devices);
+      if (err != UR_RESULT_SUCCESS) {
+        print_warning(
+            __acpp_here(),
+            ur_error_info("Could not get number of devices of platform", err));
+        continue;
+      }
+    }
+
+    auto _devices = std::vector<ur_device_handle_t>(num_devices);
+
+    {
+      const auto err = urDeviceGet(platform, UR_DEVICE_TYPE_ALL, num_devices,
+                                   _devices.data(), nullptr);
+
+      if (err != UR_RESULT_SUCCESS) {
+        print_warning(__acpp_here(),
+                      ur_error_info("Could not list devices of platform", err));
+        continue;
+      }
+    }
+
+    _devices.resize(num_devices);
+
+    // create a context for all devices
+    ur_context_handle_t platform_ctx;
+
+    {
+      const auto err =
+          urContextCreate(num_devices, _devices.data(), nullptr, &platform_ctx);
+      if (err != UR_RESULT_SUCCESS) {
+        print_warning(
+            __acpp_here(),
+            ur_error_info(
+                "ur_hardware_manager: Could not create context for platform",
+                err));
+        continue; // TODO: fallback to single device contexts
+      }
+    }
+
+    // for each device in the platform, create a hardware context
+    const auto ctx_mgr = std::make_shared<ur_context_manager>(platform_ctx);
+    for (const auto device : _devices) {
+      _contexts.emplace_back(device, ctx_mgr, platform_idx);
+    }
+  }
+}
+
+ur_hardware_manager::~ur_hardware_manager() {
+  for (const auto adapter : _adapters) {
+    urAdapterRelease(adapter);
+  }
+}
+
+std::size_t ur_hardware_manager::get_num_devices() const {
+  return _contexts.size();
+}
+std::size_t ur_hardware_manager::get_num_platforms() const {
+  return _platforms.size();
+}
+result ur_hardware_manager::device_handle_to_device_id(ur_device_handle_t d,
+                                                       device_id &out) const {
+  for (std::size_t i = 0; i < _contexts.size(); ++i) {
+    if (_contexts[i].get_ur_device() == d) {
+      out = get_device_id(i);
+      return make_success();
+    }
+  }
+  return make_error(__acpp_here(),
+                    error_info{"ze_hardware_manager: Could not convert "
+                               "ze_device_handle_t to hipSYCL device id"});
+}
+
+hardware_context *ur_hardware_manager::get_device(const std::size_t index) {
+  assert(index < _contexts.size());
+  return &_contexts[index];
+}
+
+device_id ur_hardware_manager::get_device_id(const std::size_t index) const {
+  assert(index < _contexts.size());
+  return device_id{backend_descriptor{hardware_platform::unified_runtime,
+                                      api_platform::unified_runtime},
+                   static_cast<int>(index)};
+}
+
+ur_context_handle_t ur_hardware_context::get_ur_context() const {
+  return _context->get();
+}
+ur_device_handle_t ur_hardware_context::get_ur_device() const {
+  return _device;
+}
+ur_allocator *ur_hardware_context::get_allocator() { return &_allocator; }
+
+ur_hardware_context::ur_hardware_context(
+    const ur_device_handle_t device,
+    const std::shared_ptr<ur_context_manager> &ctx,
+    const std::size_t platform_idx)
+    : _allocator{ur_allocator{device, ctx->get(), platform_idx}}, _context(ctx),
+      _platform_idx(platform_idx), _device(device) {}
+
+ur_hardware_context::~ur_hardware_context() = default;
+
+template <typename T>
+static T get_device_property(const ur_device_handle_t device,
+                             const ur_device_info_t prop) {
+  T out;
+
+  const ur_result_t err =
+      urDeviceGetInfo(device, prop, sizeof(out), &out, nullptr);
+  if (err != UR_RESULT_SUCCESS) {
+    print_warning(__acpp_here(),
+                  ur_error_info("Could not query device property", err));
+    out = T{};
+  }
+
+  return out;
+}
+
+static std::string get_device_property_string(const ur_device_handle_t device,
+                                              const ur_device_info_t prop) {
+
+  size_t out_size = 0;
+
+  {
+    const ur_result_t err =
+        urDeviceGetInfo(device, prop, 0, nullptr, &out_size);
+    if (err != UR_RESULT_SUCCESS) {
+      print_warning(__acpp_here(),
+                    ur_error_info("Could not query device property", err));
+      return "";
+    }
+  }
+
+  auto out = std::vector<char>(out_size);
+  {
+    const ur_result_t err =
+        urDeviceGetInfo(device, prop, out_size, out.data(), nullptr);
+    if (err != UR_RESULT_SUCCESS) {
+      print_warning(__acpp_here(),
+                    ur_error_info("Could not query device property", err));
+      return "";
+    }
+  }
+
+  return std::string{out.data()};
+}
+
+bool ur_hardware_context::is_cpu() const {
+  const auto type =
+      get_device_property<ur_device_type_t>(_device, UR_DEVICE_INFO_TYPE);
+  return type == UR_DEVICE_TYPE_CPU;
+}
+
+bool ur_hardware_context::is_gpu() const {
+  const auto type =
+      get_device_property<ur_device_type_t>(_device, UR_DEVICE_INFO_TYPE);
+  return type == UR_DEVICE_TYPE_GPU;
+}
+std::size_t ur_hardware_context::get_max_kernel_concurrency() const {
+  return 1; // TODO
+}
+std::size_t ur_hardware_context::get_max_memcpy_concurrency() const {
+  return 1; // TODO
+}
+
+std::string ur_hardware_context::get_device_name() const {
+  return get_device_property_string(_device, UR_DEVICE_INFO_NAME);
+}
+
+std::string ur_hardware_context::get_vendor_name() const {
+  return get_device_property_string(_device, UR_DEVICE_INFO_VENDOR);
+}
+
+std::string ur_hardware_context::get_device_arch() const {
+  return "unknown"; // TODO
+}
+bool ur_hardware_context::has(device_support_aspect aspect) const {
+  switch (aspect) {
+
+  case device_support_aspect::images:
+    return get_device_property<ur_bool_t>(_device,
+                                          UR_DEVICE_INFO_IMAGE_SUPPORTED);
+  case device_support_aspect::error_correction:
+    return get_device_property<ur_bool_t>(
+        _device, UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT);
+  case device_support_aspect::host_unified_memory:
+    return get_device_property<ur_bool_t>(_device,
+                                          UR_DEVICE_INFO_HOST_UNIFIED_MEMORY);
+  case device_support_aspect::little_endian:
+    return get_device_property<ur_bool_t>(_device,
+                                          UR_DEVICE_INFO_ENDIAN_LITTLE);
+  case device_support_aspect::global_mem_cache:
+    return get_device_property<uint64_t>(
+               _device, UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE) > 0;
+  case device_support_aspect::usm_device_allocations:
+    return get_device_property<ur_device_usm_access_capability_flags_t>(
+               _device, UR_DEVICE_INFO_USM_DEVICE_SUPPORT) &
+           UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ACCESS;
+  case device_support_aspect::usm_host_allocations:
+    return get_device_property<ur_device_usm_access_capability_flags_t>(
+               _device, UR_DEVICE_INFO_USM_HOST_SUPPORT) &
+           UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ACCESS;
+  case device_support_aspect::usm_shared_allocations:
+    // or maybe UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT
+    return get_device_property<ur_device_usm_access_capability_flags_t>(
+               _device, UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT) &
+           UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ACCESS;
+
+  case device_support_aspect::usm_system_allocations:
+    return get_device_property<ur_device_usm_access_capability_flags_t>(
+               _device, UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT) &
+           UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ACCESS;
+
+  case device_support_aspect::global_mem_cache_read_only:
+  case device_support_aspect::global_mem_cache_read_write:
+  case device_support_aspect::emulated_local_memory:
+  case device_support_aspect::sub_group_independent_forward_progress:
+  case device_support_aspect::usm_atomic_host_allocations:
+  case device_support_aspect::usm_atomic_shared_allocations:
+  case device_support_aspect::execution_timestamps:
+  case device_support_aspect::sscp_kernels:
+  case device_support_aspect::work_item_independent_forward_progress:
+    return false; // TODO
+  }
+
+  assert(false && "unreachable");
+  return false;
+}
+std::size_t ur_hardware_context::get_property(device_uint_property prop) const {
+  throw std::runtime_error("ur_hardware_context: get_property not implemented");
+}
+
+std::vector<std::size_t>
+ur_hardware_context::get_property(device_uint_list_property prop) const {
+  throw std::runtime_error("ur_hardware_context: get_property not implemented");
+}
+
+std::string ur_hardware_context::get_driver_version() const {
+  return get_device_property<char *>(_device, UR_DEVICE_INFO_DRIVER_VERSION);
+}
+std::string ur_hardware_context::get_profile() const {
+  return get_device_property<char *>(_device, UR_DEVICE_INFO_PROFILE);
+}
+std::size_t ur_hardware_context::get_platform_index() const {
+  return _platform_idx;
+}
+
+ur_context_manager::ur_context_manager(const ur_context_handle_t ctx)
+    : _context(ctx) {}
+
+ur_context_manager::~ur_context_manager() {
+  const auto err = urContextRelease(_context);
+  if (err != UR_RESULT_SUCCESS) {
+    print_warning(
+        __acpp_here(),
+        ur_error_info("ur_context_manager: Could not release context", err));
+  }
+}

--- a/src/runtime/ur/ur_queue.cpp
+++ b/src/runtime/ur/ur_queue.cpp
@@ -1,0 +1,576 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#include "hipSYCL/runtime/ur/ur_queue.hpp"
+
+#include "hipSYCL/common/hcf_container.hpp"
+#include "hipSYCL/common/spin_lock.hpp"
+#include "hipSYCL/runtime/adaptivity_engine.hpp"
+#include "hipSYCL/runtime/code_object_invoker.hpp"
+#include "hipSYCL/runtime/device_id.hpp"
+#include "hipSYCL/runtime/error.hpp"
+#include "hipSYCL/runtime/event.hpp"
+#include "hipSYCL/runtime/hints.hpp"
+#include "hipSYCL/runtime/inorder_queue.hpp"
+#include "hipSYCL/runtime/kernel_configuration.hpp"
+#include "hipSYCL/runtime/queue_completion_event.hpp"
+#include "hipSYCL/runtime/ur/ur_event.hpp"
+#include "hipSYCL/runtime/ur/ur_hardware_manager.hpp"
+#include "hipSYCL/runtime/util.hpp"
+
+#include "ur_utils.hpp"
+
+#include <cassert>
+#include <future>
+#include <utility>
+#include <vector>
+
+#ifdef HIPSYCL_WITH_SSCP_COMPILER
+
+#include "hipSYCL/compiler/llvm-to-backend/spirv/LLVMToSpirvFactory.hpp"
+#include "hipSYCL/glue/llvm-sscp/jit.hpp"
+
+#endif
+
+using namespace hipsycl::rt;
+
+namespace {
+
+result submit_ur_kernel(const ur_kernel_handle_t &kernel,
+                        const ur_queue_handle_t &queue,
+                        const range<3> &group_size, const range<3> &num_groups,
+                        void **kernel_args, const std::size_t *arg_sizes,
+                        const std::size_t num_args, const hcf_kernel_info *info,
+                        ur_event_handle_t *evt_out = nullptr) {
+
+  for (std::size_t i = 0; i < num_args; ++i) {
+    HIPSYCL_DEBUG_INFO << "ur_queue: Setting kernel argument " << i
+                       << " of size " << arg_sizes[i] << " at "
+                       << kernel_args[i] << std::endl;
+
+    const auto err =
+        urKernelSetArgValue(kernel, i, arg_sizes[i], nullptr, kernel_args[i]);
+
+    if (err != UR_RESULT_SUCCESS) {
+      return make_error(__acpp_here(),
+                        error_info{"ocl_queue: Could not set kernel argument",
+                                   error_code{"CL", static_cast<int>(err)}});
+    }
+  }
+
+  HIPSYCL_DEBUG_INFO << "ocl_queue: Submitting kernel!" << std::endl;
+  range<3> global_size = num_groups * group_size;
+
+  auto cl_global_size =
+      std::vector{global_size[0], global_size[1], global_size[2]};
+  auto cl_local_size = std::vector{group_size[0], group_size[1], group_size[2]};
+  auto offset = std::vector<size_t>{0, 0, 0};
+
+  if (global_size[2] == 1) {
+    cl_global_size = {global_size[0], global_size[1]};
+    cl_local_size = {group_size[0], group_size[1]};
+    offset = {0, 0};
+    if (global_size[1] == 1) {
+      cl_global_size = {global_size[0]};
+      cl_local_size = {group_size[0]};
+      offset = {0};
+    }
+  }
+
+  assert(cl_global_size.size() == cl_local_size.size() &&
+         cl_global_size.size() == offset.size() && "Invalid size");
+
+  const auto err = urEnqueueKernelLaunch(
+      queue, kernel, cl_global_size.size(), offset.data(),
+      cl_global_size.data(), cl_local_size.data(), 0, nullptr, evt_out);
+
+  if (err != UR_RESULT_SUCCESS) {
+    return make_error(
+        __acpp_here(),
+        ur_error_info("ur_queue: urEnqueueKernelLaunch() failed", err));
+  }
+
+  return make_success();
+}
+
+} // namespace
+
+ur_queue::ur_queue(ur_hardware_manager *hw_manager, const int device_index)
+    : _device_index(device_index), _hw_manager(hw_manager),
+      _sscp_code_object_invoker{*this} {
+  assert(hw_manager != nullptr);
+
+  const ur_hardware_context *hw_context =
+      cast<ur_hardware_context>(hw_manager->get_device(device_index));
+  assert(hw_context != nullptr);
+
+  constexpr ur_queue_properties_t queue_properties = {};
+  const ur_result_t res =
+      urQueueCreate(hw_context->get_ur_context(), hw_context->get_ur_device(),
+                    &queue_properties, &_queue);
+  if (res != UR_RESULT_SUCCESS) {
+    register_error(make_error(__acpp_here(),
+                              ur_error_info("urQueueCreate() failed", res)));
+    return;
+  }
+}
+
+ur_queue::~ur_queue() {
+  const auto err = urQueueRelease(_queue);
+  if (err != UR_RESULT_SUCCESS) {
+    register_error(make_error(__acpp_here(),
+                              ur_error_info("urQueueRelease() failed", err)));
+  }
+}
+std::shared_ptr<dag_node_event> ur_queue::insert_event() {
+  if (!_state.get_most_recent_event()) {
+    // Normally, this code path should only be triggered
+    // when no work has been submitted to the queue, and so
+    // nothing needs to be synchronized with. Thus
+    // the returned event should never actually be needed
+    // by other nodes in the DAG.
+    // However, if some work fails to execute, we can end up
+    // with the situation that the "no work submitted yet" situation
+    // appears at later stages in the program, when events
+    // are expected to work correctly.
+    // It is thus safer to enqueue a barrier here.
+    ur_event_handle_t wait_evt = nullptr;
+
+    const auto err =
+        urEnqueueEventsWaitWithBarrier(_queue, 0, nullptr, &wait_evt);
+    if (err != UR_RESULT_SUCCESS) {
+      register_error(
+          __acpp_here(),
+          ur_error_info("ur_queue: urEnqueueEventsWaitWithBarrier() failed",
+                        err));
+    }
+
+    register_submitted_op(wait_evt);
+  }
+
+  return _state.get_most_recent_event();
+}
+
+std::shared_ptr<dag_node_event> ur_queue::create_queue_completion_event() {
+  return std::make_shared<
+      queue_completion_event<ur_event_handle_t, ur_node_event>>(this);
+}
+result ur_queue::submit_kernel(kernel_operation &op, const dag_node_ptr &node) {
+
+  backend_kernel_launch_capabilities cap;
+  cap.provide_sscp_invoker(&_sscp_code_object_invoker);
+
+  // TODO: Instrumentation
+  return op.get_launcher().invoke(backend_id::ocl, this, cap, node.get());
+};
+
+void ur_queue::register_submitted_op(ur_event_handle_t evt) {
+  this->_state.set_most_recent_event(std::make_shared<ur_node_event>(evt));
+}
+
+result ur_queue::submit_memcpy(memcpy_operation &op,
+                               const dag_node_ptr &node_ptr) {
+
+  assert(op.source().get_access_ptr() != nullptr);
+  assert(op.dest().get_access_ptr() != nullptr);
+
+  const auto transfer_range = op.get_num_transferred_elements();
+
+  int dimension = 0;
+  if (transfer_range[0] > 1)
+    dimension = 3;
+  else if (transfer_range[1] > 1)
+    dimension = 2;
+  else
+    dimension = 1;
+
+  const auto src_shape = op.source().get_allocation_shape();
+  const auto dst_shape = op.dest().get_allocation_shape();
+
+  const auto src_el_size = op.source().get_element_size();
+  const auto dst_el_size = op.dest().get_element_size();
+
+  const auto copy_size = op.get_num_transferred_bytes();
+
+  // If we transfer the entire buffer, treat it as 1D memcpy for performance.
+  // TODO: The same optimization could also be applied for the general case
+  // when regions are contiguous
+  if (transfer_range == src_shape && transfer_range == dst_shape &&
+      op.source().get_access_offset() == id<3>{} &&
+      op.dest().get_access_offset() == id<3>{})
+    dimension = 1;
+
+  assert(dimension >= 1 && dimension <= 3 && "Invalid dimension");
+
+  constexpr bool is_blocking = true;
+  constexpr auto num_events_in_waitlist = 0;
+  constexpr auto events_in_waitlist = nullptr;
+
+  ur_event_handle_t event = nullptr;
+  if (dimension == 1) {
+
+    const auto src_raw_ptr = op.source().get_access_ptr();
+    const auto dst_raw_ptr = op.dest().get_access_ptr();
+
+    const ur_result_t res = urEnqueueUSMMemcpy(
+        _queue, is_blocking, dst_raw_ptr, src_raw_ptr, copy_size,
+        num_events_in_waitlist, events_in_waitlist, &event);
+
+    if (res != UR_RESULT_SUCCESS) {
+      return make_error(
+          __acpp_here(),
+          ur_error_info("ur_queue: urEnqueueUSMMemcpy() failed", res));
+    }
+
+  } else if (dimension == 2) {
+    const auto src_raw_ptr = op.source().get_access_ptr();
+    const auto dst_raw_ptr = op.dest().get_access_ptr();
+
+    const auto dest_row_pitch =
+        extract_from_range3<2>(dst_shape)[1] * dst_el_size;
+    const auto source_row_pitch =
+        extract_from_range3<2>(src_shape)[1] * src_el_size;
+    const auto num_bytes_to_copy =
+        extract_from_range3<2>(transfer_range)[1] * src_el_size;
+    const auto num_rows_to_copy = extract_from_range3<2>(transfer_range)[0];
+
+    const ur_result_t res = urEnqueueUSMMemcpy2D(
+        _queue, is_blocking, dst_raw_ptr, dest_row_pitch, src_raw_ptr,
+        source_row_pitch, num_bytes_to_copy, num_rows_to_copy,
+        num_events_in_waitlist, events_in_waitlist, &event);
+    if (res != UR_RESULT_SUCCESS) {
+      return make_error(
+          __acpp_here(),
+          ur_error_info("ur_queue: urEnqueueUSMMemcpy2D() failed", res));
+    }
+
+  } else {
+    // custom 3D memcpy
+
+    const auto dest_offset = op.dest().get_access_offset();
+    const auto src_offset = op.source().get_access_offset();
+
+    void *base_src = op.source().get_base_ptr();
+    void *base_dest = op.dest().get_base_ptr();
+
+    const auto row_size = transfer_range[2] * src_el_size;
+
+    auto current_src_offset = src_offset;
+    auto current_dest_offset = dest_offset;
+
+    auto linear_index = [](id<3> id, range<3> allocation_shape) {
+      return id[2] + allocation_shape[2] * id[1] +
+             allocation_shape[2] * allocation_shape[1] * id[0];
+    };
+
+    for (std::size_t surface = 0; surface < transfer_range[0]; ++surface) {
+      for (std::size_t row = 0; row < transfer_range[1]; ++row) {
+
+        auto current_src = static_cast<char *>(base_src);
+        auto current_dst = static_cast<char *>(base_dest);
+
+        current_src +=
+            linear_index(current_src_offset, src_shape) * src_el_size;
+
+        current_dst +=
+            linear_index(current_dest_offset, dst_shape) * dst_el_size;
+
+        assert(current_src + row_size <=
+               static_cast<char *>(base_src) + src_shape.size() * src_el_size);
+        assert(current_dst + row_size <=
+               static_cast<char *>(base_dest) + dst_shape.size() * dst_el_size);
+
+        const ur_result_t err = urEnqueueUSMMemcpy(
+            _queue, is_blocking, current_dst, current_src, row_size,
+            num_events_in_waitlist, events_in_waitlist, &event);
+
+        if (err != UR_RESULT_SUCCESS) {
+          return make_error(
+              __acpp_here(),
+              ur_error_info("ur_queue: urEnqueueUSMMemcpy() failed", err));
+        }
+
+        ++current_src_offset[1];
+        ++current_dest_offset[1];
+      }
+      current_src_offset[1] = src_offset[1];
+      current_dest_offset[1] = dest_offset[1];
+
+      ++current_dest_offset[0];
+      ++current_src_offset[0];
+    }
+  }
+
+  register_submitted_op(event);
+  return make_success();
+}
+result ur_queue::submit_prefetch(prefetch_operation &op,
+                                 const dag_node_ptr &node_ptr) {
+
+  constexpr auto flags = ur_usm_migration_flags_t{};
+  constexpr auto num_events_in_wait_list = 0;
+  constexpr auto events_in_wait_list = nullptr;
+
+  ur_event_handle_t evt;
+  const ur_result_t err =
+      urEnqueueUSMPrefetch(_queue, op.get_pointer(), op.get_num_bytes(), flags,
+                           num_events_in_wait_list, events_in_wait_list, &evt);
+
+  if (err != UR_RESULT_SUCCESS) {
+    return make_error(
+        __acpp_here(),
+        ur_error_info("ur_queue: urEnqueueUSMPrefetch() failed", err));
+  }
+
+  register_submitted_op(evt);
+  return make_success();
+}
+result ur_queue::submit_memset(memset_operation &op, const dag_node_ptr &) {
+  constexpr auto num_events_in_wait_list = 0;
+  constexpr auto events_in_wait_list = nullptr;
+
+  const auto ptr = op.get_pointer();
+  const auto pattern = op.get_pattern();
+  const auto size = op.get_num_bytes();
+
+  ur_event_handle_t evt;
+  const ur_result_t err =
+      urEnqueueUSMFill(_queue, ptr, sizeof(pattern), &pattern, size,
+                       num_events_in_wait_list, events_in_wait_list, &evt);
+  if (err != UR_RESULT_SUCCESS) {
+    return make_error(
+        __acpp_here(),
+        ur_error_info("ur_queue: urEnqueueUSMFill() failed", err));
+  }
+
+  register_submitted_op(evt);
+  return make_success();
+}
+
+result ur_queue::submit_queue_wait_for(const dag_node_ptr &evt) {
+
+  const auto ur_event = static_cast<ur_node_event *>(evt->get_event().get());
+  const auto events = std::vector{ur_event->get_event_handle()};
+
+  ur_event_handle_t wait_evt;
+  const ur_result_t err = urEnqueueEventsWaitWithBarrier(
+      _queue, events.size(), events.data(), &wait_evt);
+  if (err != UR_RESULT_SUCCESS) {
+    return make_error(
+        __acpp_here(),
+        error_info{"ocl_queue: enqueueBarrierWithWaitList() failed",
+                   error_code{"CL", err}});
+  }
+
+  register_submitted_op(wait_evt);
+  return make_success();
+}
+
+result ur_queue::submit_external_wait_for(const dag_node_ptr &node) {
+  throw std::runtime_error(
+      "ur_queue::submit_external_wait_for() not implemented");
+}
+result ur_queue::wait() {
+  const ur_result_t err = urQueueFinish(_queue);
+  if (err != UR_RESULT_SUCCESS) {
+    return make_error(__acpp_here(),
+                      error_info{"ur_queue: Couldn't finish queue",
+                                 error_code{"CL", static_cast<int>(err)}});
+  }
+  return make_success();
+}
+device_id ur_queue::get_device() const {
+  return _hw_manager->get_device_id(_device_index);
+}
+void *ur_queue::get_native_type() const { return _queue; }
+
+ur_queue_handle_t ur_queue::get_ur_queue() const { return _queue; }
+ur_hardware_manager *ur_queue::get_hardware_manager() const {
+  return _hw_manager;
+}
+
+result ur_queue::query_status(inorder_queue_status &status) {
+  const auto evt = _state.get_most_recent_event();
+  if (evt != nullptr) {
+    status = inorder_queue_status{evt->is_complete()};
+  } else {
+    status = inorder_queue_status{true};
+  }
+  return make_success();
+}
+
+result ur_queue::submit_sscp_kernel_from_code_object(
+    const kernel_operation &op, hcf_object_id hcf_object,
+    std::string_view kernel_name, const hcf_kernel_info *kernel_info,
+    const range<3> &num_groups, const range<3> &group_size,
+    unsigned local_mem_size, void **args, std::size_t *arg_sizes,
+    std::size_t num_args, const kernel_configuration &initial_config) {
+
+#ifndef HIPSYCL_WITH_SSCP_COMPILER
+  return make_error(
+      __acpp_here(),
+      error_info{"ur_queue: SSCP kernel launch was requested, but hipSYCL was "
+                 "not built with OpenCL SSCP support."});
+#else
+
+  if (kernel_info == nullptr) {
+    return make_error(
+        __acpp_here(),
+        error_info{"Could not obtain hcf kernel info for kernel " +
+                   std::string(kernel_name)});
+  }
+
+  common::spin_lock_guard lock{_sscp_submission_spin_lock};
+
+  _arg_mapper.construct_mapping(*kernel_info, args, arg_sizes, num_args);
+
+  if (!_arg_mapper.mapping_available()) {
+    return make_error(
+        __acpp_here(),
+        error_info{"Could not map C++ arguments to kernel arguments"});
+  }
+
+  kernel_adaptivity_engine adaptivity_engine{
+      hcf_object, kernel_name, kernel_info, _arg_mapper, num_groups,
+      group_size, args,        arg_sizes,   num_args,    local_mem_size};
+
+  const auto *hw_ctx = dynamic_cast<ur_hardware_context *>(
+      _hw_manager->get_device(_device_index));
+
+  const ur_context_handle_t ctx = hw_ctx->get_ur_context();
+  const ur_device_handle_t dev = hw_ctx->get_ur_device();
+
+  _config = initial_config;
+
+  _config.append_base_configuration(kernel_base_config_parameter::backend_id,
+                                    backend_id::ocl);
+  _config.append_base_configuration(
+      kernel_base_config_parameter::compilation_flow, compilation_flow::sscp);
+  _config.append_base_configuration(kernel_base_config_parameter::hcf_object_id,
+                                    hcf_object);
+
+  for (const auto &flag : kernel_info->get_compilation_flags())
+    _config.set_build_flag(flag);
+
+  for (const auto &[opt, val] : kernel_info->get_compilation_options())
+    _config.set_build_option(opt, val);
+
+  _config.set_build_option(
+      kernel_build_option::spirv_dynamic_local_mem_allocation_size,
+      local_mem_size);
+
+  // if (hw_ctx->has_intel_extension_profile()) {
+  //   _config.set_build_flag(kernel_build_flag::spirv_enable_intel_llvm_spirv_options);
+  // }
+
+  // TODO: Enable this if we are on Intel
+  // config.set_build_flag(kernel_build_flag::spirv_enable_intel_llvm_spirv_options);
+
+  const auto binary_configuration_id =
+      adaptivity_engine.finalize_binary_configuration(_config);
+  const auto code_object_configuration_id = binary_configuration_id;
+
+  // kernel_configuration::extend_hash(code_object_configuration_id,
+  //                                   kernel_base_config_parameter::runtime_device,
+  //                                   hw_ctx.);
+  //
+  // kernel_configuration::extend_hash(code_object_configuration_id,
+  //                                   kernel_base_config_parameter::runtime_context,
+  //                                   ctx.get());
+
+  auto jit_compiler = [&](std::string &compiled_image) -> bool {
+    std::vector<std::string> kernel_names;
+    const std::string selected_image_name =
+        adaptivity_engine.select_image_and_kernels(&kernel_names);
+
+    // Construct SPIR-V translator to compile the specified kernels
+    const std::unique_ptr<compiler::LLVMToBackendTranslator> translator =
+        std::move(compiler::createLLVMToSpirvTranslator(kernel_names));
+
+    // Lower kernels to SPIR-V
+    result err;
+    if (kernel_names.size() == 1) {
+      err = glue::jit::dead_argument_elimination::compile_kernel(
+          translator.get(), hcf_object, selected_image_name, _config,
+          binary_configuration_id, _reflection_map, compiled_image);
+    } else {
+      err =
+          glue::jit::compile(translator.get(), hcf_object, selected_image_name,
+                             _config, _reflection_map, compiled_image);
+    }
+
+    if (!err.is_success()) {
+      register_error(err);
+      return false;
+    }
+
+    return true;
+  };
+
+  auto code_object_constructor =
+      [&](const std::string &compiled_image) -> code_object * {
+    auto *exec_obj =
+        new ur_executable_object{ctx, dev, hcf_object, compiled_image, _config};
+
+    const result res = exec_obj->get_build_result();
+    if (!res.is_success()) {
+      register_error(res);
+      delete exec_obj;
+      return nullptr;
+    }
+
+    if (exec_obj->supported_backend_kernel_names().size() == 1)
+      exec_obj->get_jit_output_metadata().kernel_retained_arguments_indices =
+          glue::jit::dead_argument_elimination::
+              retrieve_retained_arguments_mask(binary_configuration_id);
+
+    return exec_obj;
+  };
+
+  const code_object *obj = _kernel_cache->get_or_construct_jit_code_object(
+      code_object_configuration_id, binary_configuration_id, jit_compiler,
+      code_object_constructor);
+
+  if (obj == nullptr) {
+    return make_error(__acpp_here(),
+                      error_info{"Code object construction failed"});
+  }
+
+  if (obj->get_jit_output_metadata()
+          .kernel_retained_arguments_indices.has_value()) {
+    _arg_mapper.apply_dead_argument_elimination_mask(
+        obj->get_jit_output_metadata()
+            .kernel_retained_arguments_indices.value());
+  }
+
+  ur_kernel_handle_t kernel;
+  result res = dynamic_cast<const ur_executable_object *>(obj)->get_kernel(
+      kernel_name, kernel);
+
+  if (!res.is_success())
+    return res;
+
+  HIPSYCL_DEBUG_INFO << "ur_queue: Submitting SSCP kernel " << kernel_name
+                     << std::endl;
+
+  ur_event_handle_t completion_evt;
+
+  auto submission_err = submit_ur_kernel(
+      kernel, _queue, group_size, num_groups, _arg_mapper.get_mapped_args(),
+      _arg_mapper.get_mapped_arg_sizes(), _arg_mapper.get_mapped_num_args(),
+      kernel_info, &completion_evt);
+
+  if (!submission_err.is_success())
+    return submission_err;
+
+  register_submitted_op(completion_evt);
+  return make_success();
+#endif
+}

--- a/src/runtime/ur/ur_utils.hpp
+++ b/src/runtime/ur/ur_utils.hpp
@@ -1,0 +1,197 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#ifndef UR_UTILS_HPP
+#define UR_UTILS_HPP
+
+#include "hipSYCL/runtime/error.hpp"
+
+#include <string>
+#include <ur_api.h>
+
+namespace hipsycl::rt {
+inline std::string ur_strerror(const ur_result_t res) {
+  switch (res) {
+  case UR_RESULT_SUCCESS:
+    return "Success";
+  case UR_RESULT_ERROR_INVALID_OPERATION:
+    return "Invalid operation";
+  case UR_RESULT_ERROR_INVALID_QUEUE_PROPERTIES:
+    return "Invalid queue properties";
+  case UR_RESULT_ERROR_INVALID_QUEUE:
+    return "Invalid queue";
+  case UR_RESULT_ERROR_INVALID_VALUE:
+    return "Invalid value";
+  case UR_RESULT_ERROR_INVALID_CONTEXT:
+    return "Invalid context";
+  case UR_RESULT_ERROR_INVALID_PLATFORM:
+    return "Invalid platform";
+  case UR_RESULT_ERROR_INVALID_BINARY:
+    return "Invalid binary";
+  case UR_RESULT_ERROR_INVALID_PROGRAM:
+    return "Invalid program";
+  case UR_RESULT_ERROR_INVALID_SAMPLER:
+    return "Invalid sampler";
+  case UR_RESULT_ERROR_INVALID_BUFFER_SIZE:
+    return "Invalid buffer size";
+  case UR_RESULT_ERROR_INVALID_MEM_OBJECT:
+    return "Invalid memory object";
+  case UR_RESULT_ERROR_INVALID_EVENT:
+    return "Invalid event";
+  case UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST:
+    return "Invalid event wait list";
+  case UR_RESULT_ERROR_MISALIGNED_SUB_BUFFER_OFFSET:
+    return "Misaligned sub-buffer offset";
+  case UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE:
+    return "Invalid work group size";
+  case UR_RESULT_ERROR_COMPILER_NOT_AVAILABLE:
+    return "Compiler not available";
+  case UR_RESULT_ERROR_PROFILING_INFO_NOT_AVAILABLE:
+    return "Profiling info not available";
+  case UR_RESULT_ERROR_DEVICE_NOT_FOUND:
+    return "Device not found";
+  case UR_RESULT_ERROR_INVALID_DEVICE:
+    return "Invalid device";
+  case UR_RESULT_ERROR_DEVICE_LOST:
+    return "Device lost";
+  case UR_RESULT_ERROR_DEVICE_REQUIRES_RESET:
+    return "Device requires reset";
+  case UR_RESULT_ERROR_DEVICE_IN_LOW_POWER_STATE:
+    return "Device in low power state";
+  case UR_RESULT_ERROR_DEVICE_PARTITION_FAILED:
+    return "Device partition failed";
+  case UR_RESULT_ERROR_INVALID_DEVICE_PARTITION_COUNT:
+    return "Invalid device partition count";
+  case UR_RESULT_ERROR_INVALID_WORK_ITEM_SIZE:
+    return "Invalid work item size";
+  case UR_RESULT_ERROR_INVALID_WORK_DIMENSION:
+    return "Invalid work dimension";
+  case UR_RESULT_ERROR_INVALID_KERNEL_ARGS:
+    return "Invalid kernel arguments";
+  case UR_RESULT_ERROR_INVALID_KERNEL:
+    return "Invalid kernel";
+  case UR_RESULT_ERROR_INVALID_KERNEL_NAME:
+    return "Invalid kernel name";
+  case UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX:
+    return "Invalid kernel argument index";
+  case UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE:
+    return "Invalid kernel argument size";
+  case UR_RESULT_ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE:
+    return "Invalid kernel attribute value";
+  case UR_RESULT_ERROR_INVALID_IMAGE_SIZE:
+    return "Invalid image size";
+  case UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR:
+    return "Invalid image format descriptor";
+  case UR_RESULT_ERROR_MEM_OBJECT_ALLOCATION_FAILURE:
+    return "Memory object allocation failure";
+  case UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE:
+    return "Invalid program executable";
+  case UR_RESULT_ERROR_UNINITIALIZED:
+    return "Uninitialized error";
+  case UR_RESULT_ERROR_OUT_OF_HOST_MEMORY:
+    return "Out of host memory";
+  case UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY:
+    return "Out of device memory";
+  case UR_RESULT_ERROR_OUT_OF_RESOURCES:
+    return "Out of resources";
+  case UR_RESULT_ERROR_PROGRAM_BUILD_FAILURE:
+    return "Program build failure";
+  case UR_RESULT_ERROR_PROGRAM_LINK_FAILURE:
+    return "Program link failure";
+  case UR_RESULT_ERROR_UNSUPPORTED_VERSION:
+    return "Unsupported version";
+  case UR_RESULT_ERROR_UNSUPPORTED_FEATURE:
+    return "Unsupported feature";
+  case UR_RESULT_ERROR_INVALID_ARGUMENT:
+    return "Invalid argument";
+  case UR_RESULT_ERROR_INVALID_NULL_HANDLE:
+    return "Invalid null handle";
+  case UR_RESULT_ERROR_HANDLE_OBJECT_IN_USE:
+    return "Handle object in use";
+  case UR_RESULT_ERROR_INVALID_NULL_POINTER:
+    return "Invalid null pointer";
+  case UR_RESULT_ERROR_INVALID_SIZE:
+    return "Invalid size";
+  case UR_RESULT_ERROR_UNSUPPORTED_SIZE:
+    return "Unsupported size";
+  case UR_RESULT_ERROR_UNSUPPORTED_ALIGNMENT:
+    return "Unsupported alignment";
+  case UR_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT:
+    return "Invalid synchronization object";
+  case UR_RESULT_ERROR_INVALID_ENUMERATION:
+    return "Invalid enumeration";
+  case UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION:
+    return "Unsupported enumeration";
+  case UR_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT:
+    return "Unsupported image format";
+  case UR_RESULT_ERROR_INVALID_NATIVE_BINARY:
+    return "Invalid native binary";
+  case UR_RESULT_ERROR_INVALID_GLOBAL_NAME:
+    return "Invalid global name";
+  case UR_RESULT_ERROR_FUNCTION_ADDRESS_NOT_AVAILABLE:
+    return "Function address not available";
+  case UR_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION:
+    return "Invalid group size dimension";
+  case UR_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION:
+    return "Invalid global width dimension";
+  case UR_RESULT_ERROR_PROGRAM_UNLINKED:
+    return "Program unlinked";
+  case UR_RESULT_ERROR_OVERLAPPING_REGIONS:
+    return "Overlapping regions";
+  case UR_RESULT_ERROR_INVALID_HOST_PTR:
+    return "Invalid host pointer";
+  case UR_RESULT_ERROR_INVALID_USM_SIZE:
+    return "Invalid USM size";
+  case UR_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE:
+    return "Object allocation failure";
+  case UR_RESULT_ERROR_ADAPTER_SPECIFIC:
+    return "Adapter-specific error";
+  case UR_RESULT_ERROR_LAYER_NOT_PRESENT:
+    return "Layer not present";
+  case UR_RESULT_ERROR_IN_EVENT_LIST_EXEC_STATUS:
+    return "In-event list execution status error";
+  case UR_RESULT_ERROR_DEVICE_NOT_AVAILABLE:
+    return "Device not available";
+  case UR_RESULT_ERROR_INVALID_SPEC_ID:
+    return "Invalid specialization ID";
+  case UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP:
+    return "Invalid command buffer (experimental)";
+  case UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP:
+    return "Invalid command buffer sync point (experimental)";
+  case UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP:
+    return "Invalid command buffer sync point wait list (experimental)";
+  case UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_COMMAND_HANDLE_EXP:
+    return "Invalid command buffer command handle (experimental)";
+  case UR_RESULT_ERROR_UNKNOWN:
+    return "Unknown error";
+  case UR_RESULT_FORCE_UINT32:
+    return "Force uint32 error";
+  }
+
+  return "Unknown error code";
+}
+
+inline error_info ur_error_info(const std::string &desc, const ur_result_t res) {
+  return error_info{desc + ": " + ur_strerror(res), error_code{"ur", static_cast<int>(res)}};
+}
+
+inline error_info ur_error_info(const std::string &desc, const ur_result_t res,
+                                const error_type etype) {
+  return error_info{desc + ": " + ur_strerror(res), error_code{"ur", static_cast<int>(res)}, etype};
+}
+
+inline result make_ur_error(const source_location &origin, const std::string &desc) {
+  const error_info info{desc};
+  return make_error(origin, info);
+}
+
+} // namespace hipsycl::rt
+
+#endif


### PR DESCRIPTION
This is an attempt to add an Unified Runtime backend to AdaptiveCpp.

The code in this PR has been written taking inspiration from the OpenCL backend.

The new backend can be activated with the CMake `-DWITH_UNIFIED_RUNTIME_BACKEND=ON` option.

- [x] Listing devices via `acpp-info`
- [ ] Submitting kernels
- [ ] JIT via SPIR-V (to be tested, should work OOTB)