### PR TITLE
[OpenCL] Enable Intel extension profile unconditionally

### DIFF
--- a/src/runtime/ocl/ocl_queue.cpp
+++ b/src/runtime/ocl/ocl_queue.cpp
@@ -484,10 +484,17 @@ result ocl_queue::submit_sscp_kernel_from_code_object(
   _config.set_build_option(
       kernel_build_option::spirv_dynamic_local_mem_allocation_size,
       local_mem_size);
-  if(hw_ctx->has_intel_extension_profile()) {
-    _config.set_build_flag(
-      kernel_build_flag::spirv_enable_intel_llvm_spirv_options);
-  }
+  
+  // Not all OpenCL implementations support these extensions,
+  // however if user code doesn't need them, then the compiler should in theory
+  // not generate code that requires them. This should allow us to
+  // run on all devices that *can* support this particular kernel.
+  //
+  // We may have to revisit this handling if there are any issues reported
+  // with OpenCL implementations that are not from Intel.
+  _config.set_build_flag(
+    kernel_build_flag::spirv_enable_intel_llvm_spirv_options);
+
 
   // TODO: Enable this if we are on Intel
   // config.set_build_flag(kernel_build_flag::spirv_enable_intel_llvm_spirv_options);


### PR DESCRIPTION
This should allow us to support non-Intel OpenCL implementations (pocl, rusticl) better. The underlying assumption here is that the compiler will not generate code that depends on particular extensions unless the user code actually uses features that need them.
If this assumption holds, just enabling the Intel extension profile unconditionally should allow us to run all kernels that *can* be executed by a particular OpenCL implementation.

If this turns out to cause problems, we may have to revisit this approach in the future.

Fixes #1677 