### PR TITLE
[stdpar][algorithms] Add support for `reverse` and `reverse_copy`

### DIFF
--- a/doc/algorithms.md
+++ b/doc/algorithms.md
@@ -228,6 +228,11 @@ sycl::event replace_copy(sycl::queue &q, ForwardIt1 first, ForwardIt1 last,
                          const T &new_value,
                          const std::vector<sycl::event> &deps = {});
 
+template <class BidirIt, class ForwardIt>
+sycl::event reverse_copy(sycl::queue &q, BidirIt first,
+                         BidirIt last, ForwardIt d_first,
+                         const std::vector<sycl::event> &deps = {});
+
 /// The result of the operation will be stored in out.
 ///
 /// out must point to device-accessible memory, and will be set to 0

--- a/doc/algorithms.md
+++ b/doc/algorithms.md
@@ -228,6 +228,10 @@ sycl::event replace_copy(sycl::queue &q, ForwardIt1 first, ForwardIt1 last,
                          const T &new_value,
                          const std::vector<sycl::event> &deps = {});
 
+template <class BidirIt>
+sycl::event reverse(sycl::queue &q, BidirIt first, BidirIt last,
+                     const std::vector<sycl::event> &deps = {});
+
 template <class BidirIt, class ForwardIt>
 sycl::event reverse_copy(sycl::queue &q, BidirIt first,
                          BidirIt last, ForwardIt d_first,

--- a/doc/stdpar.md
+++ b/doc/stdpar.md
@@ -38,6 +38,7 @@ Offloading is implemented for the following STL algorithms:
 |`replace_if` | |
 |`replace_copy` | |
 |`replace_copy_if` | |
+|`reverse_copy` | |
 |`transform_reduce` | all overloads |
 |`reduce` | all overloads |
 |`any_of` | |

--- a/doc/stdpar.md
+++ b/doc/stdpar.md
@@ -38,6 +38,7 @@ Offloading is implemented for the following STL algorithms:
 |`replace_if` | |
 |`replace_copy` | |
 |`replace_copy_if` | |
+|`reverse` | |
 |`reverse_copy` | |
 |`transform_reduce` | all overloads |
 |`reduce` | all overloads |

--- a/include/hipSYCL/algorithms/algorithm.hpp
+++ b/include/hipSYCL/algorithms/algorithm.hpp
@@ -411,6 +411,36 @@ sycl::event replace_copy(sycl::queue &q, ForwardIt1 first, ForwardIt1 last,
       new_value, deps);
 }
 
+template <class BidirIt, class ForwardIt>
+sycl::event reverse_copy(sycl::queue &q, BidirIt first,
+                         BidirIt last, ForwardIt d_first,
+                         const std::vector<sycl::event> &deps = {}) {
+  if (first == last)
+    return sycl::event{};
+
+  auto size = std::distance(first, last);
+
+  using value_type1 = typename std::iterator_traits<BidirIt>::value_type;
+  using value_type2 = typename std::iterator_traits<ForwardIt>::value_type;
+
+  // ??
+  if (std::is_trivially_copyable_v<BidirIt> &&
+      std::is_same_v<value_type1, value_type2> &&
+      util::is_contiguous<BidirIt>() && util::is_contiguous<ForwardIt>() &&
+      detail::should_use_memcpy(q.get_device())) {
+    return q.memcpy(&(*d_first), &(*first), size * sizeof(value_type1), deps);
+  } else {
+    return q.parallel_for(sycl::range{size}, deps,
+                          [=](sycl::id<1> id) {
+                            auto input = last;
+                            auto output = d_first;
+                            std::advance(input, -id[0]);
+                            std::advance(output, id[0]);
+                            *output = *input;
+                          });
+  }
+}
+
 // Need transform_reduce functionality for find etc, so forward
 // declare here.
 /*template <class ForwardIt, class T, class BinaryReductionOp,

--- a/include/hipSYCL/algorithms/algorithm.hpp
+++ b/include/hipSYCL/algorithms/algorithm.hpp
@@ -420,12 +420,9 @@ sycl::event reverse_copy(sycl::queue &q, BidirIt first,
 
   auto size = std::distance(first, last);
 
-  using value_type1 = typename std::iterator_traits<BidirIt>::value_type;
-  using value_type2 = typename std::iterator_traits<ForwardIt>::value_type;
-
   return q.parallel_for(sycl::range{size}, deps,
                         [=](sycl::id<1> id) {
-                          int offset = - static_cast<int>(size);
+                          int offset = static_cast<int>(size) - id[0] - 1;
                           auto input = first;
                           auto output = d_first;
                           std::advance(input, offset);

--- a/include/hipSYCL/algorithms/algorithm.hpp
+++ b/include/hipSYCL/algorithms/algorithm.hpp
@@ -423,22 +423,15 @@ sycl::event reverse_copy(sycl::queue &q, BidirIt first,
   using value_type1 = typename std::iterator_traits<BidirIt>::value_type;
   using value_type2 = typename std::iterator_traits<ForwardIt>::value_type;
 
-  // ??
-  if (std::is_trivially_copyable_v<BidirIt> &&
-      std::is_same_v<value_type1, value_type2> &&
-      util::is_contiguous<BidirIt>() && util::is_contiguous<ForwardIt>() &&
-      detail::should_use_memcpy(q.get_device())) {
-    return q.memcpy(&(*d_first), &(*first), size * sizeof(value_type1), deps);
-  } else {
-    return q.parallel_for(sycl::range{size}, deps,
-                          [=](sycl::id<1> id) {
-                            auto input = last;
-                            auto output = d_first;
-                            std::advance(input, -id[0]);
-                            std::advance(output, id[0]);
-                            *output = *input;
-                          });
-  }
+  return q.parallel_for(sycl::range{size}, deps,
+                        [=](sycl::id<1> id) {
+                          int offset = - static_cast<int>(size);
+                          auto input = first;
+                          auto output = d_first;
+                          std::advance(input, offset);
+                          std::advance(output, id[0]);
+                          *output = *input;
+                        });
 }
 
 // Need transform_reduce functionality for find etc, so forward

--- a/include/hipSYCL/algorithms/algorithm.hpp
+++ b/include/hipSYCL/algorithms/algorithm.hpp
@@ -411,6 +411,22 @@ sycl::event replace_copy(sycl::queue &q, ForwardIt1 first, ForwardIt1 last,
       new_value, deps);
 }
 
+template <class BidirIt>
+sycl::event reverse(sycl::queue &q, BidirIt first, BidirIt last,
+                     const std::vector<sycl::event> &deps = {}) {
+  auto size = std::distance(first, last);
+  if (first == last || size == 1)
+    return sycl::event{};
+
+  return q.parallel_for(sycl::range{size/2}, deps,
+                        [=](sycl::id<1> id) {
+                          auto offset = size - id[0] - 1;
+                          auto input = std::next(first, id[0]);
+                          auto output = std::next(first, offset);
+                          std::iter_swap(input, output);
+                        });
+}
+
 template <class BidirIt, class ForwardIt>
 sycl::event reverse_copy(sycl::queue &q, BidirIt first,
                          BidirIt last, ForwardIt d_first,
@@ -422,11 +438,9 @@ sycl::event reverse_copy(sycl::queue &q, BidirIt first,
 
   return q.parallel_for(sycl::range{size}, deps,
                         [=](sycl::id<1> id) {
-                          int offset = static_cast<int>(size) - id[0] - 1;
-                          auto input = first;
-                          auto output = d_first;
-                          std::advance(input, offset);
-                          std::advance(output, id[0]);
+                          auto offset = size - id[0] - 1;
+                          auto input = std::next(first, offset);
+                          auto output = std::next(d_first, id[0]);
                           *output = *input;
                         });
 }

--- a/include/hipSYCL/std/stdpar/detail/algorithm_fwd.hpp
+++ b/include/hipSYCL/std/stdpar/detail/algorithm_fwd.hpp
@@ -140,6 +140,10 @@ template <class ForwardIt1, class ForwardIt2>
 HIPSYCL_STDPAR_ENTRYPOINT ForwardIt2 move(hipsycl::stdpar::par,
                                           ForwardIt1 first, ForwardIt1 last,
                                           ForwardIt2 d_first);
+template<class BidirIt, class ForwardIt>
+HIPSYCL_STDPAR_ENTRYPOINT ForwardIt reverse_copy (hipsycl::stdpar::par,
+                                                  BidirIt first, BidirIt last,
+                                                  ForwardIt d_first);
 }
 
 #endif

--- a/include/hipSYCL/std/stdpar/detail/algorithm_fwd.hpp
+++ b/include/hipSYCL/std/stdpar/detail/algorithm_fwd.hpp
@@ -99,6 +99,10 @@ HIPSYCL_STDPAR_ENTRYPOINT ForwardIt2
 replace_copy_if(hipsycl::stdpar::par_unseq, ForwardIt1 first, ForwardIt1 last,
                 ForwardIt2 d_first, UnaryPredicate p, const T &new_value);
 
+template<class BidirIt, class ForwardIt>
+HIPSYCL_STDPAR_ENTRYPOINT ForwardIt reverse_copy (hipsycl::stdpar::par_unseq,
+                                                  BidirIt first, BidirIt last,
+                                                  ForwardIt d_first);
 /*
 template <class ForwardIt, class T>
 HIPSYCL_STDPAR_ENTRYPOINT ForwardIt find(hipsycl::stdpar::par_unseq, ForwardIt first,

--- a/include/hipSYCL/std/stdpar/detail/algorithm_fwd.hpp
+++ b/include/hipSYCL/std/stdpar/detail/algorithm_fwd.hpp
@@ -99,6 +99,10 @@ HIPSYCL_STDPAR_ENTRYPOINT ForwardIt2
 replace_copy_if(hipsycl::stdpar::par_unseq, ForwardIt1 first, ForwardIt1 last,
                 ForwardIt2 d_first, UnaryPredicate p, const T &new_value);
 
+template<class BidirIt>
+HIPSYCL_STDPAR_ENTRYPOINT void reverse (hipsycl::stdpar::par_unseq,
+                                        BidirIt first, BidirIt last);
+
 template<class BidirIt, class ForwardIt>
 HIPSYCL_STDPAR_ENTRYPOINT ForwardIt reverse_copy (hipsycl::stdpar::par_unseq,
                                                   BidirIt first, BidirIt last,
@@ -140,6 +144,11 @@ template <class ForwardIt1, class ForwardIt2>
 HIPSYCL_STDPAR_ENTRYPOINT ForwardIt2 move(hipsycl::stdpar::par,
                                           ForwardIt1 first, ForwardIt1 last,
                                           ForwardIt2 d_first);
+
+template<class BidirIt>
+HIPSYCL_STDPAR_ENTRYPOINT void reverse (hipsycl::stdpar::par,
+                                        BidirIt first, BidirIt last);
+
 template<class BidirIt, class ForwardIt>
 HIPSYCL_STDPAR_ENTRYPOINT ForwardIt reverse_copy (hipsycl::stdpar::par,
                                                   BidirIt first, BidirIt last,

--- a/include/hipSYCL/std/stdpar/detail/offload_heuristic_db.hpp
+++ b/include/hipSYCL/std/stdpar/detail/offload_heuristic_db.hpp
@@ -45,6 +45,7 @@ struct replace {};
 struct replace_if {};
 struct replace_copy {};
 struct replace_copy_if {};
+struct reverse_copy {};
 struct find {};
 struct find_if {};
 struct find_if_not {};

--- a/include/hipSYCL/std/stdpar/detail/offload_heuristic_db.hpp
+++ b/include/hipSYCL/std/stdpar/detail/offload_heuristic_db.hpp
@@ -45,6 +45,7 @@ struct replace {};
 struct replace_if {};
 struct replace_copy {};
 struct replace_copy_if {};
+struct reverse {};
 struct reverse_copy {};
 struct find {};
 struct find_if {};

--- a/include/hipSYCL/std/stdpar/pstl-impl/algorithm.hpp
+++ b/include/hipSYCL/std/stdpar/pstl-impl/algorithm.hpp
@@ -407,6 +407,29 @@ HIPSYCL_STDPAR_ENTRYPOINT ForwardIt2 replace_copy_if(
       HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), d_first, p, new_value);
 }
 
+template<class BidirIt, class ForwardIt>
+HIPSYCL_STDPAR_ENTRYPOINT ForwardIt reverse_copy (hipsycl::stdpar::par_unseq,
+                                                  BidirIt first, BidirIt last,
+                                                  ForwardIt d_first) {
+  auto offloader = [&](auto& queue) {
+    ForwardIt d_last = d_first;
+    std::advance(d_last, std::distance(first, last));
+    hipsycl::algorithms::reverse_copy(queue, first, last, d_first);
+    return d_last;
+  };
+
+  auto fallback = [&]() {
+    return std::reverse_copy(hipsycl::stdpar::par_unseq_host_fallback, first, last,
+                     d_first);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::reverse_copy{},
+                                 hipsycl::stdpar::par_unseq{}),
+      std::distance(first, last), ForwardIt, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), d_first);
+}
+
 /*
 template <class ForwardIt, class T>
 HIPSYCL_STDPAR_ENTRYPOINT ForwardIt find(const hipsycl::stdpar::par_unseq, ForwardIt first,
@@ -1016,6 +1039,29 @@ HIPSYCL_STDPAR_ENTRYPOINT ForwardIt2 replace_copy_if(
                              hipsycl::stdpar::par{}),
       std::distance(first, last), ForwardIt2, offloader, fallback, first,
       HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), d_first, p, new_value);
+}
+
+template<class BidirIt, class ForwardIt>
+HIPSYCL_STDPAR_ENTRYPOINT ForwardIt reverse_copy (hipsycl::stdpar::par,
+                                                  BidirIt first, BidirIt last,
+                                                  ForwardIt d_first) {
+  auto offloader = [&](auto& queue) {
+    ForwardIt d_last = d_first;
+    std::advance(d_last, std::distance(first, last));
+    hipsycl::algorithms::reverse_copy(queue, first, last, d_first);
+    return d_last;
+  };
+
+  auto fallback = [&]() {
+    return std::reverse_copy(hipsycl::stdpar::par_host_fallback, first, last,
+                     d_first);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD(
+      hipsycl::stdpar::algorithm(hipsycl::stdpar::algorithm_category::reverse_copy{},
+                                 hipsycl::stdpar::par{}),
+      std::distance(first, last), ForwardIt, offloader, fallback, first,
+      HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), d_first);
 }
 
 /*

--- a/include/hipSYCL/std/stdpar/pstl-impl/algorithm.hpp
+++ b/include/hipSYCL/std/stdpar/pstl-impl/algorithm.hpp
@@ -407,6 +407,25 @@ HIPSYCL_STDPAR_ENTRYPOINT ForwardIt2 replace_copy_if(
       HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), d_first, p, new_value);
 }
 
+template<class BidirIt>
+HIPSYCL_STDPAR_ENTRYPOINT void reverse (hipsycl::stdpar::par_unseq,
+                                        BidirIt first, BidirIt last) {
+  auto offloader = [&](auto& queue) {
+    hipsycl::algorithms::reverse(queue, first, last);
+  };
+
+  auto fallback = [&]() {
+    std::reverse(hipsycl::stdpar::par_unseq_host_fallback, first, last);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD_NORET(
+    hipsycl::stdpar::algorithm(
+                          hipsycl::stdpar::algorithm_category::reverse{},
+                          hipsycl::stdpar::par_unseq{}),
+    std::distance(first, last), offloader, fallback, first,
+    HIPSYCL_STDPAR_NO_PTR_VALIDATION(last));
+}
+
 template<class BidirIt, class ForwardIt>
 HIPSYCL_STDPAR_ENTRYPOINT ForwardIt reverse_copy (hipsycl::stdpar::par_unseq,
                                                   BidirIt first, BidirIt last,
@@ -1039,6 +1058,25 @@ HIPSYCL_STDPAR_ENTRYPOINT ForwardIt2 replace_copy_if(
                              hipsycl::stdpar::par{}),
       std::distance(first, last), ForwardIt2, offloader, fallback, first,
       HIPSYCL_STDPAR_NO_PTR_VALIDATION(last), d_first, p, new_value);
+}
+
+template<class BidirIt>
+HIPSYCL_STDPAR_ENTRYPOINT void reverse (hipsycl::stdpar::par,
+                                        BidirIt first, BidirIt last) {
+  auto offloader = [&](auto& queue) {
+    hipsycl::algorithms::reverse(queue, first, last);
+  };
+
+  auto fallback = [&]() {
+    std::reverse(hipsycl::stdpar::par_host_fallback, first, last);
+  };
+
+  HIPSYCL_STDPAR_OFFLOAD_NORET(
+    hipsycl::stdpar::algorithm(
+                          hipsycl::stdpar::algorithm_category::reverse{},
+                          hipsycl::stdpar::par{}),
+    std::distance(first, last), offloader, fallback, first,
+    HIPSYCL_STDPAR_NO_PTR_VALIDATION(last));
 }
 
 template<class BidirIt, class ForwardIt>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -155,6 +155,7 @@ if(WITH_PSTL_TESTS)
     pstl/replace_if.cpp
     pstl/replace_copy.cpp
     pstl/replace_copy_if.cpp
+    pstl/reverse_copy.cpp
     pstl/sort.cpp
     pstl/transform.cpp
     pstl/transform_reduce.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -156,6 +156,7 @@ if(WITH_PSTL_TESTS)
     pstl/replace_copy.cpp
     pstl/replace_copy_if.cpp
     pstl/reverse_copy.cpp
+    pstl/reverse.cpp
     pstl/sort.cpp
     pstl/transform.cpp
     pstl/transform_reduce.cpp

--- a/tests/pstl/reverse.cpp
+++ b/tests/pstl/reverse.cpp
@@ -1,0 +1,72 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <algorithm>
+#include <execution>
+#include <utility>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl.hpp>
+
+#include "pstl_test_suite.hpp"
+
+BOOST_FIXTURE_TEST_SUITE(pstl_reverse, enable_unified_shared_memory)
+
+
+template<class T, class Policy>
+void test_reverse(Policy&& pol, std::size_t problem_size) {
+  std::vector<T> device_data(problem_size), host_data(problem_size);
+  for(int i = 0; i < problem_size; ++i) {
+    device_data[i] = T{i};
+    host_data[i] = T{i};
+  }
+
+  std::reverse(pol, device_data.begin(), device_data.end());
+  std::reverse(host_data.begin(), host_data.end());
+
+  BOOST_CHECK(device_data == host_data);
+}
+
+using types = boost::mp11::mp_list<int, non_trivial_copy>;
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_empty, T, types) {
+  test_reverse<T>(std::execution::par_unseq, 0);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_single_element, T, types) {
+  test_reverse<T>(std::execution::par_unseq, 1);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_medium_size, T, types) {
+  test_reverse<T>(std::execution::par_unseq, 1000);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_medium_size_odd, T, types) {
+  test_reverse<T>(std::execution::par_unseq, 1001);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_empty, T, types) {
+  test_reverse<T>(std::execution::par, 0);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_single_element, T, types) {
+  test_reverse<T>(std::execution::par, 1);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_medium_size, T, types) {
+  test_reverse<T>(std::execution::par, 1000);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_medium_size_odd, T, types) {
+  test_reverse<T>(std::execution::par, 1001);
+}
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pstl/reverse_copy.cpp
+++ b/tests/pstl/reverse_copy.cpp
@@ -1,0 +1,70 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <algorithm>
+#include <execution>
+#include <utility>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+#include <boost/mpl/list.hpp>
+
+#include "pstl_test_suite.hpp"
+
+BOOST_FIXTURE_TEST_SUITE(pstl_reverse_copy, enable_unified_shared_memory)
+
+
+template<class T, class Policy>
+void test_reverse_copy(Policy&& pol, std::size_t problem_size) {
+  std::vector<T> data(problem_size);
+  for(int i = 0; i < problem_size; ++i) {
+    data[i] = T{i};
+  }
+  
+  std::vector<T> dest_device(problem_size);
+  std::vector<T> dest_host(problem_size);
+
+  auto ret = std::reverse_copy(pol, data.begin(), data.end(),
+                       dest_device.begin());
+  std::reverse_copy(data.begin(), data.end(), dest_host.begin());
+
+  BOOST_CHECK(ret == dest_device.begin() + problem_size);
+  BOOST_CHECK(dest_device == dest_host);
+
+  std::reverse(data.begin(), data.end());
+  BOOST_CHECK(data == dest_device);
+}
+
+using types = boost::mpl::list<int, non_trivial_copy>;
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_empty, T, types::type) {
+  test_reverse_copy<T>(std::execution::par_unseq, 0);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_single_element, T, types::type) {
+  test_reverse_copy<T>(std::execution::par_unseq, 1);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_medium_size, T, types::type) {
+  test_reverse_copy<T>(std::execution::par_unseq, 10);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_empty, T, types::type) {
+  test_reverse_copy<T>(std::execution::par, 0);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_single_element, T, types::type) {
+  test_reverse_copy<T>(std::execution::par, 1);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_medium_size, T, types::type) {
+  test_reverse_copy<T>(std::execution::par, 10);
+}
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pstl/reverse_copy.cpp
+++ b/tests/pstl/reverse_copy.cpp
@@ -15,7 +15,8 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/mpl/list.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 
@@ -43,28 +44,28 @@ void test_reverse_copy(Policy&& pol, std::size_t problem_size) {
   BOOST_CHECK(data == dest_device);
 }
 
-using types = boost::mpl::list<int, non_trivial_copy>;
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_empty, T, types::type) {
+using types = boost::mp11::mp_list<int, non_trivial_copy>;
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_empty, T, types) {
   test_reverse_copy<T>(std::execution::par_unseq, 0);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_single_element, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_single_element, T, types) {
   test_reverse_copy<T>(std::execution::par_unseq, 1);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_medium_size, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_medium_size, T, types) {
   test_reverse_copy<T>(std::execution::par_unseq, 10);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_empty, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_empty, T, types) {
   test_reverse_copy<T>(std::execution::par, 0);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_single_element, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_single_element, T, types) {
   test_reverse_copy<T>(std::execution::par, 1);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(par_medium_size, T, types::type) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(par_medium_size, T, types) {
   test_reverse_copy<T>(std::execution::par, 10);
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pstl/reverse_copy.cpp
+++ b/tests/pstl/reverse_copy.cpp
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_single_element, T, types) {
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(par_unseq_medium_size, T, types) {
-  test_reverse_copy<T>(std::execution::par_unseq, 10);
+  test_reverse_copy<T>(std::execution::par_unseq, 1000);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(par_empty, T, types) {
@@ -66,6 +66,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(par_single_element, T, types) {
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(par_medium_size, T, types) {
-  test_reverse_copy<T>(std::execution::par, 10);
+  test_reverse_copy<T>(std::execution::par, 1000);
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pstl/reverse_copy.cpp
+++ b/tests/pstl/reverse_copy.cpp
@@ -29,7 +29,7 @@ void test_reverse_copy(Policy&& pol, std::size_t problem_size) {
   for(int i = 0; i < problem_size; ++i) {
     data[i] = T{i};
   }
-  
+
   std::vector<T> dest_device(problem_size);
   std::vector<T> dest_host(problem_size);
 


### PR DESCRIPTION
This PR adds automatic offloading support for:
- [x] [reverse](https://en.cppreference.com/w/cpp/algorithm/reverse)
- [x] [reverse_copy](https://en.cppreference.com/w/cpp/algorithm/reverse_copy)