### PR TITLE
Add support for config files for runtime settings

### DIFF
--- a/bin/acpp
+++ b/bin/acpp
@@ -1924,7 +1924,8 @@ class compiler:
   def common_linker_flags(self):
     linker_args = [
       "-L"+self._acpp_lib_path,
-      "-lacpp-rt"
+      "-lacpp-rt",
+      "-lacpp-common"
     ]
 
     if sys.platform == "darwin":

--- a/doc/env_variables.md
+++ b/doc/env_variables.md
@@ -76,3 +76,22 @@ If `ACPP_S2_DUMP_IR_FILTER` filter is non-empty, AdaptiveCpp will only dump IR i
 Note that this can still lead to multiple JIT compilation dumps, e.g. if AdaptiveCpp generates multiple specialized kernels based on runtime information for one C++ kernel.
 
 
+## Configuration files
+
+All environment variables for the runtime (not JIT compiler) can also be set in a configuration file. This configuration file must be placed in the same directory as your program.
+
+1. First, AdaptiveCpp will attempt to read `acpp-config.cfg`.
+2. Next, it reads `acpp-config-<app-name>.cfg`, where `app-name` is the full filename of your program (including file extension if you are on a platform that uses an extension for programs). If some variable was already set from `acpp-config.cfg`, it will be overwritten.
+
+This allows users to specify a global behavior for all programs located in a directory, and special-case the behavior for individual programs using `acpp-config-<app-name>.cfg` files.
+
+When there are conflicting environment variables and entries in the config file, environment variables take precedence.
+
+The content of the configuration file is comprised of `<environment-variable>=<value>` entries, one per line.
+
+Example:
+```
+ACPP_DEBUG_LEVEL=0
+ACPP_ADAPTIVITY_LEVEL=2
+```
+

--- a/include/hipSYCL/common/filesystem.hpp
+++ b/include/hipSYCL/common/filesystem.hpp
@@ -11,6 +11,7 @@
 #ifndef HIPSYCL_COMMON_FILESYSTEM_HPP
 #define HIPSYCL_COMMON_FILESYSTEM_HPP
 
+#include <optional>
 #include <string>
 #include <vector>
 #include <memory>
@@ -25,6 +26,12 @@ namespace common {
 namespace filesystem {
 
 ACPP_COMMON_EXPORT std::string get_install_directory();
+// returns path to running program.
+// if filename/directory are not null, stores the filename and 
+// containing directory in them.
+ACPP_COMMON_EXPORT std::string
+get_this_executable_path(std::string* filename = nullptr,
+                         std::string* directory = nullptr);
 
 ACPP_COMMON_EXPORT std::string join_path(const std::string& base, const std::string& extra);
 

--- a/include/hipSYCL/common/settings.hpp
+++ b/include/hipSYCL/common/settings.hpp
@@ -1,0 +1,112 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#ifndef ACPP_COMMON_SETTINGS_HPP
+#define ACPP_COMMON_SETTINGS_HPP
+
+
+#include <string>
+#include <cstdlib>
+#include <sstream>
+#include <iostream>
+#include <unordered_map>
+
+#include "export.hpp"
+
+
+namespace hipsycl {
+namespace common::settings {
+
+
+namespace detail {
+ACPP_COMMON_EXPORT std::string
+generate_configuration_identifier(const std::string &name,
+                                  bool legacy_prefix = false);
+}
+
+class ACPP_COMMON_EXPORT settings_config_file {
+public:
+  static settings_config_file& get();
+  bool retrieve_setting(const std::string& key, std::string& value) const;
+private:
+  settings_config_file();
+  void load_file(const std::string& filename);
+  std::unordered_map<std::string, std::string> _values;
+};
+
+template<class T>
+bool try_retrieve_environment_variable(const std::string& name, T& out) {
+  std::string env_name =
+      detail::generate_configuration_identifier(name, false);
+  std::string legacy_env_name =
+      detail::generate_configuration_identifier(name, true);
+
+  std::string env;
+  if (const char *env_value =
+          std::getenv(env_name.c_str())) {
+    env = std::string{env_value};
+  } else if (const char *env_value =
+          std::getenv(legacy_env_name.c_str())) {
+    env = std::string{env_value};
+  }
+  
+  if (!env.empty()) {
+    
+    T val;
+    std::stringstream sstr{std::string{env}};
+    sstr >> val;
+
+    if (sstr.fail() || sstr.bad()) {
+      std::cerr << "AdaptiveCpp settings parsing: Could not parse value of environment "
+                    "variable: "
+                << env_name << std::endl;
+      return false;
+    }
+    out = val;
+    return true;
+  }
+  return false;
+}
+
+template <class T>
+bool try_retrieve_settings_variable(const std::string& name, T& out) {
+
+  if(try_retrieve_environment_variable(name, out))
+    return true;
+  
+  // try cfg file
+  std::string var_name =
+    detail::generate_configuration_identifier(name);
+  std::string value_string;
+
+  if(settings_config_file::get().retrieve_setting(var_name, value_string)) {
+
+    T val;
+    std::istringstream sstr{std::string{value_string}};
+    sstr >> val;
+
+    if (sstr.fail() || sstr.bad()) {
+      std::cerr << "AdaptiveCpp settings parsing: Could not parse value of config file "
+                    "entry: "
+                << var_name << std::endl;
+      return false;
+    }
+    out = val;
+    return true;
+  }
+  
+  return false;
+}
+
+
+}
+}
+
+#endif

--- a/include/hipSYCL/common/settings.hpp
+++ b/include/hipSYCL/common/settings.hpp
@@ -16,6 +16,7 @@
 #include <cstdlib>
 #include <sstream>
 #include <iostream>
+#include <algorithm>
 #include <unordered_map>
 
 #include "export.hpp"
@@ -26,9 +27,20 @@ namespace common::settings {
 
 
 namespace detail {
-ACPP_COMMON_EXPORT std::string
+
+inline std::string
 generate_configuration_identifier(const std::string &name,
-                                  bool legacy_prefix = false);
+                                  bool legacy_prefix = false) {
+  std::string capitalized_name = name;
+
+  std::transform(capitalized_name.begin(), capitalized_name.end(),
+                 capitalized_name.begin(), ::toupper);
+  if(legacy_prefix)
+    return "HIPSYCL_"+capitalized_name;
+  else
+    return "ACPP_"+capitalized_name;
+}
+
 }
 
 class ACPP_COMMON_EXPORT settings_config_file {

--- a/include/hipSYCL/runtime/settings.hpp
+++ b/include/hipSYCL/runtime/settings.hpp
@@ -11,15 +11,13 @@
 #ifndef HIPSYCL_RT_SETTINGS_HPP
 #define HIPSYCL_RT_SETTINGS_HPP
 
+#include "hipSYCL/common/settings.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
 
-#include <ios>
-#include <optional>
 #include <string>
 #include <cstdlib>
-#include <algorithm>
-#include <sstream>
 #include <iostream>
+#include <unordered_map>
 #include <vector>
 namespace hipsycl {
 namespace rt {
@@ -53,40 +51,6 @@ std::istream &operator>>(std::istream &istr, scheduler_type &out);
 std::istream &operator>>(std::istream &istr, visibility_mask_t &out);
 std::istream &operator>>(std::istream &istr, default_selector_behavior& out);
 
-template <class T>
-bool try_get_environment_variable(const std::string& name, T& out) {
-  std::string env_name = name;
-
-  std::transform(env_name.begin(), env_name.end(), env_name.begin(), ::toupper);
-
-  std::string env;
-  if (const char *env_value =
-          std::getenv(("ACPP_"+env_name).c_str())) {
-    env_name = "ACPP_"+env_name;
-    env = std::string{env_value};
-  } else if (const char *env_value =
-          std::getenv(("HIPSYCL_"+env_name).c_str())) {
-    env_name = "HIPSYCL_"+env_name;
-    env = std::string{env_value};
-  }
-  
-  if (!env.empty()) {
-    
-    T val;
-    std::stringstream sstr{std::string{env}};
-    sstr >> val;
-
-    if (sstr.fail() || sstr.bad()) {
-      std::cerr << "AdaptiveCpp settings parsing: Could not parse value of environment "
-                    "variable: "
-                << env_name << std::endl;
-      return false;
-    }
-    out = val;
-    return true;
-  }
-  return false;
-}
 
 enum class setting {
   debug_level,
@@ -199,56 +163,56 @@ public:
 #ifdef HIPSYCL_DEBUG_LEVEL
     default_debug_level = HIPSYCL_DEBUG_LEVEL;
 #endif
-    _debug_level = get_environment_variable_or_default<setting::debug_level>(
+    _debug_level = get_configuration_or_default<setting::debug_level>(
         default_debug_level);
     _scheduler_type =
-        get_environment_variable_or_default<setting::scheduler_type>(
+        get_configuration_or_default<setting::scheduler_type>(
             scheduler_type::unbound);
     _visibility_mask =
-        get_environment_variable_or_default<setting::visibility_mask>(
+        get_configuration_or_default<setting::visibility_mask>(
             visibility_mask_t{});
-    _dag_requirement_optimization_depth = get_environment_variable_or_default<
+    _dag_requirement_optimization_depth = get_configuration_or_default<
         setting::dag_req_optimization_depth>(10);
-    _mqe_lane_statistics_max_size = get_environment_variable_or_default<
+    _mqe_lane_statistics_max_size = get_configuration_or_default<
         setting::mqe_lane_statistics_max_size>(100);
-    _mqe_lane_statistics_decay_time_sec = get_environment_variable_or_default<
+    _mqe_lane_statistics_decay_time_sec = get_configuration_or_default<
         setting::mqe_lane_statistics_decay_time_sec>(10.0);
     _default_selector_behavior =
-        get_environment_variable_or_default<setting::default_selector_behavior>(
+        get_configuration_or_default<setting::default_selector_behavior>(
             default_selector_behavior::strict);
     _hcf_dump_directory =
-        get_environment_variable_or_default<setting::hcf_dump_directory>(
+        get_configuration_or_default<setting::hcf_dump_directory>(
             std::string{});
     _persistent_runtime =
-        get_environment_variable_or_default<setting::persistent_runtime>(false);
-    _sscp_failed_ir_dump_directory = get_environment_variable_or_default<
+        get_configuration_or_default<setting::persistent_runtime>(false);
+    _sscp_failed_ir_dump_directory = get_configuration_or_default<
         setting::sscp_failed_ir_dump_directory>(std::string{});
     _gc_trigger_batch_size =
-        get_environment_variable_or_default<setting::gc_trigger_batch_size>(128);
+        get_configuration_or_default<setting::gc_trigger_batch_size>(128);
     _ocl_no_shared_context =
-        get_environment_variable_or_default<setting::ocl_no_shared_context>(false);
+        get_configuration_or_default<setting::ocl_no_shared_context>(false);
     _ocl_show_all_devices =
-        get_environment_variable_or_default<setting::ocl_show_all_devices>(false);
+        get_configuration_or_default<setting::ocl_show_all_devices>(false);
     _no_jit_cache_population =
-        get_environment_variable_or_default<setting::no_jit_cache_population>(false);
+        get_configuration_or_default<setting::no_jit_cache_population>(false);
     _adaptivity_level =
-        get_environment_variable_or_default<setting::adaptivity_level>(1);
+        get_configuration_or_default<setting::adaptivity_level>(1);
     
     _jitopt_iads_relative_threshold =
-        get_environment_variable_or_default<setting::jitopt_iads_relative_threshold>(0.8);
+        get_configuration_or_default<setting::jitopt_iads_relative_threshold>(0.8);
     _jitopt_iads_relative_eviction_threshold =
-        get_environment_variable_or_default<setting::jitopt_iads_relative_eviction_threshold>(0.1);
+        get_configuration_or_default<setting::jitopt_iads_relative_eviction_threshold>(0.1);
     _jitopt_iads_relative_threshold_min_data =
-        get_environment_variable_or_default<setting::jitopt_iads_relative_threshold_min_data>(1024);
+        get_configuration_or_default<setting::jitopt_iads_relative_threshold_min_data>(1024);
     _enable_allocation_tracking =
-        get_environment_variable_or_default<setting::enable_allocation_tracking>(false);
+        get_configuration_or_default<setting::enable_allocation_tracking>(false);
   }
 
 private:
   template <setting S, class T>
-  T get_environment_variable_or_default(const T &default_value) {
+  T get_configuration_or_default(const T &default_value) {
     T out;
-    if(try_get_environment_variable(setting_trait<S>::str, out)) {
+    if(common::settings::try_retrieve_settings_variable(setting_trait<S>::str, out)) {
       return out;
     }
     return default_value;

--- a/include/hipSYCL/std/stdpar/detail/offload.hpp
+++ b/include/hipSYCL/std/stdpar/detail/offload.hpp
@@ -136,7 +136,8 @@ inline prefetch_mode get_prefetch_mode() noexcept {
 #else
   auto determine_prefetch_mode = [&]() -> prefetch_mode {
     std::string prefetch_mode_string;
-    if(rt::try_get_environment_variable("stdpar_prefetch_mode", prefetch_mode_string)) {
+    if (common::settings::try_retrieve_settings_variable(
+            "stdpar_prefetch_mode", prefetch_mode_string)) {
       if(prefetch_mode_string == "auto") {
         return prefetch_mode::automatic;
       } else if(prefetch_mode_string == "always") {
@@ -251,10 +252,12 @@ using host_malloc_unordered_pair_map =
 class offload_heuristic_config {
 public:
   offload_heuristic_config() {
-    if(!rt::try_get_environment_variable("stdpar_ohc_min_ops", _min_ops_per_offload_decision)) {
+    if (!common::settings::try_retrieve_settings_variable(
+            "stdpar_ohc_min_ops", _min_ops_per_offload_decision)) {
       _min_ops_per_offload_decision = 128;
     }
-    if(!rt::try_get_environment_variable("stdpar_ohc_min_time", _min_time_per_offload_decision)) {
+    if (!common::settings::try_retrieve_settings_variable(
+            "stdpar_ohc_min_time", _min_time_per_offload_decision)) {
       _min_time_per_offload_decision = 1;
     }
     // Convert from seconds to ns
@@ -366,16 +369,16 @@ private:
 
   static bool is_host_sampling_run_requested(){
     bool is_requested = false;
-    if (rt::try_get_environment_variable("stdpar_host_sampling",
-                                          is_requested))
+    if (common::settings::try_retrieve_settings_variable("stdpar_host_sampling",
+                                                         is_requested))
       return is_requested;
     return false;
   }
 
   static bool is_offload_sampling_run_requested(){
     bool is_requested = false;
-    if (rt::try_get_environment_variable("stdpar_offload_sampling",
-                                          is_requested))
+    if (common::settings::try_retrieve_settings_variable(
+            "stdpar_offload_sampling", is_requested))
       return is_requested;
     return false;
   }

--- a/include/hipSYCL/std/stdpar/detail/offload_heuristic_db.hpp
+++ b/include/hipSYCL/std/stdpar/detail/offload_heuristic_db.hpp
@@ -224,7 +224,8 @@ private:
 
   static std::string get_dataset_name() {
     std::string dataset_name;
-    if(rt::try_get_environment_variable("stdpar_dataset_name", dataset_name)) {
+    if (common::settings::try_retrieve_settings_variable("stdpar_dataset_name",
+                                                         dataset_name)) {
       return dataset_name;
     }
     return ".acpp-stdpar-profile";

--- a/include/hipSYCL/std/stdpar/detail/sycl_glue.hpp
+++ b/include/hipSYCL/std/stdpar/detail/sycl_glue.hpp
@@ -479,8 +479,8 @@ private:
     auto dev = detail::single_device_dispatch::get_queue().get_device();
 
     double user_defined_mem_pool_size = 0.0;
-    if (rt::try_get_environment_variable("stdpar_mem_pool_size",
-                                         user_defined_mem_pool_size))
+    if (common::settings::try_retrieve_settings_variable(
+            "stdpar_mem_pool_size", user_defined_mem_pool_size))
       return user_defined_mem_pool_size;
     
     // If we have system allocations, mem pool is not really needed.

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -2,7 +2,8 @@
 add_library(acpp-common SHARED
     filesystem.cpp
     appdb.cpp
-    dylib_loader.cpp  
+    dylib_loader.cpp
+    settings.cpp
   )
 
 target_include_directories(acpp-common

--- a/src/common/filesystem.cpp
+++ b/src/common/filesystem.cpp
@@ -14,7 +14,7 @@
 #include "hipSYCL/common/stable_running_hash.hpp"
 #include "hipSYCL/common/debug.hpp"
 
-#include "hipSYCL/runtime/settings.hpp"
+#include "hipSYCL/common/settings.hpp"
 
 #include <fstream>
 #include <memory>
@@ -80,6 +80,40 @@ std::string get_install_directory() {
   if(paths.empty() || !fs::is_directory(paths.back()))
     return fs::path{HIPSYCL_INSTALL_PREFIX}.string();
   return paths.back().string();
+}
+
+
+std::string get_this_executable_path(std::string* filename,
+                                    std::string* directory) {
+  auto get_path = []() -> std::string{
+#ifndef _WIN32
+    char result[PATH_MAX];
+    ssize_t num_read = readlink("/proc/self/exe", result, PATH_MAX);
+    if (num_read >= 0 && num_read <= PATH_MAX - 1) {
+      result[num_read] = '\0';
+      return std::string{result};
+    }
+    return std::string{};
+#else
+    std::vector<char> path_buff;
+    DWORD copied = 0;
+    do {
+      path_buff.resize(path_buff.size() + MAX_PATH);
+      copied = GetModuleFileNameA(0, path_buff.data(), path_buff.size());
+    } while (copied >= path_buff.size());
+
+    path_buff.resize(copied);
+
+    return std::string{path_buff.begin(), path_buff.end()};
+#endif
+  };
+
+  std::string path = get_path();
+  if(filename)
+    *filename = path.empty() ? "" : fs::path{path}.filename().string();
+  if(directory)
+    *directory = path.empty() ? "" : fs::path{path}.parent_path().string();
+  return path;
 }
 
 std::string join_path(const std::string& base, const std::string& extra) {
@@ -185,7 +219,7 @@ persistent_storage::persistent_storage() {
     return false;
   };
 
-  if(!rt::try_get_environment_variable("appdb_dir", _base_dir)) {
+  if(!settings::try_retrieve_settings_variable("appdb_dir", _base_dir)) {
     std::string home, subdirectory;
     if (get_home(home, subdirectory)) {
       _base_dir = (fs::path{home} / subdirectory).string();
@@ -194,18 +228,7 @@ persistent_storage::persistent_storage() {
     }
   }
 
-  auto get_app_path = []() -> std::string{
-
-    char result[PATH_MAX];
-    ssize_t num_read = readlink("/proc/self/exe", result, PATH_MAX);
-    if(num_read >= 0 && num_read <= PATH_MAX - 1) {
-      result[num_read] = '\0';
-      return std::string{result};
-    }
-    return std::string{};
-  };
-
-  std::string app_path = get_app_path();
+  std::string app_path = get_this_executable_path();
   _this_app_dir = generate_app_dir(app_path);
   
 #else

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -14,7 +14,6 @@
 
 #include <string>
 #include <fstream>
-#include <algorithm>
 
 namespace hipsycl {
 namespace common::settings {
@@ -45,21 +44,6 @@ void trim(std::string& str) {
   str.erase(str.find_last_not_of("\t\n\v\f\r ") + 1);
 }
 
-}
-
-namespace detail {
-std::string
-generate_configuration_identifier(const std::string &name,
-                                  bool legacy_prefix) {
-  std::string capitalized_name = name;
-
-  std::transform(capitalized_name.begin(), capitalized_name.end(),
-                 capitalized_name.begin(), ::toupper);
-  if(legacy_prefix)
-    return "HIPSYCL_"+capitalized_name;
-  else
-    return "ACPP_"+capitalized_name;
-}
 }
 
 void settings_config_file::load_file(const std::string& filename) {

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -1,0 +1,112 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "hipSYCL/common/filesystem.hpp"
+#include "hipSYCL/common/settings.hpp"
+
+#include <string>
+#include <fstream>
+#include <algorithm>
+
+namespace hipsycl {
+namespace common::settings {
+
+namespace {
+
+std::unordered_map<std::string, std::string> parse_config_file(const std::string& filename){
+  std::ifstream file{filename};
+  std::unordered_map<std::string, std::string> result;
+  if(file.is_open()) {
+    std::string line;
+    while (std::getline(file, line)) {
+      auto equal_pos = line.find("=");
+      if(equal_pos != std::string::npos) {
+        std::string key = line.substr(0, equal_pos);
+        if(equal_pos+1 < line.length()) {
+          result[key] = line.substr(equal_pos+1);
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+void trim(std::string& str) {
+  str.erase(0, str.find_first_not_of("\t\n\v\f\r "));
+  str.erase(str.find_last_not_of("\t\n\v\f\r ") + 1);
+}
+
+}
+
+namespace detail {
+std::string
+generate_configuration_identifier(const std::string &name,
+                                  bool legacy_prefix) {
+  std::string capitalized_name = name;
+
+  std::transform(capitalized_name.begin(), capitalized_name.end(),
+                 capitalized_name.begin(), ::toupper);
+  if(legacy_prefix)
+    return "HIPSYCL_"+capitalized_name;
+  else
+    return "ACPP_"+capitalized_name;
+}
+}
+
+void settings_config_file::load_file(const std::string& filename) {
+  auto kv_map = parse_config_file(filename);
+  
+  for(const auto& entry : kv_map) {
+    std::string key = entry.first;
+    std::string value = entry.second;
+    trim(key);
+    trim(value);
+    _values[key] = value;
+  }
+}
+
+settings_config_file::settings_config_file() {
+  std::string app_filename, app_directory;
+  common::filesystem::get_this_executable_path(&app_filename, &app_directory);
+  if(!app_directory.empty()){
+    std::string acpp_config_file =
+        common::filesystem::join_path(app_directory, "acpp-config.cfg");
+    if(common::filesystem::exists(acpp_config_file)) {
+      load_file(acpp_config_file);
+    }
+    if(!app_filename.empty()) {
+      std::string app_config_file = common::filesystem::join_path(
+          app_directory, "acpp-config-" + app_filename + ".cfg");
+      if(common::filesystem::exists(app_config_file)) {
+        load_file(app_config_file);
+      }
+    }
+  }
+}
+
+bool settings_config_file::retrieve_setting(const std::string& key, std::string& value) const {
+  auto it = _values.find(key);
+  if(it != _values.end()) {
+    value = it->second;
+    return true;
+  }
+  return false;
+}
+
+settings_config_file& settings_config_file::get() {
+  static settings_config_file cfg;
+  return cfg;
+}
+
+
+}
+}

--- a/src/runtime/dag_submitted_ops.cpp
+++ b/src/runtime/dag_submitted_ops.cpp
@@ -9,6 +9,7 @@
  */
 // SPDX-License-Identifier: BSD-2-Clause
 #include <cassert>
+#include <algorithm>
 
 #include "hipSYCL/runtime/dag_submitted_ops.hpp"
 #include "hipSYCL/runtime/dag_node.hpp"

--- a/src/runtime/settings.cpp
+++ b/src/runtime/settings.cpp
@@ -9,11 +9,13 @@
  */
 // SPDX-License-Identifier: BSD-2-Clause
 #include "hipSYCL/common/debug.hpp"
+#include "hipSYCL/common/filesystem.hpp"
 #include "hipSYCL/common/string_utils.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
 #include "hipSYCL/runtime/settings.hpp"
 
 #include <string>
+#include <fstream>
 
 namespace hipsycl {
 namespace rt {


### PR DESCRIPTION
From the documentation:

---
All environment variables for the runtime (not JIT compiler) can also be set in a configuration file. This configuration file must be placed in the same directory as your program.

1. First, AdaptiveCpp will attempt to read `acpp-config.cfg`.
2. Next, it reads `acpp-config-<app-name>.cfg`, where `app-name` is the full filename of your program (including file extension if you are on a platform that uses an extension for programs). If some variable was already set from `acpp-config.cfg`, it will be overwritten.

This allows users to specify a global behavior for all programs located in a directory, and special-case the behavior for individual programs using `acpp-config-<app-name>.cfg` files.

When there are conflicting environment variables and entries in the config file, environment variables take precedence.

The content of the configuration file is comprised of `<environment-variable>=<value>` entries, one by line.

Example:
```
ACPP_DEBUG_LEVEL=0
ACPP_ADAPTIVITY_LEVEL=2
```
----

@blinkfrog this PR includes a Windows-specific code path to determine the path to the running program that I could not test (`get_this_executable_path()` in `filesystem.cpp`). It would be good if you could check whether it works as intended.