### PR TITLE
Add a dark theme to the documentation pages

### DIFF
--- a/doc/stylesheets/extra.css
+++ b/doc/stylesheets/extra.css
@@ -1,3 +1,9 @@
 :root {
-    --md-primary-fg-color:        #c50d29;
-  }
+  --md-primary-fg-color: #c50d29;
+  --md-accent-fg-color: #c50d29;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: #c50d29;
+  --md-accent-fg-color: #c50d29;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,7 @@ nav:
       - 'C++ standard parallelism offloading (stdpar)' : 'stdpar.md'
       - 'AdaptiveCpp parallel algorithms library' : 'algorithms.md'
 
-  - 'AdaptiveCpp design' : 
+  - 'AdaptiveCpp design' :
       - 'Architecture' : 'architecture.md'
       - 'Runtime Specification' : 'runtime-spec.md'
       - 'HCF' : 'hcf.md'
@@ -48,6 +48,21 @@ theme:
   icon:
     repo: fontawesome/brands/github
 
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark theme
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-7
+        name: Switch to light theme
 
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
This pull request adds a button next to the search bar in the [Material for MkDocs-based documentation pages](https://adaptivecpp.github.io/AdaptiveCpp/), which, when clicked, changes the theme of said pages.

In particular, in addition to the existing light theme, this PR adds a dark theme, which, as is typical, comes with a darker background colour while making the foreground text light.

The default theme (dark or light) is automatically chosen based on the preference communicated by the user's browser through the [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) media feature.