### PR TITLE
[CI] Restructure CI to use docker containers (and enable LLVM 19&20)

### DIFF
--- a/.github/workflows/create-ci-docker/AdaptiveCpp-CI-Linux.dockerfile
+++ b/.github/workflows/create-ci-docker/AdaptiveCpp-CI-Linux.dockerfile
@@ -1,0 +1,102 @@
+ARG BASE="ubuntu:22.04"
+
+FROM ${BASE}
+
+ARG LLVM_VERSION=18
+# make empty to skip installation of ROCM and Intel Stack
+ARG ROCM_VERSION="6.2.4"
+# make empty to skip installation of CUDA
+ARG CUDA_MAJOR_VERSION="11"
+ARG CUDA_MINOR_VERSION="0"
+ARG CUDA_PATCH_VERSION="2"
+ARG CUDA_DRIVER_VERSION="450.51.05"
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get -u update \
+    && apt-get -qq upgrade \
+    # Setup Kitware repo for the latest cmake available:
+    && apt-get -qq install \
+        apt-transport-https ca-certificates gnupg software-properties-common wget apt-utils lsb-release \
+    && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
+        | gpg --dearmor - \
+        | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
+    && apt-add-repository 'deb https://apt.kitware.com/ubuntu/ jammy main' \
+    && apt-get -u update \
+    && apt-get -qq upgrade \
+    && apt-get -qq install cmake \
+        ca-certificates \
+        build-essential \
+        python3 \
+        python3-pip \
+        ninja-build \
+        ccache \
+        xz-utils \
+        curl \
+        git \
+        bzip2 \
+        lzma \
+        xz-utils \
+        unzip \
+        libnuma-dev \
+        gettext \
+        jq \
+        libtbb-dev \
+        libboost-all-dev \
+        ocl-icd-opencl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN <<EOF
+    # skip if ROCM_VERSION empty (yeah.. Intel not ROCm .. but whatever)
+    if [ -z "${ROCM_VERSION}" ]; then exit 0; fi
+    wget -q https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.16695.4/intel-igc-core_1.0.16695.4_amd64.deb
+    wget -q https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.16695.4/intel-igc-opencl_1.0.16695.4_amd64.deb
+    wget -q https://github.com/intel/compute-runtime/releases/download/24.17.29377.6/intel-level-zero-gpu-dbgsym_1.3.29377.6_amd64.ddeb
+    wget -q https://github.com/intel/compute-runtime/releases/download/24.17.29377.6/intel-level-zero-gpu_1.3.29377.6_amd64.deb
+    wget -q https://github.com/intel/compute-runtime/releases/download/24.17.29377.6/intel-opencl-icd-dbgsym_24.17.29377.6_amd64.ddeb
+    wget -q https://github.com/intel/compute-runtime/releases/download/24.17.29377.6/intel-opencl-icd_24.17.29377.6_amd64.deb
+    wget -q https://github.com/intel/compute-runtime/releases/download/24.17.29377.6/libigdgmm12_22.3.19_amd64.deb
+    wget -q https://github.com/oneapi-src/level-zero/releases/download/v1.13.5/level-zero-devel_1.13.5+u22.04_amd64.deb
+    wget -q https://github.com/oneapi-src/level-zero/releases/download/v1.13.5/level-zero_1.13.5+u22.04_amd64.deb
+    dpkg -i *.deb
+    rm *.deb
+EOF
+
+RUN <<EOF
+    # skip if CUDA_MAJOR_VERSION empty
+    if [ -z "${CUDA_MAJOR_VERSION}" ]; then exit 0; fi
+    mkdir -p /opt/cuda-${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION}
+    wget -q -O cuda-${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION}.sh https://developer.download.nvidia.com/compute/cuda/${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION}.${CUDA_PATCH_VERSION}/local_installers/cuda_${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION}.${CUDA_PATCH_VERSION}_${CUDA_DRIVER_VERSION}_linux.run
+    sh ./cuda-${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION}.sh --override --silent --toolkit --no-man-page --no-drm --no-opengl-libs --installpath=/opt/cuda-${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION} && rm ./cuda-${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION}.sh
+    ln -s /opt/cuda-${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION} /opt/cuda
+    echo "CUDA Version ${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION}.${CUDA_PATCH_VERSION}" | tee /opt/cuda-${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION}/version.txt
+EOF
+
+RUN <<EOF
+    # skip if ROCM_VERSION empty
+    if [ -z "${ROCM_VERSION}" ]; then exit 0; fi
+    wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add -
+    echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/${ROCM_VERSION} jammy main" | tee /etc/apt/sources.list.d/rocm.list
+    printf 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | tee /etc/apt/preferences.d/rocm-pin-600
+    apt-get update
+    apt-get install -y rocm-dev
+    rm -rf /var/lib/apt/lists/*
+EOF
+
+RUN <<EOF
+    wget -q https://apt.llvm.org/llvm.sh
+    chmod +x llvm.sh
+    ./llvm.sh ${LLVM_VERSION}
+    apt-get install -y libclang-${LLVM_VERSION}-dev clang-tools-${LLVM_VERSION} libomp-${LLVM_VERSION}-dev llvm-${LLVM_VERSION}-dev
+    apt-get install -y -o DPkg::options::="--force-overwrite" libclang-rt-${LLVM_VERSION}-dev
+    rm -rf /var/lib/apt/lists/*
+    python3 -m pip install lit
+    ln -s /usr/bin/FileCheck-${LLVM_VERSION} /usr/bin/FileCheck
+EOF
+
+ENV PATH="$PATH:/usr/local/cuda/bin"
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64"
+ENV CC=clang-${LLVM_VERSION}
+ENV CXX=clang++-${LLVM_VERSION}
+
+

--- a/.github/workflows/create-ci-docker/action.yml
+++ b/.github/workflows/create-ci-docker/action.yml
@@ -36,12 +36,6 @@ runs:
       shell: bash
       run: echo "::add-mask::${{ inputs.GITHUB_TOKEN }}"
     - uses: dorny/paths-filter@v3
-      id: filter-pr
-      with:
-        filters: |
-          docker:
-            - '.github/workflows/create-ci-docker/**'
-    - uses: dorny/paths-filter@v3
       id: filter-last-push
       with:
         base: ${{ github.ref }}
@@ -55,14 +49,8 @@ runs:
         BASE_OS=${{ inputs.BASE_TAG }}
         echo "BASE_OS=${BASE_OS//-/:}" >> $GITHUB_OUTPUT
 
-        # We cannot push to the target repo... Can we push to the src?
-        if [[ "${{github.event_name}}" == "pull_request" ]]; then
-          REPO_OWNER=${{ github.event.pull_request.head.repo.owner.login }}
-          echo "REPO_OWNER=${REPO_OWNER@L}" >> $GITHUB_OUTPUT
-        else
-          REPO_OWNER=${{ github.repository_owner }}
-          echo "REPO_OWNER=${REPO_OWNER@L}" >> $GITHUB_OUTPUT
-        fi
+        REPO_OWNER=${{ github.repository_owner }}
+        echo "REPO_OWNER=${REPO_OWNER@L}" >> $GITHUB_OUTPUT
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
@@ -79,10 +67,9 @@ runs:
       with:
         images: ghcr.io/${{steps.make-tagged-os.outputs.REPO_OWNER}}/adaptivecpp-ci-linux
         tags: |
-          type=raw,enable=${{ github.ref_name == 'develop' }},value=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-rocm-${{ inputs.ROCM_VERSION }}-cuda-${{ inputs.CUDA_MAJOR_VERSION }}.${{ inputs.CUDA_MINOR_VERSION }}.${{ inputs.CUDA_PATCH_VERSION }},prefix=
+          type=raw,enable=${{ github.ref_name == 'develop' || github.event_name == 'pull_request' }},value=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-rocm-${{ inputs.ROCM_VERSION }}-cuda-${{ inputs.CUDA_MAJOR_VERSION }}.${{ inputs.CUDA_MINOR_VERSION }}.${{ inputs.CUDA_PATCH_VERSION }},prefix=
           type=sha
           type=ref,event=branch
-          type=ref,event=pr
         flavor: |
           latest=false
           prefix=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-rocm-${{ inputs.ROCM_VERSION }}-cuda-${{ inputs.CUDA_MAJOR_VERSION }}.${{ inputs.CUDA_MINOR_VERSION }}.${{ inputs.CUDA_PATCH_VERSION }}-
@@ -93,10 +80,9 @@ runs:
       with:
         images: ghcr.io/${{steps.make-tagged-os.outputs.REPO_OWNER}}/adaptivecpp-ci-linux
         tags: |
-          type=raw,enable=${{ github.ref_name == 'develop' }},value=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-rocm-${{ inputs.ROCM_VERSION }},prefix=
+          type=raw,enable=${{ github.ref_name == 'develop' || github.event_name == 'pull_request' }},value=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-rocm-${{ inputs.ROCM_VERSION }},prefix=
           type=sha
           type=ref,event=branch
-          type=ref,event=pr
         flavor: |
           latest=false
           prefix=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-rocm-${{ inputs.ROCM_VERSION }}-
@@ -107,10 +93,9 @@ runs:
       with:
         images: ghcr.io/${{steps.make-tagged-os.outputs.REPO_OWNER}}/adaptivecpp-ci-linux
         tags: |
-          type=raw,enable=${{ github.ref_name == 'develop' }},value=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-cuda-${{ inputs.CUDA_MAJOR_VERSION }}.${{ inputs.CUDA_MINOR_VERSION }}.${{ inputs.CUDA_PATCH_VERSION }},prefix=
+          type=raw,enable=${{ github.ref_name == 'develop' || github.event_name == 'pull_request' }},value=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-cuda-${{ inputs.CUDA_MAJOR_VERSION }}.${{ inputs.CUDA_MINOR_VERSION }}.${{ inputs.CUDA_PATCH_VERSION }},prefix=
           type=sha
           type=ref,event=branch
-          type=ref,event=pr
         flavor: |
           latest=false
           prefix=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-cuda-${{ inputs.CUDA_MAJOR_VERSION }}.${{ inputs.CUDA_MINOR_VERSION }}.${{ inputs.CUDA_PATCH_VERSION }}-
@@ -121,10 +106,9 @@ runs:
       with:
         images: ghcr.io/${{steps.make-tagged-os.outputs.REPO_OWNER}}/adaptivecpp-ci-linux
         tags: |
-          type=raw,enable=${{ github.ref_name == 'develop' }},value=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }},prefix=
+          type=raw,enable=${{ github.ref_name == 'develop' || github.event_name == 'pull_request' }},value=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }},prefix=
           type=sha
           type=ref,event=branch
-          type=ref,event=pr
         flavor: |
           latest=false
           prefix=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-
@@ -172,14 +156,14 @@ runs:
       shell: bash
       run: |
         # use fallback if no changes were made to docker
-        if [[ "${{ steps.filter-pr.outputs.docker }}" == "false" ]]; then
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
           echo "docker_image=${{ steps.select-metadata.outputs.fallback_tag }}" >> $GITHUB_OUTPUT
         else
           echo "docker_image=${{ steps.select-metadata.outputs.docker_image }}" >> $GITHUB_OUTPUT
         fi
         
     - name: Build and push Docker images
-      if: steps.filter-last-push.outputs.docker == 'true' || steps.filter-pr.outputs.docker == 'true' && steps.tag-exists.outputs.tag == 'not found'
+      if: steps.filter-last-push.outputs.docker == 'true' || steps.tag-exists.outputs.tag == 'not found' && github.event_name != 'pull_request'
       uses: docker/build-push-action@v6
       id: build
       with:

--- a/.github/workflows/create-ci-docker/action.yml
+++ b/.github/workflows/create-ci-docker/action.yml
@@ -1,0 +1,189 @@
+name: 'AdaptiveCpp-CI-Docker-Images'
+description: 'Creates docker images containing the AdaptiveCpp CI environment'
+inputs:
+  LLVM_VERSION:
+    required: true
+    default: '18'
+  ROCM_VERSION:
+    required: true
+    default: '5.4.3'
+  CUDA_MAJOR_VERSION:
+    required: true
+    default: '11'
+  CUDA_MINOR_VERSION:
+    required: true
+    default: '0'
+  CUDA_PATCH_VERSION:
+    required: true
+    default: '2'
+  CUDA_DRIVER_VERSION:
+    required: true
+    default: '450.51.05'
+  BASE_TAG:
+    required: true
+    default: 'ubuntu-22.04'
+  GITHUB_TOKEN:
+    required: true
+  
+outputs:
+  docker_image:
+    description: "Docker image id"
+    value: ${{ steps.final-docker-image.outputs.docker_image }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Redact GITHUB_TOKEN
+      shell: bash
+      run: echo "::add-mask::${{ inputs.GITHUB_TOKEN }}"
+    - uses: dorny/paths-filter@v3
+      id: filter-pr
+      with:
+        filters: |
+          docker:
+            - '.github/workflows/create-ci-docker/**'
+    - uses: dorny/paths-filter@v3
+      id: filter-last-push
+      with:
+        base: ${{ github.ref }}
+        filters: |
+          docker:
+            - '.github/workflows/create-ci-docker/**'
+    - name: Make tagged OS
+      id: make-tagged-os
+      shell: bash
+      run: |
+        BASE_OS=${{ inputs.BASE_TAG }}
+        echo "BASE_OS=${BASE_OS//-/:}" >> $GITHUB_OUTPUT
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.GITHUB_TOKEN }}
+    - name: Docker metadata
+      uses: docker/metadata-action@v5
+      id: metadata
+      if: inputs.CUDA_MAJOR_VERSION != '' && inputs.ROCM_VERSION != ''
+      with:
+        images: ghcr.io/${{github.repository_owner}}/adaptivecpp-ci-linux
+        tags: |
+          type=raw,enable=${{ github.ref_name == 'develop' }},value=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-rocm-${{ inputs.ROCM_VERSION }}-cuda-${{ inputs.CUDA_MAJOR_VERSION }}.${{ inputs.CUDA_MINOR_VERSION }}.${{ inputs.CUDA_PATCH_VERSION }},prefix=
+          type=sha
+          type=ref,event=branch
+          type=ref,event=pr
+        flavor: |
+          latest=false
+          prefix=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-rocm-${{ inputs.ROCM_VERSION }}-cuda-${{ inputs.CUDA_MAJOR_VERSION }}.${{ inputs.CUDA_MINOR_VERSION }}.${{ inputs.CUDA_PATCH_VERSION }}-
+    - name: Docker metadata no CUDA
+      uses: docker/metadata-action@v5
+      id: metadata-no-cuda
+      if: inputs.CUDA_MAJOR_VERSION == '' && inputs.ROCM_VERSION != ''
+      with:
+        images: ghcr.io/${{github.repository_owner}}/adaptivecpp-ci-linux
+        tags: |
+          type=raw,enable=${{ github.ref_name == 'develop' }},value=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-rocm-${{ inputs.ROCM_VERSION }},prefix=
+          type=sha
+          type=ref,event=branch
+          type=ref,event=pr
+        flavor: |
+          latest=false
+          prefix=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-rocm-${{ inputs.ROCM_VERSION }}-
+    - name: Docker metadata no ROCm
+      uses: docker/metadata-action@v5
+      id: metadata-no-rocm
+      if: inputs.CUDA_MAJOR_VERSION != '' && inputs.ROCM_VERSION == ''
+      with:
+        images: ghcr.io/${{github.repository_owner}}/adaptivecpp-ci-linux
+        tags: |
+          type=raw,enable=${{ github.ref_name == 'develop' }},value=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-cuda-${{ inputs.CUDA_MAJOR_VERSION }}.${{ inputs.CUDA_MINOR_VERSION }}.${{ inputs.CUDA_PATCH_VERSION }},prefix=
+          type=sha
+          type=ref,event=branch
+          type=ref,event=pr
+        flavor: |
+          latest=false
+          prefix=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-cuda-${{ inputs.CUDA_MAJOR_VERSION }}.${{ inputs.CUDA_MINOR_VERSION }}.${{ inputs.CUDA_PATCH_VERSION }}-
+    - name: Docker metadata no CUDA no ROCm
+      uses: docker/metadata-action@v5
+      id: metadata-no-cuda-no-rocm
+      if: inputs.CUDA_MAJOR_VERSION == '' && inputs.ROCM_VERSION == ''
+      with:
+        images: ghcr.io/${{github.repository_owner}}/adaptivecpp-ci-linux
+        tags: |
+          type=raw,enable=${{ github.ref_name == 'develop' }},value=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }},prefix=
+          type=sha
+          type=ref,event=branch
+          type=ref,event=pr
+        flavor: |
+          latest=false
+          prefix=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-
+    
+    - name: Select metadata to use
+      id: select-metadata
+      shell: bash
+      run: |
+        OUTPUT_EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        if [[ -n "${{ inputs.CUDA_MAJOR_VERSION }}" && -n "${{ inputs.ROCM_VERSION }}" ]]; then
+          TAGS="${{ steps.metadata.outputs.tags }}"
+          VERSION="${{ steps.metadata.outputs.version }}"
+          FALLBACK_TAG="${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-rocm-${{ inputs.ROCM_VERSION }}-cuda-${{ inputs.CUDA_MAJOR_VERSION }}.${{ inputs.CUDA_MINOR_VERSION }}.${{ inputs.CUDA_PATCH_VERSION }}"
+        elif [[ -n "${{ inputs.CUDA_MAJOR_VERSION }}" && -z "${{ inputs.ROCM_VERSION }}" ]]; then
+          TAGS="${{ steps.metadata-no-rocm.outputs.tags }}"
+          VERSION="${{ steps.metadata-no-rocm.outputs.version }}"
+          FALLBACK_TAG="${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-cuda-${{ inputs.CUDA_MAJOR_VERSION }}.${{ inputs.CUDA_MINOR_VERSION }}.${{ inputs.CUDA_PATCH_VERSION }}"
+        elif [[ -z "${{ inputs.CUDA_MAJOR_VERSION }}" && -n "${{ inputs.ROCM_VERSION }}" ]]; then
+          TAGS="${{ steps.metadata-no-cuda.outputs.tags }}"
+          VERSION="${{ steps.metadata-no-cuda.outputs.version }}"
+          FALLBACK_TAG="${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-rocm-${{ inputs.ROCM_VERSION }}"
+        else
+          TAGS="${{ steps.metadata-no-cuda-no-rocm.outputs.tags }}"
+          VERSION="${{ steps.metadata-no-cuda-no-rocm.outputs.version }}"
+          FALLBACK_TAG="${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}"
+        fi
+        echo "docker_image=${TAGS}" | head -n 1 >> $GITHUB_OUTPUT
+        echo "version=${VERSION}" >> $GITHUB_OUTPUT
+        echo "fallback_tag=ghcr.io/${{github.repository_owner}}/adaptivecpp-ci-linux:${FALLBACK_TAG}" >> $GITHUB_OUTPUT
+        cat << EOF >> $GITHUB_OUTPUT
+        tags<<${OUTPUT_EOF}
+        ${TAGS}
+        ${OUTPUT_EOF}
+        EOF
+
+    - uses: tyriis/docker-image-tag-exists@v2.1.0
+      id: tag-exists
+      with:
+        registry: ghcr.io
+        repository: ${{github.repository_owner}}/adaptivecpp-ci-linux
+        tag: ${{ steps.select-metadata.outputs.version }}
+    
+    - name: Final docker_image value
+      id: final-docker-image
+      shell: bash
+      run: |
+        # use fallback if no changes were made to docker
+        if [[ "${{ steps.filter-pr.outputs.docker }}" == "false" ]]; then
+          echo "docker_image=${{ steps.select-metadata.outputs.fallback_tag }}" >> $GITHUB_OUTPUT
+        else
+          echo "docker_image=${{ steps.select-metadata.outputs.docker_image }}" >> $GITHUB_OUTPUT
+        fi
+        
+    - name: Build and push Docker images
+      if: steps.filter-last-push.outputs.docker == 'true' || steps.filter-pr.outputs.docker == 'true' && steps.tag-exists.outputs.tag == 'not found'
+      uses: docker/build-push-action@v6
+      id: build
+      with:
+        file: .github/workflows/create-ci-docker/AdaptiveCpp-CI-Linux.dockerfile
+        platforms: linux/amd64
+        push: true
+        tags: ${{ steps.select-metadata.outputs.tags }}
+        build-args: |
+          LLVM_VERSION=${{ inputs.LLVM_VERSION }}
+          ROCM_VERSION=${{ inputs.ROCM_VERSION }}
+          CUDA_MAJOR_VERSION=${{ inputs.CUDA_MAJOR_VERSION }}
+          CUDA_MINOR_VERSION=${{ inputs.CUDA_MINOR_VERSION }}
+          CUDA_PATCH_VERSION=${{ inputs.CUDA_PATCH_VERSION }}
+          CUDA_DRIVER_VERSION=${{ inputs.CUDA_DRIVER_VERSION }}
+          BASE=${{ steps.make-tagged-os.outputs.BASE_OS }}

--- a/.github/workflows/create-ci-docker/action.yml
+++ b/.github/workflows/create-ci-docker/action.yml
@@ -54,7 +54,8 @@ runs:
       run: |
         BASE_OS=${{ inputs.BASE_TAG }}
         echo "BASE_OS=${BASE_OS//-/:}" >> $GITHUB_OUTPUT
-
+        REPO_OWNER=${{ github.repository_owner }}
+        echo "REPO_OWNER=${REPO_OWNER@L}" >> $GITHUB_OUTPUT
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
@@ -69,7 +70,7 @@ runs:
       id: metadata
       if: inputs.CUDA_MAJOR_VERSION != '' && inputs.ROCM_VERSION != ''
       with:
-        images: ghcr.io/${{github.repository_owner}}/adaptivecpp-ci-linux
+        images: ghcr.io/${{steps.make-tagged-os.outputs.REPO_OWNER}}/adaptivecpp-ci-linux
         tags: |
           type=raw,enable=${{ github.ref_name == 'develop' }},value=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-rocm-${{ inputs.ROCM_VERSION }}-cuda-${{ inputs.CUDA_MAJOR_VERSION }}.${{ inputs.CUDA_MINOR_VERSION }}.${{ inputs.CUDA_PATCH_VERSION }},prefix=
           type=sha
@@ -83,7 +84,7 @@ runs:
       id: metadata-no-cuda
       if: inputs.CUDA_MAJOR_VERSION == '' && inputs.ROCM_VERSION != ''
       with:
-        images: ghcr.io/${{github.repository_owner}}/adaptivecpp-ci-linux
+        images: ghcr.io/${{steps.make-tagged-os.outputs.REPO_OWNER}}/adaptivecpp-ci-linux
         tags: |
           type=raw,enable=${{ github.ref_name == 'develop' }},value=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-rocm-${{ inputs.ROCM_VERSION }},prefix=
           type=sha
@@ -97,7 +98,7 @@ runs:
       id: metadata-no-rocm
       if: inputs.CUDA_MAJOR_VERSION != '' && inputs.ROCM_VERSION == ''
       with:
-        images: ghcr.io/${{github.repository_owner}}/adaptivecpp-ci-linux
+        images: ghcr.io/${{steps.make-tagged-os.outputs.REPO_OWNER}}/adaptivecpp-ci-linux
         tags: |
           type=raw,enable=${{ github.ref_name == 'develop' }},value=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-cuda-${{ inputs.CUDA_MAJOR_VERSION }}.${{ inputs.CUDA_MINOR_VERSION }}.${{ inputs.CUDA_PATCH_VERSION }},prefix=
           type=sha
@@ -111,7 +112,7 @@ runs:
       id: metadata-no-cuda-no-rocm
       if: inputs.CUDA_MAJOR_VERSION == '' && inputs.ROCM_VERSION == ''
       with:
-        images: ghcr.io/${{github.repository_owner}}/adaptivecpp-ci-linux
+        images: ghcr.io/${{steps.make-tagged-os.outputs.REPO_OWNER}}/adaptivecpp-ci-linux
         tags: |
           type=raw,enable=${{ github.ref_name == 'develop' }},value=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }},prefix=
           type=sha
@@ -145,7 +146,7 @@ runs:
         fi
         echo "docker_image=${TAGS}" | head -n 1 >> $GITHUB_OUTPUT
         echo "version=${VERSION}" >> $GITHUB_OUTPUT
-        echo "fallback_tag=ghcr.io/${{github.repository_owner}}/adaptivecpp-ci-linux:${FALLBACK_TAG}" >> $GITHUB_OUTPUT
+        echo "fallback_tag=ghcr.io/${{steps.make-tagged-os.outputs.REPO_OWNER}}/adaptivecpp-ci-linux:${FALLBACK_TAG}" >> $GITHUB_OUTPUT
         cat << EOF >> $GITHUB_OUTPUT
         tags<<${OUTPUT_EOF}
         ${TAGS}
@@ -156,7 +157,7 @@ runs:
       id: tag-exists
       with:
         registry: ghcr.io
-        repository: ${{github.repository_owner}}/adaptivecpp-ci-linux
+        repository: ${{steps.make-tagged-os.outputs.REPO_OWNER}}/adaptivecpp-ci-linux
         tag: ${{ steps.select-metadata.outputs.version }}
     
     - name: Final docker_image value

--- a/.github/workflows/create-ci-docker/action.yml
+++ b/.github/workflows/create-ci-docker/action.yml
@@ -54,8 +54,15 @@ runs:
       run: |
         BASE_OS=${{ inputs.BASE_TAG }}
         echo "BASE_OS=${BASE_OS//-/:}" >> $GITHUB_OUTPUT
-        REPO_OWNER=${{ github.repository_owner }}
-        echo "REPO_OWNER=${REPO_OWNER@L}" >> $GITHUB_OUTPUT
+
+        # We cannot push to the target repo... Can we push to the src?
+        if [[ "${{github.event_name}}" == "pull_request" ]]; then
+          REPO_OWNER=${{ github.event.pull_request.head.repo.owner.login }}
+          echo "REPO_OWNER=${REPO_OWNER@L}" >> $GITHUB_OUTPUT
+        else
+          REPO_OWNER=${{ github.repository_owner }}
+          echo "REPO_OWNER=${REPO_OWNER@L}" >> $GITHUB_OUTPUT
+        fi
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/linux-lit.yml
+++ b/.github/workflows/linux-lit.yml
@@ -3,40 +3,64 @@ name: Linux LIT tests
 on: [push, pull_request]
 
 jobs:
-  cbs:
-    name: CBS, clang ${{ matrix.clang }}, ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+  prep-container:
+    name: Prepare CI container clang ${{ matrix.clang }}, ${{ matrix.os }}
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: read
+      packages: write
+      actions: read
+    outputs:
+      docker_matrix: ${{ steps.matrix-output.outputs.json }}
     strategy:
       matrix:
-        clang: [14, 15, 16, 17, 18]
+        clang: [14, 15, 16, 17, 18, 19]
         os: [ubuntu-22.04]
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-      - name: install LLVM
-        run: |
-          sudo apt update
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh ${{matrix.clang}}
-          sudo apt-get install -y libclang-${{matrix.clang}}-dev clang-tools-${{matrix.clang}} libomp-${{matrix.clang}}-dev llvm-${{matrix.clang}}-dev
-          sudo python -m pip install lit
-          sudo ln -s /usr/bin/FileCheck-${{matrix.clang}} /usr/bin/FileCheck
-          if [[ "${{matrix.clang}}" == "16" ]]; then
-            sudo rm -r /usr/lib/clang/16*
-            sudo ln -s /usr/lib/llvm-16/lib/clang/16 /usr/lib/clang/16
-          fi
-      - name: install boost (from apt)
-        run: |
-          sudo apt-get install -y libboost-all-dev
+          fetch-depth: 20
+      - uses: ./.github/workflows/create-ci-docker
+        id: docker
+        with:
+          LLVM_VERSION: ${{ matrix.clang }}
+          ROCM_VERSION: ""
+          CUDA_MAJOR_VERSION: ""
+          BASE_TAG: ${{ matrix.os }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}    
+      - uses: beacon-biosignals/matrix-output@v1
+        id: matrix-output
+        with:
+          yaml: |
+            name: ${{ matrix.clang }}-${{ matrix.os }}
+            clang: ${{ matrix.clang }}
+            os: ${{ matrix.os }}
+            image: ${{ steps.docker.outputs.docker_image }}
+
+  cbs:
+    name: CBS, clang ${{ matrix.docker.clang }}, ${{ matrix.docker.os }}
+    needs: prep-container
+    runs-on: ${{ matrix.docker.os }}
+    strategy:
+      matrix:
+        docker: ${{fromJson(needs.prep-container.outputs.docker_matrix)}}
+    container:
+      image: ${{ matrix.docker.image }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
       - name: setup build env
         run: |
           export CXXFLAGS="$CXXFLAGS"
-          if [[ "${{matrix.clang}}" != "11" && "${{matrix.clang}}" -lt "16" ]]; then
+          if [[ "${{matrix.docker.clang}}" != "11" && "${{matrix.docker.clang}}" -lt "16" ]]; then
             export OMP_CXX_FLAGS="$CXXFLAGS -fexperimental-new-pass-manager"
-            export CC=clang-${{matrix.clang}}
-            export CXX=clang++-${{matrix.clang}}
+            export CC=clang-${{matrix.docker.clang}}
+            export CXX=clang++-${{matrix.docker.clang}}
           fi
           echo "CC=${CC}" >> $GITHUB_ENV
           echo "CXX=${CXX}" >> $GITHUB_ENV
@@ -46,65 +70,53 @@ jobs:
           mkdir build && cd build
           echo ${CXXFLAGS}
           
-          cmake -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.clang}} -DOMP_CXX_FLAGS="$OMP_CXX_FLAGS -fopenmp" -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.clang}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.clang}}/cmake .. -DCMAKE_INSTALL_PREFIX=`pwd`/install
-          make -j2 install
+          cmake -GNinja -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.docker.clang}} -DOMP_CXX_FLAGS="$OMP_CXX_FLAGS -fopenmp" -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.docker.clang}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.docker.clang}}/cmake .. -DCMAKE_INSTALL_PREFIX=`pwd`/install
+          ninja install
       - name: setup CPU tests with loop splitting
         run: |
           mkdir ${GITHUB_WORKSPACE}/build/tests-cpu
           cd ${GITHUB_WORKSPACE}/build/tests-cpu
           
-          cmake -DACPP_TARGETS=omp -DACPP_USE_ACCELERATED_CPU=true -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.clang}} -DCMAKE_CXX_FLAGS="$CXXFLAGS" ${GITHUB_WORKSPACE}/tests
+          cmake -GNinja -DACPP_TARGETS=omp -DACPP_USE_ACCELERATED_CPU=true -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.docker.clang}} -DCMAKE_CXX_FLAGS="$CXXFLAGS" ${GITHUB_WORKSPACE}/tests
       - name: build CPU tests with loop splitting
         run: |
           cd ${GITHUB_WORKSPACE}/build/tests-cpu
-          make -j2
+          ninja
       - name: run LIT tests on CPU
         run: |
           cd ${GITHUB_WORKSPACE}/build/tests-cpu
-          LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib make check-cbs
+          LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ninja check-cbs
       - name: run CPU tests
         run: |
           cd ${GITHUB_WORKSPACE}/build/tests-cpu
           LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ./sycl_tests
   sscp:
-    name: SSCP/Reflection/stdpar, clang ${{ matrix.clang }}, ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: SSCP/Reflection/stdpar, clang ${{ matrix.docker.clang }}, ${{ matrix.docker.os }}
+    needs: prep-container
+    runs-on: ${{ matrix.docker.os }}
     strategy:
       matrix:
-        clang: [14, 15, 16, 17, 18]
-        os: [ubuntu-22.04]
+        docker: ${{fromJson(needs.prep-container.outputs.docker_matrix)}}
+    container:
+      image: ${{ matrix.docker.image }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-      - name: install LLVM
-        run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh ${{matrix.clang}}
-          sudo apt-get install -y libclang-${{matrix.clang}}-dev clang-tools-${{matrix.clang}} libomp-${{matrix.clang}}-dev llvm-${{matrix.clang}}-dev
-          # install with --force-overwrite since this tries to overwrite some clang README
-          sudo apt-get install -y -o DPkg::options::="--force-overwrite" libclang-rt-${{matrix.clang}}-dev
-          sudo python -m pip install lit
-          sudo ln -s /usr/bin/FileCheck-${{matrix.clang}} /usr/bin/FileCheck
-          if [[ "${{matrix.clang}}" == "16" ]]; then
-            sudo rm -r /usr/lib/clang/16*
-            sudo ln -s /usr/lib/llvm-16/lib/clang/16 /usr/lib/clang/16
-          fi
-      - name: install boost (from apt)
-        run: |
-          sudo apt-get install -y libboost-all-dev
       - name: Install OpenCL
         run: |
-          wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
-          echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-          sudo apt-get update
-          sudo apt-get install -y intel-oneapi-runtime-opencl-2024 intel-oneapi-runtime-compilers-2024 ocl-icd-libopencl1 ocl-icd-opencl-dev
+          wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list
+          apt-get update
+          apt-get install -y intel-oneapi-runtime-opencl-2024 intel-oneapi-runtime-compilers-2024 ocl-icd-libopencl1 ocl-icd-opencl-dev
       - name: build AdaptiveCpp
         run: |
           mkdir build && cd build
-          cmake -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.clang}} -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.clang}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.clang}}/cmake -DWITH_OPENCL_BACKEND=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install ..
-          make -j2 install
+          cmake -GNinja -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.docker.clang}} -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.docker.clang}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.docker.clang}}/cmake -DWITH_OPENCL_BACKEND=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install ..
+          ninja install
       - name: Print detected devices
         run: |
           ${GITHUB_WORKSPACE}/build/install/bin/acpp-info
@@ -112,29 +124,29 @@ jobs:
         run: |
           mkdir ${GITHUB_WORKSPACE}/build/tests-sscp
           cd ${GITHUB_WORKSPACE}/build/tests-sscp  
-          cmake -DACPP_TARGETS=generic -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp  ${GITHUB_WORKSPACE}/tests
-          ACPP_VISIBILITY_MASK=ocl LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib make check-sscp
+          cmake -GNinja -DACPP_TARGETS=generic -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp  ${GITHUB_WORKSPACE}/tests
+          ACPP_VISIBILITY_MASK=ocl LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ninja check-sscp
       - name: run Reflection LIT tests (OpenCL)
         run: |
           mkdir ${GITHUB_WORKSPACE}/build/tests-reflection
           cd ${GITHUB_WORKSPACE}/build/tests-reflection  
-          cmake -DACPP_TARGETS=generic -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp  ${GITHUB_WORKSPACE}/tests
-          ACPP_VISIBILITY_MASK=ocl LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib make check-reflection
+          cmake -GNinja -DACPP_TARGETS=generic -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp  ${GITHUB_WORKSPACE}/tests
+          ACPP_VISIBILITY_MASK=ocl LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ninja check-reflection
       - name: run stdpar LIT tests (OpenCL)
         run: |
           mkdir ${GITHUB_WORKSPACE}/build/tests-stdpar
           cd ${GITHUB_WORKSPACE}/build/tests-stdpar
-          cmake -DACPP_TARGETS=generic -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp  ${GITHUB_WORKSPACE}/tests
-          ACPP_VISIBILITY_MASK=ocl LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib make check-stdpar
+          cmake -GNinja -DACPP_TARGETS=generic -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp  ${GITHUB_WORKSPACE}/tests
+          ACPP_VISIBILITY_MASK=ocl LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ninja check-stdpar
       - name: run SSCP LIT tests (OpenMP)
         run: |
           cd ${GITHUB_WORKSPACE}/build/tests-sscp  
-          ACPP_VISIBILITY_MASK=omp LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib make check-sscp
+          ACPP_VISIBILITY_MASK=omp LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ninja check-sscp
       - name: run Reflection LIT tests (OpenMP)
         run: |
           cd ${GITHUB_WORKSPACE}/build/tests-reflection  
-          ACPP_VISIBILITY_MASK=omp LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib make check-reflection
+          ACPP_VISIBILITY_MASK=omp LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ninja check-reflection
       - name: run stdpar LIT tests (OpenMP)
         run: |
           cd ${GITHUB_WORKSPACE}/build/tests-stdpar
-          ACPP_VISIBILITY_MASK=omp LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib make check-stdpar
+          ACPP_VISIBILITY_MASK=omp LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ninja check-stdpar

--- a/.github/workflows/linux-lit.yml
+++ b/.github/workflows/linux-lit.yml
@@ -54,6 +54,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}-${{matrix.docker.clang}}-${{matrix.docker.os}}-${{matrix.docker.cuda}}-${{matrix.docker.rocm}}-${{ matrix.docker.test_kind }}
       - name: setup build env
         run: |
           export CXXFLAGS="$CXXFLAGS"
@@ -70,7 +74,7 @@ jobs:
           mkdir build && cd build
           echo ${CXXFLAGS}
           
-          cmake -GNinja -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.docker.clang}} -DOMP_CXX_FLAGS="$OMP_CXX_FLAGS -fopenmp" -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.docker.clang}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.docker.clang}}/cmake .. -DCMAKE_INSTALL_PREFIX=`pwd`/install
+          cmake -GNinja -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.docker.clang}} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DOMP_CXX_FLAGS="$OMP_CXX_FLAGS -fopenmp" -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.docker.clang}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.docker.clang}}/cmake .. -DCMAKE_INSTALL_PREFIX=`pwd`/install
           ninja install
       - name: setup CPU tests with loop splitting
         run: |
@@ -106,6 +110,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}-${{matrix.docker.clang}}-${{matrix.docker.os}}-${{matrix.docker.cuda}}-${{matrix.docker.rocm}}-${{ matrix.docker.test_kind }}
       - name: Install OpenCL
         run: |
           wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
@@ -115,7 +123,7 @@ jobs:
       - name: build AdaptiveCpp
         run: |
           mkdir build && cd build
-          cmake -GNinja -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.docker.clang}} -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.docker.clang}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.docker.clang}}/cmake -DWITH_OPENCL_BACKEND=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install ..
+          cmake -GNinja -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.docker.clang}} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.docker.clang}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.docker.clang}}/cmake -DWITH_OPENCL_BACKEND=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install ..
           ninja install
       - name: Print detected devices
         run: |

--- a/.github/workflows/linux-lit.yml
+++ b/.github/workflows/linux-lit.yml
@@ -14,7 +14,7 @@ jobs:
       docker_matrix: ${{ steps.matrix-output.outputs.json }}
     strategy:
       matrix:
-        clang: [14, 15, 16, 17, 18, 19]
+        clang: [14, 15, 16, 17, 18, 19, 20]
         os: [ubuntu-22.04]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,7 +14,7 @@ jobs:
       docker_matrix: ${{ steps.matrix-output.outputs.json }}
     strategy:
       matrix:
-        clang: [15, 16, 17, 18, 19]
+        clang: [15, 16, 17, 18, 19, 20]
         os: [ubuntu-22.04]
         cuda_major_version: [11]
         cuda_minor_version: [0]

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -78,11 +78,15 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        submodules: 'recursive'
+        submodules: 'recursive'    
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ github.job }}-${{matrix.docker.clang}}-${{matrix.docker.os}}-${{matrix.docker.cuda}}-${{matrix.docker.rocm}}-${{ matrix.docker.test_kind }}
     - name: build AdaptiveCpp
       run: |
         mkdir build && cd build
-        cmake -GNinja -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.docker.clang}} -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.docker.clang}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.docker.clang}}/cmake -DWITH_CUDA_BACKEND=ON -DWITH_ROCM_BACKEND=ON -DWITH_LEVEL_ZERO_BACKEND=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install -DCUDA_TOOLKIT_ROOT_DIR=/opt/cuda -DROCM_PATH=/opt/rocm ..
+        cmake -GNinja -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.docker.clang}} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.docker.clang}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.docker.clang}}/cmake -DWITH_CUDA_BACKEND=ON -DWITH_ROCM_BACKEND=ON -DWITH_LEVEL_ZERO_BACKEND=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install -DCUDA_TOOLKIT_ROOT_DIR=/opt/cuda -DROCM_PATH=/opt/rocm ..
         ninja install
         cp /opt/cuda/lib64/stubs/libcuda.so `pwd`/install/lib/libcuda.so
         cp /opt/cuda/lib64/stubs/libcuda.so `pwd`/install/lib/libcuda.so.1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   prep-container:
-    name: Prepare CI container clang ${{ matrix.clang }}, ${{ matrix.os }}, CUDA ${{matrix.cuda_major_version}}.${{matrix.cuda_minor_version}}.${{matrix.cuda_patch_version}}, ROCm ${{matrix.rocm}}, ${{ matrix.test_kind}}
+    name: Prepare CI container clang ${{ matrix.clang }}, ${{ matrix.os }}, CUDA ${{matrix.cuda_major_version}}.${{matrix.cuda_minor_version}}.${{matrix.cuda_patch_version}}, ROCm ${{matrix.rocm}}
     runs-on: ubuntu-22.04
     permissions:
       pull-requests: read
@@ -20,7 +20,6 @@ jobs:
         cuda_minor_version: [0]
         cuda_patch_version: [2]
         rocm: [5.4.3]
-        test_kind: [cpu, sscp, gpu]
         include:
           - clang: 17
             os: ubuntu-22.04
@@ -28,14 +27,6 @@ jobs:
             cuda_minor_version: 0
             cuda_patch_version: 2
             rocm: 5.6.1
-            test_kind: sscp
-          - clang: 17
-            os: ubuntu-22.04
-            cuda_major_version: 11
-            cuda_minor_version: 0
-            cuda_patch_version: 2
-            rocm: 5.6.1
-            test_kind: gpu
     steps:
       - uses: actions/checkout@v4
         with:
@@ -60,16 +51,16 @@ jobs:
             os: ${{ matrix.os }}
             cuda: ${{matrix.cuda_major_version}}.${{matrix.cuda_minor_version}}.${{matrix.cuda_patch_version}}
             rocm: ${{matrix.rocm}}
-            test_kind: ${{matrix.test_kind}}
             image: ${{ steps.docker.outputs.docker_image }}
 
   test-clang-based:
-    name: clang ${{ matrix.docker.clang }}, ${{ matrix.docker.test_kind }}, CUDA ${{matrix.docker.cuda}}, ROCm ${{matrix.docker.rocm}}, ${{ matrix.docker.os }}
+    name: clang ${{ matrix.docker.clang }}, ${{ matrix.test_kind }}, CUDA ${{matrix.docker.cuda}}, ROCm ${{matrix.docker.rocm}}, ${{ matrix.docker.os }}
     runs-on: ${{ matrix.docker.os }}
     needs: prep-container
     strategy:
       matrix:
         docker: ${{fromJson(needs.prep-container.outputs.docker_matrix)}}
+        test_kind: [cpu, sscp, gpu]
     container:
       image: ${{ matrix.docker.image }}
     defaults:
@@ -82,7 +73,7 @@ jobs:
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
-        key: ${{ github.job }}-${{matrix.docker.clang}}-${{matrix.docker.os}}-${{matrix.docker.cuda}}-${{matrix.docker.rocm}}-${{ matrix.docker.test_kind }}
+        key: ${{ github.job }}-${{matrix.docker.clang}}-${{matrix.docker.os}}-${{matrix.docker.cuda}}-${{matrix.docker.rocm}}-${{ matrix.test_kind }}
     - name: build AdaptiveCpp
       run: |
         mkdir build && cd build
@@ -91,52 +82,52 @@ jobs:
         cp /opt/cuda/lib64/stubs/libcuda.so `pwd`/install/lib/libcuda.so
         cp /opt/cuda/lib64/stubs/libcuda.so `pwd`/install/lib/libcuda.so.1
     - name: build CPU tests
-      if: matrix.docker.test_kind == 'cpu'
+      if: matrix.test_kind == 'cpu'
       run: |
         mkdir ${GITHUB_WORKSPACE}/build/tests-cpu
         cd ${GITHUB_WORKSPACE}/build/tests-cpu
         cmake -GNinja -DACPP_TARGETS="omp" -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp ${GITHUB_WORKSPACE}/tests
         ninja
     - name: build generic SSCP tests
-      if: matrix.docker.clang >= 14 && matrix.docker.test_kind == 'sscp'
+      if: matrix.docker.clang >= 14 && matrix.test_kind == 'sscp'
       run: |
         mkdir ${GITHUB_WORKSPACE}/build/tests-sscp
         cd ${GITHUB_WORKSPACE}/build/tests-sscp
         cmake -GNinja -DACPP_TARGETS="generic" -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp -DWITH_PSTL_TESTS=ON ${GITHUB_WORKSPACE}/tests
         ninja
     - name: build CUDA tests
-      if: matrix.docker.test_kind == 'gpu'
+      if: matrix.test_kind == 'gpu'
       run: |
         mkdir ${GITHUB_WORKSPACE}/build/tests-cuda
         cd ${GITHUB_WORKSPACE}/build/tests-cuda
         cmake -GNinja -DACPP_TARGETS="cuda:sm_60" -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp ${GITHUB_WORKSPACE}/tests -DCMAKE_EXE_LINKER_FLAGS="-L/usr/lib/llvm-${{matrix.docker.clang}}/lib"
         ninja
     - name: build ROCm tests
-      if: matrix.docker.test_kind == 'gpu'
+      if: matrix.test_kind == 'gpu'
       run: |
         mkdir ${GITHUB_WORKSPACE}/build/tests-rocm
         cd ${GITHUB_WORKSPACE}/build/tests-rocm
         cmake -GNinja -DACPP_TARGETS="hip:gfx906" -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp ${GITHUB_WORKSPACE}/tests -DCMAKE_EXE_LINKER_FLAGS="-L/usr/lib/llvm-${{matrix.docker.clang}}/lib"
         ninja
     - name: build explicit multipass tests
-      if: matrix.docker.test_kind == 'gpu'
+      if: matrix.test_kind == 'gpu'
       run: |
         mkdir ${GITHUB_WORKSPACE}/build/tests-emp
         cd ${GITHUB_WORKSPACE}/build/tests-emp
         cmake -GNinja -DACPP_TARGETS="omp;cuda.explicit-multipass:sm_60;hip:gfx906" -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp ${GITHUB_WORKSPACE}/tests
         ninja
     - name: run CPU tests
-      if: matrix.docker.test_kind == 'cpu'
+      if: matrix.test_kind == 'cpu'
       run: |
         cd ${GITHUB_WORKSPACE}/build/tests-cpu
         ACPP_VISIBILITY_MASK="omp" LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ./sycl_tests
     - name: run CPU SSCP tests
-      if: matrix.docker.clang >= 14 && matrix.docker.test_kind == 'sscp'
+      if: matrix.docker.clang >= 14 && matrix.test_kind == 'sscp'
       run: |
         cd ${GITHUB_WORKSPACE}/build/tests-sscp
         ACPP_VISIBILITY_MASK="omp" LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ./sycl_tests
     - name: run PSTL tests on CPU
-      if: matrix.docker.clang >= 14 && matrix.docker.test_kind == 'sscp'
+      if: matrix.docker.clang >= 14 && matrix.test_kind == 'sscp'
       run: |
         cd ${GITHUB_WORKSPACE}/build/tests-sscp
         ACPP_VISIBILITY_MASK="omp" LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ./pstl_tests

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,117 +3,141 @@ name: Linux build and test
 on: [push, pull_request]
 
 jobs:
-  test-clang-based:
-    name: clang ${{ matrix.clang }}, ${{ matrix.os }}, CUDA ${{matrix.cuda}}, ROCm ${{matrix.rocm}}
-    runs-on: ${{ matrix.os }}
+  prep-container:
+    name: Prepare CI container clang ${{ matrix.clang }}, ${{ matrix.os }}, CUDA ${{matrix.cuda_major_version}}.${{matrix.cuda_minor_version}}.${{matrix.cuda_patch_version}}, ROCm ${{matrix.rocm}}, ${{ matrix.test_kind}}
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: read
+      packages: write
+      actions: read
+    outputs:
+      docker_matrix: ${{ steps.matrix-output.outputs.json }}
     strategy:
       matrix:
-        clang: [15, 16, 17, 18]
+        clang: [15, 16, 17, 18, 19]
         os: [ubuntu-22.04]
-        cuda: [11.0.2]
+        cuda_major_version: [11]
+        cuda_minor_version: [0]
+        cuda_patch_version: [2]
         rocm: [5.4.3]
+        test_kind: [cpu, sscp, gpu]
         include:
           - clang: 17
             os: ubuntu-22.04
-            cuda: 11.0.2
+            cuda_major_version: 11
+            cuda_minor_version: 0
+            cuda_patch_version: 2
             rocm: 5.6.1
+            test_kind: sscp
+          - clang: 17
+            os: ubuntu-22.04
+            cuda_major_version: 11
+            cuda_minor_version: 0
+            cuda_patch_version: 2
+            rocm: 5.6.1
+            test_kind: gpu
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+          fetch-depth: 20
+      - uses: ./.github/workflows/create-ci-docker
+        id: docker
+        with:
+          LLVM_VERSION: ${{ matrix.clang }}
+          ROCM_VERSION: ${{ matrix.rocm }}
+          CUDA_MAJOR_VERSION: ${{ matrix.cuda_major_version }}
+          CUDA_MINOR_VERSION: ${{ matrix.cuda_minor_version }}
+          CUDA_PATCH_VERSION: ${{ matrix.cuda_patch_version }}
+          BASE_TAG: ${{ matrix.os }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: beacon-biosignals/matrix-output@v1
+        id: matrix-output
+        with:
+          yaml: |
+            name: ${{ matrix.clang }}-${{ matrix.os }}
+            clang: ${{ matrix.clang }}
+            os: ${{ matrix.os }}
+            cuda: ${{matrix.cuda_major_version}}.${{matrix.cuda_minor_version}}.${{matrix.cuda_patch_version}}
+            rocm: ${{matrix.rocm}}
+            test_kind: ${{matrix.test_kind}}
+            image: ${{ steps.docker.outputs.docker_image }}
+
+  test-clang-based:
+    name: clang ${{ matrix.docker.clang }}, ${{ matrix.docker.test_kind }}, CUDA ${{matrix.docker.cuda}}, ROCm ${{matrix.docker.rocm}}, ${{ matrix.docker.os }}
+    runs-on: ${{ matrix.docker.os }}
+    needs: prep-container
+    strategy:
+      matrix:
+        docker: ${{fromJson(needs.prep-container.outputs.docker_matrix)}}
+    container:
+      image: ${{ matrix.docker.image }}
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
-    - name: Install OpenCL development files
-      run : |
-        sudo apt-get update
-        sudo apt-get install -y ocl-icd-opencl-dev
-    - name: Install TBB for PSTL tests
-      run : |
-        sudo apt-get install -y libtbb-dev
-    - name: install Level Zero
-      run : |
-        wget https://github.com/oneapi-src/level-zero/releases/download/v1.2.3/level-zero-devel_1.2.3+u18.04_amd64.deb
-        wget https://github.com/oneapi-src/level-zero/releases/download/v1.2.3/level-zero_1.2.3+u18.04_amd64.deb
-        sudo dpkg -i ./level-zero*
-    - name: install CUDA
-      run: |
-        mkdir -p /opt/AdaptiveCpp/cuda
-        wget -q -O cuda.sh http://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_450.51.05_linux.run
-        sudo sh ./cuda.sh --override --silent --toolkit --no-man-page --no-drm --no-opengl-libs --installpath=/opt/AdaptiveCpp/cuda || true
-        echo "CUDA Version ${{matrix.cuda}}" | sudo tee /opt/AdaptiveCpp/cuda/version.txt
-    - name: install ROCm
-      run: |
-        [[ ${{matrix.os}} == ubuntu-20.04 ]] && CODENAME=xenial
-        [[ ${{matrix.os}} == ubuntu-22.04 ]] && CODENAME=jammy
-        sudo apt-get install -y libnuma-dev cmake unzip
-        wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
-        echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/${{matrix.rocm}} $CODENAME main" | sudo tee /etc/apt/sources.list.d/rocm.list
-        printf 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
-        sudo apt-get update
-        sudo apt-get install -y rocm-dev
-    - name: install LLVM
-      run: |
-        wget https://apt.llvm.org/llvm.sh
-        chmod +x llvm.sh
-        sudo ./llvm.sh ${{matrix.clang}}
-        sudo apt-get install -y libclang-${{matrix.clang}}-dev clang-tools-${{matrix.clang}} libomp-${{matrix.clang}}-dev
-        if [[ "${{matrix.clang}}" == "16" ]]; then
-          sudo rm -r /usr/lib/clang/16*
-          sudo ln -s /usr/lib/llvm-16/lib/clang/16 /usr/lib/clang/16
-        fi
-    - name: install boost (from apt)
-      run: |
-        sudo apt-get install -y libboost-all-dev
     - name: build AdaptiveCpp
       run: |
         mkdir build && cd build
-        cmake -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.clang}} -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.clang}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.clang}}/cmake -DWITH_CUDA_BACKEND=ON -DWITH_ROCM_BACKEND=ON -DWITH_LEVEL_ZERO_BACKEND=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install -DCUDA_TOOLKIT_ROOT_DIR=/opt/AdaptiveCpp/cuda -DROCM_PATH=/opt/rocm ..
-        make -j2 install
-        cp /opt/AdaptiveCpp/cuda/lib64/stubs/libcuda.so `pwd`/install/lib/libcuda.so
-        cp /opt/AdaptiveCpp/cuda/lib64/stubs/libcuda.so `pwd`/install/lib/libcuda.so.1
+        cmake -GNinja -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${{matrix.docker.clang}} -DCLANG_EXECUTABLE_PATH=/usr/bin/clang++-${{matrix.docker.clang}} -DLLVM_DIR=/usr/lib/llvm-${{matrix.docker.clang}}/cmake -DWITH_CUDA_BACKEND=ON -DWITH_ROCM_BACKEND=ON -DWITH_LEVEL_ZERO_BACKEND=ON -DCMAKE_INSTALL_PREFIX=`pwd`/install -DCUDA_TOOLKIT_ROOT_DIR=/opt/cuda -DROCM_PATH=/opt/rocm ..
+        ninja install
+        cp /opt/cuda/lib64/stubs/libcuda.so `pwd`/install/lib/libcuda.so
+        cp /opt/cuda/lib64/stubs/libcuda.so `pwd`/install/lib/libcuda.so.1
     - name: build CPU tests
+      if: matrix.docker.test_kind == 'cpu'
       run: |
         mkdir ${GITHUB_WORKSPACE}/build/tests-cpu
         cd ${GITHUB_WORKSPACE}/build/tests-cpu
-        cmake -DACPP_TARGETS="omp" -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp ${GITHUB_WORKSPACE}/tests
-        make -j2
+        cmake -GNinja -DACPP_TARGETS="omp" -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp ${GITHUB_WORKSPACE}/tests
+        ninja
     - name: build generic SSCP tests
-      if: matrix.clang >= 14
+      if: matrix.docker.clang >= 14 && matrix.docker.test_kind == 'sscp'
       run: |
         mkdir ${GITHUB_WORKSPACE}/build/tests-sscp
         cd ${GITHUB_WORKSPACE}/build/tests-sscp
-        cmake -DACPP_TARGETS="generic" -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp -DWITH_PSTL_TESTS=ON ${GITHUB_WORKSPACE}/tests
-        make -j2
+        cmake -GNinja -DACPP_TARGETS="generic" -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp -DWITH_PSTL_TESTS=ON ${GITHUB_WORKSPACE}/tests
+        ninja
     - name: build CUDA tests
+      if: matrix.docker.test_kind == 'gpu'
       run: |
         mkdir ${GITHUB_WORKSPACE}/build/tests-cuda
         cd ${GITHUB_WORKSPACE}/build/tests-cuda
-        cmake -DACPP_TARGETS="cuda:sm_60" -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp ${GITHUB_WORKSPACE}/tests -DCMAKE_EXE_LINKER_FLAGS="-L/usr/lib/llvm-${{matrix.clang}}/lib"
-        make -j2
+        cmake -GNinja -DACPP_TARGETS="cuda:sm_60" -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp ${GITHUB_WORKSPACE}/tests -DCMAKE_EXE_LINKER_FLAGS="-L/usr/lib/llvm-${{matrix.docker.clang}}/lib"
+        ninja
     - name: build ROCm tests
+      if: matrix.docker.test_kind == 'gpu'
       run: |
         mkdir ${GITHUB_WORKSPACE}/build/tests-rocm
         cd ${GITHUB_WORKSPACE}/build/tests-rocm
-        cmake -DACPP_TARGETS="hip:gfx906" -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp ${GITHUB_WORKSPACE}/tests -DCMAKE_EXE_LINKER_FLAGS="-L/usr/lib/llvm-${{matrix.clang}}/lib"
-        make -j2
+        cmake -GNinja -DACPP_TARGETS="hip:gfx906" -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp ${GITHUB_WORKSPACE}/tests -DCMAKE_EXE_LINKER_FLAGS="-L/usr/lib/llvm-${{matrix.docker.clang}}/lib"
+        ninja
     - name: build explicit multipass tests
+      if: matrix.docker.test_kind == 'gpu'
       run: |
         mkdir ${GITHUB_WORKSPACE}/build/tests-emp
         cd ${GITHUB_WORKSPACE}/build/tests-emp
-        cmake -DACPP_TARGETS="omp;cuda.explicit-multipass:sm_60;hip:gfx906" -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp ${GITHUB_WORKSPACE}/tests
-        make -j2
+        cmake -GNinja -DACPP_TARGETS="omp;cuda.explicit-multipass:sm_60;hip:gfx906" -DAdaptiveCpp_DIR=${GITHUB_WORKSPACE}/build/install/lib/cmake/AdaptiveCpp ${GITHUB_WORKSPACE}/tests
+        ninja
     - name: run CPU tests
+      if: matrix.docker.test_kind == 'cpu'
       run: |
         cd ${GITHUB_WORKSPACE}/build/tests-cpu
         ACPP_VISIBILITY_MASK="omp" LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ./sycl_tests
     - name: run CPU SSCP tests
-      if: matrix.clang >= 14
+      if: matrix.docker.clang >= 14 && matrix.docker.test_kind == 'sscp'
       run: |
         cd ${GITHUB_WORKSPACE}/build/tests-sscp
         ACPP_VISIBILITY_MASK="omp" LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ./sycl_tests
     - name: run PSTL tests on CPU
-      if: matrix.clang >= 14
+      if: matrix.docker.clang >= 14 && matrix.docker.test_kind == 'sscp'
       run: |
         cd ${GITHUB_WORKSPACE}/build/tests-sscp
         ACPP_VISIBILITY_MASK="omp" LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/install/lib ./pstl_tests
+
+
   test-nvcxx-based:
     name: nvcxx ${{matrix.nvhpc}}, ${{matrix.os}}, CUDA ${{matrix.cuda}}
     runs-on: ${{ matrix.os }}

--- a/src/compiler/AdaptiveCppClangPlugin.cpp
+++ b/src/compiler/AdaptiveCppClangPlugin.cpp
@@ -120,16 +120,29 @@ static llvm::RegisterStandardPasses
   "v" HIPSYCL_STRINGIFY(ACPP_VERSION_MAJOR) "." HIPSYCL_STRINGIFY(                              \
       ACPP_VERSION_MINOR) "." HIPSYCL_STRINGIFY(ACPP_VERSION_PATCH)
 
+template <class CallbackF>
+struct LastEPAdapter{
+  LastEPAdapter(CallbackF &&CB) : CB(std::forward<CallbackF>(CB)) {}
+  void operator()(llvm::ModulePassManager &MPM, OptLevel Level, llvm::ThinOrFullLTOPhase) {
+    CB(MPM, Level);
+  }
+  void operator()(llvm::ModulePassManager &MPM, OptLevel Level) {
+    CB(MPM, Level);
+  }
+  CallbackF CB;
+};
+
 extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo llvmGetPassPluginInfo() {
   return {
     LLVM_PLUGIN_API_VERSION, "hipSYCL Clang plugin", HIPSYCL_PLUGIN_VERSION_STRING,
         [](llvm::PassBuilder &PB) {
           // Note: for Clang < 12, this EP is not called for O0, but the new PM isn't
           // really used there anyways..
-          PB.registerOptimizerLastEPCallback([](llvm::ModulePassManager &MPM, OptLevel) {
+          
+          PB.registerOptimizerLastEPCallback(LastEPAdapter{[&](llvm::ModulePassManager &MPM, OptLevel) {
             MPM.addPass(hipsycl::compiler::SMCPCompatPass{});
             MPM.addPass(hipsycl::compiler::GlobalsPruningPass{});
-          });
+          }});
 #ifdef HIPSYCL_WITH_REFLECTION_BUILTINS
           PB.registerPipelineStartEPCallback(
                 [&](llvm::ModulePassManager &MPM, OptLevel Level) {
@@ -146,11 +159,12 @@ extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo llvmGetPassPluginIn
               }
             });
           
-            PB.registerOptimizerLastEPCallback([&](llvm::ModulePassManager &MPM, OptLevel Level) {
+            
+          PB.registerOptimizerLastEPCallback(LastEPAdapter{[&](llvm::ModulePassManager &MPM, OptLevel) {
               MPM.addPass(SyncElisionInliningPass{});
               MPM.addPass(llvm::AlwaysInlinerPass{});
               MPM.addPass(SyncElisionPass{});
-            });
+            }});
           }
 #endif
 

--- a/src/compiler/cbs/SubCfgFormation.cpp
+++ b/src/compiler/cbs/SubCfgFormation.cpp
@@ -158,18 +158,22 @@ getLocalSizeArgumentFromAnnotation(llvm::Function &F) {
 }
 
 // identify the local size values by the store to it
-void fillStores(llvm::Value *V, int Idx, llvm::SmallVector<llvm::Value *, 3> &LocalSize) {
+void fillStores(llvm::Value *V, int Idx, bool IsIdxBytewise, llvm::SmallVector<llvm::Value *, 3> &LocalSize) {
   if (auto *Store = llvm::dyn_cast<llvm::StoreInst>(V)) {
+#if LLVM_VERSION_MAJOR >= 17
+    if(IsIdxBytewise)
+      Idx /= Store->getAccessType()->getScalarSizeInBits() / 8;
+#endif
     LocalSize[Idx] = Store->getOperand(0);
   } else if (auto *BC = llvm::dyn_cast<llvm::BitCastInst>(V)) {
     for (auto *BCU : BC->users()) {
-      fillStores(BCU, Idx, LocalSize);
+      fillStores(BCU, Idx, IsIdxBytewise, LocalSize);
     }
   } else if (auto *GEP = llvm::dyn_cast<llvm::GetElementPtrInst>(V)) {
     auto *IdxV = GEP->indices().begin() + (GEP->getNumIndices() - 1);
     auto *IdxC = llvm::cast<llvm::ConstantInt>(IdxV);
     for (auto *GU : GEP->users()) {
-      fillStores(GU, IdxC->getSExtValue(), LocalSize);
+      fillStores(GU, IdxC->getSExtValue(), GEP->getSourceElementType()->isIntegerTy(8), LocalSize);
     }
   }
 }
@@ -230,7 +234,7 @@ llvm::SmallVector<llvm::Value *, 3> getLocalSizeValues(llvm::Function &F, int Di
 
   if (!llvm::dyn_cast<llvm::Argument>(LocalSizeArg))
     for (auto *U : LocalSizeArg->users())
-      fillStores(U, 0, LocalSize);
+      fillStores(U, 0, false, LocalSize);
   else
     loadSizeValuesFromArgument(F, Dim, LocalSizeArg, DL, LocalSize, false);
 

--- a/src/compiler/cbs/SubCfgFormation.cpp
+++ b/src/compiler/cbs/SubCfgFormation.cpp
@@ -1131,6 +1131,16 @@ bool isAllocaSubCfgInternal(llvm::AllocaInst *Alloca, const std::vector<SubCFG> 
   return true;
 }
 
+template <class Instruction>
+llvm::IRBuilder<> createLoadBuilder(llvm::BasicBlock *BB, Instruction *I) {
+  return llvm::IRBuilder{BB, I->getIterator()};
+}
+
+template <class iterator>
+llvm::IRBuilder<> createLoadBuilder(llvm::BasicBlock *BB, iterator I) {
+  return llvm::IRBuilder{BB, I};
+}
+
 // Widens the allocas in the entry block to array allocas.
 // Replace uses of the original alloca with GEP that indexes the new alloca with
 // \a Idx.
@@ -1174,9 +1184,9 @@ void arrayifyAllocas(llvm::BasicBlock *EntryBlock, llvm::DominatorTree &DT,
     Alloca->setMetadata(hipsycl::compiler::MDKind::Arrayified, MDAlloca);
 
     for (auto &SubCfg : SubCfgs) {
-      auto *GepIp = SubCfg.getLoadBB()->getFirstNonPHIOrDbgOrLifetime();
+      auto GepIp = SubCfg.getLoadBB()->getFirstNonPHIOrDbgOrLifetime();
 
-      llvm::IRBuilder LoadBuilder{GepIp};
+      llvm::IRBuilder LoadBuilder = createLoadBuilder(SubCfg.getLoadBB(), GepIp);
       auto *GEP = llvm::cast<llvm::GetElementPtrInst>(LoadBuilder.CreateInBoundsGEP(
           Alloca->getAllocatedType(), Alloca, SubCfg.getContiguousIdx(), I->getName() + "_gep"));
       GEP->setMetadata(hipsycl::compiler::MDKind::Arrayified, MDAlloca);

--- a/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
+++ b/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
@@ -47,6 +47,12 @@ namespace {
 
 static const char* DynamicLocalMemArrayName = "__acpp_sscp_spirv_dynamic_local_mem";
 
+#if LLVM_VERSION_MAJOR >= 20
+#define SPIRV_INTEL_LONG_CONSTANT_EXT_NAME "SPV_INTEL_long_composites"
+#else
+#define SPIRV_INTEL_LONG_CONSTANT_EXT_NAME "SPV_INTEL_long_constant_composite"
+#endif
+
 void appendIntelLLVMSpirvOptions(llvm::SmallVector<std::string>& out) {
   llvm::SmallVector<std::string> Args {"-spirv-max-version=1.3",
       "-spirv-debug-info-version=ocl-100",
@@ -62,8 +68,8 @@ void appendIntelLLVMSpirvOptions(llvm::SmallVector<std::string>& out) {
       "vector_compute,+SPV_INTEL_fast_composite,+SPV_INTEL_fpga_buffer_location,+SPV_INTEL_joint_"
       "matrix,+SPV_INTEL_arbitrary_precision_fixed_point,+SPV_INTEL_arbitrary_precision_floating_"
       "point,+SPV_INTEL_arbitrary_precision_floating_point,+SPV_INTEL_variable_length_array,+SPV_"
-      "INTEL_fp_fast_math_mode,+SPV_INTEL_fpga_cluster_attributes,+SPV_INTEL_loop_fuse,+SPV_INTEL_"
-      "long_constant_composite,+SPV_INTEL_fpga_invocation_pipelining_attributes,+SPV_INTEL_fpga_"
+      "INTEL_fp_fast_math_mode,+SPV_INTEL_fpga_cluster_attributes,+SPV_INTEL_loop_fuse,+"
+      SPIRV_INTEL_LONG_CONSTANT_EXT_NAME ",+SPV_INTEL_fpga_invocation_pipelining_attributes,+SPV_INTEL_fpga_"
       "dsp_control,+SPV_INTEL_arithmetic_fence,+SPV_INTEL_runtime_aligned,"
       "+SPV_INTEL_optnone,+SPV_INTEL_token_type,+SPV_INTEL_bfloat16_conversion,+SPV_INTEL_joint_"
       "matrix,+SPV_INTEL_hw_thread_queries,+SPV_INTEL_memory_access_aliasing,+SPV_EXT_relaxed_printf_string_address_space"

--- a/src/libkernel/sscp/ptx/CMakeLists.txt
+++ b/src/libkernel/sscp/ptx/CMakeLists.txt
@@ -21,5 +21,5 @@ if(WITH_LLVM_TO_PTX)
       scan_inclusive.cpp
       scan_exclusive.cpp
       collpredicate.cpp
-      ADDITIONAL_ARGS -Xclang -target-feature -Xclang +sm_60)
+      ADDITIONAL_ARGS -Xclang -target-feature -Xclang +sm_60 -Xclang -target-feature -Xclang +ptx60)
 endif()

--- a/tests/pstl/transform_reduce.cpp
+++ b/tests/pstl/transform_reduce.cpp
@@ -102,23 +102,23 @@ struct aggregate {
 };
 
 BOOST_AUTO_TEST_CASE(par_unseq_aggregate) {
-  std::vector<int> data(1000);
-  for(int i = 0; i < data.size(); ++i)
+  std::vector<std::uint64_t> data(1000);
+  for(std::uint64_t i = 0; i < data.size(); ++i)
     data[i] = i;
 
-  auto transform = [](int x){
-    return aggregate<int>{x*2, x % 10};
+  auto transform = [](std::uint64_t x){
+    return aggregate<std::uint64_t>{x*2, x % 10};
   };
 
   auto reference_result = std::transform_reduce(
-      data.begin(), data.end(), aggregate<int>{0, 0}, std::plus<>{},
+      data.begin(), data.end(), aggregate<std::uint64_t>{0, 0}, std::plus<>{},
       transform);
 
   auto res =
       std::transform_reduce(std::execution::par_unseq, data.begin(), data.end(),
-                            aggregate<int>{0, 0}, std::plus<>{}, transform);
-  BOOST_CHECK(res.a == reference_result.a);
-  BOOST_CHECK(res.b == reference_result.b);
+                            aggregate<std::uint64_t>{0, 0}, std::plus<>{}, transform);
+  BOOST_CHECK_EQUAL(res.a, reference_result.a);
+  BOOST_CHECK_EQUAL(res.b, reference_result.b);
 }
 
 template<class T>


### PR DESCRIPTION
This adds a CI dockerfile and infrastructure to use the created docker images for the Linux CI flows.
Ideally, this should give us overall faster turn-around times for the CI builds.
The docker images are always built on-demand if something about the dockerfile or create-ci-docker action has changed.
This is also true for PRs and non-develop branches.
For these, the image tags are suffixed with `-<branch-name>` or `-pr-<id>`.
We need to use some hackery-pokery to propagate the image names properly from the docker job to the actual CI jobs
We use the beacon-biosignals/matrix-output@v1 for this.

As an additional change, given that job starting time got quite a bit cheaper, I also split up the linux.yml tests into multiple groups: `cpu`, `gpu` and `sscp` with the goal to reduce overall CI latency from ~50min to ~35min at the cost of adding more parallel jobs. (moving explicit multi pass from GPU to CPU variant, might improve this even more... but is unintuitive 🤔 :) )

Oh.. and also, we're using ccache for building AdaptiveCpp now -> for smaller changes (e.g. test only), building AdaptiveCpp can take as little as 30s instead of 5min+.

This PR, furthermore, includes compatibility fixes with LLVM 19 and 20 and enables them in CI.

Note: it's also kinda nice to have these docker images around for a "stable" container environment one can use on clusters and so on :)

Fixes #1690 
Prepares having CI for #1609 