### PR TITLE
[SSCP][llvm-to-amdgpu] Use --offload-arch instead of --cuda-gpu-arch when finding bitcode libraries

### DIFF
--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -132,7 +132,7 @@ public:
     
 
     llvm::SmallVector<std::string> Invocation;
-    auto OffloadArchFlag = "--cuda-gpu-arch="+TargetDevice;
+    auto OffloadArchFlag = "--offload-arch="+TargetDevice;
     auto RocmPathFlag = "--rocm-path="+std::string{RocmPath};
     auto RocmDeviceLibsFlag = "--rocm-device-lib-path="+DeviceLibsPath;
 

--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -132,7 +132,18 @@ public:
     
 
     llvm::SmallVector<std::string> Invocation;
+    // Newer ROCm versions don't handle --cuda-gpu-arch well,
+    // while older versions don't handle --offload-arch well.
+    // We do not have a good way to check the ROCm version
+    // in llvm-to-amdgpu currently, *but* we can exploit
+    // that the AdaptiveCpp LLVM version must be <= ROCm LLVM version.
+    // So, by checking for a minimum LLVM version, we also
+    // implicitly check for a minimum ROCm version.
+#if LLVM_VERSION_MAJOR >= 18
     auto OffloadArchFlag = "--offload-arch="+TargetDevice;
+#else
+    auto OffloadArchFlag = "--cuda-gpu-arch="+TargetDevice;
+#endif
     auto RocmPathFlag = "--rocm-path="+std::string{RocmPath};
     auto RocmDeviceLibsFlag = "--rocm-device-lib-path="+DeviceLibsPath;
 


### PR DESCRIPTION
It seems that certain `hipcc` versions do not take into account `--cuda-gpu-arch` anymore, which creates an issue if the default target that `hipcc` wants to use does not align with what AdaptiveCpp wants to target.

This PR therefore changes `--cuda-gpu-arch` use to `--offload-arch` which was reported to work fine.

Fixes #1723 

We may have to double check this PR against older ROCm versions to ensure that we don't run into the reverse problem there, i.e. `--offload-arch` not being fully supported yet.

Thanks to @cbyrohl for reporting and debugging!