### PR TITLE
Be more robust in case of absent SSCP OpenMP support

### DIFF
--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -307,7 +307,7 @@ if(WITH_CPU_BACKEND)
     omp/omp_hardware_manager.cpp
     omp/omp_queue.cpp)
 
-  if(TARGET omp) # ACPP_LLVM_COMPONENT with openmp active
+  if(TARGET omp AND ACPP_LLVM_COMPONENT) # ACPP_LLVM_COMPONENT with openmp active
     set(OpenMP_CXX_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR})
     get_target_property(hipSYCL_OpenMP_CXX_LIBRARIES omp LINK_LIBRARIES)
     string(JOIN " " hipSYCL_OpenMP_CXX_LIBRARIES ${hipSYCL_OpenMP_CXX_LIBRARIES})

--- a/src/runtime/omp/omp_queue.cpp
+++ b/src/runtime/omp/omp_queue.cpp
@@ -34,6 +34,12 @@
 #include "hipSYCL/runtime/adaptivity_engine.hpp"
 #include "hipSYCL/runtime/omp/omp_code_object.hpp"
 
+#ifndef WIN32 // MSVC might not have #warning?
+#ifndef _OPENMP
+#warning Building omp backend with JIT support, but OpenMP parallelization is not available - kernels will run sequentially! This points to an issue in the build system.
+#endif
+#endif
+
 #ifndef WIN32
 #include <unistd.h>
 #else


### PR DESCRIPTION
It seems that in some cases, after we do `find_package(LLVM)`, `if(TARGET omp)` evaluates to true.

When building the OpenMP backend, this causes us to enter the path for the linking-into-LLVM case. But if we do a standard clang plugin build, this causes the OpenMP backend to not be built with `-fopenmp`. This in turn causes SSCP kernels on the host to not be parallelized.

Now, I tried reproducing this in a clean build directory and couldn't. So presumably there's something stuck in the build directory where I observed this issue. But since this build directory also was never used for a linking-into-LLVM build, this is still very concerning. I don't have an understanding yet *why* exactly `find_package(LLVM)` defines the `omp` target in the problematic case.

This PR does two things to remedy the situation for the upcoming 25.02 release:
- Only enter the linking-into-LLVM code path if *both* `TARGET omp` *and* `ACPP_LLVM_COMPONENT` evaluates to true
- Add a compile-time warning if we do a build with SSCP enabled where the `omp` backend is built without OpenMP support. This should allow us to notice more easily if the issue appears again.
