### PR TITLE
Refactor float builtins that take an int argument

### DIFF
--- a/include/hipSYCL/sycl/libkernel/sscp/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins.hpp
@@ -115,7 +115,7 @@ HIPSYCL_BUILTIN float __acpp_frexp(float x, IntT* ptr) {
 
 template<class IntT>
 HIPSYCL_BUILTIN double __acpp_frexp(double x, IntT* ptr) {
-  __acpp_int64 val;
+  __acpp_int32 val;
   double res = __acpp_sscp_frexp_f64(x, &val);
   *ptr = static_cast<IntT>(val);
   return res;
@@ -131,7 +131,7 @@ HIPSYCL_BUILTIN float __acpp_ldexp(float x, IntType k) noexcept {
 
 template<class IntType>
 HIPSYCL_BUILTIN double __acpp_ldexp(double x, IntType k) noexcept {
-  return __acpp_sscp_ldexp_f64(x, static_cast<__acpp_int64>(k));
+  return __acpp_sscp_ldexp_f64(x, static_cast<__acpp_int32>(k));
 }
 
 HIPSYCL_DEFINE_SSCP_GENFLOAT_MATH_BUILTIN(lgamma)
@@ -147,7 +147,7 @@ HIPSYCL_BUILTIN float __acpp_lgamma_r(float x, IntT* ptr) {
 
 template<class IntT>
 HIPSYCL_BUILTIN double __acpp_lgamma_r(double x, IntT* ptr) {
-  __acpp_int64 val;
+  __acpp_int32 val;
   double res = __acpp_sscp_lgamma_r_f64(x, &val);
   *ptr = static_cast<IntT>(val);
   return res;
@@ -218,7 +218,7 @@ HIPSYCL_BUILTIN float __acpp_rootn(float x, IntType y) noexcept {
 
 template<class IntType>
 HIPSYCL_BUILTIN double __acpp_rootn(double x, IntType y) noexcept {
-  return __acpp_sscp_rootn_f64(x, static_cast<__acpp_int64>(y));
+  return __acpp_sscp_rootn_f64(x, static_cast<__acpp_int32>(y));
 }
 
 HIPSYCL_DEFINE_SSCP_GENFLOAT_MATH_BUILTIN(round)

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/math.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/math.hpp
@@ -111,7 +111,7 @@ HIPSYCL_SSCP_BUILTIN float __acpp_sscp_fract_f32(float, float*);
 HIPSYCL_SSCP_BUILTIN double __acpp_sscp_fract_f64(double, double*);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_frexp_f32(float, __acpp_int32*);
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_frexp_f64(double, __acpp_int64*);
+HIPSYCL_SSCP_BUILTIN double __acpp_sscp_frexp_f64(double, __acpp_int32*);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_hypot_f32(float, float);
 HIPSYCL_SSCP_BUILTIN double __acpp_sscp_hypot_f64(double, double);
@@ -120,13 +120,13 @@ HIPSYCL_SSCP_BUILTIN float __acpp_sscp_ilogb_f32(float);
 HIPSYCL_SSCP_BUILTIN double __acpp_sscp_ilogb_f64(double);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_ldexp_f32(float, __acpp_int32);
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_ldexp_f64(double, __acpp_int64);
+HIPSYCL_SSCP_BUILTIN double __acpp_sscp_ldexp_f64(double, __acpp_int32);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_lgamma_f32(float);
 HIPSYCL_SSCP_BUILTIN double __acpp_sscp_lgamma_f64(double);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_lgamma_r_f32(float, __acpp_int32*);
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_lgamma_r_f64(double, __acpp_int64*);
+HIPSYCL_SSCP_BUILTIN double __acpp_sscp_lgamma_r_f64(double, __acpp_int32*);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_log_f32(float);
 HIPSYCL_SSCP_BUILTIN double __acpp_sscp_log_f64(double);
@@ -174,7 +174,7 @@ HIPSYCL_SSCP_BUILTIN float __acpp_sscp_rint_f32(float);
 HIPSYCL_SSCP_BUILTIN double __acpp_sscp_rint_f64(double);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_rootn_f32(float, __acpp_int32);
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_rootn_f64(double, __acpp_int64);
+HIPSYCL_SSCP_BUILTIN double __acpp_sscp_rootn_f64(double, __acpp_int32);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_round_f32(float);
 HIPSYCL_SSCP_BUILTIN double __acpp_sscp_round_f64(double);

--- a/src/libkernel/sscp/amdgpu/math.cpp
+++ b/src/libkernel/sscp/amdgpu/math.cpp
@@ -111,11 +111,16 @@ HIPSYCL_SSCP_BUILTIN float __acpp_sscp_frexp_f32(float x, __acpp_int32 *y) {
   }
 }
 
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_frexp_f64(double x, __acpp_int64 *y) {
+HIPSYCL_SSCP_BUILTIN double __acpp_sscp_frexp_f64(double x, __acpp_int32 *y) {
   __acpp_int32 w;
-  double res = __ocml_frexp_f64(x, to_private(&w));
-  *y = static_cast<__acpp_int64>(w);
-  return res;
+  if(__ockl_is_private_addr(y))
+    return __ocml_frexp_f64(x, to_private(y));
+  else {
+    __acpp_int32 w;
+    float res = __ocml_frexp_f64(x, to_private(&w));
+    *y = w;
+    return res;
+  }
 }
 
 HIPSYCL_SSCP_MAP_OCML_FLOAT_BUILTIN2(hypot, __ocml_hypot)
@@ -125,7 +130,7 @@ HIPSYCL_SSCP_BUILTIN float __acpp_sscp_ldexp_f32(float x, __acpp_int32 k) {
   return __ocml_ldexp_f32(x, k);
 }
 
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_ldexp_f64(double x, __acpp_int64 k) {
+HIPSYCL_SSCP_BUILTIN double __acpp_sscp_ldexp_f64(double x, __acpp_int32 k) {
   return __ocml_ldexp_f64(x, k);
 }
 
@@ -144,11 +149,15 @@ HIPSYCL_SSCP_BUILTIN float __acpp_sscp_lgamma_r_f32(float x, __acpp_int32* y ) {
   }
 }
 
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_lgamma_r_f64(double x, __acpp_int64* y) {
-  __acpp_int32 w;
-  auto res = __ocml_lgamma_r_f64(x, to_private(&w));
-  *y = w;
-  return res;
+HIPSYCL_SSCP_BUILTIN double __acpp_sscp_lgamma_r_f64(double x, __acpp_int32* y) {
+  if(__ockl_is_private_addr(y)) {
+    return __ocml_lgamma_r_f64(x, to_private(y));
+  } else {
+    __acpp_int32 w;
+    auto res = __ocml_lgamma_r_f64(x, to_private(&w));
+    *y = w;
+    return res;
+  }
 }
 
 HIPSYCL_SSCP_MAP_OCML_FLOAT_BUILTIN(log, __ocml_log)
@@ -200,8 +209,8 @@ HIPSYCL_SSCP_BUILTIN float __acpp_sscp_rootn_f32(float x, __acpp_int32 y) {
   return __ocml_rootn_f32(x, y);
 }
 
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_rootn_f64(double x, __acpp_int64 y) {
-  return __ocml_rootn_f64(x, static_cast<__acpp_int32>(y));
+HIPSYCL_SSCP_BUILTIN double __acpp_sscp_rootn_f64(double x, __acpp_int32 y) {
+  return __ocml_rootn_f64(x, y);
 }
 
 HIPSYCL_SSCP_MAP_OCML_FLOAT_BUILTIN(round, __ocml_round)

--- a/src/libkernel/sscp/host/math.cpp
+++ b/src/libkernel/sscp/host/math.cpp
@@ -155,11 +155,8 @@ HIPSYCL_SSCP_BUILTIN float __acpp_sscp_frexp_f32(float x,
   return frexpf(x, y);
 }
 HIPSYCL_SSCP_BUILTIN double __acpp_sscp_frexp_f64(double x,
-                                                     __acpp_int64 *y) {
-  __acpp_int32 w;
-  auto res = frexp(x, &w);
-  *y = w;
-  return res;
+                                                     __acpp_int32 *y) {
+  return frexp(x, y);
 }
 
 HIPSYCL_SSCP_MAP_HOST_FLOAT_BUILTIN2(hypot)
@@ -171,7 +168,7 @@ HIPSYCL_SSCP_BUILTIN float __acpp_sscp_ldexp_f32(float x,
 }
 
 HIPSYCL_SSCP_BUILTIN double __acpp_sscp_ldexp_f64(double x,
-                                                     __acpp_int64 k) {
+                                                     __acpp_int32 k) {
   return ldexp(x, k);
 }
 
@@ -180,14 +177,11 @@ HIPSYCL_SSCP_MAP_HOST_FLOAT_BUILTIN(lgamma)
 
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_lgamma_r_f32(float x, __acpp_int32* y ) {
-  return lgammaf_r(x,y);
+  return lgammaf_r(x, y);
 }
 
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_lgamma_r_f64(double x, __acpp_int64* y) {
-  __acpp_int32 w;
-  auto res = lgamma_r(x,&w);
-  *y = w;
-  return res;
+HIPSYCL_SSCP_BUILTIN double __acpp_sscp_lgamma_r_f64(double x, __acpp_int32* y) {
+  return lgamma_r(x, y);
 }
 
 HIPSYCL_SSCP_MAP_HOST_FLOAT_BUILTIN(log)
@@ -227,7 +221,7 @@ HIPSYCL_SSCP_BUILTIN float __acpp_sscp_rootn_f32(float x,
   return __acpp_sscp_pow_f32(x, 1.f/static_cast<float>(y));
 }
 HIPSYCL_SSCP_BUILTIN double __acpp_sscp_rootn_f64(double x,
-                                                     __acpp_int64 y) {
+                                                     __acpp_int32 y) {
   return __acpp_sscp_pow_f64(x, 1./static_cast<double>(y));
 }
 

--- a/src/libkernel/sscp/ptx/math.cpp
+++ b/src/libkernel/sscp/ptx/math.cpp
@@ -101,11 +101,8 @@ HIPSYCL_SSCP_BUILTIN float __acpp_sscp_frexp_f32(float x,
   return __nv_frexpf(x, y);
 }
 HIPSYCL_SSCP_BUILTIN double __acpp_sscp_frexp_f64(double x,
-                                                     __acpp_int64 *y) {
-  __acpp_int32 w;
-  double res = __nv_frexp(x, &w);
-  *y = static_cast<__acpp_int64>(w);
-  return res;
+                                                     __acpp_int32 *y) {
+  return __nv_frexp(x, y);
 }
 
 HIPSYCL_SSCP_MAP_PTX_FLOAT_BUILTIN2(hypot, __nv_hypotf, __nv_hypot)
@@ -117,7 +114,7 @@ HIPSYCL_SSCP_BUILTIN float __acpp_sscp_ldexp_f32(float x,
 }
 
 HIPSYCL_SSCP_BUILTIN double __acpp_sscp_ldexp_f64(double x,
-                                                     __acpp_int64 k) {
+                                                     __acpp_int32 k) {
   return __nv_ldexp(x, k);
 }
 
@@ -132,7 +129,7 @@ HIPSYCL_SSCP_BUILTIN float __acpp_sscp_lgamma_r_f32(float x, __acpp_int32* y ) {
   return r;
 }
 
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_lgamma_r_f64(double x, __acpp_int64* y) {
+HIPSYCL_SSCP_BUILTIN double __acpp_sscp_lgamma_r_f64(double x, __acpp_int32* y) {
   auto r = __acpp_sscp_lgamma_f64(x);
   auto g = __acpp_sscp_tgamma_f64(x);
   *y = (g >= 0) ? 1 : -1;
@@ -192,7 +189,7 @@ HIPSYCL_SSCP_MAP_PTX_FLOAT_BUILTIN2(remainder, __nv_remainderf, __nv_remainder)
 HIPSYCL_SSCP_MAP_PTX_FLOAT_BUILTIN(rint, __nv_rintf, __nv_rint)
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_rootn_f32(float x, __acpp_int32 y) { return __acpp_sscp_pow_f32(x, 1.f/y); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_rootn_f64(double x, __acpp_int64 y) {return __acpp_sscp_pow_f64(x, 1./y); }
+HIPSYCL_SSCP_BUILTIN double __acpp_sscp_rootn_f64(double x, __acpp_int32 y) {return __acpp_sscp_pow_f64(x, 1./y); }
 
 HIPSYCL_SSCP_MAP_PTX_FLOAT_BUILTIN(round, __nv_roundf, __nv_round)
 HIPSYCL_SSCP_MAP_PTX_FLOAT_BUILTIN(rsqrt, __nv_rsqrtf, __nv_rsqrt)

--- a/src/libkernel/sscp/spirv/math.cpp
+++ b/src/libkernel/sscp/spirv/math.cpp
@@ -110,12 +110,7 @@ HIPSYCL_SSCP_BUILTIN double __acpp_sscp_fract_f64(double x, double* y) { return 
 float __spirv_ocl_frexp(float x, __acpp_int32* y);
 double __spirv_ocl_frexp(double x, __acpp_int32* y);
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_frexp_f32(float x, __acpp_int32* y ) { return __spirv_ocl_frexp(x, y); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_frexp_f64(double x, __acpp_int64* y) {
-  __acpp_int32 v;
-  auto res = __spirv_ocl_frexp(x, &v);
-  *y = v;
-  return res;
-}
+HIPSYCL_SSCP_BUILTIN double __acpp_sscp_frexp_f64(double x, __acpp_int32* y) { return __spirv_ocl_frexp(x, y); }
 
 HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN2(hypot)
 HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN(ilogb)
@@ -127,8 +122,8 @@ HIPSYCL_SSCP_BUILTIN float __acpp_sscp_ldexp_f32(float x,
   return __spirv_ocl_ldexp(x, k);
 }
 HIPSYCL_SSCP_BUILTIN double __acpp_sscp_ldexp_f64(double x,
-                                                     __acpp_int64 k) {
-  return __spirv_ocl_ldexp(x, static_cast<__acpp_int32>(k));
+                                                     __acpp_int32 k) {
+  return __spirv_ocl_ldexp(x, k);
 }
 
 HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN(tgamma)
@@ -141,11 +136,8 @@ HIPSYCL_SSCP_BUILTIN float __acpp_sscp_lgamma_r_f32(float x,
   return __spirv_ocl_lgamma_r(x, y);
 }
 HIPSYCL_SSCP_BUILTIN double __acpp_sscp_lgamma_r_f64(double x,
-                                                        __acpp_int64 *y) {
-  __acpp_int32 v;
-  auto res = __spirv_ocl_lgamma_r(x, &v);
-  *y = v;
-  return res;
+                                                        __acpp_int32 *y) {
+  return __spirv_ocl_lgamma_r(x, y);
 }
 
 HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN(log)
@@ -180,10 +172,7 @@ float __spirv_ocl_rootn(float, __acpp_int32);
 double __spirv_ocl_rootn(double, __acpp_int32);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_rootn_f32(float x, __acpp_int32 y) { return __spirv_ocl_rootn(x, y); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_rootn_f64(double x,
-                                                     __acpp_int64 y) {
-  return __spirv_ocl_rootn(x, static_cast<__acpp_int32>(y));
-}
+HIPSYCL_SSCP_BUILTIN double __acpp_sscp_rootn_f64(double x, __acpp_int32 y) { return __spirv_ocl_rootn(x, y); }
 
 HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN(round)
 HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN(rsqrt)


### PR DESCRIPTION
This changes the SSCP form associated 32-bit ints with float and 64-bit ints with double - change them both to 32-bit ints for consistency and code simplification. We were really just converting back and forth for no reason.