### PR TITLE
Make most grey text in the dark-mode documentation pages white

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -1,5 +1,6 @@
 #
-![The AdaptiveCpp Logo](img/logo/logo-color.png)
+![The AdaptiveCpp Logo](img/logo/logo-color.png#only-light)
+![The AdaptiveCpp Logo](img/logo/logo-color-dark.png#only-dark)
 
 Welcome to the documentation of AdaptiveCpp!
 

--- a/doc/stylesheets/extra.css
+++ b/doc/stylesheets/extra.css
@@ -3,9 +3,20 @@
   --md-accent-fg-color: #c50d29;
 }
 
+:root .md-typeset :is(h1, h2, h3, h4, h5, h6) {
+  color: #000000;
+}
+
 [data-md-color-scheme="slate"] {
   --md-primary-fg-color: #c50d29;
   --md-accent-fg-color: #c50d29;
+  --md-default-fg-color: #ffffff;
+  --md-typeset-color: #ffffff;
+  --md-code-fg-color: #ffffff;
+}
+
+[data-md-color-scheme="slate"] .md-typeset :is(h1, h2, h3, h4, h5, h6) {
+  color: #ffffff;
 }
 
 .md-nav__source {


### PR DESCRIPTION
Currently, most of the text on the dark-mode documentation pages is quite dark, which I find causes eye fatigue during longer reading sessions (which is obviously contrary to the aim of offering a dark mode version in the first place).

This pull request changes the default colour of the headings, the body text, and the code block text to white (instead of grey). It also ensures that the "dark" version of the AdaptiveCpp logo is shown on the documentation home page when it is viewed while dark mode is active.

---

![](https://github.com/user-attachments/assets/86ae1f95-e1b3-4d4b-85c9-9211adc17854)

***Top:** The dark-mode documentation pages prior to this pull request.*
***Bottom:** The dark-mode documentation pages after incorporation of this pull request.*

---