### PR TITLE
[CI] Add a dispatchable workflow to prime docker images.

### DIFF
--- a/.github/workflows/prime-docker.yml
+++ b/.github/workflows/prime-docker.yml
@@ -1,0 +1,52 @@
+name: Prime docker container
+
+on:
+  workflow_dispatch:
+    inputs:
+      clang:
+        description: 'LLVM Version to install'
+        required: true
+        default: 20
+      os:
+        description: 'Base Operating System'
+        required: true
+        default: "ubuntu-22.04"
+      cuda_major_version:
+        description: 'CUDA Major Version'
+        required: true
+        default: 11
+      cuda_minor_version:
+        description: 'CUDA Minor Version'
+        required: true
+        default: 0
+      cuda_patch_version:
+        description: 'CUDA Patch Version'
+        required: true
+        default: 2
+      rocm:
+        description: 'ROCm Version'
+        required: true
+        default: 5.4.3
+
+jobs:
+  prep-container:
+    name: Prepare CI container clang ${{ matrix.clang }}, ${{ matrix.os }}, CUDA ${{matrix.cuda_major_version}}.${{matrix.cuda_minor_version}}.${{matrix.cuda_patch_version}}, ROCm ${{matrix.rocm}}
+    runs-on: ubuntu-22.04
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+          fetch-depth: 20
+      - uses: ./.github/workflows/create-ci-docker
+        id: docker
+        with:
+          LLVM_VERSION: ${{ matrix.clang }}
+          ROCM_VERSION: ${{ matrix.rocm }}
+          CUDA_MAJOR_VERSION: ${{ matrix.cuda_major_version }}
+          CUDA_MINOR_VERSION: ${{ matrix.cuda_minor_version }}
+          CUDA_PATCH_VERSION: ${{ matrix.cuda_patch_version }}
+          BASE_TAG: ${{ matrix.os }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
This is necessary (at least, I haven't been able to think of anything way smarter, yet) to prime the cache for pull_requests that need a new docker image variant.