### PR TITLE
[Omp] set global_mem_size to physical mem size if available

### DIFF
--- a/include/hipSYCL/runtime/omp/omp_phys_mem.hpp
+++ b/include/hipSYCL/runtime/omp/omp_phys_mem.hpp
@@ -8,8 +8,8 @@
  * See file LICENSE in the project root for full license details.
  */
 // SPDX-License-Identifier: BSD-2-Clause
-#ifndef HIPSYCL_OMP_PHYS_MEM_HPP
-#define HIPSYCL_OMP_PHYS_MEM_HPP
+#ifndef ACPP_OMP_PHYS_MEM_HPP
+#define ACPP_OMP_PHYS_MEM_HPP
 
 #include <cstddef>
 #include <optional>
@@ -27,7 +27,7 @@ namespace rt {
  * @details This function is implemented for Mac OS X and Linux. Other platforms
  * will return std::nullopt.
  */
-std::optional<std::size_t> getPhysicalMemory();
+std::optional<std::size_t> get_physical_memory();
 } // namespace rt
 } // namespace hipsycl
 

--- a/include/hipSYCL/runtime/omp/omp_phys_mem.hpp
+++ b/include/hipSYCL/runtime/omp/omp_phys_mem.hpp
@@ -1,0 +1,34 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#ifndef HIPSYCL_OMP_PHYS_MEM_HPP
+#define HIPSYCL_OMP_PHYS_MEM_HPP
+
+#include <cstddef>
+#include <optional>
+
+namespace hipsycl {
+namespace rt {
+
+/**
+ * @brief Get the amount of physical memory (RAM) available on the system, in
+ * bytes.
+ *
+ * @return The amount of physical memory available, or std::nullopt if the
+ * information cannot be retrieved.
+ *
+ * @details This function is implemented for Mac OS X and Linux. Other platforms
+ * will return std::nullopt.
+ */
+std::optional<std::size_t> getPhysicalMemory();
+} // namespace rt
+} // namespace hipsycl
+
+#endif

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -305,7 +305,8 @@ if(WITH_CPU_BACKEND)
     omp/omp_backend.cpp
     omp/omp_event.cpp
     omp/omp_hardware_manager.cpp
-    omp/omp_queue.cpp)
+    omp/omp_queue.cpp
+    omp/omp_phys_mem.cpp)
 
   if(TARGET omp) # ACPP_LLVM_COMPONENT with openmp active
     set(OpenMP_CXX_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR})

--- a/src/runtime/omp/omp_hardware_manager.cpp
+++ b/src/runtime/omp/omp_hardware_manager.cpp
@@ -14,6 +14,7 @@
 #include "hipSYCL/runtime/omp/omp_hardware_manager.hpp"
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
+#include "hipSYCL/runtime/omp/omp_phys_mem.hpp"
 
 namespace hipsycl {
 namespace rt {
@@ -120,6 +121,15 @@ bool omp_hardware_context::has(device_support_aspect aspect) const {
 
 std::size_t
 omp_hardware_context::get_property(device_uint_property prop) const {
+
+  auto phys_mem_or_max = []() {
+    if (auto mem = getPhysicalMemory()) {
+      return *mem;
+    } else {
+      return std::numeric_limits<std::size_t>::max();
+    }
+  };
+  
   switch (prop) {
   case device_uint_property::max_compute_units:
     // Do not change this; heuristics in algorithms library
@@ -247,7 +257,7 @@ omp_hardware_context::get_property(device_uint_property prop) const {
     return 1; // TODO
     break;
   case device_uint_property::global_mem_size:
-    return std::numeric_limits<std::size_t>::max(); // TODO
+    return phys_mem_or_max(); // TODO
     break;
   case device_uint_property::max_constant_buffer_size:
     return std::numeric_limits<std::size_t>::max();

--- a/src/runtime/omp/omp_hardware_manager.cpp
+++ b/src/runtime/omp/omp_hardware_manager.cpp
@@ -123,13 +123,13 @@ std::size_t
 omp_hardware_context::get_property(device_uint_property prop) const {
 
   auto phys_mem_or_max = []() {
-    if (auto mem = getPhysicalMemory()) {
+    if (auto mem = get_physical_memory()) {
       return *mem;
     } else {
       return std::numeric_limits<std::size_t>::max();
     }
   };
-  
+
   switch (prop) {
   case device_uint_property::max_compute_units:
     // Do not change this; heuristics in algorithms library
@@ -257,7 +257,7 @@ omp_hardware_context::get_property(device_uint_property prop) const {
     return 1; // TODO
     break;
   case device_uint_property::global_mem_size:
-    return phys_mem_or_max(); // TODO
+    return phys_mem_or_max();
     break;
   case device_uint_property::max_constant_buffer_size:
     return std::numeric_limits<std::size_t>::max();

--- a/src/runtime/omp/omp_phys_mem.cpp
+++ b/src/runtime/omp/omp_phys_mem.cpp
@@ -1,0 +1,47 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#include "hipSYCL/runtime/omp/omp_phys_mem.hpp"
+
+// Mac OSX implementation:
+#if defined(__MACH__)
+#include <sys/sysctl.h>
+#include <sys/types.h>
+
+std::optional<std::size_t> hipsycl::rt::getPhysicalMemory() {
+
+int mib[]     = {CTL_HW, HW_MEMSIZE};
+int64_t value = 0;
+size_t length = sizeof(value);
+
+if (-1 == sysctl(mib, 2, &value, &length, NULL, 0)) {
+    return std::nullopt;
+}
+return value;
+}
+
+// Linux/BSD implementation:
+#elif (defined(linux) || defined(__linux__) || defined(__linux))                                   \
+|| (defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__)                      \
+    || defined(__OpenBSD__))
+
+#include <sys/sysinfo.h>
+
+std::optional<std::size_t> hipsycl::rt::getPhysicalMemory() {
+struct sysinfo info;
+sysinfo(&info);
+return info.totalram;
+}
+
+#else
+
+std::optional<std::size_t> hipsycl::rt::getPhysicalMemory() { return std::nullopt; }
+
+#endif

--- a/src/runtime/omp/omp_phys_mem.cpp
+++ b/src/runtime/omp/omp_phys_mem.cpp
@@ -40,6 +40,17 @@ sysinfo(&info);
 return info.totalram;
 }
 
+#elif _WIN32
+
+#include <windows.h>
+
+std::optional<std::size_t> hipsycl::rt::getPhysicalMemory() {
+    MEMORYSTATUSEX status;
+    status.dwLength = sizeof(status);
+    GlobalMemoryStatusEx(&status);
+    return status.ullTotalPhys;
+}
+
 #else
 
 std::optional<std::size_t> hipsycl::rt::getPhysicalMemory() { return std::nullopt; }

--- a/src/runtime/omp/omp_phys_mem.cpp
+++ b/src/runtime/omp/omp_phys_mem.cpp
@@ -15,44 +15,46 @@
 #include <sys/sysctl.h>
 #include <sys/types.h>
 
-std::optional<std::size_t> hipsycl::rt::getPhysicalMemory() {
+std::optional<std::size_t> hipsycl::rt::get_physical_memory() {
+  int mib[] = {CTL_HW, HW_MEMSIZE};
+  int64_t value = 0;
+  size_t length = sizeof(value);
 
-int mib[]     = {CTL_HW, HW_MEMSIZE};
-int64_t value = 0;
-size_t length = sizeof(value);
-
-if (-1 == sysctl(mib, 2, &value, &length, NULL, 0)) {
+  if (-1 == sysctl(mib, 2, &value, &length, NULL, 0)) {
     return std::nullopt;
-}
-return value;
-}
-
-// Linux/BSD implementation:
-#elif (defined(linux) || defined(__linux__) || defined(__linux))                                   \
-|| (defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__)                      \
-    || defined(__OpenBSD__))
-
-#include <sys/sysinfo.h>
-
-std::optional<std::size_t> hipsycl::rt::getPhysicalMemory() {
-struct sysinfo info;
-sysinfo(&info);
-return info.totalram;
+  }
+  return value;
 }
 
 #elif _WIN32
 
 #include <windows.h>
 
-std::optional<std::size_t> hipsycl::rt::getPhysicalMemory() {
-    MEMORYSTATUSEX status;
-    status.dwLength = sizeof(status);
-    GlobalMemoryStatusEx(&status);
-    return status.ullTotalPhys;
+std::optional<std::size_t> hipsycl::rt::get_physical_memory() {
+  MEMORYSTATUSEX status;
+  status.dwLength = sizeof(status);
+  GlobalMemoryStatusEx(&status);
+  return status.ullTotalPhys;
 }
 
 #else
 
-std::optional<std::size_t> hipsycl::rt::getPhysicalMemory() { return std::nullopt; }
+// Linux/BSD implementation, if not just return std::nullopt
+#ifdef __has_include
+#if __has_include(<sys/sysinfo.h>)
+#include <sys/sysinfo.h>
+#endif
+#endif
+
+std::optional<std::size_t> hipsycl::rt::get_physical_memory() {
+#ifdef __has_include
+#if __has_include(<sys/sysinfo.h>)
+  struct sysinfo info;
+  sysinfo(&info);
+  return info.totalram;
+#endif
+#endif
+  return std::nullopt;
+}
 
 #endif


### PR DESCRIPTION
This PR set the value of global_mem_size in the OpenMP device properties to be the physical memory size.

 Closes #1573

TODOs: 

- [x] Windows case
- [ ] testing ??? @illuhad What approach do you I think I should use to test this in CI if possible ?