### PR TITLE
[stdpar][algorithms] Drastically improve performance of early-exit-based algorithms (any_of, all_of, none_of)

### DIFF
--- a/include/hipSYCL/algorithms/algorithm.hpp
+++ b/include/hipSYCL/algorithms/algorithm.hpp
@@ -500,28 +500,10 @@ sycl::event early_exit_for_each(sycl::queue &q, std::size_t problem_size,
   std::size_t dispatched_global_size = streamer.get_required_global_size();
 
   auto kernel = [=](sycl::nd_item<1> idx) {
-      const std::size_t item_id = idx.get_global_id(0);
-  
-      util::abortable_data_streamer::run(problem_size, idx, [&](sycl::id<1> idx){
-        
-        if (sycl::detail::__acpp_atomic_load<
-                sycl::access::address_space::global_space>(
-                output_has_exited_early, sycl::memory_order_relaxed,
-                sycl::memory_scope_device)) {
-          return true;
-        }
-
-        if (should_exit(idx)) {
-          sycl::detail::__acpp_atomic_store<
-              sycl::access::address_space::global_space>(
-              output_has_exited_early, 1, sycl::memory_order_relaxed,
-              sycl::memory_scope_device);
-          return true;
-        }
-
-        return false;
-      });
-    };
+    util::abortable_data_streamer::run(
+        problem_size, idx, output_has_exited_early,
+        [&](sycl::id<1> idx) { return should_exit(idx); });
+  };
 
   auto evt = q.single_task(deps, [=](){*output_has_exited_early = false;});
   return q.parallel_for(sycl::nd_range<1>{dispatched_global_size, group_size}, evt,

--- a/include/hipSYCL/algorithms/util/memory_streaming.hpp
+++ b/include/hipSYCL/algorithms/util/memory_streaming.hpp
@@ -130,7 +130,7 @@ public:
 
     std::size_t desired_num_groups = 0;
     desired_num_groups =
-        dev.get_info<sycl::info::device::max_compute_units>() * 4;
+        dev.get_info<sycl::info::device::max_compute_units>() * 8;
 
     _num_groups = std::min(default_num_groups, desired_num_groups);
   }
@@ -158,45 +158,40 @@ public:
                   Early_exit_flag_type *flag, F &&f) noexcept {
 
     std::size_t gid = idx.get_global_id(0);
-    const int group_size = idx.get_local_range(0);
-    const std::size_t num_groups = (problem_size + group_size - 1) / group_size;
+    const std::size_t dispatched_range = idx.get_global_range(0);
+    const std::size_t work_per_item =
+        (problem_size + dispatched_range - 1) / dispatched_range;
     const int lid = idx.get_local_id(0);
-    const std::size_t group_id = idx.get_group(0);
 
-    for (std::size_t i = group_id; i < num_groups;
-         i += idx.get_group_range(0)) {
-      // abort group if flag is set
-      bool exit_signal_received = false;
-      if(lid == 0) {
-        // group leader obtains value and broadcasts to group
-        Early_exit_flag_type exit_flag = sycl::detail::__acpp_atomic_load<
-            sycl::access::address_space::global_space>(
-            flag, sycl::memory_order_relaxed, sycl::memory_scope_device);
-        exit_signal_received = static_cast<bool>(exit_flag);
-      }
-      exit_signal_received =
-          sycl::group_broadcast(idx.get_group(), exit_signal_received);
-      
-      if(exit_signal_received)
-        return;
-    
-      bool should_exit = false;
-      
-      if(gid < problem_size)
-        should_exit = f(sycl::id<1>{gid});
+    bool has_exited = false;
 
-      if(sycl::any_of_group(idx.get_group(), should_exit)) {
-        if(idx.get_local_id(0) == 0) {
-          sycl::detail::__acpp_atomic_store<
-              sycl::access::address_space::global_space>(
-              flag, 1, sycl::memory_order_relaxed, sycl::memory_scope_device);
-        }
-        return;
-      }
-      
-      gid += idx.get_global_range(0);
+    if(lid == 0) {
+      // group leader obtains value and broadcasts to group
+      Early_exit_flag_type exit_flag = sycl::detail::__acpp_atomic_load<
+          sycl::access::address_space::global_space>(
+          flag, sycl::memory_order_relaxed, sycl::memory_scope_device);
+      has_exited = static_cast<bool>(exit_flag);
     }
-  };
+    has_exited =
+          sycl::group_broadcast(idx.get_group(), has_exited);
+    // abort computation if exit condition met
+    if(has_exited)
+      return;
+
+    for(int i = 0; i < work_per_item; ++i) {
+      std::size_t effective_gid = gid + i * dispatched_range;
+      if(effective_gid < problem_size) {
+        has_exited = has_exited || f(sycl::id<1>{effective_gid});
+      }
+    }
+
+    has_exited = sycl::any_of_group(idx.get_group(), has_exited);
+    if(has_exited && lid == 0) {
+      sycl::detail::__acpp_atomic_store<
+            sycl::access::address_space::global_space>(
+            flag, 1, sycl::memory_order_relaxed, sycl::memory_scope_device);
+    }
+  }
 
 private:
   std::size_t _num_groups;

--- a/include/hipSYCL/algorithms/util/memory_streaming.hpp
+++ b/include/hipSYCL/algorithms/util/memory_streaming.hpp
@@ -179,7 +179,8 @@ public:
       return;
 
     for(int i = 0; i < work_per_item; ++i) {
-      std::size_t effective_gid = gid + i * dispatched_range;
+      std::size_t effective_gid =
+          get_effective_gid(gid, i, work_per_item, dispatched_range);
       if(effective_gid < problem_size) {
         has_exited = has_exited || f(sycl::id<1>{effective_gid});
       }
@@ -194,6 +195,47 @@ public:
   }
 
 private:
+  static std::size_t get_effective_gid(std::size_t gid, std::size_t batch_id,
+                                std::size_t work_per_item,
+                                std::size_t dispatched_range) {
+    std::size_t result = 0;
+    __acpp_if_target_sscp(
+        namespace jit = sycl::AdaptiveCpp_jit; jit::compile_if_else(
+            jit::reflect<jit::reflection_query::compiler_backend>() ==
+                jit::compiler_backend::host,
+            [&]() {
+              result = get_effective_gid_host(gid, batch_id, work_per_item,
+                                              dispatched_range);
+            },
+            [&]() {
+              result = get_effective_gid_device(gid, batch_id, work_per_item,
+                                                dispatched_range);
+            });
+
+        return result;
+    );
+    __acpp_if_target_device(
+      result = get_effective_gid_device(gid, batch_id, work_per_item, dispatched_range);
+    );
+    __acpp_if_target_host(
+      result = get_effective_gid_host(gid, batch_id, work_per_item, dispatched_range);
+    );
+
+    return result;
+  }
+
+  static std::size_t get_effective_gid_device(std::size_t gid, std::size_t batch_id,
+                                       std::size_t work_per_item,
+                                       std::size_t dispatched_range) {
+    return gid + batch_id * dispatched_range;
+  }
+
+  static std::size_t get_effective_gid_host(std::size_t gid, std::size_t batch_id,
+                                     std::size_t work_per_item,
+                                     std::size_t dispatched_range) {
+    return gid * work_per_item + batch_id;
+  }
+
   std::size_t _num_groups;
   std::size_t _problem_size;
   std::size_t _group_size;

--- a/include/hipSYCL/algorithms/util/memory_streaming.hpp
+++ b/include/hipSYCL/algorithms/util/memory_streaming.hpp
@@ -16,6 +16,8 @@
 #include "hipSYCL/sycl/libkernel/nd_item.hpp"
 #include "hipSYCL/sycl/info/device.hpp"
 #include "hipSYCL/sycl/jit.hpp"
+#include "hipSYCL/sycl/libkernel/atomic_builtins.hpp"
+#include "hipSYCL/sycl/libkernel/group_functions.hpp"
 #include <cstddef>
 
 
@@ -119,6 +121,7 @@ private:
 
 class abortable_data_streamer {
 public:
+  
   abortable_data_streamer(const sycl::device &dev, std::size_t problem_size,
                 std::size_t group_size)
       : _problem_size{problem_size}, _group_size{group_size} {
@@ -147,15 +150,51 @@ public:
   // as possible.
   // 
   // F is a callable of signature bool(sycl::id<1>).
-  template <class F>
+  //
+  // flag must have been initialized with a value that converts to "false".
+  // It will be set to true, if an early exit happened.
+  template <class F, class Early_exit_flag_type>
   static void run(std::size_t problem_size, sycl::nd_item<1> idx,
-                  F &&f) noexcept {
+                  Early_exit_flag_type *flag, F &&f) noexcept {
 
+    std::size_t gid = idx.get_global_id(0);
+    const int group_size = idx.get_local_range(0);
+    const std::size_t num_groups = (problem_size + group_size - 1) / group_size;
+    const int lid = idx.get_local_id(0);
+    const std::size_t group_id = idx.get_group(0);
 
-    const std::size_t gid = idx.get_global_id(0);
-    for (std::size_t i = gid; i < problem_size; i += idx.get_global_range(0)) {
-      if(f(sycl::id<1>{i}))
+    for (std::size_t i = group_id; i < num_groups;
+         i += idx.get_group_range(0)) {
+      // abort group if flag is set
+      bool exit_signal_received = false;
+      if(lid == 0) {
+        // group leader obtains value and broadcasts to group
+        Early_exit_flag_type exit_flag = sycl::detail::__acpp_atomic_load<
+            sycl::access::address_space::global_space>(
+            flag, sycl::memory_order_relaxed, sycl::memory_scope_device);
+        exit_signal_received = static_cast<bool>(exit_flag);
+      }
+      exit_signal_received =
+          sycl::group_broadcast(idx.get_group(), exit_signal_received);
+      
+      if(exit_signal_received)
         return;
+    
+      bool should_exit = false;
+      
+      if(gid < problem_size)
+        should_exit = f(sycl::id<1>{gid});
+
+      if(sycl::any_of_group(idx.get_group(), should_exit)) {
+        if(idx.get_local_id(0) == 0) {
+          sycl::detail::__acpp_atomic_store<
+              sycl::access::address_space::global_space>(
+              flag, 1, sycl::memory_order_relaxed, sycl::memory_scope_device);
+        }
+        return;
+      }
+      
+      gid += idx.get_global_range(0);
     }
   };
 

--- a/include/hipSYCL/std/stdpar/pstl-impl/algorithm.hpp
+++ b/include/hipSYCL/std/stdpar/pstl-impl/algorithm.hpp
@@ -511,13 +511,15 @@ bool any_of(hipsycl::stdpar::par_unseq, ForwardIt first, ForwardIt last,
     auto output_scratch_group =
         hipsycl::stdpar::detail::stdpar_tls_runtime::get()
             .make_scratch_group<
-                hipsycl::algorithms::util::allocation_type::host>();
+                hipsycl::algorithms::util::allocation_type::device>();
 
     auto *output = output_scratch_group
                       .obtain<hipsycl::algorithms::detail::early_exit_flag_t>(1);
     hipsycl::algorithms::any_of(queue, first, last, output, p);
+    hipsycl::algorithms::detail::early_exit_flag_t result;
+    queue.memcpy(&result, output, sizeof(hipsycl::algorithms::detail::early_exit_flag_t));
     queue.wait();
-    return static_cast<bool>(*output);
+    return static_cast<bool>(result);
   };
 
   auto fallback = [&](){

--- a/include/hipSYCL/std/stdpar/pstl-impl/algorithm.hpp
+++ b/include/hipSYCL/std/stdpar/pstl-impl/algorithm.hpp
@@ -478,13 +478,15 @@ bool all_of(hipsycl::stdpar::par_unseq, ForwardIt first, ForwardIt last,
     auto output_scratch_group =
         hipsycl::stdpar::detail::stdpar_tls_runtime::get()
             .make_scratch_group<
-                hipsycl::algorithms::util::allocation_type::host>();
+                hipsycl::algorithms::util::allocation_type::device>();
 
     auto *output = output_scratch_group
                       .obtain<hipsycl::algorithms::detail::early_exit_flag_t>(1);
     hipsycl::algorithms::all_of(queue, first, last, output, p);
+    hipsycl::algorithms::detail::early_exit_flag_t result;
+    queue.memcpy(&result, output, sizeof(hipsycl::algorithms::detail::early_exit_flag_t));
     queue.wait();
-    return static_cast<bool>(*output);
+    return static_cast<bool>(result);
   };
 
   auto fallback = [&](){
@@ -546,13 +548,15 @@ bool none_of(hipsycl::stdpar::par_unseq, ForwardIt first, ForwardIt last,
     auto output_scratch_group =
         hipsycl::stdpar::detail::stdpar_tls_runtime::get()
             .make_scratch_group<
-                hipsycl::algorithms::util::allocation_type::host>();
+                hipsycl::algorithms::util::allocation_type::device>();
 
     auto *output = output_scratch_group
                       .obtain<hipsycl::algorithms::detail::early_exit_flag_t>(1);
     hipsycl::algorithms::none_of(queue, first, last, output, p);
+    hipsycl::algorithms::detail::early_exit_flag_t result;
+    queue.memcpy(&result, output, sizeof(hipsycl::algorithms::detail::early_exit_flag_t));
     queue.wait();
-    return static_cast<bool>(*output);
+    return static_cast<bool>(result);
   };
 
   auto fallback = [&](){
@@ -1209,13 +1213,15 @@ bool all_of(hipsycl::stdpar::par, ForwardIt first, ForwardIt last,
     auto output_scratch_group =
         hipsycl::stdpar::detail::stdpar_tls_runtime::get()
             .make_scratch_group<
-                hipsycl::algorithms::util::allocation_type::host>();
+                hipsycl::algorithms::util::allocation_type::device>();
 
     auto *output = output_scratch_group
                       .obtain<hipsycl::algorithms::detail::early_exit_flag_t>(1);
     hipsycl::algorithms::all_of(queue, first, last, output, p);
+    hipsycl::algorithms::detail::early_exit_flag_t result;
+    queue.memcpy(&result, output, sizeof(hipsycl::algorithms::detail::early_exit_flag_t));
     queue.wait();
-    return static_cast<bool>(*output);
+    return static_cast<bool>(result);
   };
 
   auto fallback = [&](){
@@ -1242,13 +1248,15 @@ bool any_of(hipsycl::stdpar::par, ForwardIt first, ForwardIt last,
     auto output_scratch_group =
         hipsycl::stdpar::detail::stdpar_tls_runtime::get()
             .make_scratch_group<
-                hipsycl::algorithms::util::allocation_type::host>();
+                hipsycl::algorithms::util::allocation_type::device>();
 
     auto *output = output_scratch_group
                       .obtain<hipsycl::algorithms::detail::early_exit_flag_t>(1);
     hipsycl::algorithms::any_of(queue, first, last, output, p);
+    hipsycl::algorithms::detail::early_exit_flag_t result;
+    queue.memcpy(&result, output, sizeof(hipsycl::algorithms::detail::early_exit_flag_t));
     queue.wait();
-    return static_cast<bool>(*output);
+    return static_cast<bool>(result);
   };
 
   auto fallback = [&](){
@@ -1275,13 +1283,15 @@ bool none_of(hipsycl::stdpar::par, ForwardIt first, ForwardIt last,
     auto output_scratch_group =
         hipsycl::stdpar::detail::stdpar_tls_runtime::get()
             .make_scratch_group<
-                hipsycl::algorithms::util::allocation_type::host>();
+                hipsycl::algorithms::util::allocation_type::device>();
 
     auto *output = output_scratch_group
                       .obtain<hipsycl::algorithms::detail::early_exit_flag_t>(1);
     hipsycl::algorithms::none_of(queue, first, last, output, p);
+    hipsycl::algorithms::detail::early_exit_flag_t result;
+    queue.memcpy(&result, output, sizeof(hipsycl::algorithms::detail::early_exit_flag_t));
     queue.wait();
-    return static_cast<bool>(*output);
+    return static_cast<bool>(result);
   };
 
   auto fallback = [&](){


### PR DESCRIPTION
The `any_of`, `all_of`, `none_of` algorithms rely on early-exit-optimizations. This can substantially improve performance for inputs where the exit condition is reached early (e.g. `any_of` where the first elements already meet the condition).

However, the current implementation relies on excessive use of atomics, which can significantly limit performance in cases where the exit condition is only met late (or never) in the data.

This PR substantially optimizes this, by
- processing multiple data elements per work item to saturate memory bandwidth
- optimizing memory access patterns for CPU backend
- only performing atomics in the first work item per work group, and exchanging data within a work group using group algorithms.
- Using `device` instead of `host` memory to store the output of the flag.

With this PR, I reach close(~85% on GPU) to peak memory bandwidth for the case where the exit condition is not met while still achieving an effective memory bandwidth that is higher than peak when the exit condition is met early.
Similar numbers are achieved on CPU as well.

Some additional minor speedup on NVIDIA GPUs specifically can be achieved with the changes in #1856.

@normallytangent This should fix your performance issues :) Note that for best effect, you will also have to change your algorithms to use `device` memory for the output flag, and then copy the result back to the host using an explicit `memcpy` as I did in this PR for `any_of`/`all_of`/`none_of`.

EDIT: CI errors are unrelated :( Looks like there is currently an issue with CI.