### PR TITLE
[SSCP][llvm-to-host] Internalize global variables

### DIFF
--- a/src/compiler/llvm-to-backend/host/LLVMToHost.cpp
+++ b/src/compiler/llvm-to-backend/host/LLVMToHost.cpp
@@ -12,6 +12,7 @@
 
 #include "hipSYCL/common/debug.hpp"
 #include "hipSYCL/common/filesystem.hpp"
+#include "hipSYCL/compiler/utils/LLVMUtils.hpp"
 #include "hipSYCL/compiler/cbs/IRUtils.hpp"
 #include "hipSYCL/compiler/cbs/KernelFlattening.hpp"
 #include "hipSYCL/compiler/cbs/PipelineBuilder.hpp"
@@ -89,6 +90,13 @@ bool LLVMToHostTranslator::toBackendFlavor(llvm::Module &M, PassHandler &PH) {
 
   if (!this->linkBitcodeFile(M, BuiltinBitcodeFile))
     return false;
+
+  // Internalize all global variables - this is fine because llvm-to-backend
+  // lowering always happens *after* linking in all dependencies
+  for(auto& GV : M.globals()) {
+    if(!llvmutils::starts_with(GV.getName(), "__acpp_cbs"))
+      GV.setLinkage(llvm::GlobalValue::LinkageTypes::InternalLinkage);
+  }
 
   llvm::ModulePassManager MPM;
   PH.ModuleAnalysisManager->clear(); // for some reason we need to reset the analyses... otherwise


### PR DESCRIPTION
Not internalizing GVs that are generated e.g. for indexing into constant arrays can cause relocation errors at JIT time. Internalizing is in principle safe because all symbol resolution should be complete before doing the backend flavoring.

`__acpp_cbs_*` variables *must not* be internalized as this will again cause failures. It's not yet clear to me whether this is the only case where we must not internalize.
Otherwise, we could also try to internalize `constant` GVs, but I'm not sure that restriction is needed. 