### PR TITLE
Add static cast to a sycl::range

### DIFF
--- a/include/hipSYCL/sycl/libkernel/accessor.hpp
+++ b/include/hipSYCL/sycl/libkernel/accessor.hpp
@@ -2287,7 +2287,7 @@ public:
   ACPP_KERNEL_TARGET
   size_t get_count() const
   {
-    return _num_elements.size();
+    return static_cast<sycl::range<dimensions>>(_num_elements).size();
   }
 
   ACPP_KERNEL_TARGET
@@ -2299,7 +2299,7 @@ public:
   ACPP_KERNEL_TARGET
   size_t size() const noexcept
   {
-    return _num_elements.size();
+    return static_cast<sycl::range<dimensions>>(_num_elements).size();
   }
 
   size_type max_size() const noexcept

--- a/include/hipSYCL/sycl/libkernel/accessor.hpp
+++ b/include/hipSYCL/sycl/libkernel/accessor.hpp
@@ -2053,7 +2053,7 @@ public:
   ACPP_KERNEL_TARGET
   size_t get_count() const
   {
-    return _num_elements.size();
+    return static_cast<sycl::range<dimensions>>(_num_elements).size();
   }
 
   ACPP_KERNEL_TARGET
@@ -2065,7 +2065,7 @@ public:
   ACPP_KERNEL_TARGET
   size_t size() const noexcept
   {
-    return _num_elements.size();
+    return static_cast<sycl::range<dimensions>>(_num_elements).size();
   }
 
   size_type max_size() const noexcept


### PR DESCRIPTION
I noticed a bug when compiling the CTS, these lines don't compile unless I explicitely `static_cast` them.
The ACpp compilation works just fine, the error happens when compiling the CTS.

`/home/user/install/acpp/bin/../include/AdaptiveCpp/sycl/../hipSYCL/sycl/libkernel/accessor.hpp:2056:26: error: no member named 'size' in 'hipsycl::sycl::specialized<hipsycl::sycl::range<3>>'
 2056 |     return _num_elements.size();`