### PR TITLE
[PCUDA] Add atomic functions

### DIFF
--- a/doc/pcuda.md
+++ b/doc/pcuda.md
@@ -235,6 +235,17 @@ Supported features in device code include:
 |`__syncwarp` | |
 | Math functions from `<math.h>`/`<cmath>` | |
 | CUDA/HIP vector types | |
+|`atomicAdd[_system|_block]` | `int`, `uint`, `ull`, `float`, `double` types |
+|`atomicSub[_system|_block]` | `int`, `uint` types |
+|`atomicExch[_system|_block]` | `int`, `uint`, `ull`, `float` types |
+|`atomicMin[_system|_block]` | `int`, `uint`, `ll`, `ull` types |
+|`atomicMax[_system|_block]` | `int`, `uint`, `ll`, `ull` types |
+|`atomicAnd[_system|_block]` | `int`, `uint`, `ull` types |
+|`atomicOr[_system|_block]` | `int`, `uint`, `ull` types |
+|`atomicXor[_system|_block]` | `int`, `uint`, `ull` types |
+|`atomicCAS[_system|_block]` | `ushort`, `int`, `uint`, `ull` types |
+|`atomicInc[_system|_block]` | `uint` type |
+|`atomicDec[_system|_block]` | `uint` type |
 
 ## Supported runtime APIs
 

--- a/include/hipSYCL/pcuda/detail/atomic.hpp
+++ b/include/hipSYCL/pcuda/detail/atomic.hpp
@@ -1,0 +1,408 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+
+#ifndef ACPP_PCUDA_ATOMIC_HPP
+#define ACPP_PCUDA_ATOMIC_HPP
+
+#include "builtin_call.hpp"
+#include "hipSYCL/sycl/libkernel/sscp/builtins/atomic.hpp"
+
+#define __PCUDA_DECLARE_ATOMIC_ADD(type, builtin)                              \
+  inline type atomicAdd(type *address, type val) {                             \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        builtin(__acpp_sscp_address_space::generic_space,                      \
+                __acpp_sscp_memory_order::relaxed,                             \
+                __acpp_sscp_memory_scope::device, address, val),               \
+        static_cast<type>(0));                                                 \
+  }                                                                            \
+  inline type atomicAdd_system(type *address, type val) {                      \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        builtin(__acpp_sscp_address_space::generic_space,                      \
+                __acpp_sscp_memory_order::relaxed,                             \
+                __acpp_sscp_memory_scope::system, address, val),               \
+        static_cast<type>(0));                                                 \
+  }                                                                            \
+  inline type atomicAdd_block(type *address, type val) {                       \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        builtin(__acpp_sscp_address_space::generic_space,                      \
+                __acpp_sscp_memory_order::relaxed,                             \
+                __acpp_sscp_memory_scope::work_group, address, val),           \
+        static_cast<type>(0));                                                 \
+  }
+
+__PCUDA_DECLARE_ATOMIC_ADD(int, __acpp_sscp_atomic_fetch_add_i32)
+__PCUDA_DECLARE_ATOMIC_ADD(unsigned int, __acpp_sscp_atomic_fetch_add_u32)
+__PCUDA_DECLARE_ATOMIC_ADD(unsigned long long int, __acpp_sscp_atomic_fetch_add_u64)
+__PCUDA_DECLARE_ATOMIC_ADD(float, __acpp_sscp_atomic_fetch_add_f32)
+__PCUDA_DECLARE_ATOMIC_ADD(double, __acpp_sscp_atomic_fetch_add_f64)
+
+#define __PCUDA_DECLARE_ATOMIC_SUB(type, builtin)                              \
+  inline type atomicSub(type *address, type val) {                             \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        builtin(__acpp_sscp_address_space::generic_space,                      \
+                __acpp_sscp_memory_order::relaxed,                             \
+                __acpp_sscp_memory_scope::device, address, val),               \
+        static_cast<type>(0));                                                 \
+  }                                                                            \
+  inline type atomicSub_system(type *address, type val) {                      \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        builtin(__acpp_sscp_address_space::generic_space,                      \
+                __acpp_sscp_memory_order::relaxed,                             \
+                __acpp_sscp_memory_scope::system, address, val),               \
+        static_cast<type>(0));                                                 \
+  }                                                                            \
+  inline type atomicSub_block(type *address, type val) {                       \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        builtin(__acpp_sscp_address_space::generic_space,                      \
+                __acpp_sscp_memory_order::relaxed,                             \
+                __acpp_sscp_memory_scope::work_group, address, val),           \
+        static_cast<type>(0));                                                 \
+  }
+
+__PCUDA_DECLARE_ATOMIC_SUB(int, __acpp_sscp_atomic_fetch_sub_i32)
+__PCUDA_DECLARE_ATOMIC_SUB(unsigned int, __acpp_sscp_atomic_fetch_sub_u32)
+
+#define __PCUDA_DECLARE_ATOMIC_EXCH(type, builtin_type, builtin)               \
+  inline type atomicExch(type *address, type val) {                            \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        __builtin_bit_cast(type,                                               \
+                           builtin(__acpp_sscp_address_space::generic_space,   \
+                                   __acpp_sscp_memory_order::relaxed,          \
+                                   __acpp_sscp_memory_scope::device,           \
+                                   (builtin_type *)address,                    \
+                                   __builtin_bit_cast(builtin_type, val))),    \
+        static_cast<type>(0));                                                 \
+  }                                                                            \
+  inline type atomicExch_system(type *address, type val) {                     \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        __builtin_bit_cast(type,                                               \
+                           builtin(__acpp_sscp_address_space::generic_space,   \
+                                   __acpp_sscp_memory_order::relaxed,          \
+                                   __acpp_sscp_memory_scope::system,           \
+                                   (builtin_type *)address,                    \
+                                   __builtin_bit_cast(builtin_type, val))),    \
+        static_cast<type>(0));                                                 \
+  }                                                                            \
+  inline type atomicExch_block(type *address, type val) {                      \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        __builtin_bit_cast(type,                                               \
+                           builtin(__acpp_sscp_address_space::generic_space,   \
+                                   __acpp_sscp_memory_order::relaxed,          \
+                                   __acpp_sscp_memory_scope::work_group,       \
+                                   (builtin_type *)address,                    \
+                                   __builtin_bit_cast(builtin_type, val))),    \
+        static_cast<type>(0));                                                 \
+  }
+
+__PCUDA_DECLARE_ATOMIC_EXCH(int, __acpp_int32, __acpp_sscp_atomic_exchange_i32)
+__PCUDA_DECLARE_ATOMIC_EXCH(unsigned int, __acpp_int32,
+                            __acpp_sscp_atomic_exchange_i32)
+__PCUDA_DECLARE_ATOMIC_EXCH(unsigned long long int, __acpp_int64,
+                            __acpp_sscp_atomic_exchange_i64)
+__PCUDA_DECLARE_ATOMIC_EXCH(float, __acpp_int32, __acpp_sscp_atomic_exchange_i32)
+
+#define __PCUDA_DECLARE_ATOMIC_MIN(type, builtin)                              \
+  inline type atomicMin(type *address, type val) {                             \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        builtin(__acpp_sscp_address_space::generic_space,                      \
+                __acpp_sscp_memory_order::relaxed,                             \
+                __acpp_sscp_memory_scope::device, address, val),               \
+        static_cast<type>(0));                                                 \
+  }                                                                            \
+  inline type atomicMin_system(type *address, type val) {                      \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        builtin(__acpp_sscp_address_space::generic_space,                      \
+                __acpp_sscp_memory_order::relaxed,                             \
+                __acpp_sscp_memory_scope::system, address, val),               \
+        static_cast<type>(0));                                                 \
+  }                                                                            \
+  inline type atomicMin_block(type *address, type val) {                       \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        builtin(__acpp_sscp_address_space::generic_space,                      \
+                __acpp_sscp_memory_order::relaxed,                             \
+                __acpp_sscp_memory_scope::work_group, address, val),           \
+        static_cast<type>(0));                                                 \
+  }
+
+__PCUDA_DECLARE_ATOMIC_MIN(int, __acpp_sscp_atomic_fetch_min_i32)
+__PCUDA_DECLARE_ATOMIC_MIN(unsigned int, __acpp_sscp_atomic_fetch_min_u32)
+__PCUDA_DECLARE_ATOMIC_MIN(unsigned long long int,
+                           __acpp_sscp_atomic_fetch_min_u64)
+__PCUDA_DECLARE_ATOMIC_MIN(long long int, __acpp_sscp_atomic_fetch_min_i64)
+
+#define __PCUDA_DECLARE_ATOMIC_MAX(type, builtin)                              \
+  inline type atomicMax(type *address, type val) {                             \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        builtin(__acpp_sscp_address_space::generic_space,                      \
+                __acpp_sscp_memory_order::relaxed,                             \
+                __acpp_sscp_memory_scope::device, address, val),               \
+        static_cast<type>(0));                                                 \
+  }                                                                            \
+  inline type atomicMax_system(type *address, type val) {                      \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        builtin(__acpp_sscp_address_space::generic_space,                      \
+                __acpp_sscp_memory_order::relaxed,                             \
+                __acpp_sscp_memory_scope::system, address, val),               \
+        static_cast<type>(0));                                                 \
+  }                                                                            \
+  inline type atomicMax_block(type *address, type val) {                       \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        builtin(__acpp_sscp_address_space::generic_space,                      \
+                __acpp_sscp_memory_order::relaxed,                             \
+                __acpp_sscp_memory_scope::work_group, address, val),           \
+        static_cast<type>(0));                                                 \
+  }
+
+__PCUDA_DECLARE_ATOMIC_MAX(int, __acpp_sscp_atomic_fetch_max_i32)
+__PCUDA_DECLARE_ATOMIC_MAX(unsigned int, __acpp_sscp_atomic_fetch_max_u32)
+__PCUDA_DECLARE_ATOMIC_MAX(unsigned long long int,
+                           __acpp_sscp_atomic_fetch_max_u64)
+__PCUDA_DECLARE_ATOMIC_MAX(long long int, __acpp_sscp_atomic_fetch_max_i64)
+
+#define __PCUDA_DECLARE_ATOMIC_AND(type, builtin_type, builtin)                \
+  inline type atomicAnd(type *address, type val) {                             \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        __builtin_bit_cast(type,                                               \
+                           builtin(__acpp_sscp_address_space::generic_space,   \
+                                   __acpp_sscp_memory_order::relaxed,          \
+                                   __acpp_sscp_memory_scope::device,           \
+                                   (builtin_type *)address,                    \
+                                   __builtin_bit_cast(builtin_type, val))),    \
+        static_cast<type>(0));                                                 \
+  }                                                                            \
+  inline type atomicAnd_system(type *address, type val) {                      \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        __builtin_bit_cast(type,                                               \
+                           builtin(__acpp_sscp_address_space::generic_space,   \
+                                   __acpp_sscp_memory_order::relaxed,          \
+                                   __acpp_sscp_memory_scope::system,           \
+                                   (builtin_type *)address,                    \
+                                   __builtin_bit_cast(builtin_type, val))),    \
+        static_cast<type>(0));                                                 \
+  }                                                                            \
+  inline type atomicAnd_block(type *address, type val) {                       \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        __builtin_bit_cast(type,                                               \
+                           builtin(__acpp_sscp_address_space::generic_space,   \
+                                   __acpp_sscp_memory_order::relaxed,          \
+                                   __acpp_sscp_memory_scope::work_group,       \
+                                   (builtin_type *)address,                    \
+                                   __builtin_bit_cast(builtin_type, val))),    \
+        static_cast<type>(0));                                                 \
+  }
+
+__PCUDA_DECLARE_ATOMIC_AND(int, __acpp_int32, __acpp_sscp_atomic_fetch_and_i32)
+__PCUDA_DECLARE_ATOMIC_AND(unsigned int, __acpp_int32,
+                           __acpp_sscp_atomic_fetch_and_i32)
+__PCUDA_DECLARE_ATOMIC_AND(unsigned long long int, __acpp_int64,
+                           __acpp_sscp_atomic_fetch_and_i64)
+
+#define __PCUDA_DECLARE_ATOMIC_OR(type, builtin_type, builtin)                 \
+  inline type atomicOr(type *address, type val) {                              \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        __builtin_bit_cast(type,                                               \
+                           builtin(__acpp_sscp_address_space::generic_space,   \
+                                   __acpp_sscp_memory_order::relaxed,          \
+                                   __acpp_sscp_memory_scope::device,           \
+                                   (builtin_type *)address,                    \
+                                   __builtin_bit_cast(builtin_type, val))),    \
+        static_cast<type>(0));                                                 \
+  }                                                                            \
+  inline type atomicOr_system(type *address, type val) {                       \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        __builtin_bit_cast(type,                                               \
+                           builtin(__acpp_sscp_address_space::generic_space,   \
+                                   __acpp_sscp_memory_order::relaxed,          \
+                                   __acpp_sscp_memory_scope::system,           \
+                                   (builtin_type *)address,                    \
+                                   __builtin_bit_cast(builtin_type, val))),    \
+        static_cast<type>(0));                                                 \
+  }                                                                            \
+  inline type atomicOr_block(type *address, type val) {                        \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        __builtin_bit_cast(type,                                               \
+                           builtin(__acpp_sscp_address_space::generic_space,   \
+                                   __acpp_sscp_memory_order::relaxed,          \
+                                   __acpp_sscp_memory_scope::work_group,       \
+                                   (builtin_type *)address,                    \
+                                   __builtin_bit_cast(builtin_type, val))),    \
+        static_cast<type>(0));                                                 \
+  }
+
+__PCUDA_DECLARE_ATOMIC_OR(int, __acpp_int32, __acpp_sscp_atomic_fetch_or_i32)
+__PCUDA_DECLARE_ATOMIC_OR(unsigned int, __acpp_int32,
+                          __acpp_sscp_atomic_fetch_or_i32)
+__PCUDA_DECLARE_ATOMIC_OR(unsigned long long int, __acpp_int64,
+                          __acpp_sscp_atomic_fetch_or_i64)
+
+#define __PCUDA_DECLARE_ATOMIC_XOR(type, builtin_type, builtin)                \
+  inline type atomicXor(type *address, type val) {                             \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        __builtin_bit_cast(type,                                               \
+                           builtin(__acpp_sscp_address_space::generic_space,   \
+                                   __acpp_sscp_memory_order::relaxed,          \
+                                   __acpp_sscp_memory_scope::device,           \
+                                   (builtin_type *)address,                    \
+                                   __builtin_bit_cast(builtin_type, val))),    \
+        static_cast<type>(0));                                                 \
+  }                                                                            \
+  inline type atomicXor_system(type *address, type val) {                      \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        __builtin_bit_cast(type,                                               \
+                           builtin(__acpp_sscp_address_space::generic_space,   \
+                                   __acpp_sscp_memory_order::relaxed,          \
+                                   __acpp_sscp_memory_scope::system,           \
+                                   (builtin_type *)address,                    \
+                                   __builtin_bit_cast(builtin_type, val))),    \
+        static_cast<type>(0));                                                 \
+  }                                                                            \
+  inline type atomicXor_block(type *address, type val) {                       \
+    return PCUDA_BUILTIN_CALL_RESULT(                                          \
+        __builtin_bit_cast(type,                                               \
+                           builtin(__acpp_sscp_address_space::generic_space,   \
+                                   __acpp_sscp_memory_order::relaxed,          \
+                                   __acpp_sscp_memory_scope::work_group,       \
+                                   (builtin_type *)address,                    \
+                                   __builtin_bit_cast(builtin_type, val))),    \
+        static_cast<type>(0));                                                 \
+  }
+
+__PCUDA_DECLARE_ATOMIC_XOR(int, __acpp_int32, __acpp_sscp_atomic_fetch_xor_i32)
+__PCUDA_DECLARE_ATOMIC_XOR(unsigned int, __acpp_int32,
+                           __acpp_sscp_atomic_fetch_xor_i32)
+__PCUDA_DECLARE_ATOMIC_XOR(unsigned long long int, __acpp_int64,
+                           __acpp_sscp_atomic_fetch_xor_i64)
+
+#define __PCUDA_DECLARE_ATOMIC_CAS(type, builtin_type, builtin)                \
+  inline type atomicCAS(type *address, type compare, type val) {               \
+    if (__acpp_sscp_is_device) {                                               \
+      builtin_type expected = __builtin_bit_cast(builtin_type, compare);       \
+      builtin(__acpp_sscp_address_space::generic_space,                        \
+              __acpp_sscp_memory_order::relaxed,                               \
+              __acpp_sscp_memory_order::relaxed,                               \
+              __acpp_sscp_memory_scope::device, (builtin_type *)address,       \
+              &expected, __builtin_bit_cast(builtin_type, val));               \
+      return __builtin_bit_cast(type, expected);                               \
+    }                                                                          \
+    return val;                                                                \
+  }                                                                            \
+  inline type atomicCAS_system(type *address, type compare, type val) {        \
+    if (__acpp_sscp_is_device) {                                               \
+      builtin_type expected = __builtin_bit_cast(builtin_type, compare);       \
+      builtin(__acpp_sscp_address_space::generic_space,                        \
+              __acpp_sscp_memory_order::relaxed,                               \
+              __acpp_sscp_memory_order::relaxed,                               \
+              __acpp_sscp_memory_scope::system, (builtin_type *)address,       \
+              &expected, __builtin_bit_cast(builtin_type, val));               \
+      return __builtin_bit_cast(type, expected);                               \
+    }                                                                          \
+    return val;                                                                \
+  }                                                                            \
+  inline type atomicCAS_block(type *address, type compare, type val) {         \
+    if (__acpp_sscp_is_device) {                                               \
+      builtin_type expected = __builtin_bit_cast(builtin_type, compare);       \
+      builtin(__acpp_sscp_address_space::generic_space,                        \
+              __acpp_sscp_memory_order::relaxed,                               \
+              __acpp_sscp_memory_order::relaxed,                               \
+              __acpp_sscp_memory_scope::work_group, (builtin_type *)address,   \
+              &expected, __builtin_bit_cast(builtin_type, val));               \
+      return __builtin_bit_cast(type, expected);                               \
+    }                                                                          \
+    return val;                                                                \
+  }
+
+__PCUDA_DECLARE_ATOMIC_CAS(int, __acpp_int32, __acpp_sscp_cmp_exch_strong_i32)
+__PCUDA_DECLARE_ATOMIC_CAS(unsigned int, __acpp_int32,
+                           __acpp_sscp_cmp_exch_strong_i32)
+__PCUDA_DECLARE_ATOMIC_CAS(unsigned long long int, __acpp_int64,
+                           __acpp_sscp_cmp_exch_strong_i64)
+__PCUDA_DECLARE_ATOMIC_CAS(unsigned short int, __acpp_int16,
+                           __acpp_sscp_cmp_exch_strong_i16)
+namespace __pcuda_detail {
+inline unsigned int atomicInc(unsigned int *address, unsigned int val,
+                              __acpp_sscp_memory_scope scope) {
+  //Computes ((old >= val) ? 0 : (old+1))
+  if(__acpp_sscp_is_device) {
+    __acpp_sscp_memory_order order = __acpp_sscp_memory_order::relaxed;
+    __acpp_sscp_address_space as = __acpp_sscp_address_space::generic_space;
+
+    __acpp_int32 *i_address = (__acpp_int32 *)address;
+
+    __acpp_int32 old = __acpp_sscp_atomic_load_i32(as, order, scope, i_address);
+    __acpp_int32 desired = old;
+    do {
+      unsigned int current_old = __builtin_bit_cast(unsigned int, old);
+      desired = (current_old >= val) ? 0 : __builtin_bit_cast(__acpp_int32, current_old + 1);
+    } while (!__acpp_sscp_cmp_exch_strong_i32(as, order, order, scope, i_address, &old, desired));
+    return __builtin_bit_cast(unsigned int, old);
+  }
+  return val;
+}
+
+
+inline unsigned int atomicDec(unsigned int *address, unsigned int val,
+                              __acpp_sscp_memory_scope scope) {
+  //Computes (((old == 0) || (old > val)) ? val : (old-1)
+  if(__acpp_sscp_is_device) {
+    __acpp_sscp_memory_order order = __acpp_sscp_memory_order::relaxed;
+    __acpp_sscp_address_space as = __acpp_sscp_address_space::generic_space;
+
+    __acpp_int32 *i_address = (__acpp_int32 *)address;
+    __acpp_int32  i_val = __builtin_bit_cast(__acpp_int32, val);
+
+    __acpp_int32 old = __acpp_sscp_atomic_load_i32(as, order, scope, i_address);
+    __acpp_int32 desired = old;
+    do {
+      unsigned int current_old = __builtin_bit_cast(unsigned int, old);
+      desired = ((current_old == 0) || (current_old > val))
+                    ? i_val
+                    : __builtin_bit_cast(__acpp_int32, current_old - 1);
+    } while (!__acpp_sscp_cmp_exch_strong_i32(as, order, order, scope, i_address, &old, desired));
+    return __builtin_bit_cast(unsigned int, old);
+  }
+  return val;
+}
+
+} // namespace __pcuda_detail
+
+inline unsigned int atomicInc(unsigned int *address, unsigned int val) {
+  return __pcuda_detail::atomicInc(address, val,
+                                   __acpp_sscp_memory_scope::device);
+}
+
+inline unsigned int atomicInc_system(unsigned int *address, unsigned int val) {
+  return __pcuda_detail::atomicInc(address, val,
+                                   __acpp_sscp_memory_scope::system);
+}
+
+inline unsigned int atomicInc_block(unsigned int *address, unsigned int val) {
+  return __pcuda_detail::atomicInc(address, val,
+                                   __acpp_sscp_memory_scope::work_group);
+}
+
+inline unsigned int atomicDec(unsigned int *address, unsigned int val) {
+  return __pcuda_detail::atomicDec(address, val,
+                                   __acpp_sscp_memory_scope::device);
+}
+
+inline unsigned int atomicDec_system(unsigned int *address, unsigned int val) {
+  return __pcuda_detail::atomicDec(address, val,
+                                   __acpp_sscp_memory_scope::system);
+}
+
+inline unsigned int atomicDec_block(unsigned int *address, unsigned int val) {
+  return __pcuda_detail::atomicDec(address, val,
+                                   __acpp_sscp_memory_scope::work_group);
+}
+
+
+#endif

--- a/include/hipSYCL/pcuda/detail/builtin_call.hpp
+++ b/include/hipSYCL/pcuda/detail/builtin_call.hpp
@@ -1,0 +1,22 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+#ifndef ACPP_PCUDA_BUILTIN_CALL_HPP
+#define ACPP_PCUDA_BUILTIN_CALL_HPP
+
+#include "hipSYCL/glue/llvm-sscp/s1_ir_constants.hpp"
+
+#define PCUDA_BUILTIN_CALL(builtin) if(__acpp_sscp_is_device){builtin;}
+#define PCUDA_BUILTIN_CALL_RESULT(builtin, fallback)                           \
+  (__acpp_sscp_is_device ? (builtin) : (fallback))
+
+#endif
+

--- a/include/hipSYCL/pcuda/pcuda.hpp
+++ b/include/hipSYCL/pcuda/pcuda.hpp
@@ -19,10 +19,13 @@
 #include "hipSYCL/sycl/libkernel/sscp/builtins/core.hpp"
 #include "hipSYCL/sycl/libkernel/sscp/builtins/subgroup.hpp"
 #include "hipSYCL/sycl/libkernel/sscp/builtins/barrier.hpp"
+
 #include <cstddef>
 
+#include "detail/builtin_call.hpp"
 #include "detail/vec.hpp"
 #include "detail/math.hpp"
+#include "detail/atomic.hpp"
 #include "pcuda_runtime.hpp"
 
 #ifndef __device__
@@ -46,9 +49,6 @@
   __attribute__((annotate("acpp_local_memory")))                               \
   __attribute__((abi_tag("__acpp_local_memory_tag__")))
 
-#define PCUDA_BUILTIN_CALL(builtin) if(__acpp_sscp_is_device){builtin;}
-#define PCUDA_BUILTIN_CALL_RESULT(builtin, fallback)                           \
-  (__acpp_sscp_is_device ? (builtin) : (fallback))
 
 // needs -fdeclspec
 struct __pcudaThreadIdx {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -181,6 +181,7 @@ if(WITH_PCUDA_TESTS)
     pcuda/memory.cpp
     pcuda/stream.cpp
     pcuda/event.cpp
+    pcuda/atomic.cpp
   )
 
   target_compile_options(pcuda_tests PRIVATE --acpp-pcuda)

--- a/tests/pcuda/atomic.cpp
+++ b/tests/pcuda/atomic.cpp
@@ -1,0 +1,147 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <pcuda.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/mpl.hpp>
+#include <boost/test/unit_test.hpp>
+
+
+BOOST_AUTO_TEST_SUITE(pcuda_atomic)
+
+using add_test_types =
+    boost::mp11::mp_list<int, unsigned int, unsigned long long, float, double>;
+
+template<class T>
+void test_atomic_add() {
+  T* data;
+  const size_t problem_size = 16;
+  BOOST_CHECK(pcudaMallocManaged(&data, (problem_size + 1) * sizeof(T)) ==
+              pcudaSuccess);
+  for(int i = 0; i < problem_size+1; ++i)
+    data[i] = T(i);
+
+
+  pcudaParallelFor(1, problem_size, [=](){
+    int gid = threadIdx.x;
+    atomicAdd(data, data[gid+1]);
+  });
+  BOOST_CHECK(pcudaDeviceSynchronize() == pcudaSuccess);
+
+  T reference = T(0);
+  for(int i = 1; i < problem_size+1; ++i) {
+    reference += T(i);
+  }
+
+  BOOST_CHECK(reference == *data);
+
+  BOOST_CHECK(pcudaFree(data) == pcudaSuccess);
+}
+
+using sub_test_types =
+    boost::mp11::mp_list<int, unsigned int>;
+
+template<class T>
+void test_atomic_sub() {
+  T* data;
+  const size_t problem_size = 16;
+  const T offset = T(1024*1024);
+  BOOST_CHECK(pcudaMallocManaged(&data, (problem_size + 1) * sizeof(T)) ==
+              pcudaSuccess);
+  for(int i = 0; i < problem_size+1; ++i)
+    data[i] = T(i);
+  data[0] = offset;
+
+  pcudaParallelFor(1, problem_size, [=](){
+    int gid = threadIdx.x;
+    atomicSub(data, data[gid+1]);
+  });
+  BOOST_CHECK(pcudaDeviceSynchronize() == pcudaSuccess);
+
+  T reference = offset;
+  for(int i = 1; i < problem_size+1; ++i) {
+    reference -= T(i);
+  }
+
+  BOOST_CHECK(reference == *data);
+
+  BOOST_CHECK(pcudaFree(data) == pcudaSuccess);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(atomicAdd, T, add_test_types) {
+  test_atomic_add<T>();
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(atomicSub, T, sub_test_types) {
+  test_atomic_sub<T>();
+}
+
+
+using min_test_types =
+    boost::mp11::mp_list<int, unsigned int, unsigned long long, long long>;
+
+template<class T>
+void test_atomic_min() {
+  T* data;
+  const size_t problem_size = 16;
+  const T offset = T(1024*1024);
+  BOOST_CHECK(pcudaMallocManaged(&data, (problem_size + 1) * sizeof(T)) ==
+              pcudaSuccess);
+  for(int i = 0; i < problem_size+1; ++i)
+    data[i] = T(i);
+  data[0] = offset;
+
+  pcudaParallelFor(1, problem_size, [=](){
+    int gid = threadIdx.x;
+    atomicMin(data, data[gid+1]);
+  });
+  BOOST_CHECK(pcudaDeviceSynchronize() == pcudaSuccess);
+std::cout << *data << std::endl;
+  BOOST_CHECK(*data == 1);
+
+  BOOST_CHECK(pcudaFree(data) == pcudaSuccess);
+}
+
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(atomicMin, T, min_test_types) {
+  test_atomic_min<T>();
+}
+
+using max_test_types =
+    boost::mp11::mp_list<int, unsigned int, unsigned long long, long long>;
+
+template<class T>
+void test_atomic_max() {
+  T* data;
+  const size_t problem_size = 16;
+  const T offset = T(2);
+  BOOST_CHECK(pcudaMallocManaged(&data, (problem_size + 1) * sizeof(T)) ==
+              pcudaSuccess);
+  for(int i = 0; i < problem_size+1; ++i)
+    data[i] = T(i);
+  data[0] = offset;
+
+  pcudaParallelFor(1, problem_size, [=](){
+    int gid = threadIdx.x;
+    atomicMax(data, data[gid+1]);
+  });
+  BOOST_CHECK(pcudaDeviceSynchronize() == pcudaSuccess);
+  BOOST_CHECK(*data == problem_size);
+
+  BOOST_CHECK(pcudaFree(data) == pcudaSuccess);
+}
+
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(atomicMax, T, max_test_types) {
+  test_atomic_max<T>();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pcuda/atomic.cpp
+++ b/tests/pcuda/atomic.cpp
@@ -90,22 +90,29 @@ using min_test_types =
 
 template<class T>
 void test_atomic_min() {
+  // atomicMin/Max on ROCm seem to be bugged when managed memory is used.
+  // Use device memory isntead.
   T* data;
   const size_t problem_size = 16;
   const T offset = T(1024*1024);
-  BOOST_CHECK(pcudaMallocManaged(&data, (problem_size + 1) * sizeof(T)) ==
+  BOOST_CHECK(pcudaMalloc(&data, (problem_size + 1) * sizeof(T)) ==
               pcudaSuccess);
+  std::vector<T> input(problem_size+1);
   for(int i = 0; i < problem_size+1; ++i)
-    data[i] = T(i);
-  data[0] = offset;
+    input[i] = T(i);
+  input[0] = offset;
+  BOOST_CHECK(pcudaMemcpy(data, input.data(), input.size() * sizeof(T),
+                          pcudaMemcpyDefault) == pcudaSuccess);
 
   pcudaParallelFor(1, problem_size, [=](){
     int gid = threadIdx.x;
     atomicMin(data, data[gid+1]);
   });
   BOOST_CHECK(pcudaDeviceSynchronize() == pcudaSuccess);
-std::cout << *data << std::endl;
-  BOOST_CHECK(*data == 1);
+  BOOST_CHECK(pcudaMemcpy(input.data(), data, input.size() * sizeof(T),
+                          pcudaMemcpyDefault) == pcudaSuccess);
+
+  BOOST_CHECK(input[0] == 1);
 
   BOOST_CHECK(pcudaFree(data) == pcudaSuccess);
 }
@@ -120,21 +127,28 @@ using max_test_types =
 
 template<class T>
 void test_atomic_max() {
+  // atomicMin/Max on ROCm seem to be bugged when managed memory is used.
+  // Use device memory isntead.
   T* data;
   const size_t problem_size = 16;
   const T offset = T(2);
-  BOOST_CHECK(pcudaMallocManaged(&data, (problem_size + 1) * sizeof(T)) ==
+  BOOST_CHECK(pcudaMalloc(&data, (problem_size + 1) * sizeof(T)) ==
               pcudaSuccess);
+  std::vector<T> input(problem_size+1);
   for(int i = 0; i < problem_size+1; ++i)
-    data[i] = T(i);
-  data[0] = offset;
+    input[i] = T(i);
+  input[0] = offset;
+  BOOST_CHECK(pcudaMemcpy(data, input.data(), input.size() * sizeof(T),
+                          pcudaMemcpyDefault) == pcudaSuccess);
 
   pcudaParallelFor(1, problem_size, [=](){
     int gid = threadIdx.x;
     atomicMax(data, data[gid+1]);
   });
   BOOST_CHECK(pcudaDeviceSynchronize() == pcudaSuccess);
-  BOOST_CHECK(*data == problem_size);
+  BOOST_CHECK(pcudaMemcpy(input.data(), data, input.size() * sizeof(T),
+                          pcudaMemcpyDefault) == pcudaSuccess);
+  BOOST_CHECK(input[0] == problem_size);
 
   BOOST_CHECK(pcudaFree(data) == pcudaSuccess);
 }


### PR DESCRIPTION
This PR adds atomic functions to the device library (the classical ones, not the newer `__nv_*` compiler builtins for now).

The data type support for the individual functions may seem a bit random, but it is actually exactly what is documented in CUDA: https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomic-functions

Currently, not every single function is tested in CI - I think this is fine, since our atomic builtins in principle are already used and tested on the SYCL side.

The following functions are added (copy-pasted from the documentation contained in this PR):

| Feature | Notes |
|------------------|-------------------|
|`atomicAdd[_system,_block]` | `int`, `uint`, `ull`, `float`, `double` types |
|`atomicSub[_system,_block]` | `int`, `uint` types |
|`atomicExch[_system,_block]` | `int`, `uint`, `ull`, `float` types |
|`atomicMin[_system,_block]` | `int`, `uint`, `ll`, `ull` types |
|`atomicMax[_system,_block]` | `int`, `uint`, `ll`, `ull` types |
|`atomicAnd[_system,_block]` | `int`, `uint`, `ull` types |
|`atomicOr[_system,_block]` | `int`, `uint`, `ull` types |
|`atomicXor[_system,_block]` | `int`, `uint`, `ull` types |
|`atomicCAS[_system,_block]` | `ushort`, `int`, `uint`, `ull` types |
|`atomicInc[_system,_block]` | `uint` type |
|`atomicDec[_system,_block]` | `uint` type |