### PR TITLE
Fix Apple builds and update the docs for them.

### DIFF
--- a/doc/installing.md
+++ b/doc/installing.md
@@ -173,7 +173,9 @@ You can use it just, as you would normally: using the CMake integration or using
 
 ## Installation from source (Mac)
 
-On Mac, only the CPU backends are supported. The required steps are analogous to Linux, however you may require `LLVM_DIR` to be set to the location of the `cmake` files LLVM ships with. For instance, with a `Homebrew` installation of LLVM 20.1.2, `LLVM_DIR=/opt/homebrew/Cellar/llvm/20.1.2/lib/cmake/llvm`.
+On Mac, only the CPU backends are supported. The required steps are analogous to Linux, however, there are caveats:
+* You may require `LLVM_DIR` to be set to the directory which contains the `cmake` files that LLVM ships with. For instance, with a `Homebrew` installation of LLVM 20.1.2, `LLVM_DIR=/opt/homebrew/Cellar/llvm/20.1.2/lib/cmake/llvm`.
+* You may require `OpenCL_LIBRARY` to be set to the path of a newer version of the OpenCL library than Apple distributes. For instance, `OpenCL_LIBRARY=${OpenCL_INSTALL_PREFIX}/lib/libOpenCL.dylib`.
 
 ## Installation from source (Windows)
 

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -250,6 +250,7 @@ if(WITH_OPENCL_BACKEND)
   endif()
   add_library(ocl-headers INTERFACE)
   target_include_directories(ocl-headers INTERFACE ${ocl-headers_SOURCE_DIR})
+  file(CREATE_LINK ${ocl-headers_SOURCE_DIR}/CL ${ocl-headers_SOURCE_DIR}/OPENCL SYMBOLIC)
   
   FetchContent_Declare(ocl-cxx-headers
     GIT_REPOSITORY https://github.com/KhronosGroup/OpenCL-CLHPP


### PR DESCRIPTION
Building from HEAD on an Apple M series laptop, I have two problems:

First, I have a set of undeclared identifiers:

<details>
<summary>First issue</summary>

```
FAILED: src/runtime/CMakeFiles/rt-backend-ocl.dir/ocl/ocl_queue.cpp.o
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DCL_HPP_TARGET_OPENCL_VERSION=210 -DHIPSYCL_DEBUG_LEVEL=2 -DHIPSYCL_WITH_SSCP_COMPILER -Drt_backend_ocl_EXPORTS -I/Users/kip/misc/AdaptiveCpp/include -I/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-headers-src -I/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include -O3 -DNDEBUG -std=c++17 -flto=thin -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk -mmacosx-version-min=14.5 -fPIC -MD -MT src/runtime/CMakeFiles/rt-backend-ocl.dir/ocl/ocl_queue.cpp.o -MF src/runtime/CMakeFiles/rt-backend-ocl.dir/ocl/ocl_queue.cpp.o.d -o src/runtime/CMakeFiles/rt-backend-ocl.dir/ocl/ocl_queue.cpp.o -c /Users/kip/misc/AdaptiveCpp/src/runtime/ocl/ocl_queue.cpp
In file included from /Users/kip/misc/AdaptiveCpp/src/runtime/ocl/ocl_queue.cpp:19:
In file included from /Users/kip/misc/AdaptiveCpp/include/hipSYCL/runtime/ocl/ocl_code_object.hpp:16:
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1634:1: error: use of undeclared identifier 'CL_DEVICE_QUEUE_ON_HOST_PROPERTIES'
 1634 | CL_HPP_PARAM_NAME_INFO_2_0_(CL_HPP_DECLARE_PARAM_TRAITS_)
      | ^
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1472:23: note: expanded from macro 'CL_HPP_PARAM_NAME_INFO_2_0_'
 1472 |     F(cl_device_info, CL_DEVICE_QUEUE_ON_HOST_PROPERTIES, cl_command_queue_properties) \
      |                       ^
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1634:1: error: use of undeclared identifier 'CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES'
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1473:23: note: expanded from macro 'CL_HPP_PARAM_NAME_INFO_2_0_'
 1473 |     F(cl_device_info, CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES, cl_command_queue_properties) \
      |                       ^
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1634:1: error: use of undeclared identifier 'CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE'
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1474:23: note: expanded from macro 'CL_HPP_PARAM_NAME_INFO_2_0_'
 1474 |     F(cl_device_info, CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE, cl_uint) \
      |                       ^
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1634:1: error: use of undeclared identifier 'CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE'
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1475:23: note: expanded from macro 'CL_HPP_PARAM_NAME_INFO_2_0_'
 1475 |     F(cl_device_info, CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE, cl_uint) \
      |                       ^
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1634:1: error: use of undeclared identifier 'CL_DEVICE_MAX_ON_DEVICE_QUEUES'
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1476:23: note: expanded from macro 'CL_HPP_PARAM_NAME_INFO_2_0_'
 1476 |     F(cl_device_info, CL_DEVICE_MAX_ON_DEVICE_QUEUES, cl_uint) \
      |                       ^
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1634:1: error: use of undeclared identifier 'CL_DEVICE_MAX_ON_DEVICE_EVENTS'
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1477:23: note: expanded from macro 'CL_HPP_PARAM_NAME_INFO_2_0_'
 1477 |     F(cl_device_info, CL_DEVICE_MAX_ON_DEVICE_EVENTS, cl_uint) \
      |                       ^
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1634:1: error: use of undeclared identifier 'CL_DEVICE_MAX_PIPE_ARGS'
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1478:23: note: expanded from macro 'CL_HPP_PARAM_NAME_INFO_2_0_'
 1478 |     F(cl_device_info, CL_DEVICE_MAX_PIPE_ARGS, cl_uint) \
      |                       ^
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1634:1: error: use of undeclared identifier 'CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS'
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1479:23: note: expanded from macro 'CL_HPP_PARAM_NAME_INFO_2_0_'
 1479 |     F(cl_device_info, CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS, cl_uint) \
      |                       ^
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1634:1: error: use of undeclared identifier 'CL_DEVICE_PIPE_MAX_PACKET_SIZE'
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1480:23: note: expanded from macro 'CL_HPP_PARAM_NAME_INFO_2_0_'
 1480 |     F(cl_device_info, CL_DEVICE_PIPE_MAX_PACKET_SIZE, cl_uint) \
      |                       ^
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1634:1: error: use of undeclared identifier 'CL_DEVICE_SVM_CAPABILITIES'
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1481:23: note: expanded from macro 'CL_HPP_PARAM_NAME_INFO_2_0_'
 1481 |     F(cl_device_info, CL_DEVICE_SVM_CAPABILITIES, cl_device_svm_capabilities) \
      |                       ^
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1634:1: error: use of undeclared identifier 'CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGNMENT'
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1482:23: note: expanded from macro 'CL_HPP_PARAM_NAME_INFO_2_0_'
 1482 |     F(cl_device_info, CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGNMENT, cl_uint) \
      |                       ^
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1634:1: error: use of undeclared identifier 'CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT'
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1483:23: note: expanded from macro 'CL_HPP_PARAM_NAME_INFO_2_0_'
 1483 |     F(cl_device_info, CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT, cl_uint) \
      |                       ^
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1634:1: error: use of undeclared identifier 'CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT'
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1484:23: note: expanded from macro 'CL_HPP_PARAM_NAME_INFO_2_0_'
 1484 |     F(cl_device_info, CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT, cl_uint) \
      |                       ^
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1634:1: error: use of undeclared identifier 'CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS'
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1487:23: note: expanded from macro 'CL_HPP_PARAM_NAME_INFO_2_0_'
 1487 |     F(cl_device_info, CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS, cl_uint ) \
      |                       ^
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1634:1: error: use of undeclared identifier 'CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE'
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1488:23: note: expanded from macro 'CL_HPP_PARAM_NAME_INFO_2_0_'
 1488 |     F(cl_device_info, CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE, size_type ) \
      |                       ^
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1634:1: error: use of undeclared identifier 'CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE'
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1489:23: note: expanded from macro 'CL_HPP_PARAM_NAME_INFO_2_0_'
 1489 |     F(cl_device_info, CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE, size_type ) \
      |                       ^
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1634:1: error: use of undeclared identifier 'CL_PROFILING_COMMAND_COMPLETE'
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1490:26: note: expanded from macro 'CL_HPP_PARAM_NAME_INFO_2_0_'
 1490 |     F(cl_profiling_info, CL_PROFILING_COMMAND_COMPLETE, cl_ulong) \
      |                          ^
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1634:1: error: use of undeclared identifier 'CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM'
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1491:28: note: expanded from macro 'CL_HPP_PARAM_NAME_INFO_2_0_'
 1491 |     F(cl_kernel_exec_info, CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM, cl_bool) \
      |                            ^
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1634:1: error: use of undeclared identifier 'CL_KERNEL_EXEC_INFO_SVM_PTRS'
/Users/kip/misc/AdaptiveCpp/build/_deps/ocl-cxx-headers-src/include/CL/opencl.hpp:1492:28: note: expanded from macro 'CL_HPP_PARAM_NAME_INFO_2_0_'
 1492 |     F(cl_kernel_exec_info, CL_KERNEL_EXEC_INFO_SVM_PTRS, void**) \
      |                            ^
```

</details>

which is caused by [this conditional include here](https://github.com/KhronosGroup/OpenCL-CLHPP/blob/0bdbbfe5ecda42cff50c96cc5e33527f42fcbd45/include/CL/opencl.hpp#L522-L526). `OpenCL/opencl.h` isn't available in our downloaded dependencies. Apple, in all its _intelligence_ resolves this to some xcode SDK version of opencl, given the chance, which is incompatible with the version we're using. 

The `Homebrew` distribution of `ocl-headers` gets around this by adding a symlink `OpenCL -> CL`, which I duplicate in our CMake on this patch.

Second, I have the following set of undefined symbols:

<details>
<summary>Second issue</summary>


```
FAILED: src/runtime/librt-backend-ocl.dylib
: && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -O3 -DNDEBUG -flto=thin -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk -mmacosx-version-min=14.5 -dynamiclib -Wl,-headerpad_max_install_names  -o src/runtime/librt-backend-ocl.dylib -install_name @rpath/librt-backend-ocl.dylib src/runtime/CMakeFiles/rt-backend-ocl.dir/ocl/ocl_backend.cpp.o src/runtime/CMakeFiles/rt-backend-ocl.dir/ocl/ocl_code_object.cpp.o src/runtime/CMakeFiles/rt-backend-ocl.dir/ocl/ocl_hardware_manager.cpp.o src/runtime/CMakeFiles/rt-backend-ocl.dir/ocl/ocl_allocator.cpp.o src/runtime/CMakeFiles/rt-backend-ocl.dir/ocl/ocl_usm.cpp.o src/runtime/CMakeFiles/rt-backend-ocl.dir/ocl/ocl_event.cpp.o src/runtime/CMakeFiles/rt-backend-ocl.dir/ocl/ocl_queue.cpp.o  -Wl,-rpath,/Users/kip/misc/AdaptiveCpp/build3/src/runtime -Wl,-rpath,/Users/kip/misc/AdaptiveCpp/build3/src/compiler/llvm-to-backend -Wl,-rpath,/Users/kip/misc/AdaptiveCpp/build3/src/common  src/runtime/libacpp-rt.dylib  -framework OpenCL  src/compiler/llvm-to-backend/libllvm-to-spirv.dylib  src/compiler/llvm-to-backend/libllvm-to-backend.dylib  src/common/libacpp-common.dylib && :
Undefined symbols for architecture arm64:
  "_clCreateCommandQueueWithProperties", referenced from:
      hipsycl::rt::ocl_queue::ocl_queue(hipsycl::rt::ocl_hardware_manager*, unsigned long) in
  "_clCreateProgramWithIL", referenced from:
      hipsycl::rt::ocl_executable_object::ocl_executable_object(cl::Context const&, cl::Device&, unsigned long, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, hipsycl::rt::kernel_configuration const&) in
  "_clEnqueueSVMMemFill", referenced from:
      hipsycl::rt::ocl_usm_svm::enqueue_memset(cl::CommandQueue&, void*, int, unsigned long, std::__1::vector<cl::Event, std::__1::allocator<cl::Event>> const&, cl::Event*) in
  "_clEnqueueSVMMemcpy", referenced from:
      hipsycl::rt::ocl_usm_svm::enqueue_memcpy(cl::CommandQueue&, void*, void const*, unsigned long, std::__1::vector<cl::Event, std::__1::allocator<cl::Event>> const&, cl::Event*) in
  "_clEnqueueSVMMigrateMem", referenced from:
      hipsycl::rt::ocl_usm_svm::enqueue_prefetch(cl::CommandQueue&, void const*, unsigned long, unsigned long long, std::__1::vector<cl::Event, std::__1::allocator<cl::Event>> const&, cl::Event*) in
  "_clSVMAlloc", referenced from:
      hipsycl::rt::ocl_usm_svm::malloc_shared(unsigned long, unsigned long, int&) in
  "_clSVMFree", referenced from:
      hipsycl::rt::ocl_usm_svm::free(void*) in
  "_clSetKernelExecInfo", referenced from:
      hipsycl::rt::ocl_usm_intel_extension::enable_indirect_usm_access(cl::Kernel&) in
      hipsycl::rt::ocl_usm_intel_extension::enable_indirect_usm_access(cl::Kernel&) in
      hipsycl::rt::ocl_usm_intel_extension::enable_indirect_usm_access(cl::Kernel&) in
      hipsycl::rt::ocl_usm_svm::enable_indirect_usm_access(cl::Kernel&) in
ld: symbol(s) not found for architecture arm64
c++: error: linker command failed with exit code 1 (use -v to see invocation)
```

</details>

This makes sense, because the version of OpenCL that ships with Macs is 1.2, because Apple have decided to deprecate the use of OpenCL in favour of their Metal / Metal Shaders products :)

We can fix this, by linking against a (built from source) newer version of the OpenCL library. Hence, I've updated the docs to suggest doing this in the case that you're using a Mac.