### PR TITLE
[PCUDA] Interop: Add this_nd_item and make_queue(pcudaStream_t)

### DIFF
--- a/doc/pcuda.md
+++ b/doc/pcuda.md
@@ -359,7 +359,40 @@ q.parallel_for(range, [=](auto idx){
 
 ```
 
+Inside PCUDA code, a SYCL `nd_item` object for interoperability with SYCL code can be obtained as follows:
+
+```c++
+#include <pcuda.hpp>
+#include <sycl/sycl.hpp>
+
+void my_sycl_kernel_code(sycl::nd_item<1> item) {
+  ...
+}
+
+
+...
+
+pcudaParallelFor(num_blocks, block_size, [=](){
+  sycl::nd_item<1> idx = sycl::AdaptiveCpp_pcuda::this_nd_item<1>();
+  my_sycl_kernel_code(idx);
+});
+
+```
+
 ## Interoperability with SYCL for runtime objects
 
-TBD
+### Queue
+
+A `sycl::queue` object can be obtained from a PCUDA stream as follows:
+
+```c++
+pcudaStream_t stream = ...
+sycl::queue q = sycl::AdaptiveCpp_pcuda::make_queue(stream);
+```
+
+**Note:** 
+1. During the lifetime of the queue, the underlying backend queue is shared between the PCUDA stream and the SYCL queue. The underlying backend queue will be freed once *both* PCUDA stream and SYCL queue are no longer alive.
+2. The queue returned from `make_queue` will always be an in-order queue. However, SYCL may queue up work to perform batched submission in certain cases. This can cause SYCL work dispatched before PCUDA work to be executed *after* PCUDA work even if both submit to the same underlying queue. To avoid this, use the AdaptiveCpp instant submission mode in SYCL (see [here](macros.md)) and avoid using the buffer-accessor data management model.
+3. You can get a SYCL queue for the PCUDA default stream for the current PCUDA device using `make_queue(0)`.
+
 

--- a/include/hipSYCL/runtime/pcuda/pcuda_runtime.hpp
+++ b/include/hipSYCL/runtime/pcuda/pcuda_runtime.hpp
@@ -46,10 +46,7 @@ private:
 
 class pcuda_application {
 public:
-  static pcuda_application& get() {
-    static pcuda_application app;
-    return app;
-  }
+  static pcuda_application& get();
 
   pcuda_runtime& pcuda_rt();
   const pcuda_runtime& pcuda_rt() const;

--- a/include/hipSYCL/runtime/pcuda/pcuda_stream.hpp
+++ b/include/hipSYCL/runtime/pcuda/pcuda_stream.hpp
@@ -31,6 +31,8 @@ public:
   static pcudaError_t wait_all(device_id dev);
   inorder_queue* get_queue() const;
   static inorder_queue* get_queue(pcudaStream_t stream);
+
+  std::shared_ptr<inorder_executor> get_executor() const;
 private:
   std::shared_ptr<inorder_executor> _executor;
 };

--- a/include/hipSYCL/sycl/pcuda_interop.hpp
+++ b/include/hipSYCL/sycl/pcuda_interop.hpp
@@ -11,6 +11,11 @@
 #ifndef HIPSYCL_PCUDA_INTEROP_HPP
 #define HIPSYCL_PCUDA_INTEROP_HPP
 
+#include "libkernel/backend.hpp"
+
+#if !ACPP_LIBKERNEL_COMPILER_SUPPORTS_CUDA &&                                  \
+    !ACPP_LIBKERNEL_COMPILER_SUPPORTS_HIP
+
 #include <cassert>
 
 #include "libkernel/nd_item.hpp"
@@ -57,4 +62,5 @@ inline sycl::queue make_queue(rt::pcuda::stream* stream) {
 }
 }
 
+#endif
 #endif

--- a/include/hipSYCL/sycl/pcuda_interop.hpp
+++ b/include/hipSYCL/sycl/pcuda_interop.hpp
@@ -1,0 +1,60 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#ifndef HIPSYCL_PCUDA_INTEROP_HPP
+#define HIPSYCL_PCUDA_INTEROP_HPP
+
+#include <cassert>
+
+#include "libkernel/nd_item.hpp"
+#include "libkernel/detail/thread_hierarchy.hpp"
+#include "property.hpp"
+#include "queue.hpp"
+#include "device.hpp"
+
+#include "hipSYCL/runtime/pcuda/pcuda_stream.hpp"
+#include "hipSYCL/runtime/pcuda/pcuda_runtime.hpp"
+
+
+namespace hipsycl {
+namespace sycl {
+
+namespace AdaptiveCpp_pcuda {
+
+template<int D>
+nd_item<D> this_nd_item() {
+  const sycl::id<D> zero_offset{};
+  sycl::nd_item<D> this_item{&zero_offset, sycl::detail::get_group_id<D>(),
+                             sycl::detail::get_local_id<D>(),
+                             sycl::detail::get_local_size<D>(),
+                             sycl::detail::get_grid_size<D>()};
+  return this_item;
+}
+
+inline sycl::queue make_queue(rt::pcuda::stream* stream) {
+  if(!stream)
+    stream = rt::pcuda::pcuda_application::get().tls_state().get_default_stream();
+  assert(stream);
+
+  rt::device_id dev = rt::pcuda::stream::get_queue(stream)->get_device();
+
+  sycl::property_list props {
+    sycl::property::queue::in_order{},
+    sycl::property::queue::AdaptiveCpp_inorder_executor{stream->get_executor()}
+  };
+  return sycl::queue{sycl::device{dev}, props};
+}
+
+}
+
+}
+}
+
+#endif

--- a/include/hipSYCL/sycl/queue.hpp
+++ b/include/hipSYCL/sycl/queue.hpp
@@ -110,6 +110,13 @@ struct AdaptiveCpp_priority : public detail::queue_property {
   int priority;
 };
 
+struct AdaptiveCpp_inorder_executor : public detail::queue_property {
+  AdaptiveCpp_inorder_executor(const std::shared_ptr<rt::inorder_executor>& exec)
+  : executor{exec} {}
+
+  std::shared_ptr<rt::inorder_executor> executor;
+};
+
 struct AdaptiveCpp_retargetable : public detail::queue_property {};
 
 // backwards compatibility
@@ -1149,12 +1156,18 @@ private:
       rt::device_id rt_dev = detail::extract_rt_device(this->get_device());
       // Dedicated executor may not be supported by all backends,
       // so this might return nullptr.
-      _impl->dedicated_inorder_executor =
-          _impl->requires_runtime.get()
-              ->backends()
-              .get(rt_dev.get_backend())
-              ->create_inorder_executor(rt_dev, priority);
-      
+      if(this->has_property<property::queue::AdaptiveCpp_inorder_executor>()) {
+        _impl->dedicated_inorder_executor =
+            this->get_property<property::queue::AdaptiveCpp_inorder_executor>()
+                .executor;
+      } else {
+        _impl->dedicated_inorder_executor =
+            _impl->requires_runtime.get()
+                ->backends()
+                .get(rt_dev.get_backend())
+                ->create_inorder_executor(rt_dev, priority);
+      }
+
       if(_impl->dedicated_inorder_executor) {
         _impl->default_hints.set_hint(
             rt::hints::prefer_executor{_impl->dedicated_inorder_executor});

--- a/include/hipSYCL/sycl/sycl.hpp
+++ b/include/hipSYCL/sycl/sycl.hpp
@@ -79,6 +79,7 @@
 #include "buffer_explicit_behavior.hpp"
 #include "specialized.hpp"
 #include "jit.hpp"
+#include "pcuda_interop.hpp"
 #include "detail/namespace_compat.hpp"
 
 // Support SYCL_EXTERNAL for SSCP - we cannot have SYCL_EXTERNAL if accelerated CPU

--- a/src/runtime/pcuda/pcuda_runtime.cpp
+++ b/src/runtime/pcuda/pcuda_runtime.cpp
@@ -33,6 +33,11 @@ thread_local_state& pcuda_application::tls_state() {
   return *tls_state_ptr;
 }
 
+pcuda_application &pcuda_application::get() {
+  static pcuda_application app;
+  return app;
+}
+
 pcuda_runtime &pcuda_application::pcuda_rt() { return _pcuda_rt; }
 const pcuda_runtime &pcuda_application::pcuda_rt() const { return _pcuda_rt; }
 

--- a/src/runtime/pcuda/pcuda_stream.cpp
+++ b/src/runtime/pcuda/pcuda_stream.cpp
@@ -83,6 +83,10 @@ inorder_queue* stream::get_queue(pcudaStream_t s) {
   return static_cast<pcuda::stream*>(s)->get_queue();
 }
 
+std::shared_ptr<inorder_executor> stream::get_executor() const {
+  return _executor;
+}
+
 pcudaError_t stream::wait_all(rt::device_id dev) {
   std::vector<pcuda::stream> streams_to_wait;
   {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -196,6 +196,7 @@ if(WITH_PCUDA_TESTS)
     pcuda/stream.cpp
     pcuda/event.cpp
     pcuda/atomic.cpp
+    pcuda/interop.cpp
   )
 
   target_compile_options(pcuda_tests PRIVATE --acpp-pcuda)

--- a/tests/pcuda/interop.cpp
+++ b/tests/pcuda/interop.cpp
@@ -1,0 +1,71 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <vector>
+
+#include <pcuda.hpp>
+#include <sycl/sycl.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+
+BOOST_AUTO_TEST_SUITE(pcuda_interop);
+
+
+BOOST_AUTO_TEST_CASE(nd_item) {
+  int* data;
+  int problem_size = 1024;
+  int group_size = 128;
+  BOOST_TEST(pcudaMallocManaged(&data, problem_size * sizeof(int)) == pcudaSuccess);
+
+  for(int i = 0; i < problem_size; ++i)
+    data[i] = i;
+
+  auto err = pcudaParallelFor(problem_size / group_size, group_size, [=](){
+    auto item = sycl::AdaptiveCpp_pcuda::this_nd_item<1>();
+    data[item.get_global_linear_id()] += 1;
+  });
+  BOOST_CHECK(err == pcudaSuccess);
+
+  BOOST_CHECK(pcudaDeviceSynchronize() == pcudaSuccess);
+  for(int i = 0; i < problem_size; ++i) {
+    BOOST_CHECK(data[i] == i + 1);
+  }
+
+  BOOST_CHECK(pcudaFree(data) == pcudaSuccess);
+}
+
+BOOST_AUTO_TEST_CASE(queue) {
+  int* data;
+  int problem_size = 1024;
+  int group_size = 128;
+  BOOST_TEST(pcudaMallocManaged(&data, problem_size * sizeof(int)) == pcudaSuccess);
+
+  for(int i = 0; i < problem_size; ++i)
+    data[i] = i;
+
+  auto err = pcudaParallelFor(problem_size / group_size, group_size, [=](){
+    auto item = sycl::AdaptiveCpp_pcuda::this_nd_item<1>();
+    data[item.get_global_linear_id()] += 1;
+  });
+  BOOST_CHECK(err == pcudaSuccess);
+
+  auto queue = sycl::AdaptiveCpp_pcuda::make_queue(0);
+  queue.wait();
+  
+  for(int i = 0; i < problem_size; ++i) {
+    BOOST_CHECK(data[i] == i + 1);
+  }
+
+  BOOST_CHECK(pcudaFree(data) == pcudaSuccess);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR adds interop between PCUDA and SYCL in two ways:


* Allow getting a `sycl::nd_item` in PCUDA code using `sycl::AdaptiveCpp_pcuda::this_nd_item<Dim>()`.
* Allow getting a SYCL queue from a PCUDA stream using `sycl::AdaptiveCpp_pcuda::make_queue(pcudaStream_t)`.


The reverse interop from SYCL queue to PCUDA stream could also be added in the future, but is a bit more challenging because it's not always possible (in particular, out-of-order queues won't ever work with PCUDA).