### PR TITLE
[PCUDA] Only enable PCUDA-SYCL interop when compiling with --acpp-pcuda

### DIFF
--- a/include/hipSYCL/sycl/pcuda_interop.hpp
+++ b/include/hipSYCL/sycl/pcuda_interop.hpp
@@ -14,7 +14,7 @@
 #include "libkernel/backend.hpp"
 
 #if !ACPP_LIBKERNEL_COMPILER_SUPPORTS_CUDA &&                                  \
-    !ACPP_LIBKERNEL_COMPILER_SUPPORTS_HIP
+    !ACPP_LIBKERNEL_COMPILER_SUPPORTS_HIP && defined(__ACPP_PCUDA__)
 
 #include <cassert>
 


### PR DESCRIPTION
~Perhaps~ fixes #1837 ~?~