### PR TITLE
[acpp] Refuse compilation with --acpp-targets=generic if AdaptiveCpp was not built with SSCP support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -684,6 +684,7 @@ set(ACPP_CORE_CONFIG_FILE "{
   \"plugin-linked-into-llvm\" : \"${LLVM_ADAPTIVECPP_LINK_INTO_TOOLS}\",
   \"plugin-llvm-version-major\" : \"${PLUGIN_LLVM_VERSION_MAJOR}\",
   \"plugin-with-cpu-acceleration\" : \"${WITH_ACCELERATED_CPU}\",
+  \"plugin-with-sscp-compiler\" : \"${WITH_SSCP_COMPILER}\",
   \"default-clang\"     : \"${CLANG_INSTALLED_PATH}\",
   \"default-targets\"  : \"${DEFAULT_TARGETS}\",
   \"default-cpu-cxx\"   : \"${CMAKE_CXX_COMPILER}\",

--- a/bin/acpp
+++ b/bin/acpp
@@ -684,6 +684,13 @@ class acpp_config:
     return self._interpret_flag(self._config_db.get("plugin-with-cpu-acceleration"))
 
   @property
+  def has_plugin_sscp_compiler(self):
+    if not self._config_db.contains_key("plugin-with-sscp-compiler"):
+      raise OptionNotSet("Could not retrieve plugin SSCP compiler capability from config file")
+    return self._interpret_flag(self._config_db.get("plugin-with-sscp-compiler"))
+
+
+  @property
   def runtime_backends(self):
     backend_path = os.path.join(self.acpp_installation_path, "lib", "hipSYCL")
     content = os.listdir(backend_path)
@@ -1607,6 +1614,8 @@ class llvm_sscp_invocation:
 
     if len(targets) != 0:
       raise RuntimeError("LLVM SSCP backend does not support specifiying target architecture")
+    if not config.has_plugin_sscp_compiler:
+      raise RuntimeError("AdaptiveCpp was built without support for generic target.")
 
     self._clang_path = config.clang_path
 


### PR DESCRIPTION
Previously, when invoking `acpp --acpp-targets=generic`, we did not validate whether AdaptiveCpp was built with generic support. If SSCP is not available, this can result in difficult to understand errors (e.g. undefined references to some SSCP builtin functions and variables).

This PR makes `acpp` validate whether AdaptiveCpp was built with SSCP support before allowing running with `generic` target.