### PR TITLE
[SSCP][llvm-to-host] Use fputs instead of puts to avoid newline

### DIFF
--- a/src/libkernel/sscp/host/print.cpp
+++ b/src/libkernel/sscp/host/print.cpp
@@ -13,5 +13,5 @@
 #include <cstdio>
 
 void __acpp_sscp_print(const char* msg) {
-  puts(msg);
+  fputs(msg, stdout);
 }


### PR DESCRIPTION
Fixes #1767 