### PR TITLE
Using C++ modules with AdaptiveCpp

### DIFF
--- a/include/hipSYCL/glue/reflection.hpp
+++ b/include/hipSYCL/glue/reflection.hpp
@@ -73,13 +73,6 @@ const char* resolve_function_name(Ret (*func)(Args...)) {
 extern "C" void __acpp_reflection_init_registered_function_pointers();
 extern "C" void __acpp_function_annotation_needs_function_ptr_argument_reflection();
 
-// Compiler will generate calls to this function to register functions.
-__attribute__((used))
-inline void __acpp_reflection_associate_function_pointer(const void *func_ptr,
-                                             const char *func_name) {
-  hipsycl::rt::support::symbol_information::get()
-      .register_function_symbol(func_ptr, func_name);
-}
 
 struct __acpp_reflection_tu_init_trigger {
   __acpp_reflection_tu_init_trigger() {

--- a/include/hipSYCL/runtime/support/reflection.hpp
+++ b/include/hipSYCL/runtime/support/reflection.hpp
@@ -10,7 +10,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 #ifndef HIPSYCL_SUPPORT_REFLECTION_HPP
 #define HIPSYCL_SUPPORT_REFLECTION_HPP
-
 #include <mutex>
 #include <unordered_map>
 

--- a/src/compiler/reflection/FunctionNameExtractionPass.cpp
+++ b/src/compiler/reflection/FunctionNameExtractionPass.cpp
@@ -23,6 +23,8 @@
 #include <llvm/IR/GlobalVariable.h>
 #include <llvm/Support/Alignment.h>
 
+
+
 namespace hipsycl {
 namespace compiler {
 
@@ -61,6 +63,21 @@ bool isAnyUserReflectionAnnotatedFunction(llvm::Function* F, const utils::Proces
 
 }
 
+llvm::Type* getCharPtrType(llvm::Module* M, unsigned AS = 0) {
+  #if LLVM_VERSION_MAJOR >= 16
+      return llvm::PointerType::get(M->getContext(), AS);
+  #else
+      return llvm::PointerType::get(llvm::Type::getInt8Ty(M->getContext()), AS);
+  #endif
+  }
+  llvm::Type* getVoidPtrType(llvm::Module* M, unsigned AS = 0) {
+    #if LLVM_VERSION_MAJOR >= 16
+        return llvm::PointerType::get(M->getContext(), AS);
+    #else
+        return llvm::PointerType::get(llvm::Type::getInt8Ty(M->getContext()), AS);
+    #endif
+  }
+
 llvm::PreservedAnalyses FunctionNameExtractionPass::run(llvm::Module &M, llvm::ModuleAnalysisManager &AM) {
   std::string GVPrefix = "__acpp_functioninfo_";
 
@@ -82,11 +99,27 @@ llvm::PreservedAnalyses FunctionNameExtractionPass::run(llvm::Module &M, llvm::M
     }
   }
 
+  //declare explicitly __acpp_reflection_associate_function_pointer
+  static const char* ReflectionAssociateFunctionPointer = "__acpp_reflection_associate_function_pointer";
+  llvm::SmallVector<llvm::Type*> ParamTs;
+  // function pointer
+  ParamTs.push_back(getVoidPtrType(&M));
+  // function name
+  ParamTs.push_back(getCharPtrType(&M));  
+  // declare if not already declared
+  auto FC = M.getOrInsertFunction(ReflectionAssociateFunctionPointer,
+                                  llvm::FunctionType::get(llvm::Type::getVoidTy(M.getContext()),
+                                                          llvm::ArrayRef<llvm::Type *>{ParamTs},
+                                                          false));
+  llvm::Function *NewDeclaration = llvm::dyn_cast<llvm::Function>(FC.getCallee());
+  std::string NewDeclarationName = NewDeclaration->getName().str();
+  
+  
   llvm::Function* MapFunc = nullptr;
   for(auto& F : M)
     if(F.getName().contains("__acpp_reflection_associate_function_pointer"))
       MapFunc = &F;
-
+  
   if(MapFunc) {
     if(auto* InitFunc = M.getFunction("__acpp_reflection_init_registered_function_pointers")){
       if(InitFunc->isDeclaration() && (MapFunc->getFunctionType()->getNumParams() == 2)) {

--- a/src/runtime/support/reflection.cpp
+++ b/src/runtime/support/reflection.cpp
@@ -18,3 +18,10 @@ namespace hipsycl::rt::support {
     return si;
   }
 }
+
+// Compiler will generate calls to this function to register functions
+void __acpp_reflection_associate_function_pointer(const void *func_ptr,
+                                           const char *func_name) {
+  hipsycl::rt::support::symbol_information::get()
+      .register_function_symbol(func_ptr, func_name);
+}

--- a/src/runtime/support/reflection.cpp
+++ b/src/runtime/support/reflection.cpp
@@ -19,10 +19,9 @@ namespace hipsycl::rt::support {
   }
 }
 
-//avoid cpp name mangling
-extern "C" void __acpp_reflection_associate_function_pointer(const void*, const char*);
+
 // Compiler will generate calls to this function to register functions
-void __acpp_reflection_associate_function_pointer(const void *func_ptr,
+extern "C" void __acpp_reflection_associate_function_pointer(const void *func_ptr,
                                            const char *func_name) {
   hipsycl::rt::support::symbol_information::get()
       .register_function_symbol(func_ptr, func_name);

--- a/src/runtime/support/reflection.cpp
+++ b/src/runtime/support/reflection.cpp
@@ -19,6 +19,8 @@ namespace hipsycl::rt::support {
   }
 }
 
+//avoid cpp name mangling
+extern "C" void __acpp_reflection_associate_function_pointer(const void*, const char*);
 // Compiler will generate calls to this function to register functions
 void __acpp_reflection_associate_function_pointer(const void *func_ptr,
                                            const char *func_name) {


### PR DESCRIPTION
As brought up in [Issue#1722](https://github.com/AdaptiveCpp/AdaptiveCpp/issues/1722), trying to use AdaptiveCpp with C++ modules currently leads to a linker error with LLVM 19. An examination of the emitted LLVM IR shows that the function declaration of `__acpp_reflection_associate_function_pointer` is lost during compilation. 

This MR proposes a possible solution by declaring the function in `src/compiler/reflection/FunctionNameExtractionPass.cpp` *explicitly* and *leaving out* the [inline definition](https://github.com/AdaptiveCpp/AdaptiveCpp/blob/develop/include/hipSYCL/glue/reflection.hpp#L77) in `include/hipSYCL/glue/reflection.hpp`.