### PR TITLE
Look for CUDA libdevice harder

### DIFF
--- a/include/hipSYCL/common/filesystem.hpp
+++ b/include/hipSYCL/common/filesystem.hpp
@@ -27,6 +27,7 @@ namespace filesystem {
 ACPP_COMMON_EXPORT std::string get_install_directory();
 
 ACPP_COMMON_EXPORT std::string join_path(const std::string& base, const std::string& extra);
+ACPP_COMMON_EXPORT std::string join_path(const std::string& base, const char* extra);
 
 ACPP_COMMON_EXPORT bool exists(const std::string& path);
 
@@ -35,6 +36,14 @@ ACPP_COMMON_EXPORT std::string absolute(const std::string& path);
 ACPP_COMMON_EXPORT std::string
 join_path(const std::string &base,
           const std::vector<std::string> &additional_components);
+
+/// Variadic form of join_path, concatenates any number of strings or vectors of strings
+template<typename T, typename... Ts>
+std::string
+join_path(const std::string& base, const T& next_component,
+  const Ts& ...other_components) {
+  return join_path(join_path(base, next_component), other_components...);
+}
 
 ACPP_COMMON_EXPORT std::vector<std::string> list_regular_files(const std::string &directory,
                                             std::error_code &EC);

--- a/src/common/filesystem.cpp
+++ b/src/common/filesystem.cpp
@@ -86,6 +86,10 @@ std::string join_path(const std::string& base, const std::string& extra) {
   return (fs::path(base) / extra).string();
 }
 
+std::string join_path(const std::string& base, const char* extra) {
+  return join_path(base, std::string(extra));
+}
+
 std::string
 join_path(const std::string &base,
           const std::vector<std::string> &additional_components) {

--- a/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
+++ b/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
@@ -69,6 +69,17 @@ private:
     std::string CUDAPath = HIPSYCL_CUDA_PATH;
     std::vector<std::string> SubDir {"nvvm", "libdevice"};
     std::string BitcodeDir = common::filesystem::join_path(CUDAPath, SubDir);
+    // When CUDA is installed via system packages in /usr, the nvvm/libdevice structure
+    // will be under /usr/lib/cuda. Generalize this by checking first if the currently assumed
+    // BitcodeDir exists, and if not, trying under CUDAPath/lib/cuda/SubDir
+    if(!common::filesystem::exists(BitcodeDir)) {
+      std::vector<std::string> libCuda { "lib", "cuda" };
+      BitcodeDir = common::filesystem::join_path(CUDAPath, libCuda, SubDir);
+      // if this doesn't exist either, just give up
+      if(!common::filesystem::exists(BitcodeDir)) {
+        return false;
+      }
+    }
 
     std::error_code EC;
     auto Files = common::filesystem::list_regular_files(BitcodeDir, EC);


### PR DESCRIPTION
This is a two-commit patchset that helps AdaptiveCpp find CUDA‌ libdevice files even when they are installed in /usr. The first is a maintenance commit that introduces a variadic version of join_path, which is used in the second to add lib/cuda before nvvm/libdevice when nvvm/libdevice isn't found in HIPSYCL_CUDA_PATH.