### PR TITLE
[SSCP][llvm-to-amdgpu] Collect bitcode libraries ourselves and eliminate JIT-time dependency on hipcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,19 +233,7 @@ if(WITH_CUDA_BACKEND)
     message(SEND_ERROR "CUDA was not found")
   endif()
 endif()
-if(WITH_ROCM_BACKEND)
-  if(NOT ROCM_FOUND)
-    #  message(SEND_ERROR "hipcc was not found")
 
-    # User has requested ROCm, but we could not find hipcc.
-    # this is not necessarily a reason to abort,
-    # since we only need libhip_hcc, the HIP includes,
-    # and the ROCm device headers. It could be that we
-    # are faced with a minimal/incomplete ROCm installation
-    # that could still be enough for us.
-    # Let's assume the user knows what he/she is doing.
-  endif()
-endif()
 
 if(WITH_OPENCL_BACKEND)
   if(NOT OpenCL_FOUND)
@@ -471,6 +459,18 @@ if(BUILD_CLANG_PLUGIN)
   # Check if building on Windows and LLVM_LIBS is set, if not, use LLVM_AVAILABLE_LIBS 
   if(WIN32 AND NOT LLVM_LIBS AND LLVM_AVAILABLE_LIBS)
     llvm_map_components_to_libnames(LLVM_LIBS analysis core support passes)
+  endif()
+endif()
+
+if(WITH_ROCM_BACKEND)
+  find_path(ROCM_DEVICE_LIBS_PATH ockl.bc HINTS
+      ${ROCM_PATH}/amdgcn/bitcode
+      DOC "Path to ROCm bitcode libraries. Typically, $ROCM_PATH/amdgcn/bitcode")
+
+  if(ROCM_DEVICE_LIBS_PATH)
+    message(STATUS "Found ROCm bitcode library path: ${ROCM_DEVICE_LIBS_PATH}")
+  else()
+    message(SEND_ERROR "ROCm device library path not found; please provide the path containing the ROCm bitcode libraries (e.g. ockl.bc) manually using -DROCM_DEVICE_LIBS_PATH")
   endif()
 endif()
 

--- a/include/hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp
@@ -216,6 +216,9 @@ protected:
   bool GlobalSizesFitInInt = false;
   bool IsFastMath = false;
 
+  // If runtime/user wants a specific subgroup size, this value will be > 0.
+  int DesiredSubgroupSize = -1;
+
 private:
 
   void resolveExternalSymbols(llvm::Module& M);

--- a/include/hipSYCL/compiler/llvm-to-backend/Utils.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/Utils.hpp
@@ -348,6 +348,7 @@ std::string getClangPath();
 std::string getLLCPath();
 std::string getLLDPath();
 std::string getOptPath();
+std::string getRedistPackageBitcodePath(const std::string& backend);
 
 }
 }

--- a/include/hipSYCL/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.hpp
@@ -37,10 +37,9 @@ protected:
   virtual void migrateKernelProperties(llvm::Function* From, llvm::Function* To) override;
 private:
   std::vector<std::string> KernelNames;
-  std::string RocmDeviceLibsPath;
-  std::string RocmPath = ACPP_ROCM_PATH;
   std::string TargetDevice = "gfx900";
   int CodeObjectModelVersion = -1;
+  int WavefrontSize = 64;
 
   bool hiprtcJitLink(const std::string& Bitcode, std::string& Output);
   bool clangJitLink(llvm::Module& FlavoredModule, std::string& Output);

--- a/include/hipSYCL/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.hpp
@@ -39,8 +39,8 @@ private:
   std::vector<std::string> KernelNames;
   std::string TargetDevice = "gfx900";
   int CodeObjectModelVersion = -1;
-  int WavefrontSize = 64;
-
+  
+  int getWavefrontSize() const;
   bool hiprtcJitLink(const std::string& Bitcode, std::string& Output);
   bool clangJitLink(llvm::Module& FlavoredModule, std::string& Output);
 

--- a/include/hipSYCL/runtime/hip/hip_hardware_manager.hpp
+++ b/include/hipSYCL/runtime/hip/hip_hardware_manager.hpp
@@ -59,6 +59,8 @@ public:
 
   hip_allocator* get_allocator() const;
   hip_event_pool* get_event_pool() const;
+
+  std::size_t get_wavefront_size() const;
 private:
   std::unique_ptr<hipDeviceProp_t> _properties;
   std::unique_ptr<hip_allocator> _allocator;

--- a/include/hipSYCL/runtime/kernel_configuration.hpp
+++ b/include/hipSYCL/runtime/kernel_configuration.hpp
@@ -47,6 +47,7 @@ enum class kernel_build_option : int {
   known_group_size_y,
   known_group_size_z,
   known_local_mem_size,
+  desired_subgroup_size,
 
   ptx_version,
   ptx_target_device,

--- a/include/hipSYCL/runtime/kernel_configuration.hpp
+++ b/include/hipSYCL/runtime/kernel_configuration.hpp
@@ -52,8 +52,6 @@ enum class kernel_build_option : int {
   ptx_target_device,
 
   amdgpu_target_device,
-  amdgpu_rocm_device_libs_path,
-  amdgpu_rocm_path,
 
   spirv_dynamic_local_mem_allocation_size
 };

--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -225,7 +225,8 @@ if(WITH_SSCP_COMPILER)
       TOOL amdgpu/LLVMToAmdgpuTool.cpp)
 
     target_compile_definitions(llvm-to-amdgpu PRIVATE
-      -DACPP_ROCM_PATH="${ROCM_PATH}")
+      -DACPP_ROCM_PATH="${ROCM_PATH}"
+      -DACPP_ROCM_DEVICE_LIBS_PATH="${ROCM_DEVICE_LIBS_PATH}")
     
     find_program(HIPCC_PATH hipcc HINTS ${ROCM_PATH}/bin)
     if(HIPCC_PATH)

--- a/src/compiler/llvm-to-backend/LLVMToBackend.cpp
+++ b/src/compiler/llvm-to-backend/LLVMToBackend.cpp
@@ -241,6 +241,8 @@ bool LLVMToBackendTranslator::setBuildOption(const std::string &Option, const st
     return true;
   } else if (Option == "known-local-mem-size") {
     KnownLocalMemSize = std::stoi(Value);
+  } else if (Option == "desired-subgroup-size") {
+    DesiredSubgroupSize = std::stoi(Value);
   }
 
   return applyBuildOption(Option, Value);

--- a/src/compiler/llvm-to-backend/Utils.cpp
+++ b/src/compiler/llvm-to-backend/Utils.cpp
@@ -15,10 +15,16 @@ namespace hipsycl {
 namespace compiler {
 
 namespace {
-std::string getLLVMRedistributablePackagePath() {
+
+std::string getRedistributablePackagePath() {
   const auto install_dir = common::filesystem::get_install_directory();
   return common::filesystem::join_path(install_dir,
-                                       std::vector<std::string>{"lib", "hipSYCL", "ext", "llvm"});
+                                       std::vector<std::string>{"lib", "hipSYCL", "ext"});
+}
+
+std::string getLLVMRedistributablePackagePath() {
+  std::string RedistPkg = getRedistributablePackagePath();
+  return common::filesystem::join_path(RedistPkg, "llvm");
 }
 
 std::string replacePathPlaceholders(std::string path) {
@@ -95,6 +101,11 @@ std::string getOptPath() {
   }
 
   return path;
+}
+
+std::string getRedistPackageBitcodePath(const std::string& backend) {
+  return common::filesystem::join_path(getRedistributablePackagePath(),
+                                       std::vector<std::string>{"bitcode", backend});
 }
 
 } // namespace compiler

--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -330,8 +330,14 @@ bool LLVMToAmdgpuTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
   return true;
 }
 
+bool LLVMToAmdgpuTranslator::translateToBackendFormat(llvm::Module &FlavoredModule,
+                                                      std::string &Out) {
+  if(getWavefrontSize() != 32 && getWavefrontSize() != 64) {
+    this->registerError("LLVMToAmdgpu: Invalid wavefront size was requested: " +
+                        std::to_string(getWavefrontSize()));
+    return false;
+  }
 
-bool LLVMToAmdgpuTranslator::translateToBackendFormat(llvm::Module &FlavoredModule, std::string &Out) {
 #ifdef ACPP_HIPRTC_LINK
   HIPSYCL_DEBUG_INFO << "LLVMToAmdgpu: Invoking hipRTC...\n";
 
@@ -394,7 +400,7 @@ bool LLVMToAmdgpuTranslator::hiprtcJitLink(const std::string &Bitcode, std::stri
   };
 
   std::vector<std::string> DeviceLibs;
-  RocmDeviceLibs::determineRequiredDeviceLibs(TargetDevice, DeviceLibs, IsFastMath, WavefrontSize,
+  RocmDeviceLibs::determineRequiredDeviceLibs(TargetDevice, DeviceLibs, IsFastMath, getWavefrontSize(),
                                               CodeObjectModelVersion);
   for(const auto& Lib : DeviceLibs) {
     HIPSYCL_DEBUG_INFO << "LLVMToAmdgpu: Linking with bitcode file: " << Lib << "\n";
@@ -448,8 +454,8 @@ bool LLVMToAmdgpuTranslator::clangJitLink(llvm::Module& FlavoredModule, std::str
   };
 
   std::vector<std::string> DeviceLibs;
-  RocmDeviceLibs::determineRequiredDeviceLibs(TargetDevice, DeviceLibs, IsFastMath, WavefrontSize,
-                                              CodeObjectModelVersion);
+  RocmDeviceLibs::determineRequiredDeviceLibs(TargetDevice, DeviceLibs, IsFastMath,
+                                              getWavefrontSize(), CodeObjectModelVersion);
   for(const auto& BC : DeviceLibs)
     addBitcodeFile(BC);
 
@@ -581,6 +587,13 @@ void LLVMToAmdgpuTranslator::removeKernelProperties(llvm::Function* F) {
   }
   if(F->hasFnAttribute("amdgpu-flat-work-group-size"))
     F->removeFnAttr("amdgpu-flat-work-group-size");
+}
+
+int LLVMToAmdgpuTranslator::getWavefrontSize() const {
+  if(DesiredSubgroupSize > 0) {
+    return DesiredSubgroupSize;
+  }
+  return 64;
 }
 
 std::unique_ptr<LLVMToBackendTranslator>

--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -129,98 +129,124 @@ bool getCommandOutput(const std::string &Program, const llvm::SmallVector<std::s
 
 
 class RocmDeviceLibs {
-public:
+private:
+  static std::string extractISAAsString(const std::string &TargetDevice) {
+    std::string Result = TargetDevice;
+    // First remove the subtarget in strings like gfxABC:xnack-:sramecc-
+    // So, find first : and throw away the stuff afterwards to obtain gfxABC
+    auto ColonPos = Result.find(":");
+    if(ColonPos != std::string::npos)
+      Result = Result.substr(0, ColonPos);
 
-  static bool determineRequiredDeviceLibs(const std::string& RocmPath,
-                                          const std::string& DeviceLibsPath,
-                                          const std::string& TargetDevice,
-                                          std::vector<std::string>& BitcodeFiles,
-                                          bool IsFastMath = false,
-                                          int ForceCodeObjectModel = -1) {
-    
+    // Remove gfx prefix
+    if(Result.find("gfx") != 0)
+      return "";
+    return Result.substr(3);
+  }
 
-    llvm::SmallVector<std::string> Invocation;
-    // Newer ROCm versions don't handle --cuda-gpu-arch well,
-    // while older versions don't handle --offload-arch well.
-    // We do not have a good way to check the ROCm version
-    // in llvm-to-amdgpu currently, *but* we can exploit
-    // that the AdaptiveCpp LLVM version must be <= ROCm LLVM version.
-    // So, by checking for a minimum LLVM version, we also
-    // implicitly check for a minimum ROCm version.
-#if LLVM_VERSION_MAJOR >= 18
-    auto OffloadArchFlag = "--offload-arch="+TargetDevice;
-#else
-    auto OffloadArchFlag = "--cuda-gpu-arch="+TargetDevice;
-#endif
-    auto RocmPathFlag = "--rocm-path="+std::string{RocmPath};
-    auto RocmDeviceLibsFlag = "--rocm-device-lib-path="+DeviceLibsPath;
-
-    std::string ClangPath = getRocmClang(RocmPath);
-    
-    HIPSYCL_DEBUG_INFO << "LLVMToAmdgpu: Invoking " << ClangPath
-                       << " to determine ROCm device library list\n";
-
-    Invocation = {ClangPath, "-x", "ir",
-      "--cuda-device-only", "-O3",
-      OffloadArchFlag,
-      "-nogpuinc",
-      "/dev/null",
-      "--hip-link",
-      "-###"
-    };
-    if(IsFastMath) {
-      Invocation.push_back("-ffast-math");
-      Invocation.push_back("-fno-hip-fp32-correctly-rounded-divide-sqrt");
+  static int extractABIVersion(const std::string& ABIVersionLib) {
+    std::string Result = ABIVersionLib;
+    if(Result.find("oclc_abi_version_") != 0)
+      return -1;
+    else {
+      Result = Result.substr(std::string{"oclc_abi_version_"}.length());
+      auto DotPos = Result.find(".");
+      if(DotPos == std::string::npos)
+        return -1;
+      
+      Result = Result.substr(0, DotPos);
+      return std::stoi(Result);
     }
-    
-    if(!llvmutils::ends_with(llvm::StringRef{ClangPath}, "hipcc")) {
-      // Normally we try to use hipcc. However, when that fails,
-      // we may have fallen back to clang. In that case we may
-      // have to additionally set --rocm-path and --rocm-device-lib-path.
-      //
-      // When using hipcc, this is generally not needed as hipcc already
-      // knows how ROCm is configured. It might also have been specially
-      // tweaked by non-standard ROCm pacakges to find ROCm in unusual places.
-      //
-      // So we should not use --rocm-path and --rock-device-lib-path unless
-      // we really have to.
-      Invocation.push_back(RocmPathFlag);
-      Invocation.push_back(RocmDeviceLibsFlag);
+  }
 
-      if (!llvm::sys::fs::exists(common::filesystem::join_path(DeviceLibsPath, "ockl.bc"))) {
-        HIPSYCL_DEBUG_WARNING
-            << "LLVMToAmdgpu: Configured ROCm device bitcode library path " << DeviceLibsPath
-            << " does not seem to contain key ROCm bitcode libraries such as ockl.bc. It is "
-               "possible that builtin bitcode linking is incomplete.\n";
+  static std::string getDefaultABIVersionLib(const std::string& DeviceLibDir) {
+    std::error_code EC;
+    std::vector<std::string> Files = common::filesystem::list_regular_files(DeviceLibDir, EC);
+    if(EC)
+      return "";
+    
+    std::vector<int> AvailableCodeObjectModels;
+    for(const auto& F : Files) {
+      int ABI = extractABIVersion(F);
+      if(ABI > 0) {
+        AvailableCodeObjectModels.push_back(ABI);
       }
     }
+    if(AvailableCodeObjectModels.empty())
+      return "";
+
+    return "oclc_abi_version_" +
+           std::to_string(*std::max_element(AvailableCodeObjectModels.begin(),
+                                            AvailableCodeObjectModels.end())) +
+           ".bc";
+  }
+
+public:
+
+  static std::string getDeviceLibDirectory() {
+    static std::string Path;
+    if(!Path.empty())
+      return Path;
     
-    std::string Output;
-    if(!getCommandOutput(ClangPath, Invocation, Output))
+    std::string RedistPackagePath = getRedistPackageBitcodePath("amdgcn");
+    if (common::filesystem::exists(common::filesystem::join_path(RedistPackagePath, "ockl.bc")))
+      Path = RedistPackagePath;
+    else Path = ACPP_ROCM_DEVICE_LIBS_PATH;
+
+    return Path;
+  }
+
+  static bool determineRequiredDeviceLibs(const std::string& TargetDevice,
+                                          std::vector<std::string>& BitcodeFiles,
+                                          bool IsFastMath = false,
+                                          int WavefrontSize = 64,
+                                          int ForceCodeObjectModel = -1) {
+
+    if(WavefrontSize != 64 && WavefrontSize != 32)
       return false;
 
-    std::stringstream sstr{Output};
-    std::string CurrentComponent;
-    
-    bool ConsumeNext = false;
-    while(sstr) {
-      sstr >> CurrentComponent;
-      if(ConsumeNext) {
-        ConsumeNext = false;
-        if(CurrentComponent.find('\"') == 0)
-          CurrentComponent = CurrentComponent.substr(1);
-        if(CurrentComponent.find('\"') != std::string::npos)
-          CurrentComponent = CurrentComponent.substr(0, CurrentComponent.size() - 1);
+    std::string DeviceLibPath = getDeviceLibDirectory();
+    std::string ISA = extractISAAsString(TargetDevice);
+    if(ISA.empty())
+      return false;
 
-        auto OclcABIPos = CurrentComponent.find("oclc_abi_version");
-        if(ForceCodeObjectModel > 0 &&  (OclcABIPos != std::string::npos)) {
-          CurrentComponent.erase(OclcABIPos);
-          CurrentComponent += "oclc_abi_version_" + std::to_string(ForceCodeObjectModel)+".bc";
-        }
-        
-        BitcodeFiles.push_back(CurrentComponent);
-      } else if(CurrentComponent == "\"-mlink-builtin-bitcode\"")
-        ConsumeNext = true;
+    std::vector<std::string> NeededBitcodeLibs = {
+      "hip.bc",
+      "ockl.bc",
+      "ocml.bc",
+      "oclc_isa_version_"+ISA+".bc"
+    };
+
+    if(WavefrontSize == 64) {
+      NeededBitcodeLibs.push_back("oclc_wavefrontsize64_on.bc");
+    } else {
+      NeededBitcodeLibs.push_back("oclc_wavefrontsize64_off.bc");
+    }
+
+    // abi version
+    if(ForceCodeObjectModel != -1) {
+      NeededBitcodeLibs.push_back("oclc_abi_version_" + std::to_string(ForceCodeObjectModel) +
+                                  ".bc");
+    } else {
+      NeededBitcodeLibs.push_back(getDefaultABIVersionLib(DeviceLibPath));
+    }
+
+    if(IsFastMath) {
+      NeededBitcodeLibs.push_back("oclc_correctly_rounded_sqrt_off.bc");
+      NeededBitcodeLibs.push_back("oclc_daz_opt_on.bc");
+      NeededBitcodeLibs.push_back("oclc_finite_only_on.bc");
+      NeededBitcodeLibs.push_back("oclc_unsafe_math_on.bc");
+    } else {
+      NeededBitcodeLibs.push_back("oclc_correctly_rounded_sqrt_on.bc");
+      NeededBitcodeLibs.push_back("oclc_daz_opt_off.bc");
+      NeededBitcodeLibs.push_back("oclc_finite_only_off.bc");
+      NeededBitcodeLibs.push_back("oclc_unsafe_math_off.bc");
+    }
+
+    BitcodeFiles.clear();
+    for(const auto& L : NeededBitcodeLibs) {
+      std::string FullPath = common::filesystem::join_path(DeviceLibPath, L);
+      BitcodeFiles.push_back(FullPath);
     }
 
     return true;
@@ -229,10 +255,7 @@ public:
 
 LLVMToAmdgpuTranslator::LLVMToAmdgpuTranslator(const std::vector<std::string> &KN)
     : LLVMToBackendTranslator{static_cast<int>(sycl::AdaptiveCpp_jit::compiler_backend::amdgpu), KN, KN},
-      KernelNames{KN} {
-  RocmDeviceLibsPath = common::filesystem::join_path(RocmPath,
-                                                     std::vector<std::string>{"amdgcn", "bitcode"});
-}
+      KernelNames{KN} {}
 
 bool LLVMToAmdgpuTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
   
@@ -326,12 +349,6 @@ bool LLVMToAmdgpuTranslator::applyBuildOption(const std::string &Option, const s
   if(Option == "amdgpu-target-device") {
     TargetDevice = Value;
     return true;
-  } else if (Option == "rocm-device-libs-path") {
-    RocmDeviceLibsPath = Value;
-    return true; 
-  } else if (Option == "rocm-path") {
-    RocmPath = Value;
-    return true;
   }
 
   return false;
@@ -363,10 +380,9 @@ bool LLVMToAmdgpuTranslator::hiprtcJitLink(const std::string &Bitcode, std::stri
                           "hipSYCL SSCP Bitcode", 0, 0, 0);
 
   auto addBitcodeFile = [&](const std::string &BCFileName) -> bool {
-    std::string Path = common::filesystem::join_path(RocmDeviceLibsPath, BCFileName);
-    auto ReadResult = llvm::MemoryBuffer::getFile(Path, false);
+    auto ReadResult = llvm::MemoryBuffer::getFile(BCFileName, false);
     if(auto Err = ReadResult.getError()) {
-      this->registerError("LLVMToAmdgpu: Could not open file: " + Path);
+      this->registerError("LLVMToAmdgpu: Could not open file: " + BCFileName);
       return false;
     }
 
@@ -378,8 +394,8 @@ bool LLVMToAmdgpuTranslator::hiprtcJitLink(const std::string &Bitcode, std::stri
   };
 
   std::vector<std::string> DeviceLibs;
-  RocmDeviceLibs::determineRequiredDeviceLibs(RocmPath, RocmDeviceLibsPath, TargetDevice,
-                                              DeviceLibs, IsFastMath, CodeObjectModelVersion);
+  RocmDeviceLibs::determineRequiredDeviceLibs(TargetDevice, DeviceLibs, IsFastMath, WavefrontSize,
+                                              CodeObjectModelVersion);
   for(const auto& Lib : DeviceLibs) {
     HIPSYCL_DEBUG_INFO << "LLVMToAmdgpu: Linking with bitcode file: " << Lib << "\n";
     addBitcodeFile(Lib);
@@ -419,22 +435,21 @@ bool LLVMToAmdgpuTranslator::hiprtcJitLink(const std::string &Bitcode, std::stri
 bool LLVMToAmdgpuTranslator::clangJitLink(llvm::Module& FlavoredModule, std::string& Out) {
   
   auto addBitcodeFile = [&](const std::string &BCFileName) -> bool {
-    std::string Path = common::filesystem::join_path(RocmDeviceLibsPath, BCFileName);
-    auto ReadResult = llvm::MemoryBuffer::getFile(Path, false);
+    auto ReadResult = llvm::MemoryBuffer::getFile(BCFileName, false);
     if(auto Err = ReadResult.getError()) {
-      this->registerError("LLVMToAmdgpu: Could not open file: " + Path);
+      this->registerError("LLVMToAmdgpu: Could not open file: " + BCFileName);
       return false;
     }
 
     llvm::StringRef BC = ReadResult->get()->getBuffer();
-    this->linkBitcodeFile(FlavoredModule, Path, "", "", false);
+    this->linkBitcodeFile(FlavoredModule, BCFileName, "", "", false);
 
     return true;
   };
 
   std::vector<std::string> DeviceLibs;
-  RocmDeviceLibs::determineRequiredDeviceLibs(RocmPath, RocmDeviceLibsPath, TargetDevice,
-                                              DeviceLibs);
+  RocmDeviceLibs::determineRequiredDeviceLibs(TargetDevice, DeviceLibs, IsFastMath, WavefrontSize,
+                                              CodeObjectModelVersion);
   for(const auto& BC : DeviceLibs)
     addBitcodeFile(BC);
 

--- a/src/runtime/hip/hip_hardware_manager.cpp
+++ b/src/runtime/hip/hip_hardware_manager.cpp
@@ -442,6 +442,10 @@ std::string hip_hardware_context::get_profile() const {
   return "FULL_PROFILE";
 }
 
+std::size_t hip_hardware_context::get_wavefront_size() const {
+  return _properties->warpSize;
+}
+
 
 }
 }

--- a/src/runtime/hip/hip_queue.cpp
+++ b/src/runtime/hip/hip_queue.cpp
@@ -619,6 +619,8 @@ result hip_queue::submit_sscp_kernel_from_code_object(
 
   _config.set_build_option(kernel_build_option::amdgpu_target_device,
                           target_arch_name);
+  _config.set_build_option(kernel_build_option::desired_subgroup_size,
+                          ctx->get_wavefront_size());
 
   auto binary_configuration_id = adaptivity_engine.finalize_binary_configuration(_config);
   auto code_object_configuration_id = binary_configuration_id;

--- a/src/runtime/kernel_configuration.cpp
+++ b/src/runtime/kernel_configuration.cpp
@@ -25,8 +25,6 @@ public:
       {"ptx-version", kernel_build_option::ptx_version},
       {"ptx-target-device", kernel_build_option::ptx_target_device},
       {"amdgpu-target-device", kernel_build_option::amdgpu_target_device},
-      {"rocm-device-libs-path", kernel_build_option::amdgpu_rocm_device_libs_path},
-      {"rocm-path", kernel_build_option::amdgpu_rocm_path},
       {"spirv-dynamic-local-mem-allocation-size", kernel_build_option::spirv_dynamic_local_mem_allocation_size}
     };
 

--- a/src/runtime/kernel_configuration.cpp
+++ b/src/runtime/kernel_configuration.cpp
@@ -22,6 +22,7 @@ public:
       {"known-group-size-y", kernel_build_option::known_group_size_y},
       {"known-group-size-z", kernel_build_option::known_group_size_z},
       {"known-local-mem-size", kernel_build_option::known_local_mem_size},
+      {"desired-subgroup-size", kernel_build_option::desired_subgroup_size},
       {"ptx-version", kernel_build_option::ptx_version},
       {"ptx-target-device", kernel_build_option::ptx_target_device},
       {"amdgpu-target-device", kernel_build_option::amdgpu_target_device},


### PR DESCRIPTION
Currently we invoke `hipcc` and parse the output at JIT-time to figure out which bitcode libraries we need to link.

This has the disadvantage that it pulls in hipcc as a runtime dependency. This PR therefore adds support to determine the needed libraries ourselves, thus avoiding the hipcc dependency.

Bitcode libraries are first looked for in a directory relative to the AdaptiveCpp install root, and if that fails, in the ROCm bitcode directory that was discovered at cmake time.

@al42and - I think you have experience with AMD GPUs that support wavefronts of size 32, right? Do you know what users currently get as default when compiling with AdaptiveCpp for such targets? Currently this PR uses 64 as default for all GPUs.