### PR TITLE
Add `local_accessor` replacing local `accessor`s

### DIFF
--- a/include/hipSYCL/sycl/libkernel/multi_ptr.hpp
+++ b/include/hipSYCL/sycl/libkernel/multi_ptr.hpp
@@ -144,9 +144,8 @@ template <typename dataT, int dimensions, access::mode accessmode, access::targe
           access::placeholder isPlaceholder>
 class accessor;
 
-template <typename dataT, int dimensions = 1>
-using local_accessor = accessor<dataT, dimensions, access::mode::read_write, access::target::local,
-                                access::placeholder::false_t>;
+template <typename dataT, int dimensions>
+class local_accessor;
 
 template <typename T> struct remove_decoration {
   using type = T;
@@ -742,12 +741,12 @@ public:
   multi_ptr(accessor<ElementType, Dimensions, Mode, target::local, IsPlaceholder> a)
       : _ptr{a.get_pointer()} {}
 
-  // // Available only when:
-  // //   (Space == access::address_space::local_space ||
-  // //    Space == access::address_space::generic_space) &&
-  // //   (std::is_same_v<std::remove_const_t<ElementType>,
-  // //   std::remove_const_t<AccDataT>>) && (std::is_const_v<ElementType> ||
-  // //   !std::is_const_v<AccDataT>)
+  // Available only when:
+  //   (Space == access::address_space::local_space ||
+  //    Space == access::address_space::generic_space) &&
+  //   (std::is_same_v<std::remove_const_t<ElementType>,
+  //   std::remove_const_t<AccDataT>>) && (std::is_const_v<ElementType> ||
+  //   !std::is_const_v<AccDataT>)
   template <
       typename AccDataT, int Dimensions, access::address_space S = Space, typename E = ElementType,
       std::enable_if_t<(S == access::address_space::local_space ||

--- a/tests/compiler/cbs/accumulator_for.cpp
+++ b/tests/compiler/cbs/accumulator_for.cpp
@@ -30,7 +30,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>{local_size, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for<class dynamic_local_memory_reduction>(
         cl::sycl::nd_range<1>{global_size, local_size},

--- a/tests/compiler/cbs/add_modulo.cpp
+++ b/tests/compiler/cbs/add_modulo.cpp
@@ -30,7 +30,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>{local_size, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for<class dynamic_local_memory_reduction>(
         cl::sycl::nd_range<1>{global_size, local_size},

--- a/tests/compiler/cbs/babelstream_dot.cpp
+++ b/tests/compiler/cbs/babelstream_dot.cpp
@@ -36,7 +36,7 @@ int main()
       auto kb = d_b.template get_access<mode::read>(cgh);
       auto ksum = d_sum.template get_access<mode::discard_write>(cgh);
 
-      auto wg_sum = cl::sycl::accessor<int, 1, mode::read_write, target::local>(cl::sycl::range<1>(dot_wgsize), cgh);
+      auto wg_sum = cl::sycl::local_accessor<int, 1>(cl::sycl::range<1>(dot_wgsize), cgh);
 
       size_t N = array_size;
       cgh.parallel_for<class dot_kernel>(

--- a/tests/compiler/cbs/cond_between_barriers.cpp
+++ b/tests/compiler/cbs/cond_between_barriers.cpp
@@ -33,7 +33,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<bool, 1, mode::read_write, target::local>{1, cgh};
+      auto scratch = cl::sycl::local_accessor<bool, 1>{1, cgh};
 
       cgh.parallel_for<class test_kernel>(
         cl::sycl::nd_range<1>{global_size, local_size},

--- a/tests/compiler/cbs/conds.cpp
+++ b/tests/compiler/cbs/conds.cpp
@@ -30,7 +30,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>{local_size, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for<class dynamic_local_memory_reduction>(
         cl::sycl::nd_range<1>{global_size, local_size},

--- a/tests/compiler/cbs/conds_in_for.cpp
+++ b/tests/compiler/cbs/conds_in_for.cpp
@@ -30,7 +30,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>{local_size, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for<class dynamic_local_memory_reduction>(
         cl::sycl::nd_range<1>{global_size, local_size},

--- a/tests/compiler/cbs/const_init_accumulator_for.cpp
+++ b/tests/compiler/cbs/const_init_accumulator_for.cpp
@@ -30,7 +30,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>{local_size, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for<class dynamic_local_memory_reduction>(
         cl::sycl::nd_range<1>{global_size, local_size},

--- a/tests/compiler/cbs/for_in_cond.cpp
+++ b/tests/compiler/cbs/for_in_cond.cpp
@@ -31,7 +31,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>{local_size, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for<class dynamic_local_memory_reduction>(
         cl::sycl::nd_range<1>{global_size, local_size},

--- a/tests/compiler/cbs/group_barrier.cpp
+++ b/tests/compiler/cbs/group_barrier.cpp
@@ -30,7 +30,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>{local_size, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for<class dynamic_local_memory_reduction>(
         cl::sycl::nd_range<1>{global_size, local_size},

--- a/tests/compiler/cbs/item_dependent_cond_in_for.cpp
+++ b/tests/compiler/cbs/item_dependent_cond_in_for.cpp
@@ -31,7 +31,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>{local_size, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for<class dynamic_local_memory_reduction>(
         cl::sycl::nd_range<1>{global_size, local_size},

--- a/tests/compiler/cbs/item_dependent_for.cpp
+++ b/tests/compiler/cbs/item_dependent_for.cpp
@@ -30,7 +30,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>{local_size, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for<class dynamic_local_memory_reduction>(
         cl::sycl::nd_range<1>{global_size, local_size},

--- a/tests/compiler/cbs/multiple_indvars_for.cpp
+++ b/tests/compiler/cbs/multiple_indvars_for.cpp
@@ -30,7 +30,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>{local_size, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for<class dynamic_local_memory_reduction>(
         cl::sycl::nd_range<1>{global_size, local_size},

--- a/tests/compiler/cbs/reduce_const_for.cpp
+++ b/tests/compiler/cbs/reduce_const_for.cpp
@@ -30,7 +30,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>{local_size, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for<class dynamic_local_memory_reduction>(
         cl::sycl::nd_range<1>{global_size, local_size},

--- a/tests/compiler/cbs/reduce_do_while.cpp
+++ b/tests/compiler/cbs/reduce_do_while.cpp
@@ -31,7 +31,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>{local_size, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for<class dynamic_local_memory_reduction>(
         cl::sycl::nd_range<1>{global_size, local_size},

--- a/tests/compiler/cbs/reduce_for.cpp
+++ b/tests/compiler/cbs/reduce_for.cpp
@@ -29,7 +29,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>{local_size, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for<class dynamic_local_memory_reduction>(
         cl::sycl::nd_range<1>{global_size, local_size},

--- a/tests/compiler/cbs/reduce_for_inverse_barrier.cpp
+++ b/tests/compiler/cbs/reduce_for_inverse_barrier.cpp
@@ -30,7 +30,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>{local_size, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for<class dynamic_local_memory_reduction>(
         cl::sycl::nd_range<1>{global_size, local_size},

--- a/tests/compiler/cbs/reduce_nested_for.cpp
+++ b/tests/compiler/cbs/reduce_nested_for.cpp
@@ -30,7 +30,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>{local_size, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for<class dynamic_local_memory_reduction>(
         cl::sycl::nd_range<1>{local_size, local_size},

--- a/tests/compiler/cbs/reduce_unrolled.cpp
+++ b/tests/compiler/cbs/reduce_unrolled.cpp
@@ -30,7 +30,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>{local_size, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for<class dynamic_local_memory_reduction>(
         cl::sycl::nd_range<1>{global_size, local_size},

--- a/tests/compiler/cbs/reduce_while.cpp
+++ b/tests/compiler/cbs/reduce_while.cpp
@@ -30,7 +30,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>{local_size, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for<class dynamic_local_memory_reduction>(
         cl::sycl::nd_range<1>{global_size, local_size},

--- a/tests/compiler/cbs/reduce_while_early_update.cpp
+++ b/tests/compiler/cbs/reduce_while_early_update.cpp
@@ -30,7 +30,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>{local_size, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for<class dynamic_local_memory_reduction>(
         cl::sycl::nd_range<1>{global_size, local_size},

--- a/tests/compiler/cbs/right_heavy_cond.cpp
+++ b/tests/compiler/cbs/right_heavy_cond.cpp
@@ -30,7 +30,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>{local_size, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for<class dynamic_local_memory_reduction>(
         cl::sycl::nd_range<1>{global_size, local_size},

--- a/tests/compiler/cbs/simple_kernel.cpp
+++ b/tests/compiler/cbs/simple_kernel.cpp
@@ -30,7 +30,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>{local_size, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for(
         cl::sycl::nd_range<1>{global_size, local_size},

--- a/tests/compiler/cbs/stencil.cpp
+++ b/tests/compiler/cbs/stencil.cpp
@@ -39,7 +39,7 @@ int main()
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read>(cgh);
       auto out = bufOut.get_access<mode::discard_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 3, mode::read_write, target::local>{local_range + cl::sycl::range{2, 2, 2}, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 3>{local_range + cl::sycl::range{2, 2, 2}, cgh};
 
       cgh.parallel_for<class local_mem_stencil>(
         cl::sycl::nd_range<3>{global_range, local_range},

--- a/tests/compiler/cbs/sycl_dgemm.cpp
+++ b/tests/compiler/cbs/sycl_dgemm.cpp
@@ -31,8 +31,8 @@ void matmul_blocked(sycl::queue &Q, const size_t Ndim, const size_t Mdim, const 
      auto b = B.get_access<sycl::access_mode::read>(cgh);
      auto c = C.get_access<sycl::access_mode::read_write>(cgh);
 
-     sycl::accessor<double, 2, sycl::access_mode::read_write, sycl::access::target::local> Awrk({Bsize, Bsize}, cgh);
-     sycl::accessor<double, 2, sycl::access_mode::read_write, sycl::access::target::local> Bwrk({Bsize, Bsize}, cgh);
+     sycl::local_accessor<double, 2> Awrk({Bsize, Bsize}, cgh);
+     sycl::local_accessor<double, 2> Bwrk({Bsize, Bsize}, cgh);
 
      cgh.parallel_for(sycl::nd_range<2>{{Ndim, Mdim}, {Bsize, Bsize}}, [=](sycl::nd_item<2> idx) {
        // This work-item will compute C(i,j)

--- a/tests/compiler/cbs/two_barrier_for.cpp
+++ b/tests/compiler/cbs/two_barrier_for.cpp
@@ -30,7 +30,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>{local_size, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for<class dynamic_local_memory_reduction>(
         cl::sycl::nd_range<1>{global_size, local_size},

--- a/tests/compiler/cbs/unreachable_exit.cpp
+++ b/tests/compiler/cbs/unreachable_exit.cpp
@@ -30,7 +30,7 @@ int main()
     queue.submit([&](cl::sycl::handler &cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>{local_size, cgh};
+      auto scratch = cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for<class dynamic_local_memory_reduction>(
         cl::sycl::nd_range<1>{global_size, local_size},

--- a/tests/sycl/accessor.cpp
+++ b/tests/sycl/accessor.cpp
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(local_accessors) {
     queue.submit([&](cl::sycl::handler& cgh) {
       using namespace cl::sycl::access;
       auto acc = buf.get_access<mode::read_write>(cgh);
-      auto scratch = cl::sycl::accessor<int, 1, mode::read_write, target::local>
+      auto scratch = cl::sycl::local_accessor<int, 1>
         {local_size, cgh};
 
       cgh.parallel_for<class dynamic_local_memory_reduction>(
@@ -193,8 +193,8 @@ BOOST_AUTO_TEST_CASE(accessor_api) {
 
   // Test local accessors
   queue.submit([&](s::handler& cgh) {
-    s::accessor<int, 1, s::access::mode::read_write, s::access::target::local> acc_a(32, cgh);
-    s::accessor<int, 1, s::access::mode::read_write, s::access::target::local> acc_b(32, cgh);
+    s::local_accessor<int, 1> acc_a(32, cgh);
+    s::local_accessor<int, 1> acc_b(32, cgh);
     auto acc_c = acc_a;
 
     BOOST_REQUIRE(acc_a == acc_a);

--- a/tests/sycl/extensions.cpp
+++ b/tests/sycl/extensions.cpp
@@ -107,9 +107,7 @@ BOOST_AUTO_TEST_CASE(custom_pfwi_synchronization_extension) {
 
       auto acc = buf.get_access<cl::sycl::access::mode::read_write>(cgh);
       auto scratch =
-          cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write,
-                             cl::sycl::access::target::local>{local_size,
-                                                                    cgh};
+          cl::sycl::local_accessor<int, 1>{local_size, cgh};
 
       cgh.parallel_for_work_group<class pfwi_dispatch>(
         cl::sycl::range<1>{global_size / local_size},


### PR DESCRIPTION
This also adds a `get_multi_ptr` method, allowing users to avoid deprecation warnings.

I accidentally deleted the branch for the last PR, which caused GitHub to close the PR.