### PR TITLE
Fix kernel with a range greater than INTMAX

### DIFF
--- a/include/hipSYCL/sycl/libkernel/detail/thread_hierarchy.hpp
+++ b/include/hipSYCL/sycl/libkernel/detail/thread_hierarchy.hpp
@@ -25,7 +25,7 @@ namespace detail {
 #define HIPSYCL_DEFINE_BUILTIN_VARIABLE_QUERY(                                 \
     name, cuda_variable, hip_variable, sscp_variable, host_variable)           \
   ACPP_KERNEL_TARGET                                                        \
-  inline int name() {                                                          \
+  inline size_t name() {                                                       \
     __acpp_backend_switch(return 0, return sscp_variable(),                    \
                                  return cuda_variable, return hip_variable)    \
   }


### PR DESCRIPTION
Hello, This pull request fixes the bug preventing the generic backend from correctly invoking kernels whose globalSize is greater than INTMAX.  ( [which should be allowed ](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#nditem-class))

This should make [this test ](https://github.com/KhronosGroup/SYCL-CTS/blob/97daa051bf99d3e39f96dcba7f92614c4a5816e8/tests/range/range_api.cpp#L274C9-L274C36) from the SYCL-CTS work. 

Here is a reproducer : 
(⚠️This will use more than 50G of memory )

```
#include <sycl/sycl.hpp>
#include <omp.h>

#define WG (size_t) 16

int main(int argc, char* argv[])
{

  if (argc != 2) {
    printf("Usage: %s <size>\n", argv[0]);
    return 1;
  }
  const size_t size = std::stoull(argv[1]);

  sycl::queue q(sycl::cpu_selector_v, sycl::property::queue::in_order());

  size_t *a_d = sycl::malloc_device<size_t>(size, q);
  size_t *a = sycl::malloc_host<size_t>(size, q);

  size_t wg_cnt = (size + WG - 1) / WG;
  sycl::range<1> gws ( wg_cnt * WG );
  sycl::range<1> lws (WG);

  q.submit([&] (sycl::handler &cgh) {
    cgh.parallel_for<class fwd>(sycl::nd_range<1>(gws, lws), [=] (sycl::nd_item<1> item) {

      size_t idx = item.get_global_id(0);
      if(idx < size)
        a_d[idx] = idx;

    });
  });
  q.memcpy(a, a_d, size*sizeof(size_t));
  q.wait();

  int err = 0;
#pragma omp parallel for reduction(+:err)
  for(size_t i = 0; i<size; i++){
    if( a[i] != i )
      err += 1;
  }
  printf("verif: %s \n", err ? "FAIL" : "PASS");

  return 0;
}

```

`acpp --acpp-targets=generic -Ofast -fopenmp main.cpp -o main &&  ACPP_VISIBILITY_MASK=omp ./main 4294967296`
