### PR TITLE
Respect user-defined HIPSYCL_DEBUG_LEVEL and remove redundant local settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,11 +106,11 @@ if(NOT HIPSYCL_DEBUG_LEVEL)
   if(CMAKE_BUILD_TYPE MATCHES "Debug")
     set(HIPSYCL_DEBUG_LEVEL 3 CACHE STRING
       "Choose the debug level, options are: 0 (no debug), 1 (print errors), 2 (also print warnings), 3 (also print general information)"
-FORCE)
+  )
   else()
     set(HIPSYCL_DEBUG_LEVEL 2 CACHE STRING
       "Choose the debug level, options are: 0 (no debug), 1 (print errors), 2 (also print warnings), 3 (also print general information)"
-FORCE)
+  )
   endif()
 endif()
 

--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -12,8 +12,8 @@ else()
   add_compile_definitions(ACPP_LLVM_COMPONENT)
 endif()
 
-if(NOT HIPSYCL_DEBUG_LEVEL)
-  set(HIPSYCL_DEBUG_LEVEL 2 CACHE INTEGER)
+if(NOT DEFINED HIPSYCL_DEBUG_LEVEL)
+  message(FATAL_ERROR "HIPSYCL_DEBUG_LEVEL was not defined by the top-level CMakeLists.txt.")
 endif()
 
 if(NOT ACPP_LLVM_COMPONENT)


### PR DESCRIPTION
This PR makes the following improvements:

* Moves the default-setting logic for `HIPSYCL_DEBUG_LEVEL` to the top-level `CMakeLists.txt` only

* Removes redundant and conflicting `set(... CACHE ...)` call from subdirectory `src/compiler`

* Ensures that user-defined values via -DHIPSYCL_DEBUG_LEVEL=... or presets are respected (removes FORCE)

* Adds a validation in submodules to ensure `HIPSYCL_DEBUG_LEVEL` is set

* Fixes the issue where the macro was not propagated to compiler command lines, avoiding the need to patch debug.hpp manually

* Replaces `if(NOT HIPSYCL_DEBUG_LEVEL)` with `if(NOT DEFINED HIPSYCL_DEBUG_LEVEL)` to ensure that explicitly setting -DHIPSYCL_DEBUG_LEVEL=0 is respected. The previous check would incorrectly treat 0 as undefined and override it with the default.

This improves developer experience by adding a robust way to set default `HIPSYCL_DEBUG_LEVEL` during build configuring

I have tested these changes with older AdaptiveCpp, not with the latest, as I have some problems compiling it on Windows with LLVM Clang currently, but I expect these changes to work, because modified parts weren't changed since the version I tested. Configuring the latest AdaptiveCpp still works correctly, as expected, with `HIPSYCL_DEBUG_LEVEL` correctly set in `build.ninja`.

I know,  `HIPSYCL_DEBUG_LEVEL` should be renamed to `ACPP_DEBUG_LEVEL`, but this is better to do in a separate PR anyway.