### PR TITLE
[NFC] llvm-to-host: fix typo in assert message ("unsupport" -> "unsupported")

### DIFF
--- a/src/compiler/llvm-to-backend/host/LLVMToHost.cpp
+++ b/src/compiler/llvm-to-backend/host/LLVMToHost.cpp
@@ -389,7 +389,7 @@ createLLVMToHostTranslator(const std::vector<std::string> &KernelNames) {
 }
 
 void LLVMToHostTranslator::migrateKernelProperties(llvm::Function *From, llvm::Function *To) {
-  assert(false && "migrateKernelProperties is unsupport for LLVMToHost");
+  assert(false && "migrateKernelProperties is unsupported for LLVMToHost");
 }
 
 } // namespace compiler


### PR DESCRIPTION
Fixes a typo in an assert message: "unsupport" -> "unsupported".