### PR TITLE
Allow `multi_ptr` with decorations in builtin funtions

### DIFF
--- a/include/hipSYCL/sycl/libkernel/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/builtins.hpp
@@ -403,8 +403,8 @@ using ulonglong16 = vec<unsigned long long, 16>;
   }
 
 #define HIPSYCL_BUILTIN_GENERATOR_BINARY_T_TGENPTR(T, name, impl_name)         \
-  template <access::address_space A>                                           \
-  HIPSYCL_BUILTIN T name(T a, const multi_ptr<T, A> &b) noexcept {             \
+  template <access::address_space A, access::decorated D>                      \
+  HIPSYCL_BUILTIN T name(T a, const multi_ptr<T, A, D> &b) noexcept {          \
     if constexpr (std::is_arithmetic_v<T>) {                                   \
       return impl_name(detail::data_element(a, 0), b.get());                   \
     } else {                                                                   \
@@ -454,10 +454,10 @@ using ulonglong16 = vec<unsigned long long, 16>;
   }
 
 #define HIPSYCL_BUILTIN_GENERATOR_BINARY_T_GENINTPTR(T, name, impl_name)       \
-  template <class IntType, access::address_space A,                            \
+  template <class IntType, access::address_space A, access::decorated D,       \
             std::enable_if_t<detail::is_genint_alternative_type_v<T, IntType>, \
                              int> = 0>                                         \
-  HIPSYCL_BUILTIN T name(T a, const multi_ptr<IntType, A> &b) noexcept {       \
+  HIPSYCL_BUILTIN T name(T a, const multi_ptr<IntType, A, D> &b) noexcept {    \
     if constexpr (std::is_arithmetic_v<T>) {                                   \
       return impl_name(detail::data_element(a, 0), b.get());                   \
     } else {                                                                   \


### PR DESCRIPTION
Before this, builtins with pointers as arguments can only accept `multi_ptr`s with `access::decorated::legacy`, like `sin_val = sycl::sincos(x, sycl::private_ptr{&cos_val})`, thus causing `[[deprecated]]` warning:
```
In file included from /opt/AdaptiveCpp/bin/../include/AdaptiveCpp/sycl/sycl.hpp:14:
In file included from /opt/AdaptiveCpp/bin/../include/AdaptiveCpp/sycl/../hipSYCL/sycl/sycl.hpp:38:
In file included from /opt/AdaptiveCpp/bin/../include/AdaptiveCpp/sycl/../hipSYCL/sycl/libkernel/accessor.hpp:45:
/opt/AdaptiveCpp/bin/../include/AdaptiveCpp/sycl/../hipSYCL/sycl/libkernel/multi_ptr.hpp:1013:1: warning: 'multi_ptr<float, hipsycl::sycl::access::address_space::private_space, hipsycl::sycl::access::decorated::legacy>' is deprecated [-Wdeprecated-declarations]
 1013 | using private_ptr = multi_ptr<ElementType, access::address_space::private_space, IsDecorated>;
      | ^
/opt/AdaptiveCpp/bin/../include/AdaptiveCpp/sycl/../hipSYCL/sycl/libkernel/multi_ptr.hpp:669:9: note: 'multi_ptr<float, hipsycl::sycl::access::address_space::private_space, hipsycl::sycl::access::decorated::legacy>' has been explicitly marked deprecated here
  669 | class [[deprecated]] multi_ptr<ElementType, Space, access::decorated::legacy> {
      |         ^
1 warning generated when compiling for gfx1100.
```

This patch is to allow other decorations as arguments.

By the way, are pointers with `access::decorated::yes` and `no` treated differently now?