### PR TITLE
[SSCP][llvm-to-spirv] Don't use patched translator, instead use AdaptiveCpp fork

### DIFF
--- a/doc/install-ocl.md
+++ b/doc/install-ocl.md
@@ -2,8 +2,7 @@
 
 You will need an OpenCL implementation, and the OpenCL icd loader. The OpenCL library can be specified using `cmake -DOpenCL_LIBRARY=/path/to/libOpenCL.so`.
 
-In order to generate correct code, AdaptiveCpp needs to apply a patch to the Khronos llvm-spirv translator.
-You *must* have the `patch` command installed and available when running the AdaptiveCpp `cmake` configuration. If you have run `cmake` without the `patch` command available, please *clean your build directory* before trying again.
+In order to generate correct code, AdaptiveCpp needs to use its own fork of the Khronos LLVM-SPIRV translator hosted at https://github.com/AdaptiveCpp/SPIRV-LLVM-Translator. It will *not* work with the upstream translator. When building, AdaptiveCpp will automatically fetch and build the llvm-spirv translator for the right LLVM version.
 
 The OpenCL backend can be enabled using `cmake -DWITH_OPENCL_BACKEND=ON` when building AdaptiveCpp.
 In order to run code successfully on an OpenCL device, it must support SPIR-V ingestion and the Intel USM (unified shared memory) extension. In a degraded mode, devices supporting OpenCL fine-grained system SVM (shared virtual memory) may work as well.

--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -181,27 +181,25 @@ if(WITH_SSCP_COMPILER)
     set(LLVMSPIRV_PATH ${LLVMSPIRV_INSTALLDIR}/bin/llvm-spirv)
     set(LLVMSPIRV_RELATIVE_PATH ${LLVMSPIRV_RELATIVE_INSTALLDIR}/bin/llvm-spirv)
 
-    include(FetchContent)
-    FetchContent_Declare(LLVMSpirvTranslator
-      GIT_REPOSITORY https://github.com/KhronosGroup/SPIRV-LLVM-Translator
+    ExternalProject_Add(LLVMSpirvTranslator
+      GIT_REPOSITORY https://github.com/AdaptiveCpp/SPIRV-LLVM-Translator
       GIT_TAG origin/${LLVMSPIRV_BRANCH}
       GIT_SHALLOW ON
+      GIT_REMOTE_UPDATE_STRATEGY CHECKOUT
+      BUILD_ALWAYS OFF
+      BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/ext/llvm-spirv
+      CMAKE_ARGS
+        -DCMAKE_C_COMPILER:PATH=${CMAKE_C_COMPILER}
+        -DCMAKE_CXX_COMPILER:PATH=${CMAKE_CXX_COMPILER}
+      CMAKE_CACHE_ARGS
+        -DLLVM_SPIRV_BUILD_EXTERNAL:BOOL=YES
+        -DLLVM_DIR:PATH=${LLVM_DIR}
+        -DCMAKE_INSTALL_PREFIX:PATH=${LLVMSPIRV_INSTALLDIR}
+        -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
+      BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config Release --target install
     )
 
-    FetchContent_GetProperties(LLVMSpirvTranslator)
-    if(NOT LLVMSpirvTranslator_POPULATED)
-      FetchContent_Populate(LLVMSpirvTranslator)
-      find_program(PATCH_COMMAND NAMES patch)
-      if(NOT PATCH_COMMAND)
-        message(SEND_ERROR "The 'patch' command was not found. Install 'patch' or disable all backends that rely on SPIR-V code generation.")
-      endif()
-      execute_process(COMMAND ${PATCH_COMMAND} -N -p0 -c --fuzz=4 --ignore-whitespace -i llvm-spirv.patch ${llvmspirvtranslator_SOURCE_DIR}/lib/SPIRV/SPIRVInternal.h ${CMAKE_CURRENT_SOURCE_DIR}/spirv/llvm-spirv.patch)
-      execute_process(COMMAND ${CMAKE_COMMAND} -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} -DLLVM_SPIRV_BUILD_EXTERNAL=ON -DLLVM_DIR=${LLVM_DIR} -DCMAKE_INSTALL_PREFIX=${LLVMSPIRV_INSTALLDIR} -DCMAKE_BUILD_TYPE=Release -S ${llvmspirvtranslator_SOURCE_DIR} -B ${llvmspirvtranslator_BINARY_DIR})
-    endif()
-    
-    add_custom_target(llvm-spirv-translator ALL COMMAND ${CMAKE_COMMAND} --build ${llvmspirvtranslator_BINARY_DIR} --config Release)
-    install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} --install ${llvmspirvtranslator_BINARY_DIR})")
-
+    add_dependencies(llvm-to-spirv LLVMSpirvTranslator)
     target_compile_definitions(llvm-to-spirv PRIVATE
       -DHIPSYCL_RELATIVE_LLVMSPIRV_PATH="${LLVMSPIRV_RELATIVE_PATH}")
     


### PR DESCRIPTION
Currently we apply a patch to SPIRV-LLVM-Translator to handle address spaces in a way that works with AdaptiveCpp.

This patch is automatically applied to the translator when building AdaptiveCpp. This however has a couple of disadvantages:
- It requires `patch` as an additional dependency
- `patch` may not be available on every OS
- cmake has no mechanism to detect whether a patch has already been applied, so we use complicated hacks to avoid cmake from rebuilding the translator with every build
- This hack currently also generates several cmake deprecation warnings.

With this PR, we adopt a different approach:
- We have a fork of the translator at `AdaptiveCpp/SPIRV-LLVM-Translator` which already includes the patch in its git history
- Because of this, we can now simplify cmake and remove the patch dependency by just cloning our fork and using cmake's `ExternalProject` as usual.

In addition to the simplfiication, this fixes the issues described above.

The main drawback is that we now need to maintain the fork. However, this effort should be fairly limited:
- Occasionally we can just press the "sync fork" button for all relevant branches in our fork to pull in changes from upstream
- When we add support for a new LLVM version, we need to add the branch for that version to our fork and cherry-pick our patch commit. Since AdaptiveCpp since 25.02 refuses by default to build with unsupported LLVM versions, this step can just be part of a conscious process to add support for a new LLVM version, which will encompass:
  1. Fix any issues with new LLVM in our compiler code, then
  2. Update documentation
  3. Update cmake LLVM version checks to allow new version
  4. Pull in branch for new LLVM for SPIRV-LLVM-Translator from upstream, apply patch commit
  5. Enable new LLVM in CI
