### PR TITLE
[SSCP] Std builtins: Remap core LLVM math builtins

### DIFF
--- a/src/compiler/sscp/StdBuiltinRemapperPass.cpp
+++ b/src/compiler/sscp/StdBuiltinRemapperPass.cpp
@@ -56,6 +56,11 @@ static constexpr std::array math_builtins = {
     "sqrt",       "sqrtf",       "sqrtl",       "tan",       "tanf",       "tanl",
     "tanh",       "tanhf",       "tanhl",       "tgamma",    "tgammaf",    "tgammal"};
 
+// these are remapped for f32 and f64
+static constexpr std::array remapped_llvm_math_builtins = {
+  "sin", "cos", "sqrt"
+};
+
 using builtin_mapping = std::array<const char*, 2>;
 // We may want to complete this with soft-float functions defined here:
 // https://gcc.gnu.org/onlinedocs/gccint/Soft-float-library-routines.html
@@ -125,8 +130,13 @@ llvm::PreservedAnalyses StdBuiltinRemapperPass::run(llvm::Module &M,
       Replacements[B] = "__acpp_sscp_" + BaseName + "_" + Suffix;
     }
   }
-   for(const auto& EM : explicitly_mapped_builtins) {
+  for(const auto& EM : explicitly_mapped_builtins) {
     Replacements[EM[0]] = EM[1];
+  }
+  for(const auto& B : remapped_llvm_math_builtins) {
+    std::string builtin_name = std::string{B};
+    Replacements["llvm." + builtin_name + ".f32"] = "__acpp_sscp_" + builtin_name + "_f32";
+    Replacements["llvm." + builtin_name + ".f64"] = "__acpp_sscp_" + builtin_name + "_f64";
   }
 
   for(const auto& B: Replacements) {


### PR DESCRIPTION
We remap calls to C++ standard math functions to our `__acpp_sscp_*` math builtins. This is particularly important for stdpar and PCUDA where the normal C++ math functions are used in kernel code.

In some cases, clang will directly generate LLVM math builtin calls instead of the libc builtins that we remap. For some backends, this can cause JIT failures if the backend does not implement the particular math builtin (observed on ROCm with `llvm.cos.f64`).

To address this, this PR also remaps `llvm.sin`, `llvm.cos` and `llvm.sqrt`.