### PR TITLE
RFC: First approach to add target specific intriniscs for gfx90a targets

### DIFF
--- a/include/hipSYCL/sycl/libkernel/atomic_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/atomic_builtins.hpp
@@ -11,8 +11,9 @@
 #ifndef HIPSYCL_ATOMIC_BUILTINS_HPP
 #define HIPSYCL_ATOMIC_BUILTINS_HPP
 
-#include "hipSYCL/sycl/libkernel/backend.hpp"
-#include "hipSYCL/sycl/libkernel/detail/builtin_dispatch.hpp"
+#include "backend.hpp"
+#include "memory.hpp"
+#include "detail/builtin_dispatch.hpp"
 
 #if ACPP_LIBKERNEL_IS_DEVICE_PASS_HOST
 #include "host/atomic_builtins.hpp"
@@ -100,6 +101,14 @@ template <access::address_space S, class T>
 HIPSYCL_BUILTIN T __acpp_atomic_fetch_add(T *addr, T x, memory_order order,
                                              memory_scope scope) noexcept {
    HIPSYCL_RETURN_DISPATCH_BUILTIN(__acpp_atomic_fetch_add<S>, addr, x, order,
+                                  scope);
+}
+
+template <access::address_space S, class T>
+HIPSYCL_BUILTIN T __acpp_unsafe_atomic_fetch_add(T *addr, T x, memory_order order,
+                                             memory_scope scope) noexcept {
+   //TODO it would be better do some reflection here I think.
+   HIPSYCL_RETURN_DISPATCH_BUILTIN(__acpp_unsafe_atomic_fetch_add<S>, addr, x, order,
                                   scope);
 }
 

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/atomic_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/atomic_builtins.hpp
@@ -435,6 +435,21 @@ HIPSYCL_DEFINE_HIPLIKE_ATOMIC_INTEGRAL_NONNATIVE_OVERLOADS_AGNOSTIC(
 
 // *********************** atomic add ****************************
 
+template <access::address_space S>
+HIPSYCL_BUILTIN float __acpp_unsafe_atomic_fetch_add(float *addr, float x,
+                                                 memory_order order,
+                                                 memory_scope scope) noexcept {
+  return unsafeAtomicAdd( addr, x);
+}
+
+template <access::address_space S>
+HIPSYCL_BUILTIN double __acpp_unsafe_atomic_fetch_add(double *addr, double x,
+                                                  memory_order order,
+                                                  memory_scope scope) noexcept {
+  return unsafeAtomicAdd( addr, x);
+}
+
+
 template <access::address_space S, class T>
 HIPSYCL_HIPLIKE_BUILTIN T __acpp_atomic_fetch_add(
     T *addr, T x, memory_order order, memory_scope scope) noexcept {

--- a/include/hipSYCL/sycl/libkernel/host/atomic_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/host/atomic_builtins.hpp
@@ -250,6 +250,20 @@ HIPSYCL_BUILTIN float __acpp_atomic_fetch_add(
 }
 
 template <access::address_space S>
+HIPSYCL_BUILTIN float __acpp_unsafe_atomic_fetch_add(float *addr, float x,
+                                                 memory_order order,
+                                                 memory_scope scope) noexcept {
+  return __acpp_atomic_fetch_add<S>( addr, x, order, scope);
+}
+
+template <access::address_space S>
+HIPSYCL_BUILTIN double __acpp_unsafe_atomic_fetch_add(double *addr, double x,
+                                                  memory_order order,
+                                                  memory_scope scope) noexcept {
+  return __acpp_atomic_fetch_add<S>(addr, x,order, scope);
+}
+
+template <access::address_space S>
 HIPSYCL_BUILTIN double __acpp_atomic_fetch_add(
     double *addr, double x, memory_order order, memory_scope scope) noexcept {
   

--- a/include/hipSYCL/sycl/libkernel/sscp/atomic_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/atomic_builtins.hpp
@@ -281,7 +281,19 @@ HIPSYCL_BUILTIN double __acpp_atomic_fetch_add(double *addr, double x,
   return __acpp_sscp_atomic_fetch_add_f64(S, order, scope, addr, x);
 }
 
+template <access::address_space S>
+HIPSYCL_BUILTIN float __acpp_unsafe_atomic_fetch_add(float *addr, float x,
+                                                 memory_order order,
+                                                 memory_scope scope) noexcept {
+  return __acpp_sscp_unsafe_atomic_fetch_add_f32(S, order, scope, addr, x);
+}
 
+template <access::address_space S>
+HIPSYCL_BUILTIN double __acpp_unsafe_atomic_fetch_add(double *addr, double x,
+                                                  memory_order order,
+                                                  memory_scope scope) noexcept {
+  return __acpp_sscp_unsafe_atomic_fetch_add_f64(S, order, scope, addr, x);
+}
 
 
 template <access::address_space S, class T>

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/atomic.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/atomic.hpp
@@ -202,6 +202,15 @@ HIPSYCL_SSCP_BUILTIN __acpp_f64 __acpp_sscp_atomic_fetch_add_f64(
     __acpp_sscp_address_space as, __acpp_sscp_memory_order order,
     __acpp_sscp_memory_scope scope, __acpp_f64 *ptr, __acpp_f64 x);
 
+// Only has an effect when targeting gfx90a amdgcn
+// For other targets it will just call the regulare atomic_fetch
+HIPSYCL_SSCP_BUILTIN __acpp_f32 __acpp_sscp_unsafe_atomic_fetch_add_f32(
+    __acpp_sscp_address_space as, __acpp_sscp_memory_order order,
+    __acpp_sscp_memory_scope scope, __acpp_f32 *ptr, __acpp_f32 x);
+
+HIPSYCL_SSCP_BUILTIN __acpp_f64 __acpp_sscp_unsafe_atomic_fetch_add_f64(
+    __acpp_sscp_address_space as, __acpp_sscp_memory_order order,
+    __acpp_sscp_memory_scope scope, __acpp_f64 *ptr, __acpp_f64 x);
 
 
 HIPSYCL_SSCP_BUILTIN __acpp_int8 __acpp_sscp_atomic_fetch_sub_i8(

--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -269,7 +269,21 @@ bool LLVMToAmdgpuTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
   
   if(!this->linkBitcodeFile(M, BuiltinBitcodeFile))
     return false;
-  
+
+
+  std::string BuiltinBitcodeFileAtomicGfx90a;
+  if (TargetDevice.find("gfx90a") != std::string::npos){
+    BuiltinBitcodeFileAtomicGfx90a = common::filesystem::join_path(common::filesystem::get_install_directory(),
+      {"lib", "hipSYCL", "bitcode", "libkernel-sscp-amdgpu-amdhsa-atomic-gfx90a-full.bc"});
+  } else {
+    BuiltinBitcodeFileAtomicGfx90a = common::filesystem::join_path(common::filesystem::get_install_directory(),
+      {"lib", "hipSYCL", "bitcode", "libkernel-sscp-amdgpu-amdhsa-atomic-gfx90a_fallback-full.bc"});
+  }
+
+
+  if(!this->linkBitcodeFile(M, BuiltinBitcodeFileAtomicGfx90a))
+    return false;
+
   AddressSpaceInferencePass ASIPass {ASMap};
   ASIPass.run(M, *PH.ModuleAnalysisManager);
   

--- a/src/libkernel/sscp/amdgpu/CMakeLists.txt
+++ b/src/libkernel/sscp/amdgpu/CMakeLists.txt
@@ -21,4 +21,21 @@ if(WITH_LLVM_TO_AMDGPU_AMDHSA)
       scan_inclusive.cpp
       scan_exclusive.cpp
       ADDITIONAL_ARGS -nogpulib)
+    
+    #TODO These will generate bc files with the full prefix as well.
+    #Probably should not do that for cleanliness
+    #This should be also changed in LLVMToAmdgpu.cpp as well
+    libkernel_generate_bitcode_target(
+        TARGETNAME amdgpu-amdhsa-atomic-gfx90a 
+        TRIPLE amdgcn-amd-amdhsa
+        SOURCES 
+        atomic_gfx90a.cpp 
+        ADDITIONAL_ARGS -nogpulib -mcpu=gfx90a)
+
+    libkernel_generate_bitcode_target(
+        TARGETNAME amdgpu-amdhsa-atomic-gfx90a_fallback
+        TRIPLE amdgcn-amd-amdhsa
+        SOURCES 
+        atomic_gfx90a_fallback.cpp 
+        ADDITIONAL_ARGS -nogpulib)
 endif()

--- a/src/libkernel/sscp/amdgpu/atomic_gfx90a.cpp
+++ b/src/libkernel/sscp/amdgpu/atomic_gfx90a.cpp
@@ -1,0 +1,26 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#include "hipSYCL/sycl/libkernel/sscp/builtins/atomic.hpp"
+#include "hipSYCL/sycl/libkernel/sscp/builtins/builtin_config.hpp"
+
+
+HIPSYCL_SSCP_BUILTIN __acpp_f32 __acpp_sscp_unsafe_atomic_fetch_add_f32(
+  __acpp_sscp_address_space as, __acpp_sscp_memory_order order,
+  __acpp_sscp_memory_scope scope, __acpp_f32 *ptr, __acpp_f32 x) {
+  return __builtin_amdgcn_global_atomic_fadd_f64(ptr, x);
+}
+
+HIPSYCL_SSCP_BUILTIN __acpp_f64 __acpp_sscp_unsafe_atomic_fetch_add_f64(
+  __acpp_sscp_address_space as, __acpp_sscp_memory_order order,
+  __acpp_sscp_memory_scope scope, __acpp_f64 *ptr, __acpp_f64 x) {
+  return __builtin_amdgcn_global_atomic_fadd_f32(ptr, x);
+}
+

--- a/src/libkernel/sscp/amdgpu/atomic_gfx90a_fallback.cpp
+++ b/src/libkernel/sscp/amdgpu/atomic_gfx90a_fallback.cpp
@@ -1,0 +1,79 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#include "hipSYCL/sycl/libkernel/sscp/builtins/atomic.hpp"
+#include "hipSYCL/sycl/libkernel/sscp/builtins/builtin_config.hpp"
+
+//TODO: This should go to a common header if this approach will be used in production
+inline constexpr int builtin_memory_order(__acpp_sscp_memory_order o) noexcept {
+  switch(o){
+    case __acpp_sscp_memory_order::relaxed:
+      return __ATOMIC_RELAXED;
+    case __acpp_sscp_memory_order::acquire:
+      return __ATOMIC_ACQUIRE;
+    case __acpp_sscp_memory_order::release:
+      return __ATOMIC_RELEASE;
+    case __acpp_sscp_memory_order::acq_rel:
+      return __ATOMIC_ACQ_REL;
+    case __acpp_sscp_memory_order::seq_cst:
+      return __ATOMIC_SEQ_CST;
+  }
+  return __ATOMIC_RELAXED;
+}
+
+#ifndef __HIP_MEMORY_SCOPE_SINGLETHREAD
+ #define __HIP_MEMORY_SCOPE_SINGLETHREAD 1
+#endif
+
+#ifndef __HIP_MEMORY_SCOPE_WAVEFRONT
+ #define __HIP_MEMORY_SCOPE_WAVEFRONT 2
+#endif
+
+#ifndef __HIP_MEMORY_SCOPE_WORKGROUP
+ #define __HIP_MEMORY_SCOPE_WORKGROUP 3
+#endif
+
+#ifndef __HIP_MEMORY_SCOPE_AGENT
+ #define __HIP_MEMORY_SCOPE_AGENT 4
+#endif
+
+#ifndef __HIP_MEMORY_SCOPE_SYSTEM
+ #define __HIP_MEMORY_SCOPE_SYSTEM 5
+#endif
+
+inline constexpr int builtin_memory_scope(__acpp_sscp_memory_scope s) noexcept {
+  switch(s) {
+    case __acpp_sscp_memory_scope::work_item:
+      return __HIP_MEMORY_SCOPE_SINGLETHREAD;
+    case __acpp_sscp_memory_scope::sub_group:
+      return __HIP_MEMORY_SCOPE_WAVEFRONT;
+    case __acpp_sscp_memory_scope::work_group:
+      return __HIP_MEMORY_SCOPE_WORKGROUP;
+    case __acpp_sscp_memory_scope::device:
+      return __HIP_MEMORY_SCOPE_AGENT;
+    case __acpp_sscp_memory_scope::system:
+      return __HIP_MEMORY_SCOPE_SYSTEM;
+  }
+}
+
+HIPSYCL_SSCP_BUILTIN __acpp_f32 __acpp_sscp_unsafe_atomic_fetch_add_f32(
+    __acpp_sscp_address_space as, __acpp_sscp_memory_order order,
+    __acpp_sscp_memory_scope scope, __acpp_f32 *ptr, __acpp_f32 x) {
+    return __hip_atomic_fetch_add(ptr, x, builtin_memory_order(order),
+                                builtin_memory_scope(scope));(ptr, x);
+}
+
+HIPSYCL_SSCP_BUILTIN __acpp_f64 __acpp_sscp_unsafe_atomic_fetch_add_f64(
+    __acpp_sscp_address_space as, __acpp_sscp_memory_order order,
+    __acpp_sscp_memory_scope scope, __acpp_f64 *ptr, __acpp_f64 x) {
+    return __hip_atomic_fetch_add(ptr, x, builtin_memory_order(order),
+                                builtin_memory_scope(scope));
+}
+

--- a/src/libkernel/sscp/host/atomic.cpp
+++ b/src/libkernel/sscp/host/atomic.cpp
@@ -265,9 +265,6 @@ HIPSYCL_SSCP_BUILTIN __acpp_int64 __acpp_sscp_atomic_fetch_xor_i64(
 }
 
 
-
-// TODO: It seems that at least on gfx90a, there are additional unsafe atomic
-// operations that can yield a performance improvement. Should we expose those?
 HIPSYCL_SSCP_BUILTIN __acpp_int8 __acpp_sscp_atomic_fetch_add_i8(
     __acpp_sscp_address_space as, __acpp_sscp_memory_order order,
     __acpp_sscp_memory_scope scope, __acpp_int8 *ptr, __acpp_int8 x) {
@@ -328,6 +325,17 @@ HIPSYCL_SSCP_BUILTIN __acpp_f64 __acpp_sscp_atomic_fetch_add_f64(
   return __atomic_fetch_add(ptr, x, builtin_memory_order(order));
 }
 
+HIPSYCL_SSCP_BUILTIN __acpp_f32 __acpp_sscp_unsafe_atomic_fetch_add_f32(
+    __acpp_sscp_address_space as, __acpp_sscp_memory_order order,
+    __acpp_sscp_memory_scope scope, __acpp_f32 *ptr, __acpp_f32 x) {
+    return  __acpp_sscp_atomic_fetch_add_f32(as, order, scope, ptr, x);
+}
+
+HIPSYCL_SSCP_BUILTIN __acpp_f64 __acpp_sscp_unsafe_atomic_fetch_add_f64(
+    __acpp_sscp_address_space as, __acpp_sscp_memory_order order,
+    __acpp_sscp_memory_scope scope, __acpp_f64 *ptr, __acpp_f64 x) {
+    return  __acpp_sscp_atomic_fetch_add_f64(as, order, scope, ptr, x);
+}
 
 
 HIPSYCL_SSCP_BUILTIN __acpp_int8 __acpp_sscp_atomic_fetch_sub_i8(

--- a/src/libkernel/sscp/ptx/atomic.cpp
+++ b/src/libkernel/sscp/ptx/atomic.cpp
@@ -993,6 +993,17 @@ HIPSYCL_SSCP_BUILTIN __acpp_f64 __acpp_sscp_atomic_fetch_add_f64(
   }
 }
 
+HIPSYCL_SSCP_BUILTIN __acpp_f32 __acpp_sscp_unsafe_atomic_fetch_add_f32(
+    __acpp_sscp_address_space as, __acpp_sscp_memory_order order,
+    __acpp_sscp_memory_scope scope, __acpp_f32 *ptr, __acpp_f32 x) {
+    return  __acpp_sscp_atomic_fetch_add_f32(as, order, scope, ptr, x);
+}
+
+HIPSYCL_SSCP_BUILTIN __acpp_f64 __acpp_sscp_unsafe_atomic_fetch_add_f64(
+    __acpp_sscp_address_space as, __acpp_sscp_memory_order order,
+    __acpp_sscp_memory_scope scope, __acpp_f64 *ptr, __acpp_f64 x) {
+    return  __acpp_sscp_atomic_fetch_add_f64(as, order, scope, ptr, x);
+}
 
 
 HIPSYCL_SSCP_BUILTIN __acpp_int8 __acpp_sscp_atomic_fetch_sub_i8(

--- a/src/libkernel/sscp/spirv/atomic.cpp
+++ b/src/libkernel/sscp/spirv/atomic.cpp
@@ -495,6 +495,17 @@ HIPSYCL_SSCP_BUILTIN __acpp_f64 __acpp_sscp_atomic_fetch_add_f64(
   ADDRESS_SPACE_SWITCH(as, ptr, RETURN_ATOMIC_FADD);
 }
 
+HIPSYCL_SSCP_BUILTIN __acpp_f32 __acpp_sscp_unsafe_atomic_fetch_add_f32(
+    __acpp_sscp_address_space as, __acpp_sscp_memory_order order,
+    __acpp_sscp_memory_scope scope, __acpp_f32 *ptr, __acpp_f32 x) {
+    return  __acpp_sscp_atomic_fetch_add_f32(as, order, scope, ptr, x);
+}
+
+HIPSYCL_SSCP_BUILTIN __acpp_f64 __acpp_sscp_unsafe_atomic_fetch_add_f64(
+    __acpp_sscp_address_space as, __acpp_sscp_memory_order order,
+    __acpp_sscp_memory_scope scope, __acpp_f64 *ptr, __acpp_f64 x) {
+    return  __acpp_sscp_atomic_fetch_add_f64(as, order, scope, ptr, x);
+}
 
 #define RETURN_ATOMIC_ISUB(ptr)                                                \
   return __spirv_AtomicISub(ptr, get_spirv_scope(scope),                       \


### PR DESCRIPTION
This MR is an initial experimental approach to add target specific sscp builtins. In particular the hip unsafe atomics is exposed through the ` hipsycl::sycl::detail::__acpp_unsafe_atomic_fetch_add` function. It could be used by calling into AdaptiveCpp details the following way:

```
q.parallel_for(a.size(), [=](sycl::id<1> idx){
    constexpr auto global_adress_space = hipsycl::sycl::access::address_space::global_space;
    constexpr auto global_memory_scope = hipsycl::sycl::memory_scope::device;
    hipsycl::sycl::detail::__acpp_unsafe_atomic_fetch_add<global_adress_space>(&dev_a[0], 4.5f, relaxed_memory_order, global_memory_scope);
  });
```

