### PR TITLE
Fix broken builds due to CMake 4.0 axing compatibility with CMake < 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ if(POLICY CMP0167) # Since CMake 3.30
     cmake_policy(SET CMP0167 OLD)
 endif()
 
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 4.0)
+  # Prevent CMake >= 4.0 from failing when configuring, e.g. the ocl-cxx-headers.
+  set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+endif()
 
 set(ACPP_VERSION_MAJOR 24)
 set(ACPP_VERSION_MINOR 10)


### PR DESCRIPTION
CMake 4.0 [officially removes compatibility with versions of CMake older than 3.5](https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features). This breaks building AdaptiveCpp by causing CMake errors of the form:

```
CMake Error at build/_deps/ocl-cxx-headers-src/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Thankfully, setting `CMAKE_POLICY_VERSION_MINIMUM` to `3.5` appears to be sufficient to make CMake run without further errors (while restoring AdaptiveCpp's ability to be compiled). Hence, I have added this setting to the CMakeLists.txt for the time being.