### PR TITLE
Change some IRUtils functions to use `BasicBlock` iterators instead of `Instruction*`

### DIFF
--- a/include/hipSYCL/compiler/cbs/IRUtils.hpp
+++ b/include/hipSYCL/compiler/cbs/IRUtils.hpp
@@ -89,7 +89,7 @@ void replaceUsesOfGVWith(llvm::Function &F, llvm::StringRef GlobalVarName, llvm:
 llvm::Loop *updateDtAndLi(llvm::LoopInfo &LI, llvm::DominatorTree &DT, const llvm::BasicBlock *B,
                           llvm::Function &F);
 
-bool isBarrier(const llvm::Instruction *I, const SplitterAnnotationInfo &SAA);
+bool isBarrier(const llvm::BasicBlock::const_iterator I, const SplitterAnnotationInfo &SAA);
 bool blockHasBarrier(const llvm::BasicBlock *BB,
                      const hipsycl::compiler::SplitterAnnotationInfo &SAA);
 bool hasBarriers(const llvm::Function &F, const hipsycl::compiler::SplitterAnnotationInfo &SAA);
@@ -158,7 +158,7 @@ llvm::AllocaInst *arrayifyInstruction(llvm::Instruction *IPAllocas, llvm::Instru
                                       llvm::Value *Idx, llvm::Value *NumValues,
                                       llvm::MDTuple *MDAlloca = nullptr);
 llvm::LoadInst *loadFromAlloca(llvm::AllocaInst *Alloca, llvm::Value *Idx,
-                               llvm::Instruction *InsertBefore, const llvm::Twine &NamePrefix = "");
+                               llvm::BasicBlock::iterator InsertBefore, const llvm::Twine &NamePrefix = "");
 
 llvm::AllocaInst *getLoopStateAllocaForLoad(llvm::LoadInst &LInst);
 
@@ -179,7 +179,7 @@ template <class UserType, class Func> bool allOfUsers(llvm::Value *V, Func &&L) 
 }
 
 /// dbg handling
-void copyDgbValues(llvm::Value *From, llvm::Value *To, llvm::Instruction *InsertBefore);
+void copyDgbValues(llvm::Value *From, llvm::Value *To, llvm::BasicBlock::iterator InsertBefore);
 void dropDebugLocation(llvm::Instruction &I);
 void dropDebugLocation(llvm::BasicBlock *BB);
 

--- a/src/compiler/cbs/CanonicalizeBarriers.cpp
+++ b/src/compiler/cbs/CanonicalizeBarriers.cpp
@@ -126,7 +126,7 @@ bool canonicalizeBarriers(llvm::Function &F, SplitterAnnotationInfo &SAA) {
 
   for (auto &BB : F)
     for (auto &I : BB)
-      if (utils::isBarrier(&I, SAA))
+      if (utils::isBarrier(I.getIterator(), SAA))
         Barriers.insert(&I);
 
   // Finally add all the split points, now that we are done with the

--- a/src/compiler/cbs/IRUtils.cpp
+++ b/src/compiler/cbs/IRUtils.cpp
@@ -55,7 +55,7 @@ llvm::Loop *updateDtAndLi(llvm::LoopInfo &LI, llvm::DominatorTree &DT, const llv
   return LI.getLoopFor(B);
 }
 
-bool isBarrier(const llvm::Instruction *I, const SplitterAnnotationInfo &SAA) {
+bool isBarrier(const llvm::BasicBlock::const_iterator I, const SplitterAnnotationInfo &SAA) {
   if (const auto *CI = llvm::dyn_cast<llvm::CallInst>(I))
     return CI->getCalledFunction() && SAA.isSplitterFunc(CI->getCalledFunction());
   return false;
@@ -63,14 +63,14 @@ bool isBarrier(const llvm::Instruction *I, const SplitterAnnotationInfo &SAA) {
 
 bool blockHasBarrier(const llvm::BasicBlock *BB,
                      const hipsycl::compiler::SplitterAnnotationInfo &SAA) {
-  return std::any_of(BB->begin(), BB->end(), [&SAA](const auto &I) { return isBarrier(&I, SAA); });
+  return std::any_of(BB->begin(), BB->end(), [&SAA](const auto &I) { return isBarrier(I.getIterator(), SAA); });
 }
 
 // Returns true in case the given basic block starts with a barrier,
 // that is, contains a branch instruction after possible PHI nodes.
 bool startsWithBarrier(const llvm::BasicBlock *BB,
                        const hipsycl::compiler::SplitterAnnotationInfo &SAA) {
-  return isBarrier(BB->getFirstNonPHI(), SAA);
+  return isBarrier(BB->getFirstNonPHIIt(), SAA);
 }
 
 // Returns true in case the given basic block ends with a barrier,
@@ -79,7 +79,7 @@ bool endsWithBarrier(const llvm::BasicBlock *BB,
                      const hipsycl::compiler::SplitterAnnotationInfo &SAA) {
   const llvm::Instruction *T = BB->getTerminator();
   assert(T);
-  return BB->size() > 1 && T->getPrevNode() && isBarrier(T->getPrevNode(), SAA);
+  return BB->size() > 1 && T->getPrevNode() && isBarrier(T->getPrevNode()->getIterator(), SAA);
 }
 
 bool hasOnlyBarrier(const llvm::BasicBlock *BB,
@@ -110,7 +110,7 @@ llvm::CallInst *createBarrier(llvm::Instruction *InsertBefore, SplitterAnnotatio
   llvm::Module *M = InsertBefore->getParent()->getParent()->getParent();
 
   if (InsertBefore != &InsertBefore->getParent()->front() &&
-      isBarrier(InsertBefore->getPrevNode(), SAA))
+      isBarrier(InsertBefore->getPrevNode()->getIterator(), SAA))
     return llvm::cast<llvm::CallInst>(InsertBefore->getPrevNode());
   llvm::Function *F = llvm::cast<llvm::Function>(
       M->getOrInsertFunction(BarrierIntrinsicName, llvm::Type::getVoidTy(M->getContext()))
@@ -420,7 +420,7 @@ void arrayifyAllocas(llvm::BasicBlock *EntryBlock, llvm::Loop &L, llvm::Value *I
 // At \a InsertionPoint, a store is added that stores the \a ToArrayify
 // value to the alloca element at \a Idx.
 llvm::AllocaInst *arrayifyValue(llvm::Instruction *IPAllocas, llvm::Value *ToArrayify,
-                                llvm::Instruction *InsertionPoint, llvm::Value *Idx,
+                                llvm::BasicBlock::iterator InsertionPoint, llvm::Value *Idx,
                                 llvm::Value *NumElements, llvm::MDTuple *MDAlloca) {
   assert(Idx && "Valid WI-Index required");
 
@@ -435,7 +435,7 @@ llvm::AllocaInst *arrayifyValue(llvm::Instruction *IPAllocas, llvm::Value *ToArr
     Alloca->setAlignment(llvm::Align{hipsycl::compiler::DefaultAlignment});
   Alloca->setMetadata(hipsycl::compiler::MDKind::Arrayified, MDAlloca);
 
-  llvm::IRBuilder WriteBuilder{InsertionPoint};
+  llvm::IRBuilder WriteBuilder{&*InsertionPoint};
   llvm::Value *StoreTarget = Alloca;
   if (NumElements) {
     auto *GEP = llvm::cast<llvm::GetElementPtrInst>(WriteBuilder.CreateInBoundsGEP(
@@ -451,9 +451,9 @@ llvm::AllocaInst *arrayifyValue(llvm::Instruction *IPAllocas, llvm::Value *ToArr
 llvm::AllocaInst *arrayifyInstruction(llvm::Instruction *IPAllocas, llvm::Instruction *ToArrayify,
                                       llvm::Value *Idx, llvm::Value *NumElements,
                                       llvm::MDTuple *MDAlloca) {
-  llvm::Instruction *InsertionPoint = &*(++ToArrayify->getIterator());
+  llvm::BasicBlock::iterator InsertionPoint = ++ToArrayify->getIterator();
   if (llvm::isa<llvm::PHINode>(ToArrayify))
-    InsertionPoint = ToArrayify->getParent()->getFirstNonPHI();
+    InsertionPoint = ToArrayify->getParent()->getFirstNonPHIIt();
 
   return arrayifyValue(IPAllocas, ToArrayify, InsertionPoint, Idx, NumElements, MDAlloca);
 }
@@ -461,11 +461,11 @@ llvm::AllocaInst *arrayifyInstruction(llvm::Instruction *IPAllocas, llvm::Instru
 // load from the \a Alloca at \a Idx, if array alloca, otherwise just load the
 // alloca value
 llvm::LoadInst *loadFromAlloca(llvm::AllocaInst *Alloca, llvm::Value *Idx,
-                               llvm::Instruction *InsertBefore, const llvm::Twine &NamePrefix) {
+                               llvm::BasicBlock::iterator InsertBefore, const llvm::Twine &NamePrefix) {
   assert(Idx && "Valid WI-Index required");
   auto *MDAlloca = Alloca->getMetadata(hipsycl::compiler::MDKind::Arrayified);
 
-  llvm::IRBuilder LoadBuilder{InsertBefore};
+  llvm::IRBuilder LoadBuilder{&*InsertBefore};
   llvm::Value *LoadFrom = Alloca;
   if (Alloca->isArrayAllocation()) {
     auto *GEP = llvm::cast<llvm::GetElementPtrInst>(LoadBuilder.CreateInBoundsGEP(
@@ -491,7 +491,7 @@ llvm::AllocaInst *getLoopStateAllocaForLoad(llvm::LoadInst &LInst) {
 }
 
 // bring along the llvm.dbg.value intrinsics when cloning values
-void copyDgbValues(llvm::Value *From, llvm::Value *To, llvm::Instruction *InsertBefore) {
+void copyDgbValues(llvm::Value *From, llvm::Value *To, llvm::BasicBlock::iterator InsertBefore) {
   llvm::SmallVector<llvm::DbgValueInst *, 1> DbgValues;
   llvm::findDbgValues(DbgValues, From);
   if (!DbgValues.empty()) {

--- a/src/compiler/cbs/PHIsToAllocas.cpp
+++ b/src/compiler/cbs/PHIsToAllocas.cpp
@@ -61,7 +61,7 @@ llvm::Instruction *breakPHIToAllocas(llvm::PHINode *Phi) {
     Builder.SetInsertPoint(IncomingBB->getTerminator());
     Builder.CreateStore(V, Alloca);
   }
-  Builder.SetInsertPoint(Phi->getParent()->getFirstNonPHI());
+  Builder.SetInsertPoint(Phi->getParent()->getFirstNonPHIIt());
 
   llvm::Instruction *LoadedValue = Builder.CreateLoad(Alloca->getAllocatedType(), Alloca);
   Phi->replaceAllUsesWith(LoadedValue);

--- a/src/compiler/cbs/RemoveBarrierCalls.cpp
+++ b/src/compiler/cbs/RemoveBarrierCalls.cpp
@@ -72,7 +72,7 @@ bool removeBarrierCalls(llvm::Function &F, SplitterAnnotationInfo &SAA) {
 
   for (auto &BB : F) {
     for (auto &I : BB) {
-      if (utils::isBarrier(&I, SAA)) {
+      if (utils::isBarrier(I.getIterator(), SAA)) {
         BarriersToRemove.insert(&I);
       }
     }

--- a/src/compiler/cbs/SubCfgFormation.cpp
+++ b/src/compiler/cbs/SubCfgFormation.cpp
@@ -794,9 +794,9 @@ void SubCFG::loadMultiSubCfgValues(
             VMap[InstAllocaPair.first] = NewGEP;
             continue;
           }
-        auto *IP = LoadTerm;
+        auto IP = LoadTerm->getIterator();
         if (!InstAllocaPair.second->isArrayAllocation())
-          IP = UniformLoadTerm;
+          IP = UniformLoadTerm->getIterator();
         HIPSYCL_DEBUG_INFO << "[SubCFG] Load from Alloca " << *InstAllocaPair.second << " in "
                            << IP->getParent()->getName() << "\n";
         auto *Load = utils::loadFromAlloca(InstAllocaPair.second, NewContIdx, IP,
@@ -831,7 +831,7 @@ void SubCFG::loadUniformAndRecalcContValues(
 
   // load uniform values from allocas
   for (auto &InstAllocaPair : BaseInstAllocaMap) {
-    auto *IP = UniformLoadTerm;
+    auto IP = UniformLoadTerm->getIterator();
     HIPSYCL_DEBUG_INFO << "[SubCFG] Load base value from Alloca " << *InstAllocaPair.second
                        << " in " << IP->getParent()->getName() << "\n";
     auto *Load = utils::loadFromAlloca(InstAllocaPair.second, NewContIdx, IP,
@@ -1006,9 +1006,9 @@ void SubCFG::fixSingleSubCfgValues(
           }
 #else
           // doesn't happen if we keep the PHIs
-          auto *NewIP = LoadIP;
+          auto NewIP = LoadIP->getIterator();
           if (!Alloca->isArrayAllocation()) {
-            NewIP = UniLoadIP;
+            NewIP = UniLoadIP->getIterator();
             Idx = llvm::ConstantInt::get(ContIdx_->getType(), 0);
           }
 #endif


### PR DESCRIPTION
LLVM upstream has deprecated several functions using Instruction*, favouring BasicBlock iterators. This change removes some of those warnings by swapping out some.

The changed functions in IRUtils are:
  * isBarrier()
  * loadFromAlloca()
  * copyDgbValues() [sic]

Here's an example warning being removed:

```
[7/39] Building CXX object src/compiler/CMakeFiles/acpp-clang-cbs.dir/cbs/PHIsToAllocas.cpp.o
/Users/kip/misc/AdaptiveCpp/src/compiler/cbs/PHIsToAllocas.cpp:64:44: warning: 'getFirstNonPHI' is deprecated: Use iterators as instruction positions instead [-Wdeprecated-declarations]
   64 |   Builder.SetInsertPoint(Phi->getParent()->getFirstNonPHI());
      |                                            ^~~~~~~~~~~~~~
      |                                            getFirstNonPHIIt
/opt/homebrew/Cellar/llvm/20.1.2/include/llvm/IR/BasicBlock.h:288:3: note: 'getFirstNonPHI' has been explicitly marked deprecated here
  288 |   LLVM_DEPRECATED("Use iterators as instruction positions instead",
      |   ^
/opt/homebrew/Cellar/llvm/20.1.2/include/llvm/Support/Compiler.h:234:50: note: expanded from macro 'LLVM_DEPRECATED'
  234 | #define LLVM_DEPRECATED(MSG, FIX) __attribute__((deprecated(MSG, FIX)))
      |                                                  ^
1 warning generated.
```