### PR TITLE
[SSCP] dynamic functions: Hide fcall specialization pointer from compiler in kernel argument list

### DIFF
--- a/include/hipSYCL/glue/llvm-sscp/fcall_specialization.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/fcall_specialization.hpp
@@ -31,6 +31,16 @@ struct fcall_specialized_config {
 using fcall_config_kernel_property_t =
     __acpp_sscp_emit_param_type_annotation_fcall_specialized_config<
         const fcall_specialized_config *>;
+
+// Hides the fcall specialization ptr as an integer. This can be beneficial
+// for the adaptivity engine, which inspects pointers with dedicated logic.
+// TODO: Maybe we should have a generic mechanism to exclude certain parameters
+// from adaptivity analyses?
+inline auto
+hide_fcall_specialization_pointer(fcall_config_kernel_property_t config) {
+  return __acpp_sscp_emit_param_type_annotation_fcall_specialized_config<
+      std::intptr_t>{reinterpret_cast<std::intptr_t>(config.value)};
+}
 }
 
 #endif

--- a/include/hipSYCL/sycl/jit.hpp
+++ b/include/hipSYCL/sycl/jit.hpp
@@ -224,7 +224,13 @@ public:
     if(!_is_ready)
       prepare_for_submission();
 
-    glue::sscp::fcall_config_kernel_property_t prop{&_config};
+    // Avoid the the fcall specialization pointer from being
+    // taken into account as a pointer during adaptivity analysis.
+    // This can reduce unnecessary JIT e.g. if the fcall pointer
+    // changes alignment
+    auto prop = glue::sscp::hide_fcall_specialization_pointer(
+        glue::sscp::fcall_config_kernel_property_t{&_config});
+    
     return [prop, k](auto&&... args){
       k(decltype(args)(args)...);
     };


### PR DESCRIPTION
Pass fcall specialization pointer as `std::intptr_t`, so that we don't throw all of the pointer optimizations on it when the adaptivity engine sees it.