### PR TITLE
[SSCP] Refactor HCF registration

### DIFF
--- a/include/hipSYCL/glue/llvm-sscp/hcf_registration.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/hcf_registration.hpp
@@ -1,0 +1,50 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "s1_ir_constants.hpp"
+#include <cstdlib>
+
+
+#ifndef ACPP_SSCP_HCF_REGISTRATION_HPP
+#define ACPP_SSCP_HCF_REGISTRATION_HPP
+
+// These functions are defined in the AdaptiveCpp runtime (kernel_cache.cpp)
+extern "C" void __acpp_register_hcf(const char* hcf, std::size_t size);
+extern "C" void __acpp_unregister_hcf(std::size_t hcf_object_id);
+
+namespace hipsycl::glue::sscp {
+
+static const char* get_local_hcf_object() {
+  return __acpp_local_sscp_hcf_content;
+}
+static std::size_t get_local_hcf_size() {
+  return __acpp_local_sscp_hcf_object_size;
+}
+static std::size_t get_local_hcf_id() {
+  return __acpp_local_sscp_hcf_object_id;
+}
+
+struct static_hcf_registration {
+public:
+  static_hcf_registration() {
+    __acpp_register_hcf(get_local_hcf_object(), get_local_hcf_size());
+  }
+
+  ~static_hcf_registration() {
+    __acpp_unregister_hcf(get_local_hcf_id());
+  }
+};
+
+static static_hcf_registration __acpp_register_sscp_hcf_object;
+}
+
+
+#endif

--- a/include/hipSYCL/glue/llvm-sscp/hcf_registration.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/hcf_registration.hpp
@@ -34,10 +34,12 @@ static std::size_t get_local_hcf_id() {
 
 struct static_hcf_registration {
 public:
+  __attribute__((internal_linkage))
   static_hcf_registration() {
     __acpp_register_hcf(get_local_hcf_object(), get_local_hcf_size());
   }
 
+  __attribute__((internal_linkage))
   ~static_hcf_registration() {
     __acpp_unregister_hcf(get_local_hcf_id());
   }

--- a/include/hipSYCL/glue/llvm-sscp/sscp_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/sscp_kernel_launcher.hpp
@@ -95,6 +95,11 @@ private:
 static static_hcf_registration
     __acpp_register_sscp_hcf_object{get_local_hcf_object()};
 
+// These functions are defined in the AdaptiveCpp runtime (kernel_cache.cpp)
+extern "C" void __acpp_register_hcf(const char* hcf, std::size_t size);
+extern "C" void __acpp_unregister_hcf(std::size_t hcf_object_id);
+
+
 
 // This class effectively caches queries into the HCF cache: For each
 // kernel lambda type, a separate object is instantiated which queries the HCF cache.

--- a/include/hipSYCL/glue/llvm-sscp/sscp_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/sscp_kernel_launcher.hpp
@@ -29,6 +29,7 @@
 #include "hipSYCL/sycl/libkernel/sp_group.hpp"
 #include "hipSYCL/sycl/libkernel/group.hpp"
 #include "ir_constants.hpp"
+#include "hcf_registration.hpp"
 #include "../kernel_launcher_data.hpp"
 
 #include <array>
@@ -70,35 +71,6 @@ namespace hipsycl {
 namespace glue {
 
 namespace sscp {
-
-static std::string get_local_hcf_object() {
-  return std::string{
-      reinterpret_cast<const char *>(__acpp_local_sscp_hcf_content),
-      __acpp_local_sscp_hcf_object_size};
-}
-
-// TODO: Maybe this can be unified with the ACPP_STATIC_HCF_REGISTRATION
-// macro. We cannot use this macro directly because it expects
-// the object id to be constexpr, which it is not for the SSCP case.
-struct static_hcf_registration {
-  static_hcf_registration(const std::string& hcf_data) {
-    this->_hcf_object = rt::hcf_cache::get().register_hcf_object(
-        common::hcf_container{hcf_data});
-  }
-
-  ~static_hcf_registration() {
-    rt::hcf_cache::get().unregister_hcf_object(_hcf_object);
-  }
-private:
-  rt::hcf_object_id _hcf_object;
-};
-static static_hcf_registration
-    __acpp_register_sscp_hcf_object{get_local_hcf_object()};
-
-// These functions are defined in the AdaptiveCpp runtime (kernel_cache.cpp)
-extern "C" void __acpp_register_hcf(const char* hcf, std::size_t size);
-extern "C" void __acpp_unregister_hcf(std::size_t hcf_object_id);
-
 
 
 // This class effectively caches queries into the HCF cache: For each

--- a/src/runtime/kernel_cache.cpp
+++ b/src/runtime/kernel_cache.cpp
@@ -46,6 +46,15 @@ void for_each_exported_symbol_list(const common::hcf_container& hcf, F&& handler
 
 }
 
+extern "C" void __acpp_register_hcf(const char* hcf, std::size_t size) {
+  std::string hcf_data{hcf, size};
+  hcf_cache::get().register_hcf_object(common::hcf_container{hcf_data});
+}
+
+extern "C" void __acpp_unregister_hcf(std::size_t hcf_object_id) {
+  hcf_cache::get().unregister_hcf_object(hcf_object_id);
+}
+
 hcf_kernel_info::hcf_kernel_info(
     hcf_object_id id, const common::hcf_container::node *kernel_node)
     : _id{id} {


### PR DESCRIPTION
* Move HCF registration struct into dedicated file
* Handle HCF registry and HCF object construction inside of the runtime for reduced dependencies between headers and runtime internals