### PR TITLE
[NFC] llvm-to-backend: remove duplicate AlwaysInliner include

### DIFF
--- a/src/compiler/llvm-to-backend/LLVMToBackend.cpp
+++ b/src/compiler/llvm-to-backend/LLVMToBackend.cpp
@@ -44,7 +44,6 @@
 #include <llvm/Support/Error.h>
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Bitcode/BitcodeWriter.h>
-#include <llvm/Transforms/IPO/AlwaysInliner.h>
 #include <string>
 #include <optional>
 #include <cstdlib>


### PR DESCRIPTION
Remove a duplicated `#include <llvm/Transforms/IPO/AlwaysInliner.h>` in  
`src/compiler/llvm-to-backend/LLVMToBackend.cpp`.