### PR TITLE
Extract getPointerType and ocl info_query to their own headers

### DIFF
--- a/include/hipSYCL/compiler/LLVMUtils.hpp
+++ b/include/hipSYCL/compiler/LLVMUtils.hpp
@@ -1,0 +1,24 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#ifndef HIPSYCL_SSCP_LLVMUTILS_H
+#define HIPSYCL_SSCP_LLVMUTILS_H
+
+#include "llvm/IR/DerivedTypes.h"
+
+inline llvm::Type *getPointerType(llvm::Type *PointeeT, int AddressSpace) {
+#if LLVM_VERSION_MAJOR < 16
+  return llvm::PointerType::get(PointeeT, AddressSpace);
+#else
+  return llvm::PointerType::get(PointeeT->getContext(), AddressSpace);
+#endif
+}
+
+#endif

--- a/include/hipSYCL/runtime/ocl/ocl_query.hpp
+++ b/include/hipSYCL/runtime/ocl/ocl_query.hpp
@@ -1,0 +1,35 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#ifndef ACPP_OCL_QUERY
+#define ACPP_OCL_QUERY
+#include "hipSYCL/runtime/error.hpp"
+
+#include <CL/opencl.h>
+#include <CL/opencl.hpp>
+
+namespace hipsycl::rt {
+
+template <cl_device_info Query, class ResultT>
+ResultT info_query(const cl::Device &dev) {
+  ResultT r{};
+  cl_int err = dev.getInfo(Query, &r);
+  if (err != CL_SUCCESS) {
+    register_error(
+        __acpp_here(),
+        error_info{"ocl: Could not obtain device info", error_code{"CL", err}});
+  }
+
+  return r;
+}
+
+} // namespace hipsycl::rt
+
+#endif

--- a/src/compiler/reflection/IntrospectStructPass.cpp
+++ b/src/compiler/reflection/IntrospectStructPass.cpp
@@ -11,6 +11,7 @@
 #include "hipSYCL/compiler/reflection/IntrospectStructPass.hpp"
 #include "hipSYCL/compiler/utils/AggregateTypeUtils.hpp"
 #include "hipSYCL/common/debug.hpp"
+#include "hipSYCL/compiler/LLVMUtils.hpp"
 #include <climits>
 #include <cstdint>
 #include <llvm/IR/Constants.h>
@@ -158,14 +159,6 @@ llvm::AllocaInst *recurseOperandUntilAlloca(llvm::Instruction *I) {
   } else {
     return nullptr;
   }
-}
-
-llvm::Type* getPointerType(llvm::Type* PointeeT, int AddressSpace) {
-#if LLVM_VERSION_MAJOR < 16
-    return llvm::PointerType::get(PointeeT, AddressSpace);
-#else
-    return llvm::PointerType::get(PointeeT->getContext(), AddressSpace);
-#endif
 }
 
 } // anonymous namespace

--- a/src/compiler/sscp/StdAtomicRemapperPass.cpp
+++ b/src/compiler/sscp/StdAtomicRemapperPass.cpp
@@ -9,6 +9,7 @@
  */
 // SPDX-License-Identifier: BSD-2-Clause
 #include "hipSYCL/compiler/sscp/StdAtomicRemapperPass.hpp"
+#include "hipSYCL/compiler/LLVMUtils.hpp"
 #include "hipSYCL/common/debug.hpp"
 
 
@@ -67,14 +68,6 @@ memory_order llvmOrderingToAcppOrdering(llvm::AtomicOrdering AO) {
     return memory_order::acq_rel;
   else
     return memory_order::seq_cst;
-}
-
-llvm::Type* getPointerType(llvm::Type* PointeeT, int AddressSpace) {
-#if LLVM_VERSION_MAJOR < 16
-    return llvm::PointerType::get(PointeeT, AddressSpace);
-#else
-    return llvm::PointerType::get(PointeeT->getContext(), AddressSpace);
-#endif
 }
 
 template<class IntType>

--- a/src/runtime/ocl/ocl_hardware_manager.cpp
+++ b/src/runtime/ocl/ocl_hardware_manager.cpp
@@ -14,6 +14,7 @@
 #include "hipSYCL/runtime/hardware.hpp"
 #include "hipSYCL/runtime/ocl/ocl_allocator.hpp"
 #include "hipSYCL/runtime/ocl/ocl_hardware_manager.hpp"
+#include "hipSYCL/runtime/ocl/ocl_query.hpp"
 #include "hipSYCL/runtime/settings.hpp"
 
 #include <CL/cl.h>
@@ -35,19 +36,6 @@ namespace {
 constexpr std::array incompatible_ocl_platforms = {
     "NVIDIA CUDA", "Intel(R) FPGA Emulation Platform for OpenCL(TM)",
     "AMD Accelerated Parallel Processing"};
-
-template<int Query, class ResultT>
-ResultT info_query(const cl::Device& dev) {
-  ResultT r{};
-  cl_int err = dev.getInfo(Query, &r);
-  if(err != CL_SUCCESS) {
-    register_error(
-          __acpp_here(),
-          error_info{"ocl_hardware_context: Could not obtain device info",
-                    error_code{"CL", err}});
-  }
-  return r;
-}
 
 template<int Query, class ResultT>
 ResultT platform_info_query(const cl::Device& dev) {

--- a/src/runtime/ocl/ocl_usm.cpp
+++ b/src/runtime/ocl/ocl_usm.cpp
@@ -11,6 +11,7 @@
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/ocl/ocl_hardware_manager.hpp"
 #include "hipSYCL/runtime/ocl/ocl_usm.hpp"
+#include "hipSYCL/runtime/ocl/ocl_query.hpp"
 #include "hipSYCL/runtime/operations.hpp"
 
 #include <CL/opencl.hpp>
@@ -21,21 +22,6 @@
 namespace hipsycl {
 namespace rt {
 
-namespace {
-template<int Query, class ResultT>
-ResultT info_query(const cl::Device& dev) {
-  ResultT r{};
-  cl_int err = dev.getInfo(Query, &r);
-  if(err != CL_SUCCESS) {
-    register_error(
-          __acpp_here(),
-          error_info{"ocl_usm: Could not obtain device info",
-                    error_code{"CL", err}});
-  }
-  return r;
-}
-
-}
 
 class ocl_usm_intel_extension : public ocl_usm {
 public:


### PR DESCRIPTION
This allow building AdaptiveCpp using [unity builds](https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html). 

This mode merges .cpp files via `#includes` into a single file and then compile it. That clashes with .cpp having functions with the same name (even in anonymous namespaces).

This can speed up compilation by a lot.