### PR TITLE
Replace Boost MPL in tests with MP11

### DIFF
--- a/tests/pstl/all_of.cpp
+++ b/tests/pstl/all_of.cpp
@@ -16,6 +16,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/any_of.cpp
+++ b/tests/pstl/any_of.cpp
@@ -16,6 +16,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/copy.cpp
+++ b/tests/pstl/copy.cpp
@@ -15,7 +15,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/mpl/list.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 
@@ -40,28 +41,28 @@ void test_copy(Policy&& pol, std::size_t problem_size) {
   BOOST_CHECK(dest_device == dest_host);
 }
 
-using types = boost::mpl::list<int, non_trivial_copy>;
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_empty, T, types::type) {
+using types = boost::mp11::mp_list<int, non_trivial_copy>;
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_empty, T, types) {
   test_copy<T>(std::execution::par_unseq, 0);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_single_element, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_single_element, T, types) {
   test_copy<T>(std::execution::par_unseq, 1);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_medium_size, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_medium_size, T, types) {
   test_copy<T>(std::execution::par_unseq, 1000);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_empty, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_empty, T, types) {
   test_copy<T>(std::execution::par, 0);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_single_element, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_single_element, T, types) {
   test_copy<T>(std::execution::par, 1);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_medium_size, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_medium_size, T, types) {
   test_copy<T>(std::execution::par, 1000);
 }
 

--- a/tests/pstl/copy_if.cpp
+++ b/tests/pstl/copy_if.cpp
@@ -15,6 +15,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/copy_n.cpp
+++ b/tests/pstl/copy_n.cpp
@@ -15,7 +15,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/mpl/list.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 
@@ -48,29 +49,29 @@ BOOST_AUTO_TEST_CASE(par_unseq_negative) {
   BOOST_CHECK(ret == dest.begin());
 }
 
-using types = boost::mpl::list<int, non_trivial_copy>;
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_empty, T, types::type) {
+using types = boost::mp11::mp_list<int, non_trivial_copy>;
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_empty, T, types) {
   test_copy_n<T>(std::execution::par_unseq, 0);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_single_element, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_single_element, T, types) {
   test_copy_n<T>(std::execution::par_unseq, 1);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_medium_size, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_medium_size, T, types) {
   test_copy_n<T>(std::execution::par_unseq, 1000);
 }
 
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_empty, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_empty, T, types) {
   test_copy_n<T>(std::execution::par, 0);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_single_element, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_single_element, T, types) {
   test_copy_n<T>(std::execution::par, 1);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_medium_size, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_medium_size, T, types) {
   test_copy_n<T>(std::execution::par, 1000);
 }
 

--- a/tests/pstl/exclusive_scan.cpp
+++ b/tests/pstl/exclusive_scan.cpp
@@ -18,6 +18,8 @@
 #include <type_traits>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/fill.cpp
+++ b/tests/pstl/fill.cpp
@@ -15,7 +15,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/mpl/list.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 
@@ -41,29 +42,29 @@ void test_fill(Policy&& pol, std::size_t problem_size) {
   BOOST_CHECK(host_data == data);
 }
 
-using types = boost::mpl::list<int, non_trivial_copy>;
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_empty, T, types::type) {
+using types = boost::mp11::mp_list<int, non_trivial_copy>;
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_empty, T, types) {
   test_fill<T>(std::execution::par_unseq, 0);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_single_element, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_single_element, T, types) {
   test_fill<T>(std::execution::par_unseq, 1);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_medium_size, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_medium_size, T, types) {
   test_fill<T>(std::execution::par_unseq, 1000);
 }
 
-using types = boost::mpl::list<int, non_trivial_copy>;
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_empty, T, types::type) {
+using types = boost::mp11::mp_list<int, non_trivial_copy>;
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_empty, T, types) {
   test_fill<T>(std::execution::par, 0);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_single_element, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_single_element, T, types) {
   test_fill<T>(std::execution::par, 1);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_medium_size, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_medium_size, T, types) {
   test_fill<T>(std::execution::par, 1000);
 }
 

--- a/tests/pstl/fill_n.cpp
+++ b/tests/pstl/fill_n.cpp
@@ -15,7 +15,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/mpl/list.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 
@@ -52,16 +53,16 @@ BOOST_AUTO_TEST_CASE(par_unseq_negative) {
   BOOST_CHECK(ret == empty.begin());
 }
 
-using types = boost::mpl::list<int, non_trivial_copy>;
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_empty, T, types::type) {
+using types = boost::mp11::mp_list<int, non_trivial_copy>;
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_empty, T, types) {
   test_fill_n<T>(std::execution::par_unseq, 0);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_single_element, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_single_element, T, types) {
   test_fill_n<T>(std::execution::par_unseq, 1);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_medium_size, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_medium_size, T, types) {
   test_fill_n<T>(std::execution::par_unseq, 1000);
 }
 
@@ -74,16 +75,16 @@ BOOST_AUTO_TEST_CASE(par_negative) {
   BOOST_CHECK(ret == empty.begin());
 }
 
-using types = boost::mpl::list<int, non_trivial_copy>;
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_empty, T, types::type) {
+using types = boost::mp11::mp_list<int, non_trivial_copy>;
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_empty, T, types) {
   test_fill_n<T>(std::execution::par_unseq, 0);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_single_element, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_single_element, T, types) {
   test_fill_n<T>(std::execution::par_unseq, 1);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_medium_size, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_medium_size, T, types) {
   test_fill_n<T>(std::execution::par_unseq, 1000);
 }
 

--- a/tests/pstl/for_each.cpp
+++ b/tests/pstl/for_each.cpp
@@ -14,6 +14,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/for_each_n.cpp
+++ b/tests/pstl/for_each_n.cpp
@@ -14,6 +14,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/generate.cpp
+++ b/tests/pstl/generate.cpp
@@ -15,7 +15,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/mpl/list.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/generate_n.cpp
+++ b/tests/pstl/generate_n.cpp
@@ -15,7 +15,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/mpl/list.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/inclusive_scan.cpp
+++ b/tests/pstl/inclusive_scan.cpp
@@ -18,6 +18,8 @@
 #include <type_traits>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/memory.cpp
+++ b/tests/pstl/memory.cpp
@@ -4,6 +4,8 @@
 #include <cstdlib>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/merge.cpp
+++ b/tests/pstl/merge.cpp
@@ -18,7 +18,8 @@
 #include <random>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/mpl/list.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/none_of.cpp
+++ b/tests/pstl/none_of.cpp
@@ -15,6 +15,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/pointer_validation.cpp
+++ b/tests/pstl/pointer_validation.cpp
@@ -15,6 +15,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/reduce.cpp
+++ b/tests/pstl/reduce.cpp
@@ -16,6 +16,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/replace.cpp
+++ b/tests/pstl/replace.cpp
@@ -15,7 +15,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/mpl/list.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/replace_copy.cpp
+++ b/tests/pstl/replace_copy.cpp
@@ -15,7 +15,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/mpl/list.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/replace_copy_if.cpp
+++ b/tests/pstl/replace_copy_if.cpp
@@ -15,7 +15,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/mpl/list.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/replace_if.cpp
+++ b/tests/pstl/replace_if.cpp
@@ -15,7 +15,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/mpl/list.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/sort.cpp
+++ b/tests/pstl/sort.cpp
@@ -16,7 +16,8 @@
 #include <functional>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/mpl/list.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/std_atomic.cpp
+++ b/tests/pstl/std_atomic.cpp
@@ -16,20 +16,21 @@
 #include <atomic>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/mpl/list.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 
 
-using atomic_int_test_types = boost::mpl::list<
+using atomic_int_test_types = boost::mp11::mp_list<
   int, unsigned, long long, unsigned long long>;
 
-using atomic_test_types = boost::mpl::list<
+using atomic_test_types = boost::mp11::mp_list<
   int, unsigned, long long, unsigned long long, float, double>;
 
 BOOST_FIXTURE_TEST_SUITE(pstl_std_atomic, enable_unified_shared_memory)
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(atomic_load_store, T, atomic_test_types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(atomic_load_store, T, atomic_test_types) {
   std::vector<std::atomic<T>> data(1);
   data[0] = T{42};
 
@@ -43,7 +44,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(atomic_load_store, T, atomic_test_types::type) {
 }
 
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(atomic_exchange, T, atomic_test_types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(atomic_exchange, T, atomic_test_types) {
   std::vector<std::atomic<T>> data(1);
   data[0] = T{42};
 
@@ -57,7 +58,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(atomic_exchange, T, atomic_test_types::type) {
   BOOST_CHECK(data[0] == T{43});
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(atomic_cmp_exchange, T, atomic_test_types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(atomic_cmp_exchange, T, atomic_test_types) {
   std::vector<std::atomic<T>> data(1);
   data[0] = T{42};
   
@@ -105,33 +106,33 @@ void test_fetch_op(T expected_result, F f) {
 
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(atomic_fetch_add, T, atomic_int_test_types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(atomic_fetch_add, T, atomic_int_test_types) {
   test_fetch_op(T{44}, [](auto& x){ return x.fetch_add(T{2}, std::memory_order_relaxed);});
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(atomic_fetch_sub, T, atomic_int_test_types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(atomic_fetch_sub, T, atomic_int_test_types) {
   test_fetch_op(T{40}, [](auto& x){ return x.fetch_sub(T{2}, std::memory_order_relaxed);});
 }
 
 /* C++ 26 
-BOOST_AUTO_TEST_CASE_TEMPLATE(atomic_fetch_max, T, atomic_test_types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(atomic_fetch_max, T, atomic_test_types) {
   test_fetch_op(T{45}, [](auto& x){ return x.fetch_max(T{45}, std::memory_order_relaxed);});
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(atomic_fetch_min, T, atomic_test_types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(atomic_fetch_min, T, atomic_test_types) {
   test_fetch_op(T{41}, [](auto& x){ return x.fetch_min(T{41}, std::memory_order_relaxed);});
 }
 */
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(atomic_fetch_or, T, atomic_int_test_types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(atomic_fetch_or, T, atomic_int_test_types) {
   test_fetch_op(T{42}|T{15}, [](auto& x){ return x.fetch_or(T{15}, std::memory_order_relaxed);});
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(atomic_fetch_and, T, atomic_int_test_types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(atomic_fetch_and, T, atomic_int_test_types) {
   test_fetch_op(T{42}&T{15}, [](auto& x){ return x.fetch_and(T{15}, std::memory_order_relaxed);});
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(atomic_fetch_xor, T, atomic_int_test_types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(atomic_fetch_xor, T, atomic_int_test_types) {
   test_fetch_op(T{42}^T{30}, [](auto& x){ return x.fetch_xor(T{30}, std::memory_order_relaxed);});
 }
 

--- a/tests/pstl/std_math.cpp
+++ b/tests/pstl/std_math.cpp
@@ -15,7 +15,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/mpl/list.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/transform.cpp
+++ b/tests/pstl/transform.cpp
@@ -14,6 +14,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/transform_exclusive_scan.cpp
+++ b/tests/pstl/transform_exclusive_scan.cpp
@@ -18,6 +18,8 @@
 #include <type_traits>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/transform_inclusive_scan.cpp
+++ b/tests/pstl/transform_inclusive_scan.cpp
@@ -18,6 +18,8 @@
 #include <type_traits>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/transform_reduce.cpp
+++ b/tests/pstl/transform_reduce.cpp
@@ -15,6 +15,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/sycl/atomic.cpp
+++ b/tests/sycl/atomic.cpp
@@ -45,11 +45,11 @@ unsigned long long t_to_int(T x) {
 }
 
 using exchange_test_types =
-    boost::mpl::list<int, unsigned int, long, unsigned long, long long,
+    boost::mp11::mp_list<int, unsigned int, long, unsigned long, long long,
                      unsigned long long, float, double, int *>;
 // mainly compile test
 BOOST_AUTO_TEST_CASE_TEMPLATE(load_store_exchange, Type,
-                              exchange_test_types::type) {
+                              exchange_test_types) {
   sycl::queue q;
 
   Type initial = int_to_t<Type>(0);

--- a/tests/sycl/explicit_copy.cpp
+++ b/tests/sycl/explicit_copy.cpp
@@ -17,12 +17,12 @@ BOOST_FIXTURE_TEST_SUITE(explicit_copy_tests, reset_device_fixture)
 #ifndef HIPSYCL_TEST_NO_3D_COPIES
 using explicit_copy_test_dimensions = test_dimensions;
 #else
-using explicit_copy_test_dimensions = boost::mpl::list_c<int, 1, 2>;
+using explicit_copy_test_dimensions = boost::mp11::mp_list_c<int, 1, 2>;
 #endif
 
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(explicit_buffer_copy_host_ptr, _dimensions,
-    explicit_copy_test_dimensions::type) {
+    explicit_copy_test_dimensions) {
   namespace s = cl::sycl;
   // Specify type explicitly to workaround Clang bug #45538
   constexpr int d = _dimensions::value;
@@ -183,7 +183,7 @@ void run_two_accessors_copy_test(const callback& copy_cb) {
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(explicit_buffer_copy_two_accessors_d2d,
-  _dimensions, explicit_copy_test_dimensions::type) {
+  _dimensions, explicit_copy_test_dimensions) {
   constexpr auto d = _dimensions::value;
   namespace s = cl::sycl;
   run_two_accessors_copy_test<d>([](s::handler& cgh, s::range<d> copy_range,

--- a/tests/sycl/extensions.cpp
+++ b/tests/sycl/extensions.cpp
@@ -238,7 +238,7 @@ template<class Name, int D>
 class nd_kernel_name;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(scoped_parallelism_api, _dimensions,
-                              test_dimensions::type) {
+                              test_dimensions) {
   constexpr int d = _dimensions::value;
   test_distribute_groups<nd_kernel_name<class ScopedParallelismDistrGroups, d>,
                          d>();

--- a/tests/sycl/fill.cpp
+++ b/tests/sycl/fill.cpp
@@ -73,13 +73,13 @@ void fill_test_helper(cl::sycl::id<d> offset = cl::sycl::id<d>{}) {
 BOOST_FIXTURE_TEST_SUITE(fill_tests, reset_device_fixture)
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(fill_buffer, _dimensions,
-  test_dimensions::type) {
+  test_dimensions) {
 
   fill_test_helper<_dimensions::value>();
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(fill_with_offset, _dimensions,
-                              test_dimensions::type) {
+                              test_dimensions) {
   namespace s = cl::sycl;
   auto offset = make_test_value<s::id, _dimensions::value>({8}, {8, 8}, {8, 8, 8});
   fill_test_helper<_dimensions::value>(offset);

--- a/tests/sycl/group_functions/group_functions.hpp
+++ b/tests/sycl/group_functions/group_functions.hpp
@@ -31,12 +31,12 @@ using namespace cl;
 
 #ifdef TESTS_GROUPFUNCTION_FULL
 using test_types =
-    boost::mpl::list<char, int, unsigned int, long long, float, double, sycl::vec<int, 1>,
+    boost::mp11::mp_list<char, int, unsigned int, long long, float, double, sycl::vec<int, 1>,
                      sycl::vec<int, 2>, sycl::vec<int, 3>, sycl::vec<int, 4>,
                      sycl::vec<int, 8>, sycl::vec<short, 16>, sycl::vec<long, 3>,
                      sycl::vec<unsigned int, 3>>;
 #else
-using test_types = boost::mpl::list<char, unsigned int, float, double, sycl::vec<int, 2>>;
+using test_types = boost::mp11::mp_list<char, unsigned int, float, double, sycl::vec<int, 2>>;
 #endif
 
 namespace detail {

--- a/tests/sycl/half.cpp
+++ b/tests/sycl/half.cpp
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(half_arithmetic) {
 }
 
 using half_test_types =
-  boost::mpl::list<float, double,
+  boost::mp11::mp_list<float, double,
                    int, unsigned int,
                    long, long long,
                    unsigned long, unsigned long long>;

--- a/tests/sycl/id_range.cpp
+++ b/tests/sycl/id_range.cpp
@@ -63,7 +63,7 @@ void test_id_range_operators() {
   }
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(range_api, _dimensions, test_dimensions::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(range_api, _dimensions, test_dimensions) {
   namespace s = cl::sycl;
   constexpr auto d = _dimensions::value;
 
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(range_api, _dimensions, test_dimensions::type) {
   test_id_range_operators<s::range, d>();
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(id_api, _dimensions, test_dimensions::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(id_api, _dimensions, test_dimensions) {
   namespace s = cl::sycl;
   constexpr auto d = _dimensions::value;
 

--- a/tests/sycl/item.cpp
+++ b/tests/sycl/item.cpp
@@ -15,7 +15,7 @@
 BOOST_FIXTURE_TEST_SUITE(item_tests, reset_device_fixture)
 
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(item_api, _dimensions, test_dimensions::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(item_api, _dimensions, test_dimensions) {
   namespace s = cl::sycl;
   // Specify type explicitly to workaround Clang bug #45538
   constexpr int d = _dimensions::value;

--- a/tests/sycl/marray.cpp
+++ b/tests/sycl/marray.cpp
@@ -18,7 +18,7 @@ using namespace cl;
 
 BOOST_FIXTURE_TEST_SUITE(marray_tests, reset_device_fixture)
 
-using marray_test_types = boost::mpl::list<
+using marray_test_types = boost::mp11::mp_list<
   float,
   double,
   short,
@@ -78,7 +78,7 @@ void test(sycl::queue& q) {
 
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(marray_ops, T, marray_test_types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(marray_ops, T, marray_test_types) {
   sycl::queue q;
   
   test<T, 1>(q);

--- a/tests/sycl/math.cpp
+++ b/tests/sycl/math.cpp
@@ -12,14 +12,13 @@
 #include "sycl_test_suite.hpp"
 
 #include <bitset>
-#include <boost/mpl/joint_view.hpp>
 
 #include <cmath>
 
 BOOST_FIXTURE_TEST_SUITE(math_tests, reset_device_fixture)
 
 // list of types classified as "genfloat" in the SYCL standard
-using math_test_genfloats = boost::mpl::list<
+using math_test_genfloats = boost::mp11::mp_list<
   float,
   // vec<T,1> is not genfloat according to SYCL 2020. It's unclear
   // if this is an oversight or intentional.
@@ -226,7 +225,7 @@ namespace {
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_binary, T,
-                              math_test_genfloats::type) {
+                              math_test_genfloats) {
 
   constexpr int D = vector_length_v<T>;
   using DT = vector_elem_t<T>;
@@ -292,7 +291,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_binary, T,
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(common_functions, T,
-    math_test_genfloats::type) {
+    math_test_genfloats) {
 
   constexpr int D = vector_length_v<T>;
   using DT = vector_elem_t<T>;
@@ -380,7 +379,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(common_functions, T,
 }
 
 // some subset of types classified as "geninteger" in SYCL
-using math_test_genints = boost::mpl::list<
+using math_test_genints = boost::mp11::mp_list<
   int,
   cl::sycl::vec<int, 2>,
   cl::sycl::vec<int, 3>,
@@ -392,7 +391,7 @@ using math_test_genints = boost::mpl::list<
   unsigned long,
   cl::sycl::vec<unsigned long, 8>>;
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(builtin_int_basic, T, math_test_genints::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(builtin_int_basic, T, math_test_genints) {
 
   constexpr int D = vector_length_v<T>;
   using DT = vector_elem_t<T>;
@@ -466,13 +465,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(builtin_int_basic, T, math_test_genints::type) {
 
 
 // types allowed for the "cross" function
-using math_test_crossinputs = boost::mpl::list<
+using math_test_crossinputs = boost::mp11::mp_list<
   cl::sycl::vec<float, 3>,
   cl::sycl::vec<float, 4>,
   cl::sycl::vec<double, 3>,
   cl::sycl::vec<double, 4>>;
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(geometric_cross, T, math_test_crossinputs::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(geometric_cross, T, math_test_crossinputs) {
 
   constexpr int D = vector_length_v<T>;
   using DT = vector_elem_t<T>;
@@ -522,21 +521,21 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(geometric_cross, T, math_test_crossinputs::type) {
 
 // type classes as per SYCL standard
 
-using math_test_gengeofloats = boost::mpl::list<
+using math_test_gengeofloats = boost::mp11::mp_list<
   float,
   cl::sycl::vec<float, 2>,
   cl::sycl::vec<float, 3>,
   cl::sycl::vec<float, 4>>;
 
-using math_test_gengeodoubles = boost::mpl::list<
+using math_test_gengeodoubles = boost::mp11::mp_list<
   double,
   cl::sycl::vec<double, 2>,
   cl::sycl::vec<double, 3>,
   cl::sycl::vec<double, 4>>;
 
-using math_test_gengeo = boost::mpl::joint_view<math_test_gengeofloats, math_test_gengeodoubles>;
+using math_test_gengeo = boost::mp11::mp_append<math_test_gengeofloats, math_test_gengeodoubles>;
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(geometric, T, math_test_gengeo::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(geometric, T, math_test_gengeo) {
 
   constexpr int D = vector_length_v<T>;
   using DT = vector_elem_t<T>;
@@ -592,7 +591,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(geometric, T, math_test_gengeo::type) {
   }
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(fast_geometric, T, math_test_gengeofloats::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(fast_geometric, T, math_test_gengeofloats) {
 
   constexpr int D = vector_length_v<T>;
   using DT = vector_elem_t<T>;
@@ -646,7 +645,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(fast_geometric, T, math_test_gengeofloats::type) {
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_int, T,
-                              math_test_genfloats::type) {
+                              math_test_genfloats) {
 
   constexpr int D = vector_length_v<T>;
   using DT = vector_elem_t<T>;
@@ -693,7 +692,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_int, T,
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_genint, T,
-                              math_test_genfloats::type) {
+                              math_test_genfloats) {
 
   constexpr int D = vector_length_v<T>;
   using DT = vector_elem_t<T>;

--- a/tests/sycl/reduction.cpp
+++ b/tests/sycl/reduction.cpp
@@ -208,13 +208,13 @@ void test_two_reductions(std::size_t input_size, std::size_t local_size){
 }
 
 
-using all_test_types = boost::mpl::list<char, unsigned int, int, long long, float, 
+using all_test_types = boost::mp11::mp_list<char, unsigned int, int, long long, float, 
   double>;
 
-using large_test_types = boost::mpl::list<unsigned int, int, long long, float, 
+using large_test_types = boost::mp11::mp_list<unsigned int, int, long long, float, 
   double>;
 
-using very_large_test_types = boost::mpl::list<unsigned int, long long, float, 
+using very_large_test_types = boost::mp11::mp_list<unsigned int, long long, float, 
   double>;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(single_kernel_single_scalar_reduction, T, all_test_types) {

--- a/tests/sycl/relational.cpp
+++ b/tests/sycl/relational.cpp
@@ -11,14 +11,12 @@
 
 #include "sycl_test_suite.hpp"
 
-#include <boost/mpl/joint_view.hpp>
-
 #include <cmath>
 
 BOOST_FIXTURE_TEST_SUITE(rel_tests, reset_device_fixture)
 
 // list of types classified as "genfloat" in the SYCL standard
-using rel_test_genfloats = boost::mpl::list<
+using rel_test_genfloats = boost::mp11::mp_list<
   float,
   // vec<T,1> is not genfloat according to SYCL 2020. It's unclear
   // if this is an oversight or intentional.
@@ -99,7 +97,7 @@ namespace {
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(rel_genfloat_unary, T,
-                              rel_test_genfloats::type) {
+                              rel_test_genfloats) {
 
   constexpr int D = vector_length_v<T>;
   using DT = vector_elem_t<T>;

--- a/tests/sycl/sycl_test_suite.hpp
+++ b/tests/sycl/sycl_test_suite.hpp
@@ -16,8 +16,8 @@
 
 #define BOOST_MPL_CFG_GPU_ENABLED // Required for nvcc
 #include <boost/test/unit_test.hpp>
-#include <boost/mpl/list_c.hpp>
-#include <boost/mpl/list.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl_list.hpp>
 
 
 #define SYCL_SIMPLE_SWIZZLES
@@ -25,7 +25,7 @@
 
 #include "../common/reset.hpp"
 
-using test_dimensions = boost::mpl::list_c<int, 1, 2, 3>;
+using test_dimensions = boost::mp11::mp_list_c<int, 1, 2, 3>;
 
 
 template<int dimensions, template<int D> class T>


### PR DESCRIPTION
Boost MPL existed before variadic templates and has a hard coded maximum number of types possible. Given future changes aim to add more tested types, this preemptively migrates to MP11.