### PR TITLE
Remove unused includes and move includes from header to source in GlobalsPruningPass

### DIFF
--- a/include/hipSYCL/compiler/GlobalsPruningPass.hpp
+++ b/include/hipSYCL/compiler/GlobalsPruningPass.hpp
@@ -13,19 +13,7 @@
 
 #include "llvm/Analysis/CallGraph.h"
 #include "llvm/IR/Constants.h"
-#include "llvm/IR/Function.h"
-#include "llvm/IR/GlobalVariable.h"
-#include "llvm/IR/LegacyPassManager.h"
-#include "llvm/IR/Module.h"
 #include "llvm/Pass.h"
-#include "llvm/Support/raw_ostream.h"
-
-#include "CompilationState.hpp"
-
-#include "hipSYCL/common/debug.hpp"
-
-#include <unordered_set>
-#include <vector>
 
 namespace hipsycl {
 namespace compiler {

--- a/src/compiler/AdaptiveCppClangPlugin.cpp
+++ b/src/compiler/AdaptiveCppClangPlugin.cpp
@@ -44,6 +44,7 @@
 
 #if LLVM_VERSION_MAJOR < 16
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
+#include "llvm/IR/LegacyPassManager.h"
 #endif
 
 namespace hipsycl {

--- a/src/compiler/GlobalsPruningPass.cpp
+++ b/src/compiler/GlobalsPruningPass.cpp
@@ -1,5 +1,11 @@
 #include "hipSYCL/compiler/GlobalsPruningPass.hpp"
 
+#include "hipSYCL/common/debug.hpp"
+#include "hipSYCL/compiler/CompilationState.hpp"
+
+#include "llvm/IR/GlobalVariable.h"
+#include "llvm/IR/Module.h"
+
 namespace {
 bool canGlobalVariableBeRemoved(llvm::GlobalVariable *G) {
   G->removeDeadConstantUsers();


### PR DESCRIPTION
Other than being a best practice, it reduces the amount of code included every time the .hpp file gets included.