### PR TITLE
Partially specializing `atomic_ref` for integral and floating point types

### DIFF
--- a/include/hipSYCL/sycl/libkernel/atomic_ref.hpp
+++ b/include/hipSYCL/sycl/libkernel/atomic_ref.hpp
@@ -140,166 +140,139 @@ public:
     return compare_exchange_strong(expected, desired, order, order, scope);
   }
 
-  template <class Integral = T,
-            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
-  Integral fetch_add(Integral operand,
+private:
+  T* _ptr;
+};
+
+template <memory_order DefaultOrder, memory_scope DefaultScope,
+          access::address_space Space>
+class atomic_ref<int, DefaultOrder, DefaultScope, Space> {
+public:
+  int fetch_add(int operand,
                      memory_order order = default_read_modify_write_order,
                      memory_scope scope = default_scope) const noexcept {
     return detail::__acpp_atomic_fetch_add<Space>(_ptr, operand, order, scope);
   }
 
-  template <class Integral = T,
-            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
-  Integral fetch_sub(Integral operand,
+  int fetch_sub(int operand,
                      memory_order order = default_read_modify_write_order,
                      memory_scope scope = default_scope) const noexcept {
     return detail::__acpp_atomic_fetch_sub<Space>(_ptr, operand, order, scope);
   }
 
-  template <class Integral = T,
-            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
-  Integral fetch_and(Integral operand,
+  int fetch_and(int operand,
                      memory_order order = default_read_modify_write_order,
                      memory_scope scope = default_scope) const noexcept {
     return detail::__acpp_atomic_fetch_and<Space>(_ptr, operand, order, scope);
   }
 
-  template <class Integral = T,
-            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
-  Integral fetch_or(Integral operand,
+  int fetch_or(int operand,
                     memory_order order = default_read_modify_write_order,
                     memory_scope scope = default_scope) const noexcept {
     return detail::__acpp_atomic_fetch_or<Space>(_ptr, operand, order, scope);
   }
 
-  template <class Integral = T,
-            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
-  Integral fetch_xor(Integral operand,
+  int fetch_xor(int operand,
                      memory_order order = default_read_modify_write_order,
                      memory_scope scope = default_scope) const noexcept {
     return detail::__acpp_atomic_fetch_xor<Space>(_ptr, operand, order, scope);
   }
 
-  template <class Integral = T,
-            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
-  Integral fetch_min(Integral operand,
+  int fetch_min(int operand,
                      memory_order order = default_read_modify_write_order,
                      memory_scope scope = default_scope) const noexcept {
     return detail::__acpp_atomic_fetch_min<Space>(_ptr, operand, order, scope);
   }
 
-  template <class Integral = T,
-            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
-  Integral fetch_max(Integral operand,
+  int fetch_max(int operand,
                      memory_order order = default_read_modify_write_order,
                      memory_scope scope = default_scope) const noexcept {
     return detail::__acpp_atomic_fetch_max<Space>(_ptr, operand, order, scope);
   }
 
-  template <class Integral = T,
-            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
-  Integral operator++(int) const noexcept {
-    return fetch_add(Integral{1});
+  int operator++(int) const noexcept {
+    return fetch_add(int{1});
   }
 
-  template <class Integral = T,
-            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
-  Integral operator--(int) const noexcept {
-    return fetch_sub(Integral{1});
+  int operator--(int) const noexcept {
+    return fetch_sub(int{1});
   }
 
-  template <class Integral = T,
-            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
-  Integral operator++() const noexcept {
-    return fetch_add(Integral{1}) + 1;
+  int operator++() const noexcept {
+    return fetch_add(int{1}) + 1;
   }
 
-  template <class Integral = T,
-            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
-  Integral operator--() const noexcept {
-    return fetch_sub(Integral{1}) - 1;
+  int operator--() const noexcept {
+    return fetch_sub(int{1}) - 1;
   }
 
-  template <class Integral = T,
-            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
-  Integral operator+=(Integral op) const noexcept {
+  int operator+=(int op) const noexcept {
     return fetch_add(op);
   }
 
-  template <class Integral = T,
-            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
-  Integral operator-=(Integral op) const noexcept {
+  int operator-=(int op) const noexcept {
     return fetch_sub(op);
   }
 
-  template <class Integral = T,
-            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
-  Integral operator&=(Integral op) const noexcept {
+  int operator&=(int op) const noexcept {
     return fetch_and(op);
   }
 
-  template <class Integral = T,
-            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
-  Integral operator|=(Integral op) const noexcept {
+  int operator|=(int op) const noexcept {
     return fetch_or(op);
   }
 
-  template <class Integral = T,
-            std::enable_if_t<std::is_integral_v<Integral>, int> = 0>
-  Integral operator^=(Integral op) const noexcept {
+  int operator^=(int op) const noexcept {
     return fetch_xor(op);
   }
 
-  template <class Floating = T,
-            std::enable_if_t<std::is_floating_point_v<Floating>, int> = 0>
-  Floating fetch_add(Floating operand,
+private:
+  int* _ptr;
+};
+
+template <memory_order DefaultOrder, memory_scope DefaultScope,
+          access::address_space Space>
+class atomic_ref<float, DefaultOrder, DefaultScope, Space> {
+public:
+
+  float fetch_add(float operand,
                      memory_order order = default_read_modify_write_order,
                      memory_scope scope = default_scope) const noexcept {
     return detail::__acpp_atomic_fetch_add<Space>(_ptr, operand, order,
                                                      scope);
   }
 
-  template <class Floating = T,
-            std::enable_if_t<std::is_floating_point_v<Floating>, int> = 0>
-  Floating fetch_sub(Floating operand,
+  float fetch_sub(float operand,
                      memory_order order = default_read_modify_write_order,
                      memory_scope scope = default_scope) const noexcept {
     return detail::__acpp_atomic_fetch_sub<Space>(_ptr, operand, order,
                                                      scope);
   }
 
-  template <class Floating = T,
-            std::enable_if_t<std::is_floating_point_v<Floating>, int> = 0>
-  Floating fetch_min(Floating operand,
+  float fetch_min(float operand,
                      memory_order order = default_read_modify_write_order,
                      memory_scope scope = default_scope) const noexcept {
     return detail::__acpp_atomic_fetch_min<Space>(_ptr, operand, order,
                                                      scope);
   }
 
-  template <class Floating = T,
-            std::enable_if_t<std::is_floating_point_v<Floating>, int> = 0>
-  Floating fetch_max(Floating operand,
+  float fetch_max(float operand,
                      memory_order order = default_read_modify_write_order,
                      memory_scope scope = default_scope) const noexcept {
     return detail::__acpp_atomic_fetch_max<Space>(_ptr, operand, order,
                                                      scope);
   }
 
-  template <class Floating = T,
-            std::enable_if_t<std::is_floating_point_v<Floating>, int> = 0>
-  Floating operator+=(Floating op) const noexcept {
+  float operator+=(float op) const noexcept {
     return fetch_add(op);
   }
 
-  template <class Floating = T,
-            std::enable_if_t<std::is_floating_point_v<Floating>, int> = 0>
-  Floating operator-=(Floating op) const noexcept {
+  float operator-=(float op) const noexcept {
     return fetch_sub(op);
   }
 
 private:
-  T* _ptr;
+  float* _ptr;
 };
 
 template <typename T, memory_order DefaultOrder, memory_scope DefaultScope,

--- a/include/hipSYCL/sycl/libkernel/atomic_ref.hpp
+++ b/include/hipSYCL/sycl/libkernel/atomic_ref.hpp
@@ -148,6 +148,92 @@ template <memory_order DefaultOrder, memory_scope DefaultScope,
           access::address_space Space>
 class atomic_ref<int, DefaultOrder, DefaultScope, Space> {
 public:
+
+  static_assert(Space == access::address_space::generic_space ||
+                    Space == access::address_space::global_space ||
+                    Space == access::address_space::local_space,
+                "Invalid address space for atomic_ref");
+
+  using value_type = int;
+  using difference_type = value_type;
+
+  static constexpr std::size_t required_alignment = alignof(int);
+  // TODO
+  static constexpr bool is_always_lock_free = true;
+
+  static constexpr memory_order default_read_order =
+      memory_order_traits<DefaultOrder>::read_order;
+  static constexpr memory_order default_write_order =
+      memory_order_traits<DefaultOrder>::write_order;
+  static constexpr memory_order default_read_modify_write_order = DefaultOrder;
+  static constexpr memory_scope default_scope = DefaultScope;
+
+  bool is_lock_free() const noexcept {
+    // TODO
+    return true;
+  }
+
+  explicit atomic_ref(int& x)
+  : _ptr{&x} {}
+
+  atomic_ref(const atomic_ref&) noexcept = default;
+  atomic_ref& operator=(const atomic_ref&) = delete;
+
+  void store(int operand,
+    memory_order order = default_write_order,
+    memory_scope scope = default_scope) const noexcept {
+    detail::__acpp_atomic_store<Space>(_ptr, operand, order, scope);
+  }
+
+  int operator=(int desired) const noexcept {
+    store(desired);
+    return desired;
+  }
+
+  int load(memory_order order = default_read_order,
+    memory_scope scope = default_scope) const noexcept {
+    return detail::__acpp_atomic_load<Space>(_ptr, order, scope);
+  }
+
+  operator int() const noexcept {
+    return load();
+  }
+
+  int exchange(int operand,
+    memory_order order = default_read_modify_write_order,
+    memory_scope scope = default_scope) const noexcept {
+    return detail::__acpp_atomic_exchange<Space>(_ptr, operand, order, scope);
+  }
+
+  bool compare_exchange_weak(int &expected, int desired,
+    memory_order success,
+    memory_order failure,
+    memory_scope scope = default_scope) const noexcept {
+    return detail::__acpp_atomic_compare_exchange_weak<Space>(
+        _ptr, expected, desired, success, failure, scope);
+  }
+
+  bool
+  compare_exchange_weak(int &expected, int desired,
+                        memory_order order = default_read_modify_write_order,
+                        memory_scope scope = default_scope) const noexcept {
+    return compare_exchange_weak(expected, desired, order, order, scope);
+  }
+
+  bool compare_exchange_strong(int &expected, int desired,
+    memory_order success,
+    memory_order failure,
+    memory_scope scope = default_scope) const noexcept {
+    return detail::__acpp_atomic_compare_exchange_strong<Space>(
+        _ptr, expected, desired, success, failure, scope);
+  }
+
+  bool compare_exchange_strong(int &expected, int desired,
+    memory_order order = default_read_modify_write_order,
+    memory_scope scope = default_scope) const noexcept {
+    return compare_exchange_strong(expected, desired, order, order, scope);
+  }
+
   int fetch_add(int operand,
                      memory_order order = default_read_modify_write_order,
                      memory_scope scope = default_scope) const noexcept {
@@ -234,6 +320,91 @@ template <memory_order DefaultOrder, memory_scope DefaultScope,
           access::address_space Space>
 class atomic_ref<float, DefaultOrder, DefaultScope, Space> {
 public:
+  
+  static_assert(Space == access::address_space::generic_space ||
+                    Space == access::address_space::global_space ||
+                    Space == access::address_space::local_space,
+                "Invalid address space for atomic_ref");
+
+  using value_type = float;
+  using difference_type = value_type;
+
+  static constexpr std::size_t required_alignment = alignof(float);
+  // TODO
+  static constexpr bool is_always_lock_free = true;
+
+  static constexpr memory_order default_read_order =
+      memory_order_traits<DefaultOrder>::read_order;
+  static constexpr memory_order default_write_order =
+      memory_order_traits<DefaultOrder>::write_order;
+  static constexpr memory_order default_read_modify_write_order = DefaultOrder;
+  static constexpr memory_scope default_scope = DefaultScope;
+
+  bool is_lock_free() const noexcept {
+    // TODO
+    return true;
+  }
+
+  explicit atomic_ref(float& x)
+  : _ptr{&x} {}
+
+  atomic_ref(const atomic_ref&) noexcept = default;
+  atomic_ref& operator=(const atomic_ref&) = delete;
+
+  void store(float operand,
+    memory_order order = default_write_order,
+    memory_scope scope = default_scope) const noexcept {
+    detail::__acpp_atomic_store<Space>(_ptr, operand, order, scope);
+  }
+
+  float operator=(float desired) const noexcept {
+    store(desired);
+    return desired;
+  }
+
+  float load(memory_order order = default_read_order,
+    memory_scope scope = default_scope) const noexcept {
+    return detail::__acpp_atomic_load<Space>(_ptr, order, scope);
+  }
+
+  operator float() const noexcept {
+    return load();
+  }
+
+  float exchange(float operand,
+    memory_order order = default_read_modify_write_order,
+    memory_scope scope = default_scope) const noexcept {
+    return detail::__acpp_atomic_exchange<Space>(_ptr, operand, order, scope);
+  }
+
+  bool compare_exchange_weak(float &expected, float desired,
+    memory_order success,
+    memory_order failure,
+    memory_scope scope = default_scope) const noexcept {
+    return detail::__acpp_atomic_compare_exchange_weak<Space>(
+        _ptr, expected, desired, success, failure, scope);
+  }
+
+  bool
+  compare_exchange_weak(float &expected, float desired,
+                        memory_order order = default_read_modify_write_order,
+                        memory_scope scope = default_scope) const noexcept {
+    return compare_exchange_weak(expected, desired, order, order, scope);
+  }
+
+  bool compare_exchange_strong(float &expected, float desired,
+    memory_order success,
+    memory_order failure,
+    memory_scope scope = default_scope) const noexcept {
+    return detail::__acpp_atomic_compare_exchange_strong<Space>(
+        _ptr, expected, desired, success, failure, scope);
+  }
+
+  bool compare_exchange_strong(float &expected, float desired,
+    memory_order order = default_read_modify_write_order,
+    memory_scope scope = default_scope) const noexcept {
+    return compare_exchange_strong(expected, desired, order, order, scope);
+  }
 
   float fetch_add(float operand,
                      memory_order order = default_read_modify_write_order,


### PR DESCRIPTION
In the first commit i only added the type specific members into separate classes.

In the second commit i added every member to each class specialization.