### PR TITLE
Fix inconsistent colouring of the "Go to repository" button on mobile

### DIFF
--- a/doc/stylesheets/extra.css
+++ b/doc/stylesheets/extra.css
@@ -7,3 +7,7 @@
   --md-primary-fg-color: #c50d29;
   --md-accent-fg-color: #c50d29;
 }
+
+.md-nav__source {
+  background-color: #c50d29;
+}


### PR DESCRIPTION
This pull request resolves a theming inconsistency affecting mobile devices browsing the [Material for MkDocs-based documentation pages](https://adaptivecpp.github.io/AdaptiveCpp/).

In particular, it ensures that the button linking to the AdaptiveCpp GitHub repository has the same colour as the rest of the website title banner (crimson) instead of the colour assigned to it by Material for MkDocs by default (ultramarine). This is illustrated in the screenshots below:

---

![](https://github.com/user-attachments/assets/0903dcd4-37cd-44ed-82e4-f12fff92846c)
***Left:** The mobile version of the Material for MkDocs-based documentation pages prior to this pull request.*
***Right:** The mobile version of the Material for MkDocs-based documentation pages after incorporation of this pull request.*

---

Notably, the colouring issue addressed here does not seem to affect the desktop version of the documentation pages.