### PR TITLE
[SSCP] ranged parallel_for: On CPU, check whether WGs are in the domain only if they are at the edges

### DIFF
--- a/include/hipSYCL/glue/llvm-sscp/sscp_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/sscp_kernel_launcher.hpp
@@ -31,11 +31,14 @@
 #include "ir_constants.hpp"
 
 #include "../kernel_launcher_data.hpp"
+#include "s1_ir_constants.hpp"
 
 #include <array>
 #include <atomic>
 #include <string_view>
 
+
+extern "C" bool __acpp_sscp_jit_reflect_target_is_cpu();
 
 template <typename KernelType>
 // hipsycl_sscp_kernel causes kernel entries to be emitted to the HCF
@@ -146,8 +149,29 @@ public:
     auto this_item = sycl::detail::make_item<Dimensions>(
       sycl::detail::get_global_id<Dimensions>(), _range
     );
-    if(item_is_in_range(this_item, _range))
-      _k(this_item);
+    
+
+    if(__acpp_sscp_is_device) {
+      if(__acpp_sscp_jit_reflect_target_is_cpu()) {
+        auto grp_id = sycl::detail::get_group_id<Dimensions>();
+        auto num_grps = sycl::detail::get_grid_size<Dimensions>();
+        bool is_edge = false;
+        for(int i = 0; i < Dimensions; ++i) {
+          is_edge = is_edge || (grp_id[i] == num_grps[i]-1);
+        }
+        if(!is_edge)
+          _k(this_item);
+        else {
+          if(item_is_in_range(this_item, _range)) {
+            _k(this_item);
+          }    
+        }
+      } else {
+        if(item_is_in_range(this_item, _range)) {
+          _k(this_item);
+        }
+      }
+    }
   }
 private:
   UserKernel _k;

--- a/include/hipSYCL/glue/llvm-sscp/sscp_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/sscp_kernel_launcher.hpp
@@ -31,11 +31,14 @@
 #include "ir_constants.hpp"
 #include "hcf_registration.hpp"
 #include "../kernel_launcher_data.hpp"
+#include "s1_ir_constants.hpp"
 
 #include <array>
 #include <atomic>
 #include <string_view>
 
+
+extern "C" bool __acpp_sscp_jit_reflect_target_is_cpu();
 
 template <typename KernelType>
 // hipsycl_sscp_kernel causes kernel entries to be emitted to the HCF
@@ -146,8 +149,29 @@ public:
     auto this_item = sycl::detail::make_item<Dimensions>(
       sycl::detail::get_global_id<Dimensions>(), _range
     );
-    if(item_is_in_range(this_item, _range))
-      _k(this_item);
+    
+
+    if(__acpp_sscp_is_device) {
+      if(__acpp_sscp_jit_reflect_target_is_cpu()) {
+        auto grp_id = sycl::detail::get_group_id<Dimensions>();
+        auto num_grps = sycl::detail::get_grid_size<Dimensions>();
+        bool is_edge = false;
+        for(int i = 0; i < Dimensions; ++i) {
+          is_edge = is_edge || (grp_id[i] == num_grps[i]-1);
+        }
+        if(!is_edge)
+          _k(this_item);
+        else {
+          if(item_is_in_range(this_item, _range)) {
+            _k(this_item);
+          }    
+        }
+      } else {
+        if(item_is_in_range(this_item, _range)) {
+          _k(this_item);
+        }
+      }
+    }
   }
 private:
   UserKernel _k;


### PR DESCRIPTION
As found out in #1852, there can be a noticable performance hit in `parallel_for(range)` compared to `parallel_for(nd_range)` because `parallel_for(range)` needs to also support cases where the `range` is not divisible by the work group size, in which case the last work groups will only partially participate in the computation.

This requires an additional if statement to check whether items are still part of the parallel domain. This if statement can negatively affect the generated code.

This PR changes the logic, such that on CPU, we only do this check for the last work groups in each dimension. This allows us to have most of the work groups without the check (and thus be more efficient). This approach is possible because only the last work groups in each dimension can potentially exceed the iteration space.

@blinkfrog With this change, perf improves from ~78ms to 58ms for your original benchmark code for me! Also, OpenCL on CPU improves from 225 to ~200ms.