### PR TITLE
[SSCP][adaptivity] Auto-noalias: Only enable if the kernel does not access allocations indirectly

### DIFF
--- a/include/hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp
@@ -57,6 +57,7 @@ public:
   virtual ~LLVMToBackendTranslator() {}
 
   void setNoAliasKernelParam(const std::string& KernelName, int ParamIndex);
+  void setNoAliasIfNoIndirectAccessKernelParam(const std::string &KernelName, int ParamIndex);
   void specializeKernelArgument(const std::string &KernelName, int ParamIndex,
                                 const void *ValueBuffer);
   void specializeFunctionCalls(const std::string &FuncName,
@@ -243,6 +244,7 @@ private:
 
   std::vector<std::pair<std::string, std::vector<int>*>> FunctionsForDeadArgumentElimination;
   std::unordered_map<std::string, std::vector<int>> NoAliasParameters;
+  std::unordered_map<std::string, std::vector<int>> NoAliasIfNoIndirectAccessParameters;
 
   // map from kernel name to list of (param index, alignment)
   std::unordered_map<std::string, std::vector<std::pair<int, int>>> KnownPtrParamAlignments;

--- a/include/hipSYCL/compiler/utils/IndirectAccess.hpp
+++ b/include/hipSYCL/compiler/utils/IndirectAccess.hpp
@@ -1,0 +1,63 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#ifndef ACPP_INDIRECT_ACCESS_UTILS_HPP
+#define ACPP_INDIRECT_ACCESS_UTILS_HPP
+
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Type.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/Support/Casting.h>
+
+namespace hipsycl {
+namespace compiler {
+namespace utils {
+
+// Note: This function should be run after optimizations and inlining!
+// It does *not* handle function calls!
+// TODO: Generalize this if we ever want to support partially inlined kernels
+inline bool IsFunctionFreeOfIndirectAccess(llvm::Function* F) {
+  if(!F)
+    return true;
+  for(auto& BB : *F) {
+    for(auto& I : BB) {
+      if(auto* ITP = llvm::dyn_cast<llvm::IntToPtrInst>(&I))
+        return false;
+      else if(auto* BI = llvm::dyn_cast<llvm::BitCastInst>(&I)) {
+        if(BI->getType()->isPointerTy() && !BI->getSrcTy()->isPointerTy()) {
+          return false;
+        }
+      }
+      else if(auto* LI = llvm::dyn_cast<llvm::LoadInst>(&I)) {
+        if(LI->getType()->isPointerTy())
+          return false;
+      } else if(auto* AI = llvm::dyn_cast<llvm::AtomicRMWInst>(&I)) {
+        if(AI->getType()->isPointerTy())
+          return false;
+      } else if(auto* CB = llvm::dyn_cast<llvm::CallBase>(&I)) {
+        // User functions should be inlined at the point this
+        // analysis is run. So this is mainly to handle 
+        // LLVM, AdaptiveCpp, backend builtins.
+        if(CB->getType()->isPointerTy())
+          return false;
+        if(CB->isIndirectCall())
+          return false;
+      }
+    }
+  }
+  return true;
+}
+
+}
+}
+}
+
+#endif

--- a/include/hipSYCL/glue/llvm-sscp/jit.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/jit.hpp
@@ -257,6 +257,12 @@ inline rt::result compile(compiler::LLVMToBackendTranslator *translator,
                            << std::endl;
         translator->setNoAliasKernelParam(translator->getKernels().front(), i);
       }
+      if(config.has_kernel_param_flag(i, rt::kernel_param_flag::noalias_if_no_indirect_access)) {
+        HIPSYCL_DEBUG_INFO << "jit: Setting argument " << i
+                           << " to noalias-if-no-indirect-access " << std::endl;
+        translator->setNoAliasIfNoIndirectAccessKernelParam(
+            translator->getKernels().front(), i);
+      }
     }
     for(const auto& entry : config.known_alignments()) {
       HIPSYCL_DEBUG_INFO << "jit: Setting argument " << entry.first

--- a/include/hipSYCL/runtime/kernel_configuration.hpp
+++ b/include/hipSYCL/runtime/kernel_configuration.hpp
@@ -72,7 +72,8 @@ enum class kernel_build_flag : int {
 enum class kernel_param_flag : int {
   // these values are used as bit masks and should
   // always have a value of a power of 2
-  noalias = 1
+  noalias = 1,
+  noalias_if_no_indirect_access = 2
 };
 
 

--- a/src/compiler/llvm-to-backend/LLVMToBackend.cpp
+++ b/src/compiler/llvm-to-backend/LLVMToBackend.cpp
@@ -21,6 +21,7 @@
 #include "hipSYCL/compiler/llvm-to-backend/Utils.hpp"
 #include "hipSYCL/compiler/sscp/IRConstantReplacer.hpp"
 #include "hipSYCL/compiler/sscp/KernelOutliningPass.hpp"
+#include "hipSYCL/compiler/utils/IndirectAccess.hpp"
 #include "hipSYCL/compiler/utils/ProcessFunctionAnnotationsPass.hpp"
 #include "hipSYCL/compiler/utils/LLVMUtils.hpp"
 #include "hipSYCL/glue/llvm-sscp/jit-reflection/queries.hpp"
@@ -442,6 +443,27 @@ bool LLVMToBackendTranslator::prepareIR(llvm::Module &M) {
       return false;
     }
 
+    // After optimizations, we can check for indirect access effectively.
+    // But we need to handle noalias-if-no-indirect-access before
+    // dead argument elimination, since parameter index won't be correct
+    // anymore afterwards!
+    for(auto& P : NoAliasIfNoIndirectAccessParameters) {
+      auto* F = M.getFunction(P.first);
+      if(F && utils::IsFunctionFreeOfIndirectAccess(F)) {
+        for (int i : P.second) {
+          HIPSYCL_DEBUG_INFO << "LLVMToBackend: Attaching noalias attribute to parameter " << i
+                              << " of kernel " << P.first << "\n";
+          if (i < F->getFunctionType()->getNumParams())
+            if (!F->hasParamAttribute(i, llvm::Attribute::AttrKind::NoAlias))
+              F->addParamAttr(i, llvm::Attribute::AttrKind::NoAlias);
+        }
+      } else {
+        HIPSYCL_DEBUG_INFO << "LLVMToBackend: Cannot prove that kernel " << P.first
+                           << " does not perform indirect access; not attaching noalias attribute"
+                           << "\n";
+      }
+    }
+
     for(const auto& Entry : FunctionsForDeadArgumentElimination) {
       if(auto* F = M.getFunction(Entry.first)) {
         if(isKernelAfterFlavoring(*F)) {
@@ -695,6 +717,11 @@ void LLVMToBackendTranslator::specializeFunctionCalls(
 
 void LLVMToBackendTranslator::setNoAliasKernelParam(const std::string &KernelName, int ParamIndex) {
   NoAliasParameters[KernelName].push_back(ParamIndex);
+}
+
+void LLVMToBackendTranslator::setNoAliasIfNoIndirectAccessKernelParam(const std::string &KernelName,
+                                                                      int ParamIndex) {
+  NoAliasIfNoIndirectAccessParameters[KernelName].push_back(ParamIndex);
 }
 
 void LLVMToBackendTranslator::provideExternalSymbolResolver(ExternalSymbolResolver Resolver) {

--- a/src/runtime/adaptivity_engine.cpp
+++ b/src/runtime/adaptivity_engine.cpp
@@ -324,7 +324,8 @@ kernel_adaptivity_engine::finalize_binary_configuration(
                 HIPSYCL_DEBUG_INFO << "adaptivity_engine: Inferred noalias "
                                       "pointer semantics for kernel argument "
                                   << i << std::endl;
-                config.set_kernel_param_flag(i, kernel_param_flag::noalias);
+                config.set_kernel_param_flag(
+                    i, kernel_param_flag::noalias_if_no_indirect_access);
               }
             }
             ++alloc_index;


### PR DESCRIPTION
The automatic-noalias JIT-time optimization is only safe if the kernel does not perform indirect access. Previously this check was missing.

This PR adds the check using a simple logic to check for LLVM instructions in the kernel that might result in new pointer values - loads that return a `ptr`, `inttoptr` and so on. This check is run *after* the optimization pipeline so we can benefit from SROA etc.
Currently, we do not step into called functions to check them as well, which is fine because SSCP aggressively inlines code. If we ever change this we also need to improve the indirect-access-check.