### PR TITLE
Fix behaviour of sycl::free

### DIFF
--- a/include/hipSYCL/sycl/usm.hpp
+++ b/include/hipSYCL/sycl/usm.hpp
@@ -283,7 +283,8 @@ T *aligned_alloc(std::size_t alignment, std::size_t count, const sycl::queue &q,
 }
 
 inline void free(void *ptr, const sycl::context &ctx) {
-  return rt::deallocate(detail::select_usm_allocator(ctx), ptr);
+  if (ptr != nullptr)
+    return rt::deallocate(detail::select_usm_allocator(ctx), ptr);
 }
 
 inline void free(void *ptr, const sycl::queue &q) {


### PR DESCRIPTION
As far as I can tell, calling `free` on a `nullptr` should have no effect (https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_memory_deallocation_functions).
This works for the OMP backend; the HIP backend, however, fails with `[AdaptiveCpp Error] from /AdaptiveCpp/src/runtime/hip/hip_allocator.cpp:118 @ query_pointer(): hip_allocator: query_pointer(): pointer is unknown by backend (error code = HIP:1)` upon calling `free` on a `nullptr`.

Minimal example:
```cpp
#include <sycl/sycl.hpp>

int main() {
    // Backend must be HIP
    sycl::queue queue{sycl::gpu_selector_v};
    sycl::free(nullptr, queue);

    return 0;
}
```