### PR TITLE
[cmake][llvm-to-spirv] Don't install llvm-spirv translator during build step

### DIFF
--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -196,8 +196,17 @@ if(WITH_SSCP_COMPILER)
         -DLLVM_DIR:PATH=${LLVM_DIR}
         -DCMAKE_INSTALL_PREFIX:PATH=${LLVMSPIRV_INSTALLDIR}
         -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
-      BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config Release --target install
+      BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config Release
+      INSTALL_COMMAND ""
     )
+
+    add_custom_target(InstallLLVMSpirvTranslator
+      COMMAND ${CMAKE_COMMAND} --build ${CMAKE_CURRENT_BINARY_DIR}/ext/llvm-spirv --target install
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/ext/llvm-spirv
+    )
+
+    #install(TARGETS InstallLLVMSpirvTranslator)
+    install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} --build . --target InstallLLVMSpirvTranslator)")
 
     add_dependencies(llvm-to-spirv LLVMSpirvTranslator)
     target_compile_definitions(llvm-to-spirv PRIVATE


### PR DESCRIPTION
Fixes #1847 