### PR TITLE
[CBS] Get way more conservative on when not to widen allocas.

### DIFF
--- a/src/compiler/cbs/SubCfgFormation.cpp
+++ b/src/compiler/cbs/SubCfgFormation.cpp
@@ -158,10 +158,11 @@ getLocalSizeArgumentFromAnnotation(llvm::Function &F) {
 }
 
 // identify the local size values by the store to it
-void fillStores(llvm::Value *V, int Idx, bool IsIdxBytewise, llvm::SmallVector<llvm::Value *, 3> &LocalSize) {
+void fillStores(llvm::Value *V, int Idx, bool IsIdxBytewise,
+                llvm::SmallVector<llvm::Value *, 3> &LocalSize) {
   if (auto *Store = llvm::dyn_cast<llvm::StoreInst>(V)) {
 #if LLVM_VERSION_MAJOR >= 17
-    if(IsIdxBytewise)
+    if (IsIdxBytewise)
       Idx /= Store->getAccessType()->getScalarSizeInBits() / 8;
 #endif
     LocalSize[Idx] = Store->getOperand(0);
@@ -1079,24 +1080,58 @@ void purgeLifetime(SubCFG &Cfg) {
     I->eraseFromParent();
 }
 
+// look through geps and bitcasts to find the alloca
+llvm::AllocaInst *getAllocaFromGEP(llvm::Value *V) {
+  if (auto *GEP = llvm::dyn_cast<llvm::GetElementPtrInst>(V))
+    return getAllocaFromGEP(GEP->getPointerOperand());
+  if (auto *BC = llvm::dyn_cast<llvm::BitCastInst>(V))
+    return getAllocaFromGEP(BC->getOperand(0));
+  if (auto *AI = llvm::dyn_cast<llvm::AllocaInst>(V))
+    return AI;
+  return nullptr;
+}
+
 // fills \a Hull with all transitive users of \a Alloca
-void fillUserHull(llvm::AllocaInst *Alloca, llvm::SmallVectorImpl<llvm::Instruction *> &Hull) {
+// returns true, if address is captured by a function
+bool fillUserHull(llvm::AllocaInst *Alloca, llvm::SmallVectorImpl<llvm::Instruction *> &Hull) {
   llvm::SmallVector<llvm::Instruction *, 8> WL;
-  std::transform(Alloca->user_begin(), Alloca->user_end(), std::back_inserter(WL),
-                 [](auto *U) { return llvm::cast<llvm::Instruction>(U); });
+  WL.push_back(Alloca);
+
   llvm::SmallPtrSet<llvm::Instruction *, 32> AlreadySeen;
   while (!WL.empty()) {
     auto *I = WL.pop_back_val();
     AlreadySeen.insert(I);
-    Hull.push_back(I);
-    for (auto *U : I->users()) {
-      if (auto *UI = llvm::dyn_cast<llvm::Instruction>(U)) {
-        if (!AlreadySeen.contains(UI))
-          if (UI->mayReadOrWriteMemory() || UI->getType()->isPointerTy())
+    if(!I->getParent()->isEntryBlock())
+      Hull.push_back(I);
+
+    for (auto &U : I->uses()) {
+      if (auto *UI = llvm::dyn_cast<llvm::Instruction>(U.getUser())) {
+        if (!AlreadySeen.contains(UI)) {
+          if (auto SI = llvm::dyn_cast<llvm::StoreInst>(I)) {
+            if (SI->getPointerOperand()) {
+              if (auto *StoredToAlloca = getAllocaFromGEP(SI->getPointerOperand());
+                  StoredToAlloca && AlreadySeen.insert(StoredToAlloca).second) {
+                HIPSYCL_DEBUG_INFO << "[SubCFG] Found alloca " << *StoredToAlloca
+                                   << " in store: " << *SI << "\n";
+                WL.push_back(StoredToAlloca);
+              }
+            }
+          } else if (UI->mayReadOrWriteMemory() || UI->getType()->isPointerTy())
             WL.push_back(UI);
+          if (auto CI = llvm::dyn_cast<llvm::CallBase>(UI)) {
+            auto OperandNo = CI->getArgOperandNo(&U);
+            if (!CI->dataOperandHasImpliedAttr(OperandNo, llvm::Attribute::NoCapture) &&
+                !CI->dataOperandHasImpliedAttr(OperandNo, llvm::Attribute::StructRet)) {
+              HIPSYCL_DEBUG_INFO << "[SubCFG] Found function call that captures " << *I << ": "
+                                 << *CI << " OperandNo: " << OperandNo << "\n";
+              return true;
+            }
+          }
+        }
       }
     }
   }
+  return false;
 }
 
 // checks if all uses of an alloca are in just a single subcfg (doesn't have to be arrayified!)
@@ -1105,7 +1140,8 @@ bool isAllocaSubCfgInternal(llvm::AllocaInst *Alloca, const std::vector<SubCFG> 
   llvm::SmallPtrSet<llvm::BasicBlock *, 16> UserBlocks;
   {
     llvm::SmallVector<llvm::Instruction *, 32> Users;
-    fillUserHull(Alloca, Users);
+    if (fillUserHull(Alloca, Users))
+      return false; // alloca use captured by function.. unclear what the function may do with it.
     utils::PtrSetWrapper<decltype(UserBlocks)> Wrapper{UserBlocks};
     std::transform(Users.begin(), Users.end(), std::inserter(Wrapper, UserBlocks.end()),
                    [](auto *I) { return I->getParent(); });
@@ -1136,8 +1172,7 @@ llvm::IRBuilder<> createLoadBuilder(llvm::BasicBlock *BB, Instruction *I) {
   return llvm::IRBuilder{BB, I->getIterator()};
 }
 
-template <class iterator>
-llvm::IRBuilder<> createLoadBuilder(llvm::BasicBlock *BB, iterator I) {
+template <class iterator> llvm::IRBuilder<> createLoadBuilder(llvm::BasicBlock *BB, iterator I) {
   return llvm::IRBuilder{BB, I};
 }
 
@@ -1291,8 +1326,7 @@ void formSubCfgs(llvm::Function &F, llvm::LoopInfo &LI, llvm::DominatorTree &DT,
     Cfg.arrayifyMultiSubCfgValues(InstAllocaMap, BaseInstAllocaMap, InstContReplicaMap, SubCFGs,
                                   F.getEntryBlock().getTerminator(), ReqdArrayElements, VecInfo);
 
-  llvm::BasicBlock *NewExit =
-      llvm::BasicBlock::Create(F.getContext(), "cbs.exit", &F);
+  llvm::BasicBlock *NewExit = llvm::BasicBlock::Create(F.getContext(), "cbs.exit", &F);
   llvm::IRBuilder<> ExitBuilder(NewExit);
   ExitBuilder.CreateRetVoid();
 
@@ -1306,8 +1340,8 @@ void formSubCfgs(llvm::Function &F, llvm::LoopInfo &LI, llvm::DominatorTree &DT,
 
   llvm::BasicBlock *WhileHeader = nullptr;
   WhileHeader =
-      generateWhileSwitchAround(&F.getEntryBlock(), F.getEntryBlock().getSingleSuccessor(),
-                                NewExit, LastBarrierIdStorage, SubCFGs);
+      generateWhileSwitchAround(&F.getEntryBlock(), F.getEntryBlock().getSingleSuccessor(), NewExit,
+                                LastBarrierIdStorage, SubCFGs);
 
   llvm::removeUnreachableBlocks(F);
 

--- a/src/compiler/cbs/SubCfgFormation.cpp
+++ b/src/compiler/cbs/SubCfgFormation.cpp
@@ -1101,25 +1101,25 @@ bool fillUserHull(llvm::AllocaInst *Alloca, llvm::SmallVectorImpl<llvm::Instruct
   while (!WL.empty()) {
     auto *I = WL.pop_back_val();
     AlreadySeen.insert(I);
-    if(!I->getParent()->isEntryBlock())
+    if (!I->getParent()->isEntryBlock())
       Hull.push_back(I);
 
     for (auto &U : I->uses()) {
       if (auto *UI = llvm::dyn_cast<llvm::Instruction>(U.getUser())) {
         if (!AlreadySeen.contains(UI)) {
-          if (auto SI = llvm::dyn_cast<llvm::StoreInst>(I)) {
-            if (SI->getPointerOperand()) {
-              if (auto *StoredToAlloca = getAllocaFromGEP(SI->getPointerOperand());
-                  StoredToAlloca && AlreadySeen.insert(StoredToAlloca).second) {
-                HIPSYCL_DEBUG_INFO << "[SubCFG] Found alloca " << *StoredToAlloca
-                                   << " in store: " << *SI << "\n";
-                WL.push_back(StoredToAlloca);
-              }
+          if (auto SI = llvm::dyn_cast<llvm::StoreInst>(UI)) {
+            if (auto *StoredToAlloca = getAllocaFromGEP(SI->getPointerOperand());
+                StoredToAlloca && AlreadySeen.insert(StoredToAlloca).second) {
+              HIPSYCL_DEBUG_INFO << "[SubCFG] Found alloca " << *StoredToAlloca
+                                 << " in store: " << *SI << "\n";
+              WL.push_back(StoredToAlloca);
+              continue;
             }
-          } else if (UI->mayReadOrWriteMemory() || UI->getType()->isPointerTy())
+          }
+          if (UI->mayReadOrWriteMemory() || UI->getType()->isPointerTy())
             WL.push_back(UI);
           if (auto CI = llvm::dyn_cast<llvm::CallBase>(UI)) {
-            auto OperandNo = CI->getArgOperandNo(&U);
+            auto OperandNo = U.getOperandNo();
             if (!CI->dataOperandHasImpliedAttr(OperandNo, llvm::Attribute::NoCapture) &&
                 !CI->dataOperandHasImpliedAttr(OperandNo, llvm::Attribute::StructRet)) {
               HIPSYCL_DEBUG_INFO << "[SubCFG] Found function call that captures " << *I << ": "

--- a/tests/compiler/cbs/repeated_group_reduce.cpp
+++ b/tests/compiler/cbs/repeated_group_reduce.cpp
@@ -1,0 +1,65 @@
+// RUN: %acpp %s -o %t --acpp-targets=omp --acpp-use-accelerated-cpu
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s -o %t --acpp-targets=omp --acpp-use-accelerated-cpu -O
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s -o %t --acpp-targets=generic
+// RUN: ACPP_VISIBILITY_MASK=omp; %t | FileCheck %s
+// RUN: %acpp %s -o %t --acpp-targets=generic -O
+// RUN: ACPP_VISIBILITY_MASK=omp; %t | FileCheck %s
+
+// this tests mostly -O0 for omp where there's a lot more alloca pain
+// specifically this might trigger, if we don't arrayify allocas whose address
+// is stored at another location and is thus used across subcfgs (without being
+// unique / workitem)
+
+#include <sycl/sycl.hpp>
+
+using f64_3 = sycl::vec<double, 3>;
+
+template <class T, class Func> inline T map_vector(const T &in, Func &&f) {
+  return {f(in[0]), f(in[1]), f(in[2])};
+}
+
+int main() {
+  sycl::queue q{};
+
+  std::vector<f64_3> input_data = {
+      {1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}, {7.0, 8.0, 9.0}, {10.0, 11.0, 12.0}};
+  std::vector<f64_3> output_data(input_data.size(), {0.0, 0.0, 0.0});
+  {
+    sycl::buffer<f64_3> input_buf(input_data.data(), input_data.size());
+    sycl::buffer<f64_3> output_buf(output_data.data(), output_data.size());
+
+    q.submit([&](sycl::handler &cgh) {
+      sycl::accessor in(input_buf, cgh, sycl::read_only);
+      sycl::accessor out(output_buf, cgh, sycl::write_only);
+
+      cgh.parallel_for(sycl::nd_range<1>(input_data.size(), input_data.size()),
+                       [=](sycl::nd_item<1> item) {
+                         sycl::group<1> group = item.get_group();
+
+                         auto v = in[item.get_global_linear_id()];
+
+                         f64_3 sum = map_vector(v, [&](auto component) {
+                           auto ret = sycl::reduce_over_group(
+                               group, component,
+                               sycl::plus<decltype(component)>{});
+                           return ret;
+                         });
+
+                         out[item.get_global_linear_id()] = sum;
+                       });
+    });
+  }
+  for (size_t i = 0; i < output_data.size(); ++i) {
+
+    for (size_t j = 0; j < 3; ++j) {
+      // CHECK: 22 26 30
+      // CHECK: 22 26 30
+      // CHECK: 22 26 30
+      // CHECK: 22 26 30
+      std::cout << output_data[i][j] << " ";
+    }
+    std::cout << "\n";
+  }
+}


### PR DESCRIPTION
We have to widen allocas, so that each work item get's it's own alloca slot, whenever, the alloca is used across multiple SubCFGs.
This commit adds into consideration that this might as well happen, when the pointer to the alloca is stored somewhere else.
This can happen whenever the pointer is stored or if it is being used by a function.
When it's used by a function, we try to be nice and don't arrayify whenever the pointer operand is marked as "nocapture" or as "sret" (struct return, i.e. being initialized).

Fixes #1759 