### PR TITLE
Fix AdaptiveCpp build on Ubuntu 20.04

### DIFF
--- a/tests/pstl/all_of.cpp
+++ b/tests/pstl/all_of.cpp
@@ -17,7 +17,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/any_of.cpp
+++ b/tests/pstl/any_of.cpp
@@ -17,7 +17,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/copy.cpp
+++ b/tests/pstl/copy.cpp
@@ -16,7 +16,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/copy_if.cpp
+++ b/tests/pstl/copy_if.cpp
@@ -16,7 +16,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/copy_n.cpp
+++ b/tests/pstl/copy_n.cpp
@@ -16,7 +16,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/exclusive_scan.cpp
+++ b/tests/pstl/exclusive_scan.cpp
@@ -19,7 +19,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/fill.cpp
+++ b/tests/pstl/fill.cpp
@@ -16,7 +16,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/fill_n.cpp
+++ b/tests/pstl/fill_n.cpp
@@ -16,7 +16,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/for_each.cpp
+++ b/tests/pstl/for_each.cpp
@@ -15,7 +15,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/for_each_n.cpp
+++ b/tests/pstl/for_each_n.cpp
@@ -15,7 +15,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/generate.cpp
+++ b/tests/pstl/generate.cpp
@@ -16,7 +16,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/generate_n.cpp
+++ b/tests/pstl/generate_n.cpp
@@ -16,7 +16,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/inclusive_scan.cpp
+++ b/tests/pstl/inclusive_scan.cpp
@@ -19,7 +19,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/memory.cpp
+++ b/tests/pstl/memory.cpp
@@ -5,7 +5,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/merge.cpp
+++ b/tests/pstl/merge.cpp
@@ -19,7 +19,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/none_of.cpp
+++ b/tests/pstl/none_of.cpp
@@ -16,7 +16,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/pointer_validation.cpp
+++ b/tests/pstl/pointer_validation.cpp
@@ -16,7 +16,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/reduce.cpp
+++ b/tests/pstl/reduce.cpp
@@ -17,7 +17,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/replace.cpp
+++ b/tests/pstl/replace.cpp
@@ -16,7 +16,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/replace_copy.cpp
+++ b/tests/pstl/replace_copy.cpp
@@ -16,7 +16,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/replace_copy_if.cpp
+++ b/tests/pstl/replace_copy_if.cpp
@@ -16,7 +16,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/replace_if.cpp
+++ b/tests/pstl/replace_if.cpp
@@ -16,7 +16,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/sort.cpp
+++ b/tests/pstl/sort.cpp
@@ -17,7 +17,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/std_atomic.cpp
+++ b/tests/pstl/std_atomic.cpp
@@ -17,7 +17,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/std_math.cpp
+++ b/tests/pstl/std_math.cpp
@@ -16,7 +16,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/transform.cpp
+++ b/tests/pstl/transform.cpp
@@ -15,7 +15,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/transform_exclusive_scan.cpp
+++ b/tests/pstl/transform_exclusive_scan.cpp
@@ -19,7 +19,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/transform_inclusive_scan.cpp
+++ b/tests/pstl/transform_inclusive_scan.cpp
@@ -19,7 +19,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/pstl/transform_reduce.cpp
+++ b/tests/pstl/transform_reduce.cpp
@@ -16,7 +16,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 #include "pstl_test_suite.hpp"
 

--- a/tests/sycl/sycl_test_suite.hpp
+++ b/tests/sycl/sycl_test_suite.hpp
@@ -17,7 +17,7 @@
 #define BOOST_MPL_CFG_GPU_ENABLED // Required for nvcc
 #include <boost/test/unit_test.hpp>
 #include <boost/mp11/list.hpp>
-#include <boost/mp11/mpl_list.hpp>
+#include <boost/mp11/mpl.hpp>
 
 
 #define SYCL_SIMPLE_SWIZZLES


### PR DESCRIPTION
The specific header included does not exist on Boost 1.71, replace it with the more general header.