### PR TITLE
Enable direct peer access for CUDA and HIP

### DIFF
--- a/src/runtime/cuda/cuda_hardware_manager.cpp
+++ b/src/runtime/cuda/cuda_hardware_manager.cpp
@@ -11,6 +11,7 @@
 #include "hipSYCL/runtime/cuda/cuda_hardware_manager.hpp"
 #include "hipSYCL/runtime/cuda/cuda_event_pool.hpp"
 #include "hipSYCL/runtime/cuda/cuda_allocator.hpp"
+#include "hipSYCL/runtime/cuda/cuda_device_manager.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/hardware.hpp"
@@ -57,7 +58,7 @@ cuda_hardware_manager::cuda_hardware_manager(hardware_platform hw_platform)
   }
 
   for (int dev = 0; dev < num_devices; ++dev) {
-    cudaSetDevice(dev);
+    cuda_device_manager::get().activate_device(dev);
 
     for (int peer_dev = 0; peer_dev < num_devices; ++peer_dev) {
       if (peer_dev != dev) {

--- a/src/runtime/cuda/cuda_hardware_manager.cpp
+++ b/src/runtime/cuda/cuda_hardware_manager.cpp
@@ -56,6 +56,27 @@ cuda_hardware_manager::cuda_hardware_manager(hardware_platform hw_platform)
     _devices.emplace_back(dev);
   }
 
+  for (int dev = 0; dev < num_devices; ++dev) {
+    cudaSetDevice(dev);
+
+    for (int peer_dev = 0; peer_dev < num_devices; ++peer_dev) {
+      if (peer_dev != dev) {
+        int can_access;
+        err = cudaDeviceCanAccessPeer(&can_access, dev, peer_dev);
+
+        if (err == cudaSuccess && can_access) {
+          err = cudaDeviceEnablePeerAccess(peer_dev, 0);
+
+          if (err != cudaSuccess && err != cudaErrorPeerAccessAlreadyEnabled) {
+            print_warning(
+              __acpp_here(),
+              error_info{"cuda_hardware_manager: Could not enable peer access",
+                error_code{"CUDA", err}});
+          }
+        }
+      }
+    }
+  }
 }
 
 

--- a/src/runtime/hip/hip_hardware_manager.cpp
+++ b/src/runtime/hip/hip_hardware_manager.cpp
@@ -13,7 +13,9 @@
 #include "hipSYCL/runtime/hip/hip_event_pool.hpp"
 #include "hipSYCL/runtime/hip/hip_allocator.hpp"
 #include "hipSYCL/runtime/hip/hip_target.hpp"
+#include "hipSYCL/runtime/hip/hip_device_manager.hpp"
 #include "hipSYCL/runtime/error.hpp"
+
 #include <exception>
 #include <cstdlib>
 #include <limits>
@@ -80,7 +82,7 @@ hip_hardware_manager::hip_hardware_manager(hardware_platform hw_platform)
   }
 
   for (int dev = 0; dev < num_devices; ++dev) {
-    hipSetDevice(dev);
+    hip_device_manager::get().activate_device(dev);
 
     for (int peer_dev = 0; peer_dev < num_devices; ++peer_dev) {
       if (peer_dev != dev) {

--- a/src/runtime/hip/hip_hardware_manager.cpp
+++ b/src/runtime/hip/hip_hardware_manager.cpp
@@ -79,6 +79,27 @@ hip_hardware_manager::hip_hardware_manager(hardware_platform hw_platform)
     _devices.emplace_back(dev);
   }
 
+  for (int dev = 0; dev < num_devices; ++dev) {
+    hipSetDevice(dev);
+
+    for (int peer_dev = 0; peer_dev < num_devices; ++peer_dev) {
+      if (peer_dev != dev) {
+        int can_access;
+        err = hipDeviceCanAccessPeer(&can_access, dev, peer_dev);
+
+        if (err == hipSuccess && can_access) {
+          err = hipDeviceEnablePeerAccess(peer_dev, 0);
+
+          if (err != hipSuccess && err != hipErrorPeerAccessAlreadyEnabled) {
+            print_warning(
+              __acpp_here(),
+              error_info{"hip_hardware_manager: Could not enable peer access",
+                error_code{"HIP", err}});
+          }
+        }
+      }
+    }
+  }
 }
 
 


### PR DESCRIPTION
Following the recent discussion in https://github.com/AdaptiveCpp/AdaptiveCpp/discussions/1849, this patch adds direct peer-to-peer access for NVIDIA and AMD GPUs.