### PR TITLE
[SSCP][PCUDA][SYCL 2020] Add atomic memory fence support

### DIFF
--- a/doc/pcuda.md
+++ b/doc/pcuda.md
@@ -235,6 +235,7 @@ Supported features in device code include:
 |`__syncwarp` | |
 | Math functions from `<math.h>`/`<cmath>` | |
 | CUDA/HIP vector types | |
+|`__threadfence[_system,_block]` | |
 |`atomicAdd[_system,_block]` | `int`, `uint`, `ull`, `float`, `double` types |
 |`atomicSub[_system,_block]` | `int`, `uint` types |
 |`atomicExch[_system,_block]` | `int`, `uint`, `ull`, `float` types |

--- a/include/hipSYCL/pcuda/pcuda.hpp
+++ b/include/hipSYCL/pcuda/pcuda.hpp
@@ -170,6 +170,21 @@ inline void __syncwarp() {
       __acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed));
 }
 
+inline void __threadfence() {
+  PCUDA_BUILTIN_CALL(__acpp_sscp_memory_fence(
+      __acpp_sscp_memory_scope::device, __acpp_sscp_memory_order::seq_cst));
+}
+
+inline void __threadfence_system() {
+  PCUDA_BUILTIN_CALL(__acpp_sscp_memory_fence(
+      __acpp_sscp_memory_scope::system, __acpp_sscp_memory_order::seq_cst));
+}
+
+inline void __threadfence_block() {
+  PCUDA_BUILTIN_CALL(__acpp_sscp_memory_fence(
+      __acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::seq_cst));
+}
+
 ///////////////// Kernel launch mechanisms ////////////////////
 
 struct __pcuda_dummy_configuration_t {};

--- a/include/hipSYCL/sycl/libkernel/atomic_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/atomic_builtins.hpp
@@ -124,6 +124,10 @@ HIPSYCL_BUILTIN T __acpp_atomic_fetch_max(T *addr, T x, memory_order order,
                                   scope);
 }
 
+HIPSYCL_BUILTIN void __acpp_atomic_fence(memory_order order, memory_scope scope){
+  HIPSYCL_DISPATCH_BUILTIN(__acpp_atomic_fence, order, scope);
+} 
+
 
 }
 }

--- a/include/hipSYCL/sycl/libkernel/atomic_ref.hpp
+++ b/include/hipSYCL/sycl/libkernel/atomic_ref.hpp
@@ -42,6 +42,11 @@ struct memory_order_traits<memory_order::seq_cst> {
 };
 
 
+inline void atomic_fence(memory_order order, memory_scope scope) {
+  detail::__acpp_atomic_fence(order, scope);
+}
+
+
 template <typename T, memory_order DefaultOrder, memory_scope DefaultScope,
           access::address_space Space = access::address_space::generic_space>
 class atomic_ref {

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/atomic_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/atomic_builtins.hpp
@@ -596,6 +596,16 @@ __acpp_atomic_fetch_max(double *addr, double x, memory_order order,
       addr, old, x, order, order, scope));
   return x;
 }
+
+HIPSYCL_BUILTIN void __acpp_atomic_fence(memory_order order, memory_scope scope){
+  if(scope == memory_scope::system)
+    __threadfence_system();
+  else if (scope == memory_scope::device)
+    __threadfence();
+  else if (scope == memory_scope::work_group)
+    __threadfence_block();
+} 
+
 }
 }
 }

--- a/include/hipSYCL/sycl/libkernel/host/atomic_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/host/atomic_builtins.hpp
@@ -311,6 +311,11 @@ HIPSYCL_BUILTIN T __acpp_atomic_fetch_max(T *addr, T x, memory_order order,
   return x;
 }
 
+HIPSYCL_BUILTIN void __acpp_atomic_fence(memory_order order,
+                                         memory_scope scope) noexcept {
+  __atomic_thread_fence(builtin_memory_order(order));
+}
+
 }
 }
 }

--- a/include/hipSYCL/sycl/libkernel/sscp/atomic_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/atomic_builtins.hpp
@@ -20,6 +20,7 @@
 #if ACPP_LIBKERNEL_IS_DEVICE_PASS_SSCP
 
 #include "builtins/atomic.hpp"
+#include "builtins/barrier.hpp"
 
 namespace hipsycl {
 namespace sycl {
@@ -464,7 +465,10 @@ HIPSYCL_BUILTIN double __acpp_atomic_fetch_max(double *addr, double x,
   return __acpp_sscp_atomic_fetch_max_f64(S, order, scope, addr, x);
 }
 
-
+HIPSYCL_BUILTIN void __acpp_atomic_fence(memory_order order,
+                                         memory_scope scope) noexcept {
+  __acpp_sscp_memory_fence(scope, order);
+}
 
 #undef return_cast
 

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/barrier.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/barrier.hpp
@@ -20,4 +20,8 @@ HIPSYCL_SSCP_CONVERGENT_BUILTIN void
 __acpp_sscp_sub_group_barrier(__acpp_sscp_memory_scope fence_scope,
                               __acpp_sscp_memory_order);
 
+HIPSYCL_SSCP_BUILTIN
+void __acpp_sscp_memory_fence(__acpp_sscp_memory_scope scope,
+                              __acpp_sscp_memory_order order);
+
 #endif

--- a/src/libkernel/sscp/amdgpu/barrier.cpp
+++ b/src/libkernel/sscp/amdgpu/barrier.cpp
@@ -92,3 +92,9 @@ __acpp_sscp_sub_group_barrier(__acpp_sscp_memory_scope fence_scope,
 
   __acpp_amdgpu_mem_fence(fence_scope, order);
 }
+
+HIPSYCL_SSCP_BUILTIN
+void __acpp_sscp_memory_fence(__acpp_sscp_memory_scope scope,
+                              __acpp_sscp_memory_order order) {
+  __acpp_amdgpu_mem_fence(scope, order);
+}

--- a/src/libkernel/sscp/host/barrier.cpp
+++ b/src/libkernel/sscp/host/barrier.cpp
@@ -9,6 +9,7 @@
  */
 // SPDX-License-Identifier: BSD-2-Clause
 #include "hipSYCL/sycl/libkernel/sscp/builtins/barrier.hpp"
+#include "hipSYCL/sycl/libkernel/sscp/builtins/builtin_config.hpp"
 
 extern "C" [[clang::convergent]] void __acpp_cbs_barrier();
 
@@ -34,4 +35,22 @@ __acpp_sscp_sub_group_barrier(__acpp_sscp_memory_scope fence_scope,
                               __acpp_sscp_memory_order order) {
 
   __acpp_cpu_mem_fence(fence_scope, order);
+}
+
+
+HIPSYCL_SSCP_BUILTIN
+void __acpp_sscp_memory_fence(__acpp_sscp_memory_scope scope,
+                              __acpp_sscp_memory_order order) {
+  int fence_order = __ATOMIC_RELAXED;
+
+  if(order == __acpp_sscp_memory_order::acq_rel)
+    fence_order = __ATOMIC_ACQ_REL;
+  else if(order == __acpp_sscp_memory_order::acquire)
+    fence_order = __ATOMIC_ACQUIRE;
+  else if(order == __acpp_sscp_memory_order::release)
+    fence_order = __ATOMIC_RELEASE;
+  else if(order == __acpp_sscp_memory_order::seq_cst)
+    fence_order = __ATOMIC_SEQ_CST;
+
+  __atomic_thread_fence(fence_order);
 }

--- a/src/libkernel/sscp/ptx/barrier.cpp
+++ b/src/libkernel/sscp/ptx/barrier.cpp
@@ -14,9 +14,9 @@ HIPSYCL_SSCP_CONVERGENT_BUILTIN void
 __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope fence_scope,
                                __acpp_sscp_memory_order) {
 
-  if(fence_scope == hipsycl::sycl::memory_scope::system) {
+  if(fence_scope == __acpp_sscp_memory_scope::system) {
     __nvvm_membar_sys();
-  } else if(fence_scope == hipsycl::sycl::memory_scope::device) {
+  } else if(fence_scope == __acpp_sscp_memory_scope::device) {
     __nvvm_membar_gl();
   }
   // syncthreads is already a clang builtin
@@ -27,11 +27,11 @@ HIPSYCL_SSCP_CONVERGENT_BUILTIN void
 __acpp_sscp_sub_group_barrier(__acpp_sscp_memory_scope fence_scope,
                               __acpp_sscp_memory_order) {
 
-  if(fence_scope == hipsycl::sycl::memory_scope::system) {
+  if(fence_scope == __acpp_sscp_memory_scope::system) {
     __nvvm_membar_sys();
-  } else if(fence_scope == hipsycl::sycl::memory_scope::device) {
+  } else if(fence_scope == __acpp_sscp_memory_scope::device) {
     __nvvm_membar_gl();
-  } else if(fence_scope == hipsycl::sycl::memory_scope::work_group) {
+  } else if(fence_scope == __acpp_sscp_memory_scope::work_group) {
     __nvvm_membar_cta();
   }
   // We cannot call __nvvm_bar_warp_sync(-1) since this builtin
@@ -40,3 +40,16 @@ __acpp_sscp_sub_group_barrier(__acpp_sscp_memory_scope fence_scope,
   // TODO: Disable this line if ptx < 60
   asm("bar.warp.sync -1;");
 }
+
+HIPSYCL_SSCP_BUILTIN
+void __acpp_sscp_memory_fence(__acpp_sscp_memory_scope scope,
+                              __acpp_sscp_memory_order order) {
+  if (scope == __acpp_sscp_memory_scope::system) {
+    __nvvm_membar_sys();
+  } else if (scope == __acpp_sscp_memory_scope::device) {
+    __nvvm_membar_gl();
+  } else if (scope == __acpp_sscp_memory_scope::work_group) {
+    __nvvm_membar_cta();
+  }
+}
+

--- a/src/libkernel/sscp/spirv/barrier.cpp
+++ b/src/libkernel/sscp/spirv/barrier.cpp
@@ -17,6 +17,9 @@ __attribute__((convergent)) extern "C" void
 __spirv_ControlBarrier(__spv::ScopeFlag Execution, __spv::ScopeFlag Memory,
                        __acpp_uint32 Semantics);
 
+extern "C" void __spirv_MemoryBarrier(__spv::ScopeFlag Memory,
+                                      __acpp_uint32 Semantics);
+
 HIPSYCL_SSCP_CONVERGENT_BUILTIN void
 __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope fence_scope,
                                __acpp_sscp_memory_order mem_order) {
@@ -51,3 +54,20 @@ __acpp_sscp_sub_group_barrier(__acpp_sscp_memory_scope fence_scope,
 
   __spirv_ControlBarrier(__spv::ScopeFlag::Subgroup, mem_fence_scope, flags);
 }
+
+HIPSYCL_SSCP_BUILTIN
+void __acpp_sscp_memory_fence(__acpp_sscp_memory_scope scope,
+                              __acpp_sscp_memory_order order) {
+  __spv::ScopeFlag mem_fence_scope = get_spirv_scope(scope);
+  __acpp_uint32 flags = get_spirv_memory_semantics(order);
+
+  if(scope == __acpp_sscp_memory_scope::sub_group)
+    flags |= __spv::MemorySemanticsMaskFlag::SubgroupMemory;
+  else if(scope == __acpp_sscp_memory_scope::work_group)
+    flags |= __spv::MemorySemanticsMaskFlag::WorkgroupMemory;
+  else if(scope == __acpp_sscp_memory_scope::device)
+    flags |= __spv::MemorySemanticsMaskFlag::CrossWorkgroupMemory;
+
+  __spirv_MemoryBarrier(mem_fence_scope, flags);
+}
+

--- a/tests/sycl/atomic.cpp
+++ b/tests/sycl/atomic.cpp
@@ -230,4 +230,25 @@ BOOST_AUTO_TEST_CASE(fetch_op) {
 #endif
 }
 
+BOOST_AUTO_TEST_CASE(atomic_fence) {
+  // This is mainly a compile-test. Testing atomic memory semantics is hard...
+  
+  sycl::queue q;
+  int* data = sycl::malloc_shared<int>(1, q);
+  *data = 0;
+  size_t range = 1024;
+
+  q.parallel_for(range, [=](auto idx){
+    sycl::atomic_ref<int, sycl::memory_order::relaxed,
+                       sycl::memory_scope::device> a{*data};
+
+    ++a;
+    sycl::atomic_fence(sycl::memory_order::relaxed, sycl::memory_scope::device);
+  }).wait();
+
+  BOOST_CHECK(*data == range);
+
+  sycl::free(data, q);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/sycl/atomic.cpp
+++ b/tests/sycl/atomic.cpp
@@ -230,6 +230,8 @@ BOOST_AUTO_TEST_CASE(fetch_op) {
 #endif
 }
 
+
+#ifndef ACPP_LIBKERNEL_CUDA_NVCXX // nvc++ has some issue with this test
 BOOST_AUTO_TEST_CASE(atomic_fence) {
   // This is mainly a compile-test. Testing atomic memory semantics is hard...
   
@@ -250,5 +252,6 @@ BOOST_AUTO_TEST_CASE(atomic_fence) {
 
   sycl::free(data, q);
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
* Add new SSCP `__acpp_sscp_memory_fence` builtin
* Implement PCUDA `__threadfence, __threadfence_system, __threadfence_block`
* Implement SYCL 2020 `sycl::atomic_fence()`.