### PR TITLE
[SSCP][llvm-to-ptx] Look for libdevice.bc also in relative directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -474,6 +474,27 @@ if(WITH_ROCM_BACKEND)
   endif()
 endif()
 
+
+if(WITH_CUDA_BACKEND)
+  find_path(CUDA_DEVICE_LIBS_PATH libdevice.10.bc HINTS
+      ${CUDA_TOOLKIT_ROOT_DIR}/nvvm/libdevice
+      DOC "Path containing the CUDA bitcode libraries. Typically, $CUDA_PATH/nvvm/libdevice")
+  
+  if(NOT CUDA_DEVICE_LIBS_PATH AND CUDA_TOOLKIT_ROOT_DIR STREQUAL "/usr")
+    find_path(CUDA_DEVICE_LIBS_PATH libdevice.10.bc HINTS
+      /usr/lib/cuda/nvvm/libdevice)
+  endif()
+
+  if(CUDA_DEVICE_LIBS_PATH)
+    message(STATUS "Found CUDA bitcode library path: ${CUDA_DEVICE_LIBS_PATH}")
+  else()
+    message(SEND_ERROR "CUDA device library path not found; please provide the path containing the CUDA bitcode libraries (libdevice.10.bc) manually using -DCUDA_DEVICE_LIBS_PATH")
+  endif()
+endif()
+
+
+
+
 #add_compile_definitions(HIPSYCL_DEBUG_LEVEL="${HIPSYCL_DEBUG_LEVEL}")
 #Use add_definitions for now for older cmake versions
 cmake_policy(SET CMP0005 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,11 +479,6 @@ if(WITH_CUDA_BACKEND)
   find_path(CUDA_DEVICE_LIBS_PATH libdevice.10.bc HINTS
       ${CUDA_TOOLKIT_ROOT_DIR}/nvvm/libdevice
       DOC "Path containing the CUDA bitcode libraries. Typically, $CUDA_PATH/nvvm/libdevice")
-  
-  if(NOT CUDA_DEVICE_LIBS_PATH AND CUDA_TOOLKIT_ROOT_DIR STREQUAL "/usr")
-    find_path(CUDA_DEVICE_LIBS_PATH libdevice.10.bc HINTS
-      /usr/lib/cuda/nvvm/libdevice)
-  endif()
 
   if(CUDA_DEVICE_LIBS_PATH)
     message(STATUS "Found CUDA bitcode library path: ${CUDA_DEVICE_LIBS_PATH}")

--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -215,7 +215,8 @@ if(WITH_SSCP_COMPILER)
       TOOL ptx/LLVMToPtxTool.cpp)
 
     target_compile_definitions(llvm-to-ptx PRIVATE
-      -DHIPSYCL_CUDA_PATH="${CUDA_TOOLKIT_ROOT_DIR}")
+      -DHIPSYCL_CUDA_PATH="${CUDA_TOOLKIT_ROOT_DIR}"
+      -DACPP_CUDA_DEVICE_LIBS_PATH="${CUDA_DEVICE_LIBS_PATH}")
   endif()
 
   if(WITH_LLVM_TO_AMDGPU_AMDHSA)

--- a/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
+++ b/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
@@ -44,49 +44,25 @@ namespace {
 
 
 
-class LibdevicePath {
-public:
-  static bool get(std::string& Out) {
-    static LibdevicePath P;
-
-    if(P.IsFound)
-      Out = P.Path;
-    return P.IsFound;
+std::string getDeviceLibPath() {
+  static std::string Path;
+  if(!Path.empty()) {
+    return Path;
   }
-private:
-  LibdevicePath() {
-    IsFound = findLibdevice(Path);
-
-    if(IsFound) {
-      HIPSYCL_DEBUG_INFO << "LLVMToPtx: Found libdevice: " << Path << "\n";
-    } else {
-      HIPSYCL_DEBUG_INFO << "LLVMToPtx: Could not find CUDA libdevice!\n";
-    }
+  
+  std::string LibdeviceName = "libdevice.10.bc";
+  std::string RedistPackagePath = 
+    common::filesystem::join_path(getRedistPackageBitcodePath("ptx"), LibdeviceName);
+  if (common::filesystem::exists(RedistPackagePath)) {
+    Path = RedistPackagePath;
+  } else {
+    Path = 
+      common::filesystem::join_path(ACPP_CUDA_DEVICE_LIBS_PATH, LibdeviceName);
   }
 
-  bool findLibdevice(std::string& Out) {
-    
-    std::string CUDAPath = HIPSYCL_CUDA_PATH;
-    std::vector<std::string> SubDir {"nvvm", "libdevice"};
-    std::string BitcodeDir = common::filesystem::join_path(CUDAPath, SubDir);
+  return Path;
+}
 
-    std::error_code EC;
-    auto Files = common::filesystem::list_regular_files(BitcodeDir, EC);
-    if(EC) return false;
-
-    for(const auto& F : Files) {
-      if (F.find("libdevice.") != std::string::npos && F.find(".bc") != std::string::npos) {
-        Out = F;
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  std::string Path;
-  bool IsFound;
-};
 
 void setNVVMReflectParameter(llvm::Module& M, llvm::StringRef Name, int Value) {
   llvm::SmallVector<llvm::Metadata*, 4> Metadata;
@@ -205,11 +181,8 @@ bool LLVMToPtxTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
     common::filesystem::join_path(common::filesystem::get_install_directory(),
       {"lib", "hipSYCL", "bitcode", "libkernel-sscp-ptx-full.bc"});
   
-  std::string LibdeviceFile;
-  if(!LibdevicePath::get(LibdeviceFile)) {
-    this->registerError("LLVMToPtx: Could not find CUDA libdevice bitcode library");
-    return false;
-  }
+  std::string LibdeviceFile = getDeviceLibPath();
+  HIPSYCL_DEBUG_INFO << "LLVMToPtx: Using libdevice at " << LibdeviceFile << "\n";
 
   AddressSpaceInferencePass ASIPass {ASMap};
   ASIPass.run(M, *PH.ModuleAnalysisManager);


### PR DESCRIPTION
In analogy to what we now do for AMD in #1835, this changes how we look for libdevice on CUDA:

1. First, find `libdevice` at cmake time in the CUDA SDK
   1.1. For CUDA installations in `/usr`, also take into account unusual libdevice locations as proposed in #1826 
2. At JIT-time, first try to find libdevice in a relative location if we have a redistributable package
3. Otherwise, look at the location we have from step 1.

This aligns with what we do on AMD.

@Oblomov, are you happy with that change? Can you check whether it works for your use case?