### PR TITLE
[NFC][doc] Clarify that LLVM_DIR may be required when building on Mac.

### DIFF
--- a/doc/installing.md
+++ b/doc/installing.md
@@ -173,7 +173,7 @@ You can use it just, as you would normally: using the CMake integration or using
 
 ## Installation from source (Mac)
 
-On Mac, only the CPU backends are supported. The required steps are analogous to Linux.
+On Mac, only the CPU backends are supported. The required steps are analogous to Linux, however you may require `LLVM_DIR` to be set to the location of the `cmake` files LLVM ships with. For instance, with a `Homebrew` installation of LLVM 20.1.2, `LLVM_DIR=/opt/homebrew/Cellar/llvm/20.1.2/lib/cmake/llvm`.
 
 ## Installation from source (Windows)
 


### PR DESCRIPTION
I can't build on Mac without `LLVM_DIR` set.