### PR TITLE
[CBS] fix missing erasure of replaced load instructions

### DIFF
--- a/src/compiler/cbs/IRUtils.cpp
+++ b/src/compiler/cbs/IRUtils.cpp
@@ -40,6 +40,7 @@ void replaceUsesOfGVWith(llvm::Function &F, llvm::StringRef GlobalVarName, llvm:
     if (auto I = llvm::dyn_cast<llvm::LoadInst>(U); I && I->getFunction() == &F) {
       HIPSYCL_DEBUG_INFO << LogPrefix << "RUOGVW: " << *I << " with " << *To << "\n";
       I->replaceAllUsesWith(To);
+      ToErase.push_back(I);
     }
   }
   for (auto I : ToErase)


### PR DESCRIPTION
In `src/compiler/cbs/IRUtils.cpp`, `replaceUsesOfGVWith`, after replacing uses of `LoadInst` with new value, the original load instructions were not being erased. This change adds each replaced `LoadInst` to the `ToErase` vector to ensure proper cleanup.