### PR TITLE
[stdpar][algorithms] Add support for `move`

### DIFF
--- a/doc/algorithms.md
+++ b/doc/algorithms.md
@@ -185,6 +185,10 @@ sycl::event copy_n(sycl::queue &q, ForwardIt1 first, Size count,
                    ForwardIt2 result,
                    const std::vector<sycl::event> &deps = {});
 
+template <class ForwardIt1, class ForwardIt2>
+sycl::event move(sycl::queue &q, ForwardIt1 first, ForwardIt1 last,
+                 ForwardIt2 d_first, const std::vector<sycl::event> &deps = {});
+
 template <class ForwardIt, class T>
 sycl::event fill(sycl::queue &q, ForwardIt first, ForwardIt last,
                  const T &value, const std::vector<sycl::event> &deps = {});

--- a/doc/stdpar.md
+++ b/doc/stdpar.md
@@ -29,6 +29,7 @@ Offloading is implemented for the following STL algorithms:
 |`copy` | |
 |`copy_n` | |
 |`copy_if` | |
+|`move` | |
 |`fill` | |
 |`fill_n` | |
 |`generate` | |

--- a/include/hipSYCL/std/stdpar/detail/algorithm_fwd.hpp
+++ b/include/hipSYCL/std/stdpar/detail/algorithm_fwd.hpp
@@ -17,6 +17,8 @@
 
 namespace std {
 
+///////////////////////////// par_unseq policy /////////////////////////////
+
 template <class ForwardIt, class UnaryFunction2>
 HIPSYCL_STDPAR_ENTRYPOINT void for_each(hipsycl::stdpar::par_unseq, ForwardIt first,
                                         ForwardIt last, UnaryFunction2 f);
@@ -54,6 +56,11 @@ template <class ForwardIt1, class Size, class ForwardIt2>
 HIPSYCL_STDPAR_ENTRYPOINT ForwardIt2 copy_n(hipsycl::stdpar::par_unseq,
                                             ForwardIt1 first, Size count,
                                             ForwardIt2 result);
+
+template <class ForwardIt1, class ForwardIt2>
+HIPSYCL_STDPAR_ENTRYPOINT ForwardIt2 move(hipsycl::stdpar::par_unseq,
+                                          ForwardIt1 first, ForwardIt1 last,
+                                          ForwardIt2 d_first);
 
 template <class ForwardIt, class T>
 HIPSYCL_STDPAR_ENTRYPOINT void fill(hipsycl::stdpar::par_unseq, ForwardIt first,
@@ -123,6 +130,12 @@ HIPSYCL_STDPAR_ENTRYPOINT
 bool none_of(hipsycl::stdpar::par_unseq, ForwardIt first, ForwardIt last,
             UnaryPredicate p );
 
+///////////////////////////// par policy /////////////////////////////
+
+template <class ForwardIt1, class ForwardIt2>
+HIPSYCL_STDPAR_ENTRYPOINT ForwardIt2 move(hipsycl::stdpar::par,
+                                          ForwardIt1 first, ForwardIt1 last,
+                                          ForwardIt2 d_first);
 }
 
 #endif

--- a/include/hipSYCL/std/stdpar/detail/offload_heuristic_db.hpp
+++ b/include/hipSYCL/std/stdpar/detail/offload_heuristic_db.hpp
@@ -36,6 +36,7 @@ struct transform {};
 struct copy {};
 struct copy_if {};
 struct copy_n {};
+struct move {};
 struct fill {};
 struct fill_n {};
 struct generate {};

--- a/include/hipSYCL/std/stdpar/pstl-impl/algorithm.hpp
+++ b/include/hipSYCL/std/stdpar/pstl-impl/algorithm.hpp
@@ -209,6 +209,29 @@ ForwardIt2 copy_n(hipsycl::stdpar::par_unseq,
       count, ForwardIt2, offloader, fallback, first, count, result);
 }
 
+template <class ForwardIt1, class ForwardIt2>
+HIPSYCL_STDPAR_ENTRYPOINT ForwardIt2 move(hipsycl::stdpar::par_unseq,
+                                          ForwardIt1 first, ForwardIt1 last,
+                                          ForwardIt2 d_first) {
+  auto offloader = [&](auto& queue){
+    ForwardIt2 d_last = d_first;
+    std::advance(d_last, std::distance(first, last));
+    hipsycl::algorithms::move(queue, first, last, d_first);
+    return d_last;
+  };
+
+  auto fallback = [&]() {
+    return std::move(hipsycl::stdpar::par_unseq_host_fallback, first, last,
+                     d_first);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::move{},
+                                 hipsycl::stdpar::par_unseq{}),
+      std::distance(first, last), ForwardIt2, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), d_first);
+}
+
 template<class ForwardIt, class T >
 HIPSYCL_STDPAR_ENTRYPOINT
 void fill(hipsycl::stdpar::par_unseq,
@@ -793,6 +816,29 @@ ForwardIt2 copy_n(hipsycl::stdpar::par,
       hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::copy_n{},
                                  hipsycl::stdpar::par{}),
       count, ForwardIt2, offloader, fallback, first, count, result);
+}
+
+template <class ForwardIt1, class ForwardIt2>
+HIPSYCL_STDPAR_ENTRYPOINT ForwardIt2 move(const hipsycl::stdpar::par,
+                                          ForwardIt1 first, ForwardIt1 last,
+                                          ForwardIt2 d_first) {
+  auto offloader = [&](auto& queue){
+    ForwardIt2 d_last = d_first;
+    std::advance(d_last, std::distance(first, last));
+    hipsycl::algorithms::move(queue, first, last, d_first);
+    return d_last;
+  };
+
+  auto fallback = [&]() {
+    return std::move(hipsycl::stdpar::par_host_fallback, first, last,
+                     d_first);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::move{},
+                                 hipsycl::stdpar::par{}),
+      std::distance(first, last), ForwardIt2, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), d_first);
 }
 
 template<class ForwardIt, class T >

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -148,6 +148,7 @@ if(WITH_PSTL_TESTS)
     pstl/inclusive_scan.cpp
     pstl/memory.cpp
     pstl/merge.cpp
+    pstl/move.cpp
     pstl/none_of.cpp
     pstl/reduce.cpp
     pstl/replace.cpp

--- a/tests/pstl/move.cpp
+++ b/tests/pstl/move.cpp
@@ -1,0 +1,72 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <algorithm>
+#include <execution>
+#include <utility>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+#include <boost/mpl/list.hpp>
+
+#include "pstl_test_suite.hpp"
+
+BOOST_FIXTURE_TEST_SUITE(pstl_move, enable_unified_shared_memory)
+
+template<class T, class Policy>
+void test_move(Policy&& pol, std::size_t problem_size) {
+    std::vector<T> data(problem_size);
+    for (int i = 0; i < problem_size; ++i) {
+        data[i] = T{i};
+    }
+
+    auto input_device = data;
+    auto input_host = data;
+
+    std::vector<T> dest_device(problem_size);
+    std::vector<T> dest_host(problem_size);
+
+    auto ret = std::move(pol, input_device.begin(), input_device.end(),
+                         dest_device.begin());
+    std::move(input_host.begin(), input_host.end(), dest_host.begin());
+
+    BOOST_CHECK(ret == dest_device.begin() + problem_size);
+    BOOST_CHECK(dest_device == dest_host);
+    BOOST_CHECK(data == dest_device);
+    BOOST_CHECK(data == dest_host);
+}
+
+using types = boost::mpl::list<int, non_trivial_move>;
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_empty, T, types::type) {
+    test_move<T>(std::execution::par_unseq, 0);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_single_element, T, types::type) {
+    test_move<T>(std::execution::par_unseq, 1);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_medium_size, T, types::type) {
+    test_move<T>(std::execution::par_unseq, 1000);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_empty, T, types::type) {
+    test_move<T>(std::execution::par, 0);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_single_element, T, types::type) {
+    test_move<T>(std::execution::par, 1);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_medium_size, T, types::type) {
+    test_move<T>(std::execution::par, 1000);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pstl/move.cpp
+++ b/tests/pstl/move.cpp
@@ -15,7 +15,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/mpl/list.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 
@@ -44,28 +45,28 @@ void test_move(Policy&& pol, std::size_t problem_size) {
     BOOST_CHECK(data == dest_host);
 }
 
-using types = boost::mpl::list<int, non_trivial_move>;
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_empty, T, types::type) {
+using types = boost::mp11::mp_list<int, non_trivial_move>;
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_empty, T, types) {
     test_move<T>(std::execution::par_unseq, 0);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_single_element, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_single_element, T, types) {
     test_move<T>(std::execution::par_unseq, 1);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_medium_size, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_medium_size, T, types) {
     test_move<T>(std::execution::par_unseq, 1000);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_empty, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_empty, T, types) {
     test_move<T>(std::execution::par, 0);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_single_element, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_single_element, T, types) {
     test_move<T>(std::execution::par, 1);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_medium_size, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_medium_size, T, types) {
     test_move<T>(std::execution::par, 1000);
 }
 

--- a/tests/pstl/pstl_test_suite.hpp
+++ b/tests/pstl/pstl_test_suite.hpp
@@ -58,4 +58,45 @@ struct non_trivial_copy {
   int x;
 };
 
+
+static thread_local int move_counter = 0;
+struct non_trivial_move {
+
+  non_trivial_move(){}
+
+  non_trivial_move(int val)
+  : x{val} {}
+
+  non_trivial_move(const non_trivial_move& other)
+  : x{other.x} {}
+
+  non_trivial_move& operator=(const non_trivial_move& other) {
+    x = other.x;
+    return *this;
+  }
+
+  non_trivial_move(non_trivial_move&& other) {
+    x = std::move(other.x);
+    __acpp_if_target_host(++move_counter;)
+  }
+
+  non_trivial_move& operator=(non_trivial_move&& other) {
+    if (this != &other) {
+      x = std::move(other.x);
+      __acpp_if_target_host(++move_counter;)
+    }
+    return *this;
+  }  
+
+  friend bool operator==(const non_trivial_move &a, const non_trivial_move &b) {
+    return a.x == b.x;
+  }
+
+  friend bool operator!=(const non_trivial_move &a, const non_trivial_move &b) {
+    return a.x != b.x;
+  }
+
+  int x;
+};
+
 #endif


### PR DESCRIPTION
This PR adds automatic offloading support for [move](https://en.cppreference.com/w/cpp/algorithm/move).