### PR TITLE
Handle Expected<T> from TempFile::create() to prevent potential crashes

### DIFF
--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -92,7 +92,7 @@ bool getCommandOutput(const std::string &Program, const llvm::SmallVector<std::s
     return false;
   }
 
-  AtScopeExit DestroyOutputFile([&]() { auto Err = OutputFile->discard(); });
+  AtScopeExit DestroyOutputFile([&]() { consumeError(std::move(OutputFile->discard())); });
 
   llvm::SmallVector<llvm::StringRef> InvocationRef;
   for(const auto& S: Invocation)
@@ -423,24 +423,23 @@ bool LLVMToAmdgpuTranslator::clangJitLink(llvm::Module& FlavoredModule, std::str
   auto OutputFile = llvm::sys::fs::TempFile::create("acpp-sscp-amdgpu-%%%%%%.hipfb");
   auto DummyFile = llvm::sys::fs::TempFile::create("acpp-sscp-amdgpu-dummy-%%%%%%.cpp");
 
-  std::string OutputFilename = OutputFile->TmpName;
-
   auto checkFileError = [&](auto& F) {
     auto E = F.takeError();
     if(E){
-      this->registerError("LLVMToAmdgpu: Could not create temp file: "+InputFile->TmpName);
+      this->registerError("LLVMToAmdgpu: Could not create temp file: " + F->TmpName);
       return false;
     }
     return true;
   };
 
   if(!checkFileError(InputFile)) return false;
+  if(!checkFileError(OutputFile)) return false;
   if(!checkFileError(DummyFile)) return false;
 
-  AtScopeExit DestroyInputFile([&]() { auto Err = InputFile->discard(); });
-  AtScopeExit DestroyOutputFile([&]() { auto Err = OutputFile->discard(); });
-  AtScopeExit DestroyDummyFile([&]() { auto Err = DummyFile->discard(); });
-  
+  AtScopeExit DestroyInputFile([&]() { consumeError(std::move(InputFile->discard())); });
+  AtScopeExit DestroyOutputFile([&]() { consumeError(std::move(OutputFile->discard())); });
+  AtScopeExit DestroyDummyFile([&]() { consumeError(std::move(DummyFile->discard())); });
+
   llvm::raw_fd_ostream InputStream{InputFile->FD, false};
   llvm::raw_fd_ostream DummyStream{DummyFile->FD, false};
 
@@ -457,7 +456,7 @@ bool LLVMToAmdgpuTranslator::clangJitLink(llvm::Module& FlavoredModule, std::str
   llvm::SmallVector<std::string> Invocation = {
       ClangPath, "-x", "hip", "-O3", "-nogpuinc", OffloadArchFlag, "--cuda-device-only",
         "-Xclang", "-mlink-bitcode-file", "-Xclang", InputFile->TmpName,
-        "-o",  OutputFilename, DummyFile->TmpName
+        "-o",  OutputFile->TmpName, DummyFile->TmpName
   };
 
   llvm::SmallVector<llvm::StringRef> InvocationRef;

--- a/src/compiler/llvm-to-backend/host/LLVMToHost.cpp
+++ b/src/compiler/llvm-to-backend/host/LLVMToHost.cpp
@@ -135,16 +135,8 @@ bool LLVMToHostTranslator::translateToBackendFormat(llvm::Module &FlavoredModule
     return false;
   }
 
-  std::string OutputFilename = OutputFile->TmpName;
-
-  AtScopeExit DestroyInputFile([&]() {
-    if (InputFile->discard())
-      ;
-  });
-  AtScopeExit DestroyOutputFile([&]() {
-    if (OutputFile->discard())
-      ;
-  });
+  AtScopeExit DestroyInputFile([&]() { consumeError(std::move(InputFile->discard())); });
+  AtScopeExit DestroyOutputFile([&]() { consumeError(std::move(OutputFile->discard())); });
 
   std::error_code EC;
   llvm::raw_fd_ostream InputStream{InputFile->FD, false};
@@ -164,7 +156,7 @@ bool LLVMToHostTranslator::translateToBackendFormat(llvm::Module &FlavoredModule
                                                     "-Wno-pass-failed",
                                                     "-fPIC",
                                                     "-o",
-                                                    OutputFilename,
+                                                    OutputFile->TmpName,
                                                     InputFile->TmpName};
 
   std::string ArgString;


### PR DESCRIPTION
Add proper error handling for `TempFile::create()` by checking `takeError()` and `discard()`

I get a crash with the following error without this change:

```
Expected<T> must be checked before access or destruction.
Expected<T> value was in success state. (Note: Expected<T> values in
success mode must still be checked prior to being destroyed).
```