### PR TITLE
[SSCP][llvm-to-amdgpu] Fix discovery of default ABI version if LLVM module is not tagged with ABI version

### DIFF
--- a/include/hipSYCL/common/filesystem.hpp
+++ b/include/hipSYCL/common/filesystem.hpp
@@ -48,7 +48,7 @@ ACPP_COMMON_EXPORT std::vector<std::string> list_regular_files(const std::string
 ACPP_COMMON_EXPORT std::vector<std::string> list_regular_files(const std::string &directory,
                                             const std::string &extension,
                                             std::error_code &EC);
-
+ACPP_COMMON_EXPORT std::string filename(const std::string& path);
 /// Writes data atomically to filename
 ACPP_COMMON_EXPORT bool atomic_write(const std::string& filename, const std::string& data);
 

--- a/src/common/filesystem.cpp
+++ b/src/common/filesystem.cpp
@@ -154,6 +154,10 @@ std::vector<std::string> list_regular_files(const std::string& directory,
   return result;
 }
 
+ACPP_COMMON_EXPORT std::string filename(const std::string& path) {
+  return fs::path{path}.filename().string();
+}
+
 bool exists(const std::string& path) {
   return fs::exists(path);
 }

--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -162,6 +162,9 @@ private:
   static std::string getDefaultABIVersionLib(const std::string& DeviceLibDir) {
     std::error_code EC;
     std::vector<std::string> Files = common::filesystem::list_regular_files(DeviceLibDir, EC);
+    for(auto& S : Files) {
+      S = common::filesystem::filename(S);
+    }
     if(EC)
       return "";
     
@@ -228,7 +231,8 @@ public:
       NeededBitcodeLibs.push_back("oclc_abi_version_" + std::to_string(ForceCodeObjectModel) +
                                   ".bc");
     } else {
-      NeededBitcodeLibs.push_back(getDefaultABIVersionLib(DeviceLibPath));
+      std::string DefaultABILib = getDefaultABIVersionLib(DeviceLibPath);
+      NeededBitcodeLibs.push_back(DefaultABILib);
     }
 
     if(IsFastMath) {


### PR DESCRIPTION
When AdaptiveCpp is built against older LLVM versions (e.g. 15), then our bitcode libraries don't come  pre-tagged with a target ROCm ABI version. In this case, we need to manually figure out the target ABI so that we can link the appropriate `oclc_ABI_version_*.bc` file.

Currently, this fallback code path tries to list files in the ROCm bitcode library path, and then attempts to parse the filenames to obtain available ABI versions. However, it assumes that `list_regular_files` returns filenames, when in fact it returns the full paths.

This can cause the wrong or no `oclc_ABI_version_*.bc` to be linked. This PR fixes that.

@al42and I think this might be related to your issue.