### PR TITLE
[SSCP] dynamic functions: Handle multiple undefined dynamic functions in the same TU

### DIFF
--- a/src/compiler/sscp/DynamicFunctionSupport.cpp
+++ b/src/compiler/sscp/DynamicFunctionSupport.cpp
@@ -82,7 +82,14 @@ llvm::PreservedAnalyses HostSideDynamicFunctionHandlerPass::run(llvm::Module &M,
       if (F->isDeclaration()) {
         F->setLinkage(llvm::GlobalValue::LinkOnceODRLinkage);
         auto BB = llvm::BasicBlock::Create(M.getContext(), "entry", F);
-        new llvm::UnreachableInst(M.getContext(), BB);
+        // It seems that LLVM handles functions that only have unreachable inst differently
+        // if there address is taken - we can no longer get unique function pointer
+        // addresses for those, which breaks reflection. So try to generate a trivial function
+        // instead.
+        if(F->getReturnType()->isVoidTy())
+          llvm::ReturnInst::Create(M.getContext(), BB);
+        else
+          llvm::ReturnInst::Create(M.getContext(), llvm::UndefValue::get(F->getReturnType()), BB);
       }
     }
   }

--- a/tests/compiler/sscp/dynamic_function.cpp
+++ b/tests/compiler/sscp/dynamic_function.cpp
@@ -26,6 +26,10 @@ void execute_operations_with_definition(int* data, sycl::item<1> idx) {
 
 void execute_operations_without_definition(int* data, sycl::item<1> idx);
 
+// Checks that we can distinguish two undefined dynamic functions in the same
+// TU
+void execute_operations_without_definition2(int* data, sycl::item<1> idx);
+
 
 int main() {
   sycl::queue q = get_queue();
@@ -52,6 +56,20 @@ int main() {
     dyn_function_config.define(&execute_operations_without_definition, &myfunction1);
     q.parallel_for(sycl::range{1}, dyn_function_config.apply([=](sycl::item<1> idx){
       execute_operations_without_definition(data, idx);
+    }));
+
+    q.wait();
+    // CHECK: 1
+    std::cout << *data << std::endl;
+  }
+
+  {
+    *data = 0;
+  
+    sycl::AdaptiveCpp_jit::dynamic_function_config dyn_function_config;
+    dyn_function_config.define(&execute_operations_without_definition2, &myfunction1);
+    q.parallel_for(sycl::range{1}, dyn_function_config.apply([=](sycl::item<1> idx){
+      execute_operations_without_definition2(data, idx);
     }));
 
     q.wait();


### PR DESCRIPTION
Dynamic functions are supposed to work when just a declaration is provided, which can then be set at JIT-time to a definition.

To avoid linking issues on the host side, we currently add a function body with an `UnreachableInst`. However, it turns out that such unreachable functions are not assigned a unique address by LLVM when their address is taken, which breaks our reflection support. This breaks dynamic functions when multiple dynamic function entry points are available in one TU.

This PR fixes this by generating `ReturnInst`  instead of `UnreachableInst`