### PR TITLE
[NFC][doc] Update outdated CMake invocation for building LLVM

### DIFF
--- a/doc/install-llvm.md
+++ b/doc/install-llvm.md
@@ -33,25 +33,25 @@ It is generally not necessary to compile LLVM by yourself. However, if you wish 
 - Generate `libLLVM.so`: `-DLLVM_BUILD_LLVM_DYLIB=ON` (only required if the SSCP compilation flow is enabled when building AdaptiveCpp, which is true by default for supported versions of LLVM)
 - Enable the correct backends for your hardware: `nvptx` for NVIDIA GPUs and `amdgpu` for AMD GPUs.
 
-An example build of LLVM 15 from source might look like this:
+An example build of LLVM 20 from source might look like this:
 
 ```
-git clone https://github.com/llvm/llvm-project -b release/15.x
+git clone https://github.com/llvm/llvm-project -b release/20.x
 cd llvm-project
 mkdir -p build
 cd build
 
 INSTALL_PREFIX=/path/to/desired/llvm/installation/directory
 
-cmake -DCMAKE_C_COMPILER=`which gcc` -DCMAKE_CXX_COMPILER=`which g++` \
+cmake -DCMAKE_C_COMPILER=`which gcc` \
+      -DCMAKE_CXX_COMPILER=`which g++` \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX \
-      -DLLVM_ENABLE_PROJECTS="clang;compiler-rt;lld;openmp" \
+      -DLLVM_ENABLE_PROJECTS="clang;lld;openmp" \
+      -DLLVM_ENABLE_RUNTIMES=compiler-rt \
       -DOPENMP_ENABLE_LIBOMPTARGET=OFF \
-      -DCMAKE_BUILD_TYPE=Release \
       -DLLVM_ENABLE_ASSERTIONS=OFF \
       -DLLVM_TARGETS_TO_BUILD="AMDGPU;NVPTX;X86" \
-      -DCLANG_ANALYZER_ENABLE_Z3_SOLVER=0 \
       -DLLVM_INCLUDE_BENCHMARKS=0 \
       -DLLVM_INCLUDE_EXAMPLES=0 \
       -DLLVM_INCLUDE_TESTS=0 \
@@ -61,7 +61,9 @@ cmake -DCMAKE_C_COMPILER=`which gcc` -DCMAKE_CXX_COMPILER=`which g++` \
       -DLLVM_ENABLE_BINDINGS=OFF \
       -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=OFF \
       -DLLVM_BUILD_LLVM_DYLIB=ON \
-      -DLLVM_ENABLE_DUMP=OFF  ../llvm
+      -DLLVM_ENABLE_DUMP=OFF \
+      ../llvm
+
 make install
 ```
 


### PR DESCRIPTION
The example CMake command for building LLVM, which is provided in the install-llvm.md documentation file, is a bit outdated. I have therefore updated it. In particular, I have made the following changes:

- Bump the LLVM version used from 15 to 20.

- Use `-DLLVM_ENABLE_RUNTIMES=compiler-rt` instead of enabling `compiler-rt` via `-DLLVM_ENABLE_PROJECTS`, as enabling `compiler-rt` through `LLVM_ENABLE_PROJECTS` [was deprecated in LLVM 20](https://releases.llvm.org/20.1.0/docs/ReleaseNotes.html#changes-to-building-llvm) and will result in an error starting in LLVM 21, according to the following check in LLVM 20's llvm/CMakeLists.txt:

	```cmake
	if ("compiler-rt" IN_LIST LLVM_ENABLE_PROJECTS)
	  message(WARNING "Using LLVM_ENABLE_PROJECTS=compiler-rt is deprecated now, and will "
	    "become a fatal error in the LLVM 21 release.  Please use "
	    "-DLLVM_ENABLE_RUNTIMES=compiler-rt or see the instructions at "
	    "https://compiler-rt.llvm.org/ for building the runtimes.")
	endif()
	```

	I have checked, and this usage of `LLVM_ENABLE_RUNTIMES` seems to have already been supported in the oldest version of LLVM supported by us (LLVM 15).

- Support for the `-DCLANG_ANALYZER_ENABLE_Z3_SOLVER` flag [was removed all the way back in LLVM 9](https://releases.llvm.org/9.0.0/docs/ReleaseNotes.html?utm_source=chatgpt.com#non-comprehensive-list-of-changes-in-this-release); hence, I have removed it here as well.

- `CMAKE_BUILD_TYPE` was previously set twice for no apparent reason. I have therefore removed one of its occurrences.