### PR TITLE
Remove the use of raw pointers in backend.hpp get(backend_id)

### DIFF
--- a/include/hipSYCL/algorithms/util/allocation_cache.hpp
+++ b/include/hipSYCL/algorithms/util/allocation_cache.hpp
@@ -53,7 +53,7 @@ public:
     std::lock_guard<std::mutex> lock{_mutex};
     
     for(auto& allocation : _allocations) {
-      auto* allocator = _rt.get()->backends()
+      auto* allocator = _rt.get()->backend_mgr()
           .get(allocation.dev.get_backend())
           ->get_allocator(allocation.dev);
       rt::deallocate(allocator, allocation.ptr);
@@ -69,7 +69,7 @@ private:
       result.dev = dev;
       result.size = min_size;
 
-      auto allocator = _rt.get()->backends()
+      auto allocator = _rt.get()->backend_mgr()
                        .get(dev.get_backend())
                        ->get_allocator(dev);
 

--- a/include/hipSYCL/runtime/backend.hpp
+++ b/include/hipSYCL/runtime/backend.hpp
@@ -64,22 +64,16 @@ class backend_manager
 {
 public:
   using backend_list_type =
-      std::vector<std::unique_ptr<backend>>;
+      std::vector<std::shared_ptr<backend>>;
 
   backend_manager();
   ~backend_manager();
-  
-  backend* get(backend_id) const;
+
+  const backend_list_type &backends() const { return _backends; }
+  std::shared_ptr<backend> get(backend_id) const;
+
   hw_model& hardware_model();
   const hw_model& hardware_model() const;
-
-  template<class F>
-  void for_each_backend(F f)
-  {
-    for(auto& b : _backends){
-      f(b.get());
-    }
-  }
 
 private:
   backend_loader _loader;

--- a/include/hipSYCL/runtime/device_list.hpp
+++ b/include/hipSYCL/runtime/device_list.hpp
@@ -67,7 +67,7 @@ public:
     std::size_t count = 0;
 
     for_each_backend([&](backend_id b) {
-      if (_rt->backends().get(b)->get_hardware_platform() == plat)
+      if (_rt->backend_mgr().get(b)->get_hardware_platform() == plat)
         ++count;
     });
     

--- a/include/hipSYCL/runtime/runtime.hpp
+++ b/include/hipSYCL/runtime/runtime.hpp
@@ -35,14 +35,14 @@ public:
   const dag_manager& dag() const
   { return _dag_manager; }
 
-  backend_manager &backends() { return _backends; }
+  backend_manager &backend_mgr() { return _backend_manager; }
 
-  const backend_manager &backends() const { return _backends; }
+  const backend_manager &backend_mgr() const { return _backend_manager; }
 
 private:
   // !! Attention: order is important, as backends have to be still present,
   // when the dag_manager is destructed!
-  backend_manager _backends;
+  backend_manager _backend_manager;
   dag_manager _dag_manager;
 };
 

--- a/include/hipSYCL/std/stdpar/detail/offload.hpp
+++ b/include/hipSYCL/std/stdpar/detail/offload.hpp
@@ -105,7 +105,7 @@ bool validate_all_pointers(const Args&... args){
   auto& q = detail::single_device_dispatch::get_queue();
   auto* allocator = q.get_context()
       .AdaptiveCpp_runtime()
-      ->backends()
+      ->backend_mgr()
       .get(q.get_device().get_backend())
       ->get_allocator(q.get_device().AdaptiveCpp_device_id());
 

--- a/include/hipSYCL/std/stdpar/detail/sycl_glue.hpp
+++ b/include/hipSYCL/std/stdpar/detail/sycl_glue.hpp
@@ -65,7 +65,7 @@ private:
         _shared_scratch_cache{algorithms::util::allocation_type::shared},
         _host_scratch_cache{algorithms::util::allocation_type::host} {
           auto dev = _queue.get_device().AdaptiveCpp_device_id();
-          auto* be = _queue.get_context().AdaptiveCpp_runtime()->backends().get(
+          auto* be = _queue.get_context().AdaptiveCpp_runtime()->backend_mgr().get(
               dev.get_backend());
           if (be->get_hardware_manager()
                   ->get_device(dev.get_id())

--- a/include/hipSYCL/sycl/buffer.hpp
+++ b/include/hipSYCL/sycl/buffer.hpp
@@ -1210,13 +1210,13 @@ private:
     if(!_impl->data->has_allocation(host_device)){
       if(this->has_property<property::buffer::use_optimized_host_memory>()){
         // TODO: Actually may need to use non-host backend here...
-        auto* allocator = rt->backends().get(host_device.get_backend())
+        auto* allocator = rt->backend_mgr().get(host_device.get_backend())
                 ->get_allocator(host_device);
         host_ptr = rt::allocate_host(allocator, alignof(T),
                                      _impl->data->get_num_elements().size() *
                                          sizeof(T));
       } else {
-        auto *allocator = rt->backends()
+        auto *allocator = rt->backend_mgr()
                               .get(host_device.get_backend())
                               ->get_allocator(host_device);
         host_ptr = rt::allocate_device(allocator, alignof(T),
@@ -1230,7 +1230,7 @@ private:
 
       _impl->data->add_empty_allocation(
           host_device, host_ptr,
-          rt->backends().get(host_device.get_backend())
+          rt->backend_mgr().get(host_device.get_backend())
               ->get_allocator(host_device),
           true /*takes_ownership*/);
     }
@@ -1272,7 +1272,7 @@ private:
     _impl->data->add_nonempty_allocation(detail::get_host_device(),
 					 const_cast<std::remove_const_t<T>*>(host_memory),
                                          _impl->requires_runtime.get()
-                                             ->backends()
+                                             ->backend_mgr()
                                              .get(host_device.get_backend())
                                              ->get_allocator(host_device),
                                          false /*takes_ownership*/);
@@ -1301,7 +1301,7 @@ private:
 
       rt::device_id dev = detail::extract_rt_device(desc.desc.dev);
       rt::backend_allocator *allocator = _impl->requires_runtime.get()
-                                             ->backends()
+                                             ->backend_mgr()
                                              .get(dev.get_backend())
                                              ->get_allocator(dev);
 

--- a/include/hipSYCL/sycl/context.hpp
+++ b/include/hipSYCL/sycl/context.hpp
@@ -132,7 +132,7 @@ public:
     rt::platform_id last_platform;
 
     this->_impl->devices.for_each_backend([&](rt::backend_id b) {
-      rt::backend* backend = this->_impl->requires_runtime.get()->backends().get(b);
+      rt::backend* backend = this->_impl->requires_runtime.get()->backend_mgr().get(b);
 
       for (std::size_t platform_index = 0;
            platform_index < backend->get_hardware_manager()->get_num_platforms();

--- a/include/hipSYCL/sycl/device.hpp
+++ b/include/hipSYCL/sycl/device.hpp
@@ -281,7 +281,9 @@ private:
   rt::runtime_keep_alive_token _requires_runtime;
 
   rt::hardware_context *get_rt_device() const {
-    auto ptr = _requires_runtime.get()->backends().get(_device_id.get_backend())
+    auto ptr = _requires_runtime.get()
+                   ->backend_mgr()
+                   .get(_device_id.get_backend())
                    ->get_hardware_manager()
                    ->get_device(_device_id.get_id());
     if (!ptr) {

--- a/include/hipSYCL/sycl/queue.hpp
+++ b/include/hipSYCL/sycl/queue.hpp
@@ -1151,7 +1151,7 @@ private:
       // so this might return nullptr.
       _impl->dedicated_inorder_executor =
           _impl->requires_runtime.get()
-              ->backends()
+              ->backend_mgr()
               .get(rt_dev.get_backend())
               ->create_inorder_executor(rt_dev, priority);
       

--- a/include/hipSYCL/sycl/usm_query.hpp
+++ b/include/hipSYCL/sycl/usm_query.hpp
@@ -59,7 +59,7 @@ inline rt::backend_id select_usm_backend(const context &ctx) {
           << std::endl;
     }
     auto backend_it = devs.find_first_backend([&](rt::backend_id b) {
-      return ctx.AdaptiveCpp_runtime()->backends().get(b)->get_hardware_platform() !=
+      return ctx.AdaptiveCpp_runtime()->backend_mgr().get(b)->get_hardware_platform() !=
              rt::hardware_platform::cpu;
     });
     assert(backend_it != devs.backends_end());
@@ -76,7 +76,7 @@ inline rt::backend_id select_usm_backend(const context &ctx) {
           << std::endl;
     }
     auto backend_it = devs.find_first_backend([&](rt::backend_id b) {
-      return ctx.AdaptiveCpp_runtime()->backends().get(b)->get_hardware_platform() ==
+      return ctx.AdaptiveCpp_runtime()->backend_mgr().get(b)->get_hardware_platform() ==
              rt::hardware_platform::cpu;
     });
     assert(backend_it != devs.backends_end());
@@ -105,7 +105,7 @@ inline rt::backend_allocator *select_usm_allocator(const context &ctx) {
   rt::backend_id selected_backend = select_usm_backend(ctx);
 
   rt::backend &backend_object =
-      *ctx.AdaptiveCpp_runtime()->backends().get(selected_backend);
+      *ctx.AdaptiveCpp_runtime()->backend_mgr().get(selected_backend);
 
   if (backend_object.get_hardware_manager()->get_num_devices() == 0)
     throw exception{make_error_code(errc::memory_allocation),
@@ -122,7 +122,7 @@ inline rt::backend_allocator *select_usm_allocator(const context &ctx,
   rt::backend_id selected_backend = select_usm_backend(ctx);
 
   rt::backend &backend_object =
-      *ctx.AdaptiveCpp_runtime()->backends().get(selected_backend);
+      *ctx.AdaptiveCpp_runtime()->backend_mgr().get(selected_backend);
   rt::device_id d = detail::extract_rt_device(dev);
   
   if(d.get_backend() == selected_backend)
@@ -136,7 +136,7 @@ inline rt::backend_allocator *select_device_allocator(const device &dev) {
   rt::device_id d = detail::extract_rt_device(dev);
 
   rt::backend &backend_object =
-      *dev.AdaptiveCpp_runtime()->backends().get(d.get_backend());
+      *dev.AdaptiveCpp_runtime()->backend_mgr().get(d.get_backend());
   return backend_object.get_allocator(d);
 }
 }

--- a/src/runtime/dag_direct_scheduler.cpp
+++ b/src/runtime/dag_direct_scheduler.cpp
@@ -86,7 +86,7 @@ result ensure_allocation_exists(runtime *rt,
         bmem_req->get_data_region()->get_element_size();
 
     backend_allocator *allocator =
-        rt->backends().get(target_dev.get_backend())->get_allocator(target_dev);
+        rt->backend_mgr().get(target_dev.get_backend())->get_allocator(target_dev);
     // Currently we just pass 0 for the alignment which should
     // cause backends to align to the largest supported type.
     // TODO: A better solution might be to select a custom alignment
@@ -183,7 +183,7 @@ select_executor(runtime *rt, dag_node_ptr node, operation *op) {
         return std::make_pair(user_preferred_executor, preferred_device);
 
     return std::make_pair(
-        rt->backends().get(executor_backend)->get_executor(preferred_device),
+        rt->backend_mgr().get(executor_backend)->get_executor(preferred_device),
         preferred_device);
 
   } else {
@@ -193,7 +193,7 @@ select_executor(runtime *rt, dag_node_ptr node, operation *op) {
       return std::make_pair(user_preferred_executor, dev);
 
     return std::make_pair(
-        rt->backends().get(dev.get_backend())->get_executor(dev), dev);
+        rt->backend_mgr().get(dev.get_backend())->get_executor(dev), dev);
   }
 }
 

--- a/src/runtime/dag_unbound_scheduler.cpp
+++ b/src/runtime/dag_unbound_scheduler.cpp
@@ -29,12 +29,13 @@ void dag_unbound_scheduler::submit(dag_node_ptr node) {
     // when schedulers are constructed the runtime is typically
     // locked because it is just starting up, so this would
     // create a deadlock
-    _rt->backends().for_each_backend([this](backend *b) {
-      std::size_t num_devs = b->get_hardware_manager()->get_num_devices();
+    for (const auto &b : _rt->backend_mgr().backends()) {
+      const auto num_devs = b->get_hardware_manager()->get_num_devices();
+
       for (std::size_t i = 0; i < num_devs; ++i) {
         this->_devices.push_back(b->get_hardware_manager()->get_device_id(i));
       }
-    });
+    }
   }
 
   if(!node->get_execution_hints().has_hint<hints::bind_to_device>()){


### PR DESCRIPTION
Rename backends() to backend_mgr() in device.hpp and introduce a backend() function in backend.hpp, to remove the unneeded for_each lambda.

Adapt user code.