### PR TITLE
[PCUDA] Remove outlining attribute from __device__ for compatibility with lambda functions

### DIFF
--- a/include/hipSYCL/pcuda/pcuda.hpp
+++ b/include/hipSYCL/pcuda/pcuda.hpp
@@ -29,7 +29,17 @@
 #include "pcuda_runtime.hpp"
 
 #ifndef __device__
-#define __device__ __attribute__((annotate("hipsycl_sscp_outlining")))
+// Ideally, we could set __device__ to 
+// __attribute__((annotate("hipsycl_sscp_outlining"))).
+// However, clang is not fully compatible with GCC with the placement
+// of GNU-style attributes on lambda functions, leading to incompatibilities
+// with nvcc code.
+// This is unfortunate since we would need __device__ e.g. for 
+// cross-TU linking of device functions similarly to SYCL_EXTERNAL.
+// For now users will have to use --acpp-export-all, which might however be overkill.
+// Also, it might be insufficient if we later decide to add support
+// for virtual functions or function pointers.
+#define __device__
 #endif
 
 #ifndef __host__


### PR DESCRIPTION
clang does not support the GNU syntax for GNU-style attributes on lambda functions ( `[] __attribute__((attrib)) (int param) {...}`).

We currently `#define __device__ __attribute__((annotate("hipsycl_sscp_outlining")))`. Due to the mentioned incompatibility in the clang frontend, this breaks compilation for code bases that rely on device or host-device lambdas.

The main reason for our definition of `__device__` is to have device code linkage across TUs, i.e. get `__device__` functions exported for the JIT linker.

As a hotfix for the compilation issue, this PR `#define`s away `__device__`. Users can still get cross-TU device code linkage using `--acpp-export-all`, if desired.
This is a hotfix, and we might have to look into better solutions in the future. Due to the prevalence of device lambdas in some code bases, this needs to be addressed quickly.


Note: Curiously, the `__device__` and `__host__` attributes in clang's own CUDA frontend do not have this issue. Presumably clang special cases those and handles them differently when parsing :(
