### PR TITLE
Remove raw pointer usage from allocator.{c|h}pp

### DIFF
--- a/include/hipSYCL/runtime/allocator.hpp
+++ b/include/hipSYCL/runtime/allocator.hpp
@@ -68,13 +68,13 @@ public:
   virtual ~backend_allocator(){}
 };
 
-void *allocate_device(backend_allocator *alloc, size_t min_alignment,
+void *allocate_device(backend_allocator &alloc, size_t min_alignment,
                       size_t size_bytes, const allocation_hints &hints = {});
-void *allocate_host(backend_allocator *alloc, size_t min_alignment,
+void *allocate_host(backend_allocator &alloc, size_t min_alignment,
                     size_t bytes, const allocation_hints &hints = {});
-void *allocate_shared(backend_allocator* alloc, size_t bytes,
+void *allocate_shared(backend_allocator &alloc, size_t bytes,
                       const allocation_hints &hints = {});
-void deallocate(backend_allocator* alloc, void *mem);
+void deallocate(backend_allocator &alloc, void *mem);
 
 
 }

--- a/src/runtime/allocator.cpp
+++ b/src/runtime/allocator.cpp
@@ -18,44 +18,44 @@
 namespace hipsycl {
 namespace rt {
 
-void *allocate_device(backend_allocator *alloc, size_t min_alignment,
+void *allocate_device(backend_allocator &alloc, size_t min_alignment,
                       size_t size_bytes, const allocation_hints &hints) {
-  auto *ptr = alloc->raw_allocate(min_alignment, size_bytes, hints);
+  auto *ptr = alloc.raw_allocate(min_alignment, size_bytes, hints);
   if(ptr) {
     application::event_handler_layer().on_new_allocation(
         ptr, size_bytes,
-        allocation_info{alloc->get_device(),
+        allocation_info{alloc.get_device(),
                         allocation_info::allocation_type::device});
   }
   return ptr;
 }
 
-void *allocate_host(backend_allocator *alloc, size_t min_alignment,
+void *allocate_host(backend_allocator &alloc, size_t min_alignment,
                     size_t bytes, const allocation_hints &hints) {
-  auto* ptr = alloc->raw_allocate_optimized_host(min_alignment, bytes, hints);
+  auto* ptr = alloc.raw_allocate_optimized_host(min_alignment, bytes, hints);
   if(ptr) {
     application::event_handler_layer().on_new_allocation(
         ptr, bytes,
-        allocation_info{alloc->get_device(),
+        allocation_info{alloc.get_device(),
                         allocation_info::allocation_type::host});
   }
   return ptr;
 }
 
-void *allocate_shared(backend_allocator *alloc, size_t bytes,
+void *allocate_shared(backend_allocator &alloc, size_t bytes,
                       const allocation_hints &hints) {
-  auto* ptr = alloc->raw_allocate_usm(bytes, hints);
+  auto* ptr = alloc.raw_allocate_usm(bytes, hints);
   if(ptr) {
     application::event_handler_layer().on_new_allocation(
         ptr, bytes,
-        allocation_info{alloc->get_device(),
+        allocation_info{alloc.get_device(),
                         allocation_info::allocation_type::host});
   }
   return ptr;
 }
 
-void deallocate(backend_allocator* alloc, void *mem) {
-  alloc->raw_free(mem);
+void deallocate(backend_allocator &alloc, void *mem) {
+  alloc.raw_free(mem);
   application::event_handler_layer().on_deallocation(mem);
 }
 

--- a/src/runtime/dag_direct_scheduler.cpp
+++ b/src/runtime/dag_direct_scheduler.cpp
@@ -91,7 +91,7 @@ result ensure_allocation_exists(runtime *rt,
     // cause backends to align to the largest supported type.
     // TODO: A better solution might be to select a custom alignment
     // best on sizeof(T). This requires querying backend alignment capabilities.
-    void *ptr = rt::allocate_device(allocator, 0, num_bytes);
+    void *ptr = rt::allocate_device(*allocator, 0, num_bytes);
 
     if(!ptr)
       return register_error(


### PR DESCRIPTION
We don't need raw pointers for these operations. Let's reduce the number of raw pointers passed around.