### PR TITLE
Add `get_backend` for the platform

### DIFF
--- a/include/hipSYCL/runtime/device_id.hpp
+++ b/include/hipSYCL/runtime/device_id.hpp
@@ -83,11 +83,11 @@ class device_id
 public:
   device_id() = default;
   device_id(backend_descriptor b, int id);
-  
+
   bool is_host() const;
   backend_id get_backend() const;
   backend_descriptor get_full_backend_descriptor() const;
-  
+
   int get_id() const;
 
   void dump(std::ostream& ostr) const;

--- a/include/hipSYCL/sycl/platform.hpp
+++ b/include/hipSYCL/sycl/platform.hpp
@@ -19,6 +19,7 @@
 #include "hipSYCL/runtime/device_id.hpp"
 
 #include "types.hpp"
+#include "backend.hpp"
 #include "device_selector.hpp"
 #include "info/info.hpp"
 #include "version.hpp"
@@ -55,6 +56,9 @@ public:
         rt::platform_id{dev.get_backend(), static_cast<int>(platform_index)};
   }
 
+  backend get_backend() const noexcept {
+    return _platform.get_backend();
+  }
 
   std::vector<device>
   get_devices(info::device_type type = info::device_type::all) const {

--- a/src/runtime/settings.cpp
+++ b/src/runtime/settings.cpp
@@ -65,7 +65,7 @@ visibility_mask_t::mapped_type parse_device_visibility_mask(const std::string& s
       } else if(components[0] != "*") {
         current.platform_name_match = components[0]; 
       }
-      
+
       if(is_number(components[1])) {
         current.device_index_equality = std::stoi(components[1]);
       } else if(components[1] != "*") {
@@ -74,7 +74,7 @@ visibility_mask_t::mapped_type parse_device_visibility_mask(const std::string& s
     }
     device_visibility_conditions.push_back(current);
   }
-  
+
   return device_visibility_conditions;
 }
 
@@ -84,7 +84,7 @@ bool device_matches(const visibility_mask_t::mapped_type &conditions,
                     const std::string &platform_name) {
   if(conditions.empty())
     return true;
-  
+
   // The logic is: All individual device visibility conditions are connected by or,
   // but the conditions within each condition are connected by and.
   for(const auto& c : conditions) {
@@ -135,14 +135,14 @@ bool has_device_visibility_mask(const visibility_mask_t& mask, backend_id backen
 std::istream &operator>>(std::istream &istr, visibility_mask_t &out) {
   std::string str;
   istr >> str;
-  // have to copy, as otherweise might be interpreted as failing, although everything is fine.
+  // have to copy, as otherwise might be interpreted as failing, although everything is fine.
   std::istringstream istream{str};
 
   std::string backend_specific_substring;
   while(std::getline(istream, backend_specific_substring, ';')) {
     if(backend_specific_substring.empty())
       continue;
-    
+
     std::size_t delimiter = backend_specific_substring.find(':');
     std::string name;
     if(delimiter != std::string::npos) {


### PR DESCRIPTION
The first commit is a trivial change that implements `get_backend` for the SYCL platform class too, as required by the spec.

The second commit is a trivial cleanup patch that removes some spurious whitespace and fixes a typo (I felt there was no need for a separate PR for this, but do let me know if it would be preferred).