### PR TITLE
Fix undefined reference in case HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO is defined

### DIFF
--- a/include/hipSYCL/sycl/libkernel/group.hpp
+++ b/include/hipSYCL/sycl/libkernel/group.hpp
@@ -264,9 +264,9 @@ public:
   }
 
   friend bool operator==(const group<Dimensions>& lhs, const group<Dimensions>& rhs){
-    return lhs._group_id == rhs._group_id &&
-           lhs._local_range == rhs._local_range &&
-           lhs._num_groups == rhs._num_groups;
+    return lhs.get_group_id() == rhs.get_group_id() &&
+           lhs.get_local_range() == rhs.get_local_range() &&
+           lhs.get_group_range() == rhs.get_group_range();
   }
 
   friend bool operator!=(const group<Dimensions>& lhs, const group<Dimensions>& rhs){


### PR DESCRIPTION
In case `HIPSYCL_ONDEMAND_ITERATION_SPACE_INFO` is defined the private members of the group class are not defined. Let's call the public interface to carry out the comparison. 

I encountered this issue during the SMCP build of GROMACS