### PR TITLE
[SSCP] dynamic_functions: Fix kernel caching across multiple application runs

### DIFF
--- a/include/hipSYCL/sycl/jit.hpp
+++ b/include/hipSYCL/sycl/jit.hpp
@@ -254,7 +254,7 @@ private:
       common::stable_running_hash hash;
       hash(entry.first.data(), entry.first.size());
       for(const auto& s : entry.second)
-        hash(entry.second.data(), entry.second.size());
+        hash(s.data(), s.size());
       _config.unique_hash ^= hash.get_current_hash();
     }
   }


### PR DESCRIPTION
The function call specialization configuration was previously hashed incorrectly, hashing `std::vector<string>` instead of hashing the actual string data. This caused variable information like the data pointer to enter the hash. This breaks kernel caching.

This PR fixes this.