### PR TITLE
Update self-hosted CI image to ROCm 6.2, LLVM 18

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -41,7 +41,7 @@ jobs:
           destination: ./_site
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
 
 
 

--- a/.github/workflows/linux-self-hosted.yml
+++ b/.github/workflows/linux-self-hosted.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: [self-hosted, gpu-nvidia]
     strategy:
       matrix:
-        clang_version: ['15']
+        clang_version: ['18']
         cuda: ['11.0']
         nvhpc_version: ['22.11']
     steps:
@@ -98,7 +98,7 @@ jobs:
     runs-on: [self-hosted, gpu-amd]
     strategy:
       matrix:
-        clang_version: ['15']
+        clang_version: ['18']
         cuda: ['11.0'] # Just to be able to build the backend for explicit multipass
     steps:
     - uses: actions/checkout@v4
@@ -154,7 +154,7 @@ jobs:
     runs-on: [self-hosted, gpu-intel]
     strategy:
       matrix:
-        clang_version: ['15']
+        clang_version: ['18']
     steps:
     - uses: actions/checkout@v4
     - name: clear JIT cache

--- a/.github/workflows/runner.def
+++ b/.github/workflows/runner.def
@@ -3,13 +3,16 @@ From: ubuntu:22.04
 
 %post
 export DEBIAN_FRONTEND=noninteractive
-export ROCM_VERSION="5.4.3"
+export ROCM_VERSION="6.2.4"
 
 export NVHPC_MAJOR_VERSION="22"
 export NVHPC_MINOR_VERSION="11"
 
 apt-get update
 apt-get install -y libboost-all-dev wget git libnuma-dev cmake curl unzip apt-transport-https ca-certificates software-properties-common sudo build-essential gettext libcurl4-openssl-dev openssh-client libnuma-dev jq libtbb-dev
+
+wget https://github.com/oneapi-src/level-zero/releases/download/v1.13.5/level-zero-devel_1.13.5+u22.04_amd64.deb
+wget https://github.com/oneapi-src/level-zero/releases/download/v1.13.5/level-zero_1.13.5+u22.04_amd64.deb
 
 wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.16695.4/intel-igc-core_1.0.16695.4_amd64.deb
 wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.16695.4/intel-igc-opencl_1.0.16695.4_amd64.deb
@@ -18,9 +21,6 @@ wget https://github.com/intel/compute-runtime/releases/download/24.17.29377.6/in
 wget https://github.com/intel/compute-runtime/releases/download/24.17.29377.6/intel-opencl-icd-dbgsym_24.17.29377.6_amd64.ddeb
 wget https://github.com/intel/compute-runtime/releases/download/24.17.29377.6/intel-opencl-icd_24.17.29377.6_amd64.deb
 wget https://github.com/intel/compute-runtime/releases/download/24.17.29377.6/libigdgmm12_22.3.19_amd64.deb
-
-wget https://github.com/oneapi-src/level-zero/releases/download/v1.13.5/level-zero-devel_1.13.5+u22.04_amd64.deb
-wget https://github.com/oneapi-src/level-zero/releases/download/v1.13.5/level-zero_1.13.5+u22.04_amd64.deb
 
 sudo dpkg -i *.deb
 
@@ -34,12 +34,12 @@ wget https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64/nvhpc-20${NVHPC_
 apt-get install -y ./nvhpc-*
 
 wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
-echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/${ROCM_VERSION} focal main" | sudo tee /etc/apt/sources.list.d/rocm.list
+echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/${ROCM_VERSION} jammy main" | sudo tee /etc/apt/sources.list.d/rocm.list
 printf 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
 apt-get update
 apt-get install -y rocm-dev
 
 wget https://apt.llvm.org/llvm.sh
 chmod +x llvm.sh
-./llvm.sh 15
-apt-get install -y libclang-15-dev clang-tools-15 libomp-15-dev
+./llvm.sh 18
+apt-get install -y libclang-18-dev clang-tools-18 libomp-18-dev

--- a/.github/workflows/runner.def
+++ b/.github/workflows/runner.def
@@ -14,13 +14,13 @@ apt-get install -y libboost-all-dev wget git libnuma-dev cmake curl unzip apt-tr
 wget https://github.com/oneapi-src/level-zero/releases/download/v1.13.5/level-zero-devel_1.13.5+u22.04_amd64.deb
 wget https://github.com/oneapi-src/level-zero/releases/download/v1.13.5/level-zero_1.13.5+u22.04_amd64.deb
 
-wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.16695.4/intel-igc-core_1.0.16695.4_amd64.deb
-wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.16695.4/intel-igc-opencl_1.0.16695.4_amd64.deb
-wget https://github.com/intel/compute-runtime/releases/download/24.17.29377.6/intel-level-zero-gpu-dbgsym_1.3.29377.6_amd64.ddeb
-wget https://github.com/intel/compute-runtime/releases/download/24.17.29377.6/intel-level-zero-gpu_1.3.29377.6_amd64.deb
-wget https://github.com/intel/compute-runtime/releases/download/24.17.29377.6/intel-opencl-icd-dbgsym_24.17.29377.6_amd64.ddeb
-wget https://github.com/intel/compute-runtime/releases/download/24.17.29377.6/intel-opencl-icd_24.17.29377.6_amd64.deb
-wget https://github.com/intel/compute-runtime/releases/download/24.17.29377.6/libigdgmm12_22.3.19_amd64.deb
+wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.14828.8/intel-igc-core_1.0.14828.8_amd64.deb
+wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.14828.8/intel-igc-opencl_1.0.14828.8_amd64.deb
+wget https://github.com/intel/compute-runtime/releases/download/23.30.26918.9/intel-level-zero-gpu-dbgsym_1.3.26918.9_amd64.ddeb
+wget https://github.com/intel/compute-runtime/releases/download/23.30.26918.9/intel-level-zero-gpu_1.3.26918.9_amd64.deb
+wget https://github.com/intel/compute-runtime/releases/download/23.30.26918.9/intel-opencl-icd-dbgsym_23.30.26918.9_amd64.ddeb
+wget https://github.com/intel/compute-runtime/releases/download/23.30.26918.9/intel-opencl-icd_23.30.26918.9_amd64.deb
+wget https://github.com/intel/compute-runtime/releases/download/23.30.26918.9/libigdgmm12_22.3.0_amd64.deb
 
 sudo dpkg -i *.deb
 

--- a/include/hipSYCL/compiler/SMCPCompatPass.hpp
+++ b/include/hipSYCL/compiler/SMCPCompatPass.hpp
@@ -1,0 +1,30 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#ifndef ACPP_SMCP_COMPAT_PASS_HPP
+#define ACPP_SMCP_COMPAT_PASS_HPP
+
+#include <llvm/IR/PassManager.h>
+#include "CompilationState.hpp"
+
+namespace hipsycl {
+namespace compiler {
+
+class SMCPCompatPass : public llvm::PassInfoMixin<SMCPCompatPass> {
+public:
+  llvm::PreservedAnalyses run(llvm::Module &M,
+                              llvm::ModuleAnalysisManager &MAM);
+};
+
+}
+}
+
+#endif
+

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp
@@ -447,8 +447,10 @@ HIPSYCL_HIPLIKE_BUILTIN T __acpp_clz(T x) noexcept {
   using Usigned = typename std::make_unsigned<T>::type; 
 
   constexpr T diff = CHAR_BIT*(sizeof(__acpp_int32) - sizeof(Usigned));
+  constexpr T size = CHAR_BIT*sizeof(T);
 
-  return __clz(static_cast<__acpp_int32>(static_cast<Usigned>(x)))-diff;
+  auto v = static_cast<__acpp_int32>(static_cast<Usigned>(x));
+  return v ? __clz(v)-diff : size;
   
 }
 
@@ -459,7 +461,7 @@ template <class T,
 HIPSYCL_HIPLIKE_BUILTIN T __acpp_clz(T x) noexcept {
 
   return __clz(static_cast<__acpp_int32>(x));
-  
+
 }
 
 template <class T,

--- a/src/compiler/AdaptiveCppClangPlugin.cpp
+++ b/src/compiler/AdaptiveCppClangPlugin.cpp
@@ -12,6 +12,7 @@
 
 #include "hipSYCL/compiler/FrontendPlugin.hpp"
 #include "hipSYCL/compiler/GlobalsPruningPass.hpp"
+#include "hipSYCL/compiler/SMCPCompatPass.hpp"
 #include "hipSYCL/compiler/cbs/PipelineBuilder.hpp"
 
 
@@ -125,6 +126,7 @@ extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo llvmGetPassPluginIn
           // Note: for Clang < 12, this EP is not called for O0, but the new PM isn't
           // really used there anyways..
           PB.registerOptimizerLastEPCallback([](llvm::ModulePassManager &MPM, OptLevel) {
+            MPM.addPass(hipsycl::compiler::SMCPCompatPass{});
             MPM.addPass(hipsycl::compiler::GlobalsPruningPass{});
           });
 #ifdef HIPSYCL_WITH_REFLECTION_BUILTINS

--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -78,6 +78,7 @@ endif()
 add_library(acpp-clang MODULE
   AdaptiveCppClangPlugin.cpp
   GlobalsPruningPass.cpp
+  SMCPCompatPass.cpp
   ${SSCP_COMPILER}
   ${STDPAR_COMPILER}
   ${REFLECTION_BUILTINS}

--- a/src/compiler/SMCPCompatPass.cpp
+++ b/src/compiler/SMCPCompatPass.cpp
@@ -1,0 +1,35 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "hipSYCL/compiler/SMCPCompatPass.hpp"
+
+namespace hipsycl {
+namespace compiler {
+
+llvm::PreservedAnalyses SMCPCompatPass::run(llvm::Module& M, llvm::ModuleAnalysisManager& MAM) {
+  if (!CompilationStateManager::getASTPassState().isDeviceCompilation())
+    return llvm::PreservedAnalyses::all();
+  
+  // LLVM 18 does not yet support readlane.i32. However,
+  // LLVM 18 based ROCm (e.g. ROCm 6.2) may already use this builtin.
+#if LLVM_VERSION_MAJOR == 18
+  for(auto& F : M) {
+    if(F.getName() == "llvm.amdgcn.readlane.i32")
+      F.setName("llvm.amdgcn.readlane");
+  }
+#endif
+
+  return llvm::PreservedAnalyses::none();
+}
+
+}
+}
+

--- a/src/compiler/SMCPCompatPass.cpp
+++ b/src/compiler/SMCPCompatPass.cpp
@@ -20,7 +20,7 @@ llvm::PreservedAnalyses SMCPCompatPass::run(llvm::Module& M, llvm::ModuleAnalysi
   
   // LLVM 18 does not yet support readlane.i32. However,
   // LLVM 18 based ROCm (e.g. ROCm 6.2) may already use this builtin.
-#if LLVM_VERSION_MAJOR == 18
+#if LLVM_VERSION_MAJOR == 18 && !defined(ROCM_CLANG_VERSION)
   for(auto& F : M) {
     if(F.getName() == "llvm.amdgcn.readlane.i32")
       F.setName("llvm.amdgcn.readlane");


### PR DESCRIPTION
Update self-hosted CI to ROCm 6.2 and LLVM 18.

This hopefully fixes #1666. The image is already live, so when CI passes on this PR, we should be good.