### PR TITLE
Fixing fast-math flag transmission to JIT Host compiler

### DIFF
--- a/src/runtime/omp/omp_queue.cpp
+++ b/src/runtime/omp/omp_queue.cpp
@@ -464,6 +464,11 @@ result omp_queue::submit_sscp_kernel_from_code_object(
   _config.append_base_configuration(
       kernel_base_config_parameter::hcf_object_id, hcf_object);
 
+  for(const auto& flag : kernel_info->get_compilation_flags())
+    _config.set_build_flag(flag);
+  for(const auto& opt : kernel_info->get_compilation_options())
+    _config.set_build_option(opt.first, opt.second);
+
   auto binary_configuration_id =
       adaptivity_engine.finalize_binary_configuration(_config);
   auto code_object_configuration_id = binary_configuration_id;


### PR DESCRIPTION
This PR activate flags transmission to the JIT Host compiler. 
Currently, using the ffast-math flag at compile time, does not toggle `IsFastMath`. 
This prevents `libkernel-sscp-host-fast-full.bc` to be loaded (libkernel-sscp-host-full.bc is loaded instead). 
And the [condition](https://github.com/AdaptiveCpp/AdaptiveCpp/blob/799002752fc1ecf49a347de048d3680bdf00190d/src/compiler/llvm-to-backend/host/LLVMToHost.cpp#L253) that adds fast-math flags to the llc invocation is never true. 

