### PR TITLE
[SSCP] Add experimental device support for assert()

### DIFF
--- a/include/hipSYCL/compiler/sscp/DeviceAssertPass.hpp
+++ b/include/hipSYCL/compiler/sscp/DeviceAssertPass.hpp
@@ -1,0 +1,31 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#ifndef ACPP_DEVICE_ASSERT_PASS_HPP
+#define ACPP_DEVICE_ASSERT_PASS_HPP
+
+#include <llvm/IR/PassManager.h>
+
+namespace hipsycl {
+namespace compiler {
+
+class DeviceAssertPass : public llvm::PassInfoMixin<DeviceAssertPass> {
+public:
+  llvm::PreservedAnalyses run(llvm::Module &M,
+                              llvm::ModuleAnalysisManager &MAM);
+
+};
+
+}
+}
+
+
+#endif
+

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/assert.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/assert.hpp
@@ -1,0 +1,25 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#ifndef HIPSYCL_SSCP_BUILTINS_ASSERT_HPP
+#define HIPSYCL_SSCP_BUILTINS_ASSERT_HPP
+
+#include "builtin_config.hpp"
+
+HIPSYCL_SSCP_BUILTIN void __acpp_sscp_assert_fail(const char *assertion,
+                                                  const char *file,
+                                                  __acpp_uint32 line,
+                                                  const char *function);
+
+HIPSYCL_SSCP_BUILTIN void
+__acpp_sscp_glibcxx_assert_fail(const char *file, __acpp_int32 line,
+                                const char *function, const char *assertion);
+
+#endif

--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -66,6 +66,7 @@ if(WITH_SSCP_COMPILER)
     sscp/AggregateArgumentExpansionPass.cpp
     sscp/StdBuiltinRemapperPass.cpp
     sscp/StdAtomicRemapperPass.cpp
+    sscp/DeviceAssertPass.cpp
     sscp/pcuda/FreeKernelCall.cpp
     sscp/pcuda/StaticLocalMemoryPass.cpp
     sscp/pcuda/ExternDynamicLocalMemoryPass.cpp)

--- a/src/compiler/sscp/DeviceAssertPass.cpp
+++ b/src/compiler/sscp/DeviceAssertPass.cpp
@@ -1,0 +1,112 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#include "hipSYCL/compiler/sscp/DeviceAssertPass.hpp"
+
+
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/InstrTypes.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
+
+
+namespace hipsycl {
+namespace compiler {
+
+namespace {
+
+llvm::Type* getCharPtrType(llvm::Module* M, unsigned AS = 0) {
+#if LLVM_VERSION_MAJOR >= 16
+    return llvm::PointerType::get(M->getContext(), AS);
+#else
+    return llvm::PointerType::get(llvm::Type::getInt8Ty(M->getContext()), AS);
+#endif
+}
+
+// void __assert_fail(const char * assertion, const char * file, unsigned int line, const char * function);
+// void  __glibcxx_assert_fail(const char* __file, int __line, const char* __function, const char* __condition)
+//_ZSt21__glibcxx_assert_failPKciS0_S0_(ptr noundef, i32 noundef, ptr noundef, ptr noundef) local_unnamed_addr #0
+
+static const char* AssertFailBuiltinName = "__acpp_sscp_assert_fail";
+static const char* GlibcxxAssertFailBuiltinName = "__acpp_sscp_glibcxx_assert_fail";
+
+llvm::Function* getAssertFailBuiltin(llvm::Module& M) {
+  if(auto* F = M.getFunction(AssertFailBuiltinName))
+    return F;
+  else {
+    llvm::SmallVector<llvm::Type*> ParamTs;
+    // assertion
+    ParamTs.push_back(getCharPtrType(&M));
+    // file
+    ParamTs.push_back(getCharPtrType(&M));
+    // line
+    ParamTs.push_back(llvm::Type::getInt32Ty(M.getContext()));
+    // function name
+    ParamTs.push_back(getCharPtrType(&M));
+
+    auto FC = M.getOrInsertFunction(AssertFailBuiltinName,
+                                    llvm::FunctionType::get(llvm::Type::getVoidTy(M.getContext()),
+                                                            llvm::ArrayRef<llvm::Type *>{ParamTs},
+                                                            false));
+    llvm::Function *NewDeclaration = llvm::dyn_cast<llvm::Function>(FC.getCallee());
+    NewDeclaration->setLinkage(llvm::GlobalValue::LinkageTypes::ExternalLinkage);
+    return NewDeclaration;
+  }
+}
+
+llvm::Function* getGlibcxxAssertFailBuiltin(llvm::Module& M) {
+  if(auto* F = M.getFunction(GlibcxxAssertFailBuiltinName))
+    return F;
+  else {
+    llvm::SmallVector<llvm::Type*> ParamTs;
+    // file
+    ParamTs.push_back(getCharPtrType(&M));
+    // line
+    ParamTs.push_back(llvm::Type::getInt32Ty(M.getContext()));
+    // function name
+    ParamTs.push_back(getCharPtrType(&M));
+    // assertion
+    ParamTs.push_back(getCharPtrType(&M));
+
+    auto FC = M.getOrInsertFunction(GlibcxxAssertFailBuiltinName,
+                                    llvm::FunctionType::get(llvm::Type::getVoidTy(M.getContext()),
+                                                            llvm::ArrayRef<llvm::Type *>{ParamTs},
+                                                            false));
+    llvm::Function *NewDeclaration = llvm::dyn_cast<llvm::Function>(FC.getCallee());
+    NewDeclaration->setLinkage(llvm::GlobalValue::LinkageTypes::ExternalLinkage);
+    return NewDeclaration;
+  }
+}
+
+void replaceAssertFunction(llvm::Module &M, llvm::StringRef FunctionName,
+                           llvm::Function *Replacement) {
+  if(auto* F = M.getFunction(FunctionName)) {
+    F->replaceAllUsesWith(Replacement);
+    F->dropAllReferences();
+    F->eraseFromParent();
+  }
+}
+
+} // namespace
+
+llvm::PreservedAnalyses DeviceAssertPass::run(llvm::Module &M,
+                                            llvm::ModuleAnalysisManager &MAM) {
+
+  static const char* OriginalAssertFail = "__assert_fail";
+  static const char* OriginalGlibcxxAssertFail = "_ZSt21__glibcxx_assert_failPKciS0_S0_";
+  replaceAssertFunction(M, OriginalAssertFail, getAssertFailBuiltin(M));
+  replaceAssertFunction(M, OriginalGlibcxxAssertFail, getGlibcxxAssertFailBuiltin(M));
+
+  return llvm::PreservedAnalyses::none();
+}
+}
+}
+

--- a/src/compiler/sscp/TargetSeparationPass.cpp
+++ b/src/compiler/sscp/TargetSeparationPass.cpp
@@ -17,6 +17,7 @@
 #include "hipSYCL/compiler/sscp/StdBuiltinRemapperPass.hpp"
 #include "hipSYCL/compiler/sscp/DynamicFunctionSupport.hpp"
 #include "hipSYCL/compiler/sscp/StdAtomicRemapperPass.hpp"
+#include "hipSYCL/compiler/sscp/DeviceAssertPass.hpp"
 #include "hipSYCL/compiler/CompilationState.hpp"
 #include "hipSYCL/compiler/cbs/IRUtils.hpp"
 #include "hipSYCL/compiler/sscp/pcuda/ExternDynamicLocalMemoryPass.hpp"
@@ -255,6 +256,9 @@ std::unique_ptr<llvm::Module> generateDeviceIR(llvm::Module &M,
   // Remap atomics
   StdAtomicRemapperPass SAMP;
   SAMP.run(*DeviceModule, DeviceMAM);
+  // Handle assert() in device code
+  DeviceAssertPass DAP;
+  DAP.run(*DeviceModule, DeviceMAM);
 
   // Fix attributes for generic IR representation
   llvm::SmallVector<llvm::Attribute::AttrKind, 16> AttrsToRemove;

--- a/src/libkernel/sscp/amdgpu/CMakeLists.txt
+++ b/src/libkernel/sscp/amdgpu/CMakeLists.txt
@@ -3,6 +3,7 @@ if(WITH_LLVM_TO_AMDGPU_AMDHSA)
       TARGETNAME amdgpu-amdhsa 
       TRIPLE amdgcn-amd-amdhsa
       SOURCES 
+      assert.cpp
       atomic.cpp 
       barrier.cpp 
       core.cpp

--- a/src/libkernel/sscp/amdgpu/assert.cpp
+++ b/src/libkernel/sscp/amdgpu/assert.cpp
@@ -1,0 +1,40 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "hipSYCL/sycl/libkernel/sscp/builtins/assert.hpp"
+#include "hipSYCL/sycl/libkernel/sscp/builtins/print.hpp"
+#include "hipSYCL/sycl/libkernel/sscp/builtins/builtin_config.hpp"
+
+
+HIPSYCL_SSCP_BUILTIN void __acpp_sscp_assert_fail(const char *assertion,
+                                                  const char *file,
+                                                  __acpp_uint32 line,
+                                                  const char *function) {
+  __acpp_sscp_print("[AdaptiveCpp][amdgpu] device assertion '");
+  __acpp_sscp_print(assertion);
+  __acpp_sscp_print("' failed in file '");
+  __acpp_sscp_print(file);
+  __acpp_sscp_print("', function '");
+  __acpp_sscp_print(function);
+  __acpp_sscp_print("' (kernel abortion is not yet supported for this target)\n");
+}
+
+HIPSYCL_SSCP_BUILTIN void
+__acpp_sscp_glibcxx_assert_fail(const char *file, __acpp_int32 line,
+                                const char *function, const char *assertion) {
+  __acpp_sscp_print("[AdaptiveCpp][amdgpu] GLIBCXX device assertion '");
+  __acpp_sscp_print(assertion);
+  __acpp_sscp_print("' failed in file '");
+  __acpp_sscp_print(file);
+  __acpp_sscp_print("', function '");
+  __acpp_sscp_print(function);
+  __acpp_sscp_print("' (kernel abortion is not yet supported for this target)\n");
+}

--- a/src/libkernel/sscp/host/CMakeLists.txt
+++ b/src/libkernel/sscp/host/CMakeLists.txt
@@ -4,6 +4,7 @@ if(WITH_LLVM_TO_HOST)
   endif()
 
   set(HOST_LIBKERNEL_BITCODE_SOURCES
+    assert.cpp
     atomic.cpp
     barrier.cpp
     core.cpp

--- a/src/libkernel/sscp/host/assert.cpp
+++ b/src/libkernel/sscp/host/assert.cpp
@@ -1,0 +1,37 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "hipSYCL/sycl/libkernel/sscp/builtins/assert.hpp"
+#include "hipSYCL/sycl/libkernel/sscp/builtins/builtin_config.hpp"
+
+#include <cstdlib>
+#include <cstdio>
+
+HIPSYCL_SSCP_BUILTIN void __acpp_sscp_assert_fail(const char *assertion,
+                                                  const char *file,
+                                                  __acpp_uint32 line,
+                                                  const char *function) {
+  printf("[AdaptiveCpp][host] device assertion '%s' failed in file '%s', "
+         "function '%s', line '%d'\n",
+         assertion, file, function, line);
+  std::abort();
+  __builtin_unreachable();
+}
+
+HIPSYCL_SSCP_BUILTIN void
+__acpp_sscp_glibcxx_assert_fail(const char *file, __acpp_int32 line,
+                                const char *function, const char *assertion) {
+  printf("[AdaptiveCpp][host] GLIBCXX device assertion %s failed in file '%s', "
+         "function '%s', line '%d'\n",
+         assertion, file, function, line);
+  std::abort();
+  __builtin_unreachable();
+}

--- a/src/libkernel/sscp/ptx/CMakeLists.txt
+++ b/src/libkernel/sscp/ptx/CMakeLists.txt
@@ -7,6 +7,7 @@ if(WITH_LLVM_TO_PTX)
       TARGETNAME ptx 
       TRIPLE nvptx64-nvidia-cuda
       SOURCES 
+      assert.cpp
       atomic.cpp
       barrier.cpp
       core.cpp

--- a/src/libkernel/sscp/ptx/assert.cpp
+++ b/src/libkernel/sscp/ptx/assert.cpp
@@ -1,0 +1,44 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "hipSYCL/sycl/libkernel/sscp/builtins/assert.hpp"
+#include "hipSYCL/sycl/libkernel/sscp/builtins/print.hpp"
+#include "hipSYCL/sycl/libkernel/sscp/builtins/builtin_config.hpp"
+
+
+HIPSYCL_SSCP_BUILTIN void __acpp_sscp_assert_fail(const char *assertion,
+                                                  const char *file,
+                                                  __acpp_uint32 line,
+                                                  const char *function) {
+  __acpp_sscp_print("[AdaptiveCpp][ptx] device assertion '");
+  __acpp_sscp_print(assertion);
+  __acpp_sscp_print("' failed in file '");
+  __acpp_sscp_print(file);
+  __acpp_sscp_print("', function '");
+  __acpp_sscp_print(function);
+  __acpp_sscp_print("'\n");
+  asm("trap;");
+  __builtin_unreachable();
+}
+
+HIPSYCL_SSCP_BUILTIN void
+__acpp_sscp_glibcxx_assert_fail(const char *file, __acpp_int32 line,
+                                const char *function, const char *assertion) {
+  __acpp_sscp_print("[AdaptiveCpp][ptx] GLIBCXX device assertion '");
+  __acpp_sscp_print(assertion);
+  __acpp_sscp_print("' failed in file '");
+  __acpp_sscp_print(file);
+  __acpp_sscp_print("', function '");
+  __acpp_sscp_print(function);
+  __acpp_sscp_print("'\n");
+  asm("trap;");
+  __builtin_unreachable();
+}

--- a/src/libkernel/sscp/spirv/CMakeLists.txt
+++ b/src/libkernel/sscp/spirv/CMakeLists.txt
@@ -4,6 +4,7 @@ if(WITH_LLVM_TO_SPIRV)
       TARGETNAME spirv 
       TRIPLE spir64-unknown-unknown
       SOURCES 
+      assert.cpp
       atomic.cpp
       barrier.cpp
       core.cpp

--- a/src/libkernel/sscp/spirv/assert.cpp
+++ b/src/libkernel/sscp/spirv/assert.cpp
@@ -1,0 +1,42 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "hipSYCL/sycl/libkernel/sscp/builtins/assert.hpp"
+#include "hipSYCL/sycl/libkernel/sscp/builtins/builtin_config.hpp"
+
+template <typename... Args>
+extern int __spirv_ocl_printf(const char *Format, Args... args);
+
+static const char assert_fail_string[] =
+    "[AdaptiveCpp][spirv] device assertion '%s' failed in file '%s', function '%s', "
+    "line %d (kernel abortion is unsupported on this target)\n";
+
+static const char glibcxx_assert_fail_string[] =
+    "[AdaptiveCpp][spirv] GLIBCXX device assertion '%s' failed in file '%s', "
+    "function '%s', "
+    "line '%d' (kernel abortion is unsupported on this target)\n";
+
+HIPSYCL_SSCP_BUILTIN void __acpp_sscp_assert_fail(const char *assertion,
+                                                  const char *file,
+                                                  __acpp_uint32 line,
+                                                  const char *function) {
+  // It seems that printf is incorrectly handled by Intel CPU OpenCL
+  // let's ignore for now.
+  //__spirv_ocl_printf(assert_fail_string, assertion, file, function, line);
+}
+
+HIPSYCL_SSCP_BUILTIN void
+__acpp_sscp_glibcxx_assert_fail(const char *file, __acpp_int32 line,
+                                const char *function, const char *assertion) {
+  // It seems that printf is incorrectly handled by Intel CPU OpenCL
+  // let's ignore for now.
+  //__spirv_ocl_printf(glibcxx_assert_fail_string, assertion, file, function, line);
+}

--- a/tests/compiler/sscp/assert.cpp
+++ b/tests/compiler/sscp/assert.cpp
@@ -1,0 +1,34 @@
+// RUN: %acpp %s -o %t --acpp-targets=generic
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s -o %t --acpp-targets=generic -O3
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s -o %t --acpp-targets=generic -O3 -ffast-math
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s -o %t --acpp-targets=generic -g
+// RUN: %t | FileCheck %s
+
+#include <iostream>
+#include <cassert>
+#include <sycl/sycl.hpp>
+#include "common.hpp"
+
+
+#include <sycl/sycl.hpp>
+
+int main() {
+  sycl::queue q = get_queue();
+
+
+  auto const x = sycl::malloc_shared<int>(1, q);
+  *x = 32;
+
+  q.submit(
+      [&](sycl::handler &cgh) { cgh.single_task([=]() { assert(x[0] == 32); x[0] += 1; }); });
+
+  q.wait();
+  // CHECK: 33
+  std::cout << *x << std::endl;
+
+  sycl::free(x, q);
+  return 0;
+}


### PR DESCRIPTION
Add device `assert()` support for the generic SSCP compiler.

* Supports both normal `__assert_fail` from `assert()` as well as `std::__glibcxx_assert_fail` as used inside libstdc++
* Behavior of assert failure is backend specific:
   - On `omp`, the error is printed and the application aborted
   - On `cuda`, the error is printed and the kernel aborted
   - On `hip`, the error is printed, and then the kernel enters UB (is there a way to abort kernels on AMD?)
   - On `ocl/ze`, there seems to be an issue with the SPIR-V `printf` builtin on the Intel OpenCL CPU runtime which we use in CI. So we cannot even print :( The kernel just enters UB if the assertion failure is triggered.

Fixes #1795 