### PR TITLE
Add `local_accessor` replacing local `accessor`s

### DIFF
--- a/include/hipSYCL/sycl/libkernel/multi_ptr.hpp
+++ b/include/hipSYCL/sycl/libkernel/multi_ptr.hpp
@@ -144,9 +144,8 @@ template <typename dataT, int dimensions, access::mode accessmode, access::targe
           access::placeholder isPlaceholder>
 class accessor;
 
-template <typename dataT, int dimensions = 1>
-using local_accessor = accessor<dataT, dimensions, access::mode::read_write, access::target::local,
-                                access::placeholder::false_t>;
+template <typename dataT, int dimensions>
+class local_accessor;
 
 template <typename T> struct remove_decoration {
   using type = T;


### PR DESCRIPTION
This also adds a `get_multi_ptr` method, allowing users to avoid deprecation warnings.