### PR TITLE
[SSCP] Avoid including stddef.h in SSCP builtin definitions

### DIFF
--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/core.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/core.hpp
@@ -14,7 +14,6 @@
 #include "builtin_config.hpp"
 #include "core_typed.hpp"
 
-#include <stddef.h>
 
 HIPSYCL_SSCP_BUILTIN __acpp_uint64 __acpp_sscp_get_local_id_x();
 HIPSYCL_SSCP_BUILTIN __acpp_uint64 __acpp_sscp_get_local_id_y();
@@ -32,65 +31,5 @@ HIPSYCL_SSCP_BUILTIN __acpp_uint64 __acpp_sscp_get_num_groups_x();
 HIPSYCL_SSCP_BUILTIN __acpp_uint64 __acpp_sscp_get_num_groups_y();
 HIPSYCL_SSCP_BUILTIN __acpp_uint64 __acpp_sscp_get_num_groups_z();
 
-// This is used to implement the optimization in llvm-to-backend to treat
-// all queries as fitting into int.
-// The implementation is provided by the compiler and does not need to be implemented
-// by backends.
-HIPSYCL_SSCP_BUILTIN bool
-__acpp_sscp_if_global_sizes_fit_in_int();
-
-template<int Dim>
-size_t __acpp_sscp_get_global_linear_id() {
-  if(__acpp_sscp_if_global_sizes_fit_in_int()) {
-    return __acpp_sscp_typed_get_global_linear_id<Dim, int>();
-  } else {
-    return __acpp_sscp_typed_get_global_linear_id<Dim, size_t>();
-  }
-}
-
-template<int Dim>
-size_t __acpp_sscp_get_group_linear_id() {
-  if(__acpp_sscp_if_global_sizes_fit_in_int()) {
-    return __acpp_sscp_typed_get_group_linear_id<Dim, int>();
-  } else {
-    return __acpp_sscp_typed_get_group_linear_id<Dim, size_t>();
-  }
-}
-
-template<int Dim>
-size_t __acpp_sscp_get_local_linear_id() {
-  if(__acpp_sscp_if_global_sizes_fit_in_int()) {
-    return __acpp_sscp_typed_get_local_linear_id<Dim, int>();
-  } else {
-    return __acpp_sscp_typed_get_local_linear_id<Dim, size_t>();
-  }
-}
-
-template<int Dim>
-size_t __acpp_sscp_get_global_size() {
-  if(__acpp_sscp_if_global_sizes_fit_in_int()) {
-    return __acpp_sscp_typed_get_global_size<Dim, int>();
-  } else {
-    return __acpp_sscp_typed_get_global_size<Dim, size_t>();
-  }
-}
-
-template<int Dim>
-size_t __acpp_sscp_get_local_size() {
-  if(__acpp_sscp_if_global_sizes_fit_in_int()) {
-    return __acpp_sscp_typed_get_local_size<Dim, int>();
-  } else {
-    return __acpp_sscp_typed_get_local_size<Dim, size_t>();
-  }
-}
-
-template<int Dim>
-size_t __acpp_sscp_get_num_groups() {
-  if(__acpp_sscp_if_global_sizes_fit_in_int()) {
-    return __acpp_sscp_typed_get_num_groups<Dim, int>();
-  } else {
-    return __acpp_sscp_typed_get_num_groups<Dim, size_t>();
-  }
-}
 
 #endif

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/core_typed.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/core_typed.hpp
@@ -13,7 +13,6 @@
 
 #include "builtin_config.hpp"
 
-#include <stddef.h>
 
 HIPSYCL_SSCP_BUILTIN __acpp_uint64 __acpp_sscp_get_local_id_x();
 HIPSYCL_SSCP_BUILTIN __acpp_uint64 __acpp_sscp_get_local_id_y();

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/detail/reduction.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/detail/reduction.hpp
@@ -45,7 +45,7 @@ template <__acpp_sscp_algorithm_op binary_op, typename OutType> OutType sg_reduc
   return sg_reduce_impl(x, op{}, lrange);
 }
 
-template <size_t shmem_array_length, typename OutType, typename MemoryType,
+template <__acpp_uint64 shmem_array_length, typename OutType, typename MemoryType,
           typename BinaryOperation>
 OutType wg_reduce(OutType x, BinaryOperation op, MemoryType *shrd_mem) {
 
@@ -78,7 +78,7 @@ OutType wg_reduce(OutType x, BinaryOperation op, MemoryType *shrd_mem) {
 
   // Now we are filled up shared memory with the results of all the subgroups
   // We reduce in shared memory until it fits into one sg
-  size_t elements_in_shmem =
+  __acpp_uint64 elements_in_shmem =
       num_subgroups < shmem_array_length ? num_subgroups : shmem_array_length;
   for (int i = shmem_array_length / 2; i >= first_sg_size; i /= 2) {
     if (wg_lid < i && wg_lid + i < elements_in_shmem) {

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/detail/scan_generic.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/detail/scan_generic.hpp
@@ -26,7 +26,7 @@ template <int SharedMemorySize, bool ExclusiveScan, typename OutType, typename M
 OutType wg_generic_scan(OutType x, BinaryOperation op, MemoryType shrd_mem, OutType init = 0) {
 
   // The last element of the shared memory is used to store the total sum for exclusive scans.
-  const size_t shmem_array_length = SharedMemorySize - 1;
+  const int shmem_array_length = SharedMemorySize - 1;
 
   const __acpp_uint32 wg_lid = __acpp_sscp_typed_get_local_linear_id<3, int>();
   const __acpp_uint32 wg_size = __acpp_sscp_typed_get_local_size<3, int>();

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/linear_id.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/linear_id.hpp
@@ -1,0 +1,85 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+
+// THIS FILE INCLUDES STANDARD LIBRARY HEADERS AND MUST NOT BE 
+// USED IN THE DEFINITION OF SSCP BUILTINS!
+
+#ifndef HIPSYCL_SSCP_BUILTINS_LINEAR_ID_HPP
+#define HIPSYCL_SSCP_BUILTINS_LINEAR_ID_HPP
+
+#include "core.hpp"
+#include "core_typed.hpp"
+
+#include <stddef.h>
+
+// This is used to implement the optimization in llvm-to-backend to treat
+// all queries as fitting into int.
+// The implementation is provided by the compiler and does not need to be implemented
+// by backends.
+HIPSYCL_SSCP_BUILTIN bool
+__acpp_sscp_if_global_sizes_fit_in_int();
+
+template<int Dim>
+size_t __acpp_sscp_get_global_linear_id() {
+  if(__acpp_sscp_if_global_sizes_fit_in_int()) {
+    return __acpp_sscp_typed_get_global_linear_id<Dim, int>();
+  } else {
+    return __acpp_sscp_typed_get_global_linear_id<Dim, size_t>();
+  }
+}
+
+template<int Dim>
+size_t __acpp_sscp_get_group_linear_id() {
+  if(__acpp_sscp_if_global_sizes_fit_in_int()) {
+    return __acpp_sscp_typed_get_group_linear_id<Dim, int>();
+  } else {
+    return __acpp_sscp_typed_get_group_linear_id<Dim, size_t>();
+  }
+}
+
+template<int Dim>
+size_t __acpp_sscp_get_local_linear_id() {
+  if(__acpp_sscp_if_global_sizes_fit_in_int()) {
+    return __acpp_sscp_typed_get_local_linear_id<Dim, int>();
+  } else {
+    return __acpp_sscp_typed_get_local_linear_id<Dim, size_t>();
+  }
+}
+
+template<int Dim>
+size_t __acpp_sscp_get_global_size() {
+  if(__acpp_sscp_if_global_sizes_fit_in_int()) {
+    return __acpp_sscp_typed_get_global_size<Dim, int>();
+  } else {
+    return __acpp_sscp_typed_get_global_size<Dim, size_t>();
+  }
+}
+
+template<int Dim>
+size_t __acpp_sscp_get_local_size() {
+  if(__acpp_sscp_if_global_sizes_fit_in_int()) {
+    return __acpp_sscp_typed_get_local_size<Dim, int>();
+  } else {
+    return __acpp_sscp_typed_get_local_size<Dim, size_t>();
+  }
+}
+
+template<int Dim>
+size_t __acpp_sscp_get_num_groups() {
+  if(__acpp_sscp_if_global_sizes_fit_in_int()) {
+    return __acpp_sscp_typed_get_num_groups<Dim, int>();
+  } else {
+    return __acpp_sscp_typed_get_num_groups<Dim, size_t>();
+  }
+}
+
+#endif

--- a/include/hipSYCL/sycl/libkernel/sscp/sscp_backend.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/sscp_backend.hpp
@@ -56,6 +56,7 @@
 
  #include "hipSYCL/glue/llvm-sscp/ir_constants.hpp"
  #include "builtins/core.hpp"
+ #include "builtins/linear_id.hpp"
  
 #else
  #define ACPP_LIBKERNEL_COMPILER_SUPPORTS_SSCP 0

--- a/src/libkernel/sscp/amdgpu/core.cpp
+++ b/src/libkernel/sscp/amdgpu/core.cpp
@@ -9,19 +9,19 @@
  */
 // SPDX-License-Identifier: BSD-2-Clause
 #include "hipSYCL/sycl/libkernel/sscp/builtins/core.hpp"
-#include <stddef.h>
 
-extern "C" size_t __ockl_get_global_offset(unsigned);
-extern "C" size_t __ockl_get_global_id(unsigned);
-extern "C" size_t __ockl_get_local_id(unsigned);
-extern "C" size_t __ockl_get_group_id(unsigned);
-extern "C" size_t __ockl_get_global_size(unsigned);
-extern "C" size_t __ockl_get_local_size(unsigned);
-extern "C" size_t __ockl_get_num_groups(unsigned);
-extern "C" unsigned __ockl_get_work_dim(unsigned);
-extern "C" size_t __ockl_get_enqueued_local_size(unsigned);
-extern "C" size_t __ockl_get_global_linear_id(unsigned);
-extern "C" size_t __ockl_get_local_linear_id(unsigned);
+
+extern "C" __acpp_uint64 __ockl_get_global_offset(unsigned);
+extern "C" __acpp_uint64 __ockl_get_global_id(unsigned);
+extern "C" __acpp_uint64 __ockl_get_local_id(unsigned);
+extern "C" __acpp_uint64 __ockl_get_group_id(unsigned);
+extern "C" __acpp_uint64 __ockl_get_global_size(unsigned);
+extern "C" __acpp_uint64 __ockl_get_local_size(unsigned);
+extern "C" __acpp_uint64 __ockl_get_num_groups(unsigned);
+extern "C" __acpp_uint32 __ockl_get_work_dim(unsigned);
+extern "C" __acpp_uint64 __ockl_get_enqueued_local_size(unsigned);
+extern "C" __acpp_uint64 __ockl_get_global_linear_id(unsigned);
+extern "C" __acpp_uint64 __ockl_get_local_linear_id(unsigned);
 
 HIPSYCL_SSCP_BUILTIN __acpp_uint64 __acpp_sscp_get_local_id_x() {
   return __ockl_get_local_id(0);

--- a/src/libkernel/sscp/amdgpu/reduction.cpp
+++ b/src/libkernel/sscp/amdgpu/reduction.cpp
@@ -75,7 +75,7 @@ ACPP_SUBGROUP_INT_REDUCTION(u64, uint64)
   HIPSYCL_SSCP_CONVERGENT_BUILTIN                                                                  \
   __acpp_##type __acpp_sscp_work_group_reduce_##type(__acpp_sscp_algorithm_op op,                  \
                                                      __acpp_##type x) {                            \
-    constexpr size_t shmem_array_length = 32;                                                      \
+    constexpr int shmem_array_length = 32;                                                      \
     ACPP_SHMEM_ATTRIBUTE __acpp_##type shrd_mem[shmem_array_length];                               \
     switch (op) {                                                                                  \
     case __acpp_sscp_algorithm_op::plus:                                                           \
@@ -103,7 +103,7 @@ ACPP_WORKGROUP_FLOAT_REDUCTION(f64)
   HIPSYCL_SSCP_CONVERGENT_BUILTIN                                                                  \
   __acpp_##type __acpp_sscp_work_group_reduce_##fn_suffix(__acpp_sscp_algorithm_op op,             \
                                                           __acpp_##type x) {                       \
-    constexpr size_t shmem_array_length = 32;                                                      \
+    constexpr int shmem_array_length = 32;                                                      \
     ACPP_SHMEM_ATTRIBUTE __acpp_##type shrd_mem[shmem_array_length];                               \
     switch (op) {                                                                                  \
     case __acpp_sscp_algorithm_op::plus:                                                           \

--- a/src/libkernel/sscp/amdgpu/scan_exclusive.cpp
+++ b/src/libkernel/sscp/amdgpu/scan_exclusive.cpp
@@ -89,7 +89,7 @@ ACPP_SUBGROUP_INT_SCAN(u64, uint64)
   HIPSYCL_SSCP_CONVERGENT_BUILTIN                                                                  \
   __acpp_##type __acpp_sscp_work_group_exclusive_scan_##type(                                      \
       __acpp_sscp_algorithm_op op, __acpp_##type x, __acpp_##type init) {                          \
-    constexpr size_t shmem_array_length = 32;                                                      \
+    constexpr int shmem_array_length = 32;                                                      \
     ACPP_SHMEM_ATTRIBUTE __acpp_##type shrd_mem[shmem_array_length];                               \
     switch (op) {                                                                                  \
     case __acpp_sscp_algorithm_op::plus:                                                           \
@@ -117,7 +117,7 @@ ACPP_WORKGROUP_FLOAT_SCAN(f64)
   HIPSYCL_SSCP_CONVERGENT_BUILTIN                                                                  \
   __acpp_##type __acpp_sscp_work_group_exclusive_scan_##fn_suffix(                                 \
       __acpp_sscp_algorithm_op op, __acpp_##type x, __acpp_##type init) {                          \
-    constexpr size_t shmem_array_length = 32;                                                      \
+    constexpr int shmem_array_length = 32;                                                      \
     ACPP_SHMEM_ATTRIBUTE __acpp_##type shrd_mem[shmem_array_length];                               \
     switch (op) {                                                                                  \
     case __acpp_sscp_algorithm_op::plus:                                                           \

--- a/src/libkernel/sscp/amdgpu/scan_inclusive.cpp
+++ b/src/libkernel/sscp/amdgpu/scan_inclusive.cpp
@@ -78,7 +78,7 @@ ACPP_SUBGROUP_INT_SCAN(u64, uint64)
   HIPSYCL_SSCP_CONVERGENT_BUILTIN                                                                  \
   __acpp_##type __acpp_sscp_work_group_inclusive_scan_##type(__acpp_sscp_algorithm_op op,          \
                                                              __acpp_##type x) {                    \
-    constexpr size_t shmem_array_length = 32;                                                      \
+    constexpr int shmem_array_length = 32;                                                      \
     ACPP_SHMEM_ATTRIBUTE __acpp_##type shrd_mem[shmem_array_length];                               \
     switch (op) {                                                                                  \
     case __acpp_sscp_algorithm_op::plus:                                                           \
@@ -106,7 +106,7 @@ ACPP_WORKGROUP_FLOAT_SCAN(f64)
   HIPSYCL_SSCP_CONVERGENT_BUILTIN                                                                  \
   __acpp_##type __acpp_sscp_work_group_inclusive_scan_##fn_suffix(__acpp_sscp_algorithm_op op,     \
                                                                   __acpp_##type x) {               \
-    constexpr size_t shmem_array_length = 32;                                                      \
+    constexpr int shmem_array_length = 32;                                                      \
     ACPP_SHMEM_ATTRIBUTE __acpp_##type shrd_mem[shmem_array_length];                               \
     switch (op) {                                                                                  \
     case __acpp_sscp_algorithm_op::plus:                                                           \

--- a/src/libkernel/sscp/amdgpu/subgroup.cpp
+++ b/src/libkernel/sscp/amdgpu/subgroup.cpp
@@ -52,7 +52,7 @@ HIPSYCL_SSCP_BUILTIN __acpp_uint32 __acpp_sscp_get_subgroup_max_size() {
 }
 
 HIPSYCL_SSCP_BUILTIN __acpp_uint32 __acpp_sscp_get_subgroup_id() {
-  size_t local_tid =
+  __acpp_uint32 local_tid =
       __acpp_sscp_get_local_id_x() +
       __acpp_sscp_get_local_id_y() * __acpp_sscp_get_local_size_x() +
       __acpp_sscp_get_local_id_z() * __acpp_sscp_get_local_size_x() *

--- a/src/libkernel/sscp/host/reduction.cpp
+++ b/src/libkernel/sscp/host/reduction.cpp
@@ -77,7 +77,7 @@ ACPP_SUBGROUP_INT_REDUCTION(u64, uint64)
   HIPSYCL_SSCP_CONVERGENT_BUILTIN                                                                  \
   __acpp_##type __acpp_sscp_work_group_reduce_##type(__acpp_sscp_algorithm_op op,                  \
                                                      __acpp_##type x) {                            \
-    constexpr size_t shmem_array_length = 32;                                                      \
+    constexpr int shmem_array_length = 32;                                                      \
     __acpp_##type *shrd_mem =                                                                      \
         static_cast<__acpp_##type *>(__acpp_sscp_host_get_internal_local_memory());                \
     switch (op) {                                                                                  \
@@ -106,7 +106,7 @@ ACPP_WORKGROUP_FLOAT_REDUCTION(f64)
   HIPSYCL_SSCP_CONVERGENT_BUILTIN                                                                  \
   __acpp_##type __acpp_sscp_work_group_reduce_##fn_suffix(__acpp_sscp_algorithm_op op,             \
                                                           __acpp_##type x) {                       \
-    constexpr size_t shmem_array_length = 32;                                                      \
+    constexpr int shmem_array_length = 32;                                                      \
     __acpp_##type *shrd_mem =                                                                      \
         static_cast<__acpp_##type *>(__acpp_sscp_host_get_internal_local_memory());                \
     switch (op) {                                                                                  \

--- a/src/libkernel/sscp/host/subgroup.cpp
+++ b/src/libkernel/sscp/host/subgroup.cpp
@@ -24,7 +24,7 @@ HIPSYCL_SSCP_BUILTIN __acpp_uint32 __acpp_sscp_get_subgroup_max_size() {
 }
 
 HIPSYCL_SSCP_BUILTIN __acpp_uint32 __acpp_sscp_get_subgroup_id() {
-  size_t local_tid =
+  __acpp_uint32 local_tid =
       __acpp_sscp_get_local_id_x() +
       __acpp_sscp_get_local_id_y() * (__acpp_sscp_get_local_size_x() +
       __acpp_sscp_get_local_id_z() * __acpp_sscp_get_local_size_x());

--- a/src/libkernel/sscp/ptx/reduction.cpp
+++ b/src/libkernel/sscp/ptx/reduction.cpp
@@ -77,7 +77,7 @@ ACPP_SUBGROUP_INT_REDUCTION(u64, uint64)
   HIPSYCL_SSCP_CONVERGENT_BUILTIN                                                                  \
   __acpp_##type __acpp_sscp_work_group_reduce_##type(__acpp_sscp_algorithm_op op,                  \
                                                      __acpp_##type x) {                            \
-    constexpr size_t shmem_array_length = 32;                                                      \
+    constexpr int shmem_array_length = 32;                                                      \
     ACPP_SHMEM_ATTRIBUTE __acpp_##type shrd_mem[shmem_array_length];                               \
     switch (op) {                                                                                  \
     case __acpp_sscp_algorithm_op::plus:                                                           \
@@ -106,7 +106,7 @@ ACPP_WORKGROUP_FLOAT_REDUCTION(f64)
   HIPSYCL_SSCP_CONVERGENT_BUILTIN                                                                  \
   __acpp_##type __acpp_sscp_work_group_reduce_##fn_suffix(__acpp_sscp_algorithm_op op,             \
                                                           __acpp_##type x) {                       \
-    constexpr size_t shmem_array_length = 32;                                                      \
+    constexpr int shmem_array_length = 32;                                                      \
     ACPP_SHMEM_ATTRIBUTE __acpp_##type shrd_mem[shmem_array_length];                               \
     switch (op) {                                                                                  \
     case __acpp_sscp_algorithm_op::plus:                                                           \

--- a/src/libkernel/sscp/ptx/scan_exclusive.cpp
+++ b/src/libkernel/sscp/ptx/scan_exclusive.cpp
@@ -91,7 +91,7 @@ ACPP_SUBGROUP_INT_SCAN(u64, uint64)
   HIPSYCL_SSCP_CONVERGENT_BUILTIN                                                                  \
   __acpp_##type __acpp_sscp_work_group_exclusive_scan_##type(                                      \
       __acpp_sscp_algorithm_op op, __acpp_##type x, __acpp_##type init) {                          \
-    constexpr size_t shmem_array_length = 32;                                                      \
+    constexpr int shmem_array_length = 32;                                                      \
     ACPP_SHMEM_ATTRIBUTE __acpp_##type shrd_mem[shmem_array_length];                               \
     switch (op) {                                                                                  \
     case __acpp_sscp_algorithm_op::plus:                                                           \
@@ -120,7 +120,7 @@ ACPP_WORKGROUP_FLOAT_SCAN(f64)
   HIPSYCL_SSCP_CONVERGENT_BUILTIN                                                                  \
   __acpp_##type __acpp_sscp_work_group_exclusive_scan_##fn_suffix(                                 \
       __acpp_sscp_algorithm_op op, __acpp_##type x, __acpp_##type init) {                          \
-    constexpr size_t shmem_array_length = 32;                                                      \
+    constexpr int shmem_array_length = 32;                                                      \
     ACPP_SHMEM_ATTRIBUTE __acpp_##type shrd_mem[shmem_array_length];                               \
     switch (op) {                                                                                  \
     case __acpp_sscp_algorithm_op::plus:                                                           \

--- a/src/libkernel/sscp/ptx/scan_inclusive.cpp
+++ b/src/libkernel/sscp/ptx/scan_inclusive.cpp
@@ -80,7 +80,7 @@ ACPP_SUBGROUP_INT_SCAN(u64, uint64)
   HIPSYCL_SSCP_CONVERGENT_BUILTIN                                                                  \
   __acpp_##type __acpp_sscp_work_group_inclusive_scan_##type(__acpp_sscp_algorithm_op op,          \
                                                              __acpp_##type x) {                    \
-    constexpr size_t shmem_array_length = 32;                                                      \
+    constexpr int shmem_array_length = 32;                                                      \
     ACPP_SHMEM_ATTRIBUTE __acpp_##type shrd_mem[shmem_array_length];                               \
     switch (op) {                                                                                  \
     case __acpp_sscp_algorithm_op::plus:                                                           \
@@ -109,7 +109,7 @@ ACPP_WORKGROUP_FLOAT_SCAN(f64)
   HIPSYCL_SSCP_CONVERGENT_BUILTIN                                                                  \
   __acpp_##type __acpp_sscp_work_group_inclusive_scan_##fn_suffix(__acpp_sscp_algorithm_op op,     \
                                                                   __acpp_##type x) {               \
-    constexpr size_t shmem_array_length = 32;                                                      \
+    constexpr int shmem_array_length = 32;                                                      \
     ACPP_SHMEM_ATTRIBUTE __acpp_##type shrd_mem[shmem_array_length];                               \
     switch (op) {                                                                                  \
     case __acpp_sscp_algorithm_op::plus:                                                           \

--- a/src/libkernel/sscp/ptx/subgroup.cpp
+++ b/src/libkernel/sscp/ptx/subgroup.cpp
@@ -36,7 +36,7 @@ HIPSYCL_SSCP_BUILTIN __acpp_uint32 __acpp_sscp_get_subgroup_max_size() {
 }
 
 HIPSYCL_SSCP_BUILTIN __acpp_uint32 __acpp_sscp_get_subgroup_id() {
-  size_t local_tid =
+  __acpp_uint32 local_tid =
       __acpp_sscp_get_local_id_x() +
       __acpp_sscp_get_local_id_y() * __acpp_sscp_get_local_size_x() +
       __acpp_sscp_get_local_id_z() * __acpp_sscp_get_local_size_x() *

--- a/src/libkernel/sscp/spirv/core.cpp
+++ b/src/libkernel/sscp/spirv/core.cpp
@@ -9,13 +9,12 @@
  */
 // SPDX-License-Identifier: BSD-2-Clause
 #include "hipSYCL/sycl/libkernel/sscp/builtins/core.hpp"
-#include <stddef.h>
 
 
-size_t __spirv_BuiltInLocalInvocationId(int);
-size_t __spirv_BuiltInWorkgroupId(int);
-size_t __spirv_BuiltInWorkgroupSize(int);
-size_t __spirv_BuiltInNumWorkgroups(int);
+__acpp_uint64 __spirv_BuiltInLocalInvocationId(int);
+__acpp_uint64 __spirv_BuiltInWorkgroupId(int);
+__acpp_uint64 __spirv_BuiltInWorkgroupSize(int);
+__acpp_uint64 __spirv_BuiltInNumWorkgroups(int);
 
 HIPSYCL_SSCP_BUILTIN __acpp_uint64 __acpp_sscp_get_local_id_x() {
   return __spirv_BuiltInLocalInvocationId(0);

--- a/src/libkernel/sscp/spirv/reduction.cpp
+++ b/src/libkernel/sscp/spirv/reduction.cpp
@@ -75,7 +75,7 @@ ACPP_SUBGROUP_INT_REDUCTION(u64, uint64)
   HIPSYCL_SSCP_CONVERGENT_BUILTIN                                                                  \
   __acpp_##type __acpp_sscp_work_group_reduce_##type(__acpp_sscp_algorithm_op op,                  \
                                                      __acpp_##type x) {                            \
-    constexpr size_t shmem_array_length = 32;                                                      \
+    constexpr int shmem_array_length = 32;                                                      \
     ACPP_SHMEM_ATTRIBUTE __acpp_##type shrd_mem[shmem_array_length];                               \
     switch (op) {                                                                                  \
     case __acpp_sscp_algorithm_op::plus:                                                           \
@@ -103,7 +103,7 @@ ACPP_WORKGROUP_FLOAT_REDUCTION(f64)
   HIPSYCL_SSCP_CONVERGENT_BUILTIN                                                                  \
   __acpp_##type __acpp_sscp_work_group_reduce_##fn_suffix(__acpp_sscp_algorithm_op op,             \
                                                           __acpp_##type x) {                       \
-    constexpr size_t shmem_array_length = 32;                                                      \
+    constexpr int shmem_array_length = 32;                                                      \
     ACPP_SHMEM_ATTRIBUTE __acpp_##type shrd_mem[shmem_array_length];                               \
     switch (op) {                                                                                  \
     case __acpp_sscp_algorithm_op::plus:                                                           \

--- a/src/libkernel/sscp/spirv/scan_exclusive.cpp
+++ b/src/libkernel/sscp/spirv/scan_exclusive.cpp
@@ -89,7 +89,7 @@ ACPP_SUBGROUP_INT_SCAN(u64, uint64)
   HIPSYCL_SSCP_CONVERGENT_BUILTIN                                                                  \
   __acpp_##type __acpp_sscp_work_group_exclusive_scan_##type(                                      \
       __acpp_sscp_algorithm_op op, __acpp_##type x, __acpp_##type init) {                          \
-    constexpr size_t shmem_array_length = 33;                                                      \
+    constexpr int shmem_array_length = 33;                                                      \
     ACPP_SHMEM_ATTRIBUTE __acpp_##type shrd_mem[shmem_array_length];                               \
     switch (op) {                                                                                  \
     case __acpp_sscp_algorithm_op::plus:                                                           \
@@ -117,7 +117,7 @@ ACPP_WORKGROUP_FLOAT_SCAN(f64)
   HIPSYCL_SSCP_CONVERGENT_BUILTIN                                                                  \
   __acpp_##type __acpp_sscp_work_group_exclusive_scan_##fn_suffix(                                 \
       __acpp_sscp_algorithm_op op, __acpp_##type x, __acpp_##type init) {                          \
-    constexpr size_t shmem_array_length = 33;                                                      \
+    constexpr int shmem_array_length = 33;                                                      \
     ACPP_SHMEM_ATTRIBUTE __acpp_##type shrd_mem[shmem_array_length];                               \
     switch (op) {                                                                                  \
     case __acpp_sscp_algorithm_op::plus:                                                           \

--- a/src/libkernel/sscp/spirv/scan_inclusive.cpp
+++ b/src/libkernel/sscp/spirv/scan_inclusive.cpp
@@ -78,7 +78,7 @@ ACPP_SUBGROUP_INT_SCAN(u64, uint64)
   HIPSYCL_SSCP_CONVERGENT_BUILTIN                                                                  \
   __acpp_##type __acpp_sscp_work_group_inclusive_scan_##type(__acpp_sscp_algorithm_op op,          \
                                                              __acpp_##type x) {                    \
-    constexpr size_t shmem_array_length = 33;                                                      \
+    constexpr int shmem_array_length = 33;                                                      \
     ACPP_SHMEM_ATTRIBUTE __acpp_##type shrd_mem[shmem_array_length];                               \
     switch (op) {                                                                                  \
     case __acpp_sscp_algorithm_op::plus:                                                           \
@@ -106,7 +106,7 @@ ACPP_WORKGROUP_FLOAT_SCAN(f64)
   HIPSYCL_SSCP_CONVERGENT_BUILTIN                                                                  \
   __acpp_##type __acpp_sscp_work_group_inclusive_scan_##fn_suffix(__acpp_sscp_algorithm_op op,     \
                                                                   __acpp_##type x) {               \
-    constexpr size_t shmem_array_length = 33;                                                      \
+    constexpr int shmem_array_length = 33;                                                      \
     ACPP_SHMEM_ATTRIBUTE __acpp_##type shrd_mem[shmem_array_length];                               \
     switch (op) {                                                                                  \
     case __acpp_sscp_algorithm_op::plus:                                                           \


### PR DESCRIPTION
Currently, the SSCP group algorithm builtins pull in `stddef.h`, presumably  for the `size_t` type. This is a regression and should not happen since standard library headers are generally unsupported in device builtin libraries.

This PR replaces the include, and the `size_t` use with other appropriate types.