### PR TITLE
Use execution_hints to propagate properties informations to backends allocator

### DIFF
--- a/include/hipSYCL/runtime/allocator.hpp
+++ b/include/hipSYCL/runtime/allocator.hpp
@@ -13,6 +13,7 @@
 
 #include "device_id.hpp"
 #include "error.hpp"
+#include "hints.hpp"
 
 namespace hipsycl {
 namespace rt {
@@ -36,18 +37,22 @@ public:
 
   /// Raw allocation mechanism that does not interact with the runtime's
   /// event handler mechanism. Should not be called directly in most cases.
-  virtual void *raw_allocate(size_t min_alignment, size_t size_bytes) = 0;
+  virtual void *raw_allocate(size_t min_alignment, size_t size_bytes,
+                             const allocation_hints &hints = {}) = 0;
   /// Optimized host memory - may be page-locked, device mapped if supported
   /// Raw mechanism that does not interact with the runtime's
   /// event handler mechanism. Should not be called directly in most cases.
-  virtual void* raw_allocate_optimized_host(size_t min_alignment, size_t bytes) = 0;
+  virtual void*
+  raw_allocate_optimized_host(size_t min_alignment, size_t bytes,
+                              const allocation_hints &hints = {}) = 0;
   /// Raw free mechanism that does not interact with the runtime's
   /// event handler mechanism. Should not be called directly in most cases.
   virtual void raw_free(void *mem) = 0;
   /// Allocate memory accessible both from the host and the backend.
   /// Raw mechanism that does not interact with the runtime's
   /// event handler mechanism. Should not be called directly in most cases.
-  virtual void *raw_allocate_usm(size_t bytes) = 0;
+  virtual void *raw_allocate_usm(size_t bytes,
+                                 const allocation_hints &hints = {}) = 0;
   
   virtual device_id get_device() const = 0;
 
@@ -64,10 +69,11 @@ public:
 };
 
 void *allocate_device(backend_allocator *alloc, size_t min_alignment,
-                      size_t size_bytes);
+                      size_t size_bytes, const allocation_hints &hints = {});
 void *allocate_host(backend_allocator *alloc, size_t min_alignment,
-                              size_t bytes);
-void *allocate_shared(backend_allocator* alloc, size_t bytes);
+                    size_t bytes, const allocation_hints &hints = {});
+void *allocate_shared(backend_allocator* alloc, size_t bytes,
+                      const allocation_hints &hints = {});
 void deallocate(backend_allocator* alloc, void *mem);
 
 

--- a/include/hipSYCL/runtime/cuda/cuda_allocator.hpp
+++ b/include/hipSYCL/runtime/cuda/cuda_allocator.hpp
@@ -12,6 +12,7 @@
 #define HIPSYCL_CUDA_ALLOCATOR_HPP
 
 #include "../allocator.hpp"
+#include "../hints.hpp"
 
 namespace hipsycl {
 namespace rt {
@@ -21,14 +22,17 @@ class cuda_allocator : public backend_allocator
 public:
   cuda_allocator(backend_descriptor desc, int cuda_device);
 
-  virtual void* raw_allocate(size_t min_alignment, size_t size_bytes) override;
+  virtual void* raw_allocate(size_t min_alignment, size_t size_bytes,
+                             const allocation_hints &hints = {}) override;
 
-  virtual void *raw_allocate_optimized_host(size_t min_alignment,
-                                            size_t bytes) override;
+  virtual void *
+  raw_allocate_optimized_host(size_t min_alignment, size_t bytes,
+                              const allocation_hints &hints = {}) override;
   
   virtual void raw_free(void *mem) override;
 
-  virtual void *raw_allocate_usm(size_t bytes) override;
+  virtual void *raw_allocate_usm(size_t bytes,
+                                 const allocation_hints &hints = {}) override;
   virtual bool is_usm_accessible_from(backend_descriptor b) const override;
 
   virtual result query_pointer(const void* ptr, pointer_info& out) const override;

--- a/include/hipSYCL/runtime/hints.hpp
+++ b/include/hipSYCL/runtime/hints.hpp
@@ -219,6 +219,11 @@ HIPSYCL_RT_HINTS_MAP_GETTER(request_instrumentation_finish_timestamp,
                             _request_instrumentation_finish_timestamp);
 HIPSYCL_RT_HINTS_MAP_GETTER(instant_execution,
                             _instant_execution);
+
+struct allocation_hints {
+
+};
+
 }
 }
 

--- a/include/hipSYCL/runtime/hip/hip_allocator.hpp
+++ b/include/hipSYCL/runtime/hip/hip_allocator.hpp
@@ -12,6 +12,7 @@
 #define HIPSYCL_HIP_ALLOCATOR_HPP
 
 #include "../allocator.hpp"
+#include "../hints.hpp"
 
 namespace hipsycl {
 namespace rt {
@@ -21,14 +22,17 @@ class hip_allocator : public backend_allocator
 public:
   hip_allocator(backend_descriptor desc, int hip_device);
 
-  virtual void* raw_allocate(size_t min_alignment, size_t size_bytes) override;
+  virtual void* raw_allocate(size_t min_alignment, size_t size_bytes,
+                             const allocation_hints &hints = {}) override;
 
-  virtual void *raw_allocate_optimized_host(size_t min_alignment,
-                                           size_t bytes) override;
+  virtual void *
+  raw_allocate_optimized_host(size_t min_alignment, size_t bytes,
+                              const allocation_hints &hints = {}) override;
   
   virtual void raw_free(void *mem) override;
 
-  virtual void *raw_allocate_usm(size_t bytes) override;
+  virtual void *raw_allocate_usm(size_t bytes,
+                                 const allocation_hints &hints = {}) override;
   virtual bool is_usm_accessible_from(backend_descriptor b) const override;
 
   virtual result query_pointer(const void* ptr, pointer_info& out) const override;

--- a/include/hipSYCL/runtime/ocl/ocl_allocator.hpp
+++ b/include/hipSYCL/runtime/ocl/ocl_allocator.hpp
@@ -14,6 +14,7 @@
 #include <CL/opencl.hpp>
 
 #include "../allocator.hpp"
+#include "../hints.hpp"
 #include "ocl_usm.hpp"
 
 namespace hipsycl {
@@ -25,14 +26,17 @@ public:
   ocl_allocator() = default;
   ocl_allocator(rt::device_id dev, ocl_usm* usm_provier);
 
-  virtual void* raw_allocate(size_t min_alignment, size_t size_bytes) override;
+  virtual void* raw_allocate(size_t min_alignment, size_t size_bytes,
+                             const allocation_hints &hints = {}) override;
 
-  virtual void *raw_allocate_optimized_host(size_t min_alignment,
-                                        size_t bytes) override;
+  virtual void *
+  raw_allocate_optimized_host(size_t min_alignment, size_t bytes,
+                              const allocation_hints &hints = {}) override;
   
   virtual void raw_free(void *mem) override;
 
-  virtual void *raw_allocate_usm(size_t bytes) override;
+  virtual void *raw_allocate_usm(size_t bytes,
+                                 const allocation_hints &hints = {}) override;
   virtual bool is_usm_accessible_from(backend_descriptor b) const override;
 
   virtual result query_pointer(const void* ptr, pointer_info& out) const override;

--- a/include/hipSYCL/runtime/omp/omp_allocator.hpp
+++ b/include/hipSYCL/runtime/omp/omp_allocator.hpp
@@ -12,6 +12,7 @@
 #define HIPSYCL_OMP_ALLOCATOR_HPP
 
 #include "../allocator.hpp"
+#include "../hints.hpp"
 
 namespace hipsycl {
 namespace rt {
@@ -21,14 +22,17 @@ class omp_allocator : public backend_allocator
 public:
   omp_allocator(const device_id &my_device);
   
-  virtual void* raw_allocate(size_t min_alignment, size_t size_bytes) override;
+  virtual void* raw_allocate(size_t min_alignment, size_t size_bytes,
+                             const allocation_hints &hints = {}) override;
 
-  virtual void *raw_allocate_optimized_host(size_t min_alignment,
-                                        size_t bytes) override;
+  virtual void *
+  raw_allocate_optimized_host(size_t min_alignment, size_t bytes,
+                              const allocation_hints &hints = {}) override;
   
   virtual void raw_free(void *mem) override;
 
-  virtual void *raw_allocate_usm(size_t bytes) override;
+  virtual void *raw_allocate_usm(size_t bytes,
+                                 const allocation_hints &hints = {}) override;
   virtual bool is_usm_accessible_from(backend_descriptor b) const override;
 
   virtual result query_pointer(const void *ptr,

--- a/include/hipSYCL/runtime/ze/ze_allocator.hpp
+++ b/include/hipSYCL/runtime/ze/ze_allocator.hpp
@@ -12,6 +12,7 @@
 #define HIPSYCL_ZE_ALLOCATOR_HPP
 
 #include "../allocator.hpp"
+#include "../hints.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
 #include "ze_hardware_manager.hpp"
 
@@ -26,14 +27,17 @@ public:
   ze_allocator(std::size_t device_index, const ze_hardware_context *dev,
                const ze_hardware_manager *hw_manager);
 
-  virtual void* raw_allocate(size_t min_alignment, size_t size_bytes) override;
+  virtual void* raw_allocate(size_t min_alignment, size_t size_bytes,
+                             const allocation_hints &hints = {}) override;
 
-  virtual void *raw_allocate_optimized_host(size_t min_alignment,
-                                            size_t bytes) override;
+  virtual void *
+  raw_allocate_optimized_host(size_t min_alignment, size_t bytes,
+                              const allocation_hints &hints = {}) override;
   
   virtual void raw_free(void *mem) override;
 
-  virtual void *raw_allocate_usm(size_t bytes) override;
+  virtual void *raw_allocate_usm(size_t bytes,
+                                 const allocation_hints &hints = {}) override;
   virtual bool is_usm_accessible_from(backend_descriptor b) const override;
 
   virtual result query_pointer(const void* ptr, pointer_info& out) const override;

--- a/include/hipSYCL/sycl/property.hpp
+++ b/include/hipSYCL/sycl/property.hpp
@@ -45,6 +45,7 @@ class buffer_property : public property {};
 class accessor_property : public property {};
 class cg_property : public property {};
 class reduction_property : public property {};
+class usm_property : public property {};
 class unknown_property : public property {};
 
 template<class SyclObjectT>

--- a/include/hipSYCL/sycl/usm.hpp
+++ b/include/hipSYCL/sycl/usm.hpp
@@ -27,18 +27,24 @@
 #include "hipSYCL/runtime/application.hpp"
 #include "hipSYCL/runtime/backend.hpp"
 #include "hipSYCL/runtime/allocator.hpp"
+#include "hipSYCL/runtime/hints.hpp"
 
 namespace hipsycl {
 namespace sycl {
 
+// Wrapper namespace to declare all usm properties
+namespace property::usm {
+
+}
 
 // Explicit USM
 
 inline void *malloc_device(size_t num_bytes, const device &dev,
                            const context &ctx,
                            const property_list &propList = {}) {
+  rt::allocation_hints hints{};
   return rt::allocate_device(detail::select_device_allocator(dev), 0,
-                             num_bytes);
+                             num_bytes, hints);
 }
 
 template <typename T>
@@ -62,8 +68,9 @@ T* malloc_device(std::size_t count, const queue &q,
 inline void *aligned_alloc_device(std::size_t alignment, std::size_t num_bytes,
                                   const device &dev, const context &ctx,
                                   const property_list &propList = {}) {
+  rt::allocation_hints hints{};
   return rt::allocate_device(detail::select_device_allocator(dev), alignment,
-                             num_bytes);
+                             num_bytes, hints);
 }
 
 template <typename T>
@@ -93,7 +100,9 @@ T *aligned_alloc_device(std::size_t alignment, std::size_t count,
 
 inline void *malloc_host(std::size_t num_bytes, const context &ctx,
                          const property_list &propList = {}) {
-  return rt::allocate_host(detail::select_usm_allocator(ctx), 0, num_bytes);
+  rt::allocation_hints hints{};
+  return rt::allocate_host(detail::select_usm_allocator(ctx), 0, num_bytes,
+                           hints);
 }
 
 template <typename T> T *malloc_host(std::size_t count, const context &ctx,
@@ -114,7 +123,9 @@ template <typename T> T *malloc_host(std::size_t count, const queue &q,
 inline void *malloc_shared(std::size_t num_bytes, const device &dev,
                            const context &ctx,
                            const property_list &propList = {}) {
-  return rt::allocate_shared(detail::select_usm_allocator(ctx, dev), num_bytes);
+  rt::allocation_hints hints{};
+  return rt::allocate_shared(detail::select_usm_allocator(ctx, dev), num_bytes,
+                             hints);
 }
 
 template <typename T>
@@ -137,8 +148,9 @@ template <typename T> T *malloc_shared(std::size_t count, const queue &q,
 inline void *aligned_alloc_host(std::size_t alignment, std::size_t num_bytes,
                                 const context &ctx,
                                 const property_list &propList = {}) {
+  rt::allocation_hints hints{};
   return rt::allocate_host(detail::select_usm_allocator(ctx), alignment,
-                           num_bytes);
+                           num_bytes, hints);
 }
 
 template <typename T>
@@ -166,7 +178,9 @@ T *aligned_alloc_host(std::size_t alignment, std::size_t count,
 inline void *aligned_alloc_shared(std::size_t alignment, std::size_t num_bytes,
                                   const device &dev, const context &ctx,
                                   const property_list &propList = {}) {
-  return rt::allocate_shared(detail::select_usm_allocator(ctx, dev), num_bytes);
+  rt::allocation_hints hints{};
+  return rt::allocate_shared(detail::select_usm_allocator(ctx, dev), num_bytes,
+                             hints);
 }
 
 template <typename T>

--- a/src/runtime/allocator.cpp
+++ b/src/runtime/allocator.cpp
@@ -12,14 +12,15 @@
 #include "hipSYCL/runtime/allocator.hpp"
 #include "hipSYCL/runtime/allocation_tracker.hpp"
 #include "hipSYCL/runtime/application.hpp"
+#include "hipSYCL/runtime/hints.hpp"
 #include "hipSYCL/runtime/runtime_event_handlers.hpp"
 
 namespace hipsycl {
 namespace rt {
 
 void *allocate_device(backend_allocator *alloc, size_t min_alignment,
-                      size_t size_bytes) {
-  auto *ptr = alloc->raw_allocate(min_alignment, size_bytes);
+                      size_t size_bytes, const allocation_hints &hints) {
+  auto *ptr = alloc->raw_allocate(min_alignment, size_bytes, hints);
   if(ptr) {
     application::event_handler_layer().on_new_allocation(
         ptr, size_bytes,
@@ -30,8 +31,8 @@ void *allocate_device(backend_allocator *alloc, size_t min_alignment,
 }
 
 void *allocate_host(backend_allocator *alloc, size_t min_alignment,
-                              size_t bytes) {
-  auto* ptr = alloc->raw_allocate_optimized_host(min_alignment, bytes);
+                    size_t bytes, const allocation_hints &hints) {
+  auto* ptr = alloc->raw_allocate_optimized_host(min_alignment, bytes, hints);
   if(ptr) {
     application::event_handler_layer().on_new_allocation(
         ptr, bytes,
@@ -41,8 +42,9 @@ void *allocate_host(backend_allocator *alloc, size_t min_alignment,
   return ptr;
 }
 
-void *allocate_shared(backend_allocator *alloc, size_t bytes) {
-  auto* ptr = alloc->raw_allocate_usm(bytes);
+void *allocate_shared(backend_allocator *alloc, size_t bytes,
+                      const allocation_hints &hints) {
+  auto* ptr = alloc->raw_allocate_usm(bytes, hints);
   if(ptr) {
     application::event_handler_layer().on_new_allocation(
         ptr, bytes,

--- a/src/runtime/cuda/cuda_allocator.cpp
+++ b/src/runtime/cuda/cuda_allocator.cpp
@@ -13,6 +13,7 @@
 #include "hipSYCL/runtime/cuda/cuda_allocator.hpp"
 #include "hipSYCL/runtime/cuda/cuda_device_manager.hpp"
 #include "hipSYCL/runtime/error.hpp"
+#include "hipSYCL/runtime/hints.hpp"
 
 namespace hipsycl {
 namespace rt {
@@ -21,7 +22,8 @@ cuda_allocator::cuda_allocator(backend_descriptor desc, int cuda_device)
     : _backend_descriptor{desc}, _dev{cuda_device}
 {}
       
-void *cuda_allocator::raw_allocate(size_t min_alignment, size_t size_bytes)
+void *cuda_allocator::raw_allocate(size_t min_alignment, size_t size_bytes,
+                                   const allocation_hints &hints)
 {
   void *ptr;
   cuda_device_manager::get().activate_device(_dev);
@@ -38,8 +40,10 @@ void *cuda_allocator::raw_allocate(size_t min_alignment, size_t size_bytes)
   return ptr;
 }
 
-void *cuda_allocator::raw_allocate_optimized_host(size_t min_alignment,
-                                                  size_t bytes) {
+void *
+cuda_allocator::raw_allocate_optimized_host(size_t min_alignment,
+                                            size_t bytes,
+                                            const allocation_hints &hints) {
   void *ptr;
   cuda_device_manager::get().activate_device(_dev);
 
@@ -79,7 +83,8 @@ void cuda_allocator::raw_free(void *mem) {
   }
 }
 
-void * cuda_allocator::raw_allocate_usm(size_t bytes)
+void * cuda_allocator::raw_allocate_usm(size_t bytes,
+                                        const allocation_hints &hints)
 {
   cuda_device_manager::get().activate_device(_dev);
   

--- a/src/runtime/hip/hip_allocator.cpp
+++ b/src/runtime/hip/hip_allocator.cpp
@@ -12,6 +12,7 @@
 #include "hipSYCL/runtime/hip/hip_allocator.hpp"
 #include "hipSYCL/runtime/hip/hip_device_manager.hpp"
 #include "hipSYCL/runtime/error.hpp"
+#include "hipSYCL/runtime/hints.hpp"
 
 namespace hipsycl {
 namespace rt {
@@ -20,7 +21,8 @@ hip_allocator::hip_allocator(backend_descriptor desc, int hip_device)
     : _backend_descriptor{desc}, _dev{hip_device}
 {}
       
-void *hip_allocator::raw_allocate(size_t min_alignment, size_t size_bytes)
+void *hip_allocator::raw_allocate(size_t min_alignment, size_t size_bytes,
+                                  const allocation_hints &hints)
 {
   void *ptr;
   hip_device_manager::get().activate_device(_dev);
@@ -38,7 +40,8 @@ void *hip_allocator::raw_allocate(size_t min_alignment, size_t size_bytes)
 }
 
 void *hip_allocator::raw_allocate_optimized_host(size_t min_alignment,
-                                                size_t bytes) {
+                                                 size_t bytes,
+                                                 const allocation_hints &hints) {
   void *ptr;
   hip_device_manager::get().activate_device(_dev);
 
@@ -78,7 +81,8 @@ void hip_allocator::raw_free(void *mem) {
   }
 }
 
-void * hip_allocator::raw_allocate_usm(size_t bytes)
+void * hip_allocator::raw_allocate_usm(size_t bytes,
+                                       const allocation_hints &hints)
 {
   hip_device_manager::get().activate_device(_dev);
 

--- a/src/runtime/ocl/ocl_allocator.cpp
+++ b/src/runtime/ocl/ocl_allocator.cpp
@@ -10,6 +10,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 #include "hipSYCL/runtime/device_id.hpp"
 #include "hipSYCL/runtime/error.hpp"
+#include "hipSYCL/runtime/hints.hpp"
 
 #include "hipSYCL/runtime/ocl/ocl_allocator.hpp"
 #include <cstddef>
@@ -20,7 +21,8 @@ namespace rt {
 ocl_allocator::ocl_allocator(rt::device_id dev, ocl_usm* usm)
 : _dev{dev}, _usm{usm} {}
 
-void* ocl_allocator::raw_allocate(size_t min_alignment, size_t size_bytes) {
+void* ocl_allocator::raw_allocate(size_t min_alignment, size_t size_bytes,
+                                  const allocation_hints &hints) {
   if(!_usm->is_available()) {
     register_error(__acpp_here(),
                    error_info{"ocl_allocator: OpenCL device does not have valid USM provider",
@@ -41,7 +43,8 @@ void* ocl_allocator::raw_allocate(size_t min_alignment, size_t size_bytes) {
 }
 
 void *ocl_allocator::raw_allocate_optimized_host(size_t min_alignment,
-                                             size_t bytes) {
+                                                 size_t bytes,
+                                                 const allocation_hints &hints) {
   if(!_usm->is_available()) {
     register_error(__acpp_here(),
                    error_info{"ocl_allocator: OpenCL device does not have valid USM provider",
@@ -76,7 +79,8 @@ void ocl_allocator::raw_free(void *mem) {
   }
 }
 
-void *ocl_allocator::raw_allocate_usm(size_t bytes) {
+void *ocl_allocator::raw_allocate_usm(size_t bytes,
+                                      const allocation_hints &hints) {
   if(!_usm->is_available()) {
     register_error(__acpp_here(),
                    error_info{"ocl_allocator: OpenCL device does not have valid USM provider",

--- a/src/runtime/ze/ze_allocator.cpp
+++ b/src/runtime/ze/ze_allocator.cpp
@@ -13,6 +13,7 @@
 #include "hipSYCL/runtime/device_id.hpp"
 #include "hipSYCL/runtime/ze/ze_allocator.hpp"
 #include "hipSYCL/runtime/error.hpp"
+#include "hipSYCL/runtime/hints.hpp"
 #include "hipSYCL/runtime/util.hpp"
 
 namespace hipsycl {
@@ -29,7 +30,8 @@ ze_allocator::ze_allocator(std::size_t device_index,
                       static_cast<int>(device_index)};
 }
 
-void* ze_allocator::raw_allocate(size_t min_alignment, size_t size_bytes) {
+void* ze_allocator::raw_allocate(size_t min_alignment, size_t size_bytes,
+                                 const allocation_hints &hints) {
   
   void* out = nullptr;
 
@@ -54,7 +56,8 @@ void* ze_allocator::raw_allocate(size_t min_alignment, size_t size_bytes) {
 }
 
 void* ze_allocator::raw_allocate_optimized_host(size_t min_alignment,
-                                                size_t bytes) {
+                                                size_t bytes,
+                                                const allocation_hints &hints) {
   void* out = nullptr;
   ze_host_mem_alloc_desc_t desc;
   
@@ -85,7 +88,8 @@ void ze_allocator::raw_free(void *mem) {
   }
 }
 
-void* ze_allocator::raw_allocate_usm(size_t bytes) {
+void* ze_allocator::raw_allocate_usm(size_t bytes,
+                                     const allocation_hints &hints) {
 
   void* out = nullptr;
 


### PR DESCRIPTION
This PR builds upon  #1684 , to support properties on USM memory allocator.   
  
Goal is to support runtime allocators properties such as :  

```
int *p = sycl::malloc_device<int>(size, queue, sycl::property_list{my_property} );
```
  
As of today, SYCL has no predefined allocator-specific properties. Nonetheless adding this support could help to give, for instance, hints about NUMA allocation memory nodes.  
  
This PR propagates properties expressed  by the developer to each backend allocators.
This has been done by reusing the `hints` mechanism (already used for `queues`, `handlers`, `buffers` and `dags`) to be consistent with the rest of AdaptiveCpp.  
  
A closer look to AdpativeCpp reveal that  `hints` are stored in a class member of `dag_node`.
This solution is not well suited for the `backend_allocator` class since two consecutives allocations may have differents properties.

Therefore I opted to pass `hints` as function argument of every function of each backend allocators.