### PR TITLE
KnownGroupSize type should be size_t instead of int

### DIFF
--- a/include/hipSYCL/compiler/llvm-to-backend/GlobalSizesFitInI32OptPass.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/GlobalSizesFitInI32OptPass.hpp
@@ -19,14 +19,14 @@ namespace compiler {
 
 class GlobalSizesFitInI32OptPass : public llvm::PassInfoMixin<GlobalSizesFitInI32OptPass> {
 public:
-  GlobalSizesFitInI32OptPass(bool GlobalSizesFitInInt, int KnownGroupSizeX = -1,
-                             int KnownGroupSizeY = -1, int KnownGroupSizeZ = -1);
+  GlobalSizesFitInI32OptPass(bool GlobalSizesFitInInt, size_t KnownGroupSizeX = 0,
+                             size_t KnownGroupSizeY = 0, size_t KnownGroupSizeZ = 0);
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
 private:
-  int KnownGroupSizeX;
-  int KnownGroupSizeY;
-  int KnownGroupSizeZ;
+  size_t KnownGroupSizeX;
+  size_t KnownGroupSizeY;
+  size_t KnownGroupSizeZ;
   bool GlobalSizesFitInInt;
 };
 

--- a/include/hipSYCL/compiler/llvm-to-backend/KnownGroupSizeOptPass.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/KnownGroupSizeOptPass.hpp
@@ -19,14 +19,14 @@ namespace compiler {
 
 class KnownGroupSizeOptPass : public llvm::PassInfoMixin<KnownGroupSizeOptPass> {
 public:
-  KnownGroupSizeOptPass(int KnownGroupSizeX = -1, int KnownGroupSizeY = -1,
-                        int KnownGroupSizeZ = -1);
+  KnownGroupSizeOptPass(size_t KnownGroupSizeX = 0, size_t KnownGroupSizeY = 0,
+                        size_t KnownGroupSizeZ = 0);
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
 private:
-  int KnownGroupSizeX;
-  int KnownGroupSizeY;
-  int KnownGroupSizeZ;
+  size_t KnownGroupSizeX;
+  size_t KnownGroupSizeY;
+  size_t KnownGroupSizeZ;
 };
 
 }

--- a/include/hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp
@@ -206,9 +206,9 @@ protected:
 
   // These will be non-zero if work group sizes are known at jit time.
   // Backends should check these values for being != 0 before using them.
-  int KnownGroupSizeX = 0;
-  int KnownGroupSizeY = 0;
-  int KnownGroupSizeZ = 0;
+  size_t KnownGroupSizeX = 0;
+  size_t KnownGroupSizeY = 0;
+  size_t KnownGroupSizeZ = 0;
 
   // Will be >= 0 if set by option. Backends using this should therefore check >= 0.
   std::int64_t KnownLocalMemSize = -1;

--- a/include/hipSYCL/compiler/llvm-to-backend/host/HostKernelWrapperPass.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/host/HostKernelWrapperPass.hpp
@@ -18,11 +18,11 @@ namespace compiler {
 
 class HostKernelWrapperPass : public llvm::PassInfoMixin<HostKernelWrapperPass> {
   std::int64_t DynamicLocalMemSize;
-  std::array<int, 3> KnownWgSize;
+  std::array<size_t, 3> KnownWgSize;
 
 public:
-  explicit HostKernelWrapperPass(std::int64_t DynamicLocalMemSize, int KnownGroupSizeX,
-                                 int KnownGroupSizeY, int KnownGroupSizeZ)
+  explicit HostKernelWrapperPass(std::int64_t DynamicLocalMemSize, size_t KnownGroupSizeX,
+                                 size_t KnownGroupSizeY, size_t KnownGroupSizeZ)
       : DynamicLocalMemSize{DynamicLocalMemSize},
         KnownWgSize{KnownGroupSizeX, KnownGroupSizeY, KnownGroupSizeZ} {}
 

--- a/src/compiler/llvm-to-backend/GlobalSizesFitInI32OptPass.cpp
+++ b/src/compiler/llvm-to-backend/GlobalSizesFitInI32OptPass.cpp
@@ -71,8 +71,8 @@ bool insertRangeAssumptionForBuiltinCalls(llvm::Module &M, llvm::StringRef Built
   return true;
 }
 
-GlobalSizesFitInI32OptPass::GlobalSizesFitInI32OptPass(bool FitsInInt, int GroupSizeX,
-                                                       int GroupSizeY, int GroupSizeZ)
+GlobalSizesFitInI32OptPass::GlobalSizesFitInI32OptPass(bool FitsInInt, size_t GroupSizeX,
+                                                       size_t GroupSizeY, size_t GroupSizeZ)
     : GlobalSizesFitInInt{FitsInInt}, KnownGroupSizeX{GroupSizeX}, KnownGroupSizeY{GroupSizeY},
       KnownGroupSizeZ{GroupSizeZ} {}
 

--- a/src/compiler/llvm-to-backend/KnownGroupSizeOptPass.cpp
+++ b/src/compiler/llvm-to-backend/KnownGroupSizeOptPass.cpp
@@ -22,7 +22,7 @@ namespace compiler {
 namespace {
 
 
-bool applyKnownGroupSize(llvm::Module &M, int KnownGroupSize,
+bool applyKnownGroupSize(llvm::Module &M, size_t KnownGroupSize,
                          llvm::StringRef GetGroupSizeBuiltinName,
                          llvm::StringRef GetLocalIdBuiltinName) {
 
@@ -67,7 +67,7 @@ bool applyKnownGroupSize(llvm::Module &M, int KnownGroupSize,
 
 }
 
-KnownGroupSizeOptPass::KnownGroupSizeOptPass(int GroupSizeX, int GroupSizeY, int GroupSizeZ)
+KnownGroupSizeOptPass::KnownGroupSizeOptPass(size_t GroupSizeX, size_t GroupSizeY, size_t GroupSizeZ)
     : KnownGroupSizeX{GroupSizeX}, KnownGroupSizeY{GroupSizeY}, KnownGroupSizeZ{GroupSizeZ} {}
 
 

--- a/src/compiler/llvm-to-backend/LLVMToBackend.cpp
+++ b/src/compiler/llvm-to-backend/LLVMToBackend.cpp
@@ -230,13 +230,13 @@ bool LLVMToBackendTranslator::setBuildOption(const std::string &Option, const st
   HIPSYCL_DEBUG_INFO << "LLVMToBackend: Using build option: " << Option << "=" << Value << "\n";
 
   if(Option == "known-group-size-x") {
-    KnownGroupSizeX = std::stoi(Value);
+    KnownGroupSizeX = std::stoull(Value);
     return true;
   } else if (Option == "known-group-size-y") {
-    KnownGroupSizeY = std::stoi(Value);
+    KnownGroupSizeY = std::stoull(Value);
     return true;
   } else if (Option == "known-group-size-z") {
-    KnownGroupSizeZ = std::stoi(Value);
+    KnownGroupSizeZ = std::stoull(Value);
     return true;
   } else if (Option == "known-local-mem-size") {
     KnownLocalMemSize = std::stoi(Value);

--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -574,7 +574,7 @@ void LLVMToAmdgpuTranslator::applyKernelProperties(llvm::Function* F) {
   F->setCallingConv(llvm::CallingConv::AMDGPU_KERNEL);
 
   if (KnownGroupSizeX != 0 && KnownGroupSizeY != 0 && KnownGroupSizeZ != 0) {
-    int FlatGroupSize = KnownGroupSizeX * KnownGroupSizeY * KnownGroupSizeZ;
+    size_t FlatGroupSize = KnownGroupSizeX * KnownGroupSizeY * KnownGroupSizeZ;
 
     if (!F->hasFnAttribute("amdgpu-flat-work-group-size"))
       F->addFnAttr("amdgpu-flat-work-group-size",

--- a/src/compiler/llvm-to-backend/host/HostKernelWrapperPass.cpp
+++ b/src/compiler/llvm-to-backend/host/HostKernelWrapperPass.cpp
@@ -64,7 +64,7 @@ void replaceUsesOfGVWith(llvm::Function &F, llvm::StringRef GlobalVarName, llvm:
  * struct and the user arguments need to be passed to the wrapper.
  */
 llvm::Function *makeWrapperFunction(llvm::Function &F, std::int64_t DynamicLocalMemSize,
-                                    const std::array<int, 3> &KnownWgSize) {
+                                    const std::array<size_t, 3> &KnownWgSize) {
   auto M = F.getParent();
   auto &Ctx = M->getContext();
 

--- a/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
+++ b/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
@@ -384,6 +384,7 @@ void LLVMToPtxTranslator::applyKernelProperties(llvm::Function* F) {
   M.getOrInsertNamedMetadata("nvvm.annotations")
       ->addOperand(llvm::MDTuple::get(M.getContext(), Operands));
 
+  auto SizeT = M.getDataLayout().getLargestLegalIntType(M.getContext());
   if(KnownGroupSizeX > 0 && KnownGroupSizeY > 0 && KnownGroupSizeZ > 0) {
 
     llvm::SmallVector<llvm::Metadata*, 7> KnownGroupSizeOperands;
@@ -391,15 +392,15 @@ void LLVMToPtxTranslator::applyKernelProperties(llvm::Function* F) {
     
     KnownGroupSizeOperands.push_back(llvm::MDString::get(M.getContext(), "maxntidx"));
     KnownGroupSizeOperands.push_back(llvm::ValueAsMetadata::getConstant(
-      llvm::ConstantInt::get(llvm::Type::getInt32Ty(M.getContext()), KnownGroupSizeX)));
+      llvm::ConstantInt::get(SizeT, KnownGroupSizeX)));
 
     KnownGroupSizeOperands.push_back(llvm::MDString::get(M.getContext(), "maxntidy"));
     KnownGroupSizeOperands.push_back(llvm::ValueAsMetadata::getConstant(
-      llvm::ConstantInt::get(llvm::Type::getInt32Ty(M.getContext()), KnownGroupSizeY)));
+      llvm::ConstantInt::get(SizeT, KnownGroupSizeY)));
     
     KnownGroupSizeOperands.push_back(llvm::MDString::get(M.getContext(), "maxntidz"));
     KnownGroupSizeOperands.push_back(llvm::ValueAsMetadata::getConstant(
-      llvm::ConstantInt::get(llvm::Type::getInt32Ty(M.getContext()), KnownGroupSizeZ)));
+      llvm::ConstantInt::get(SizeT, KnownGroupSizeZ)));
     
     M.getOrInsertNamedMetadata("nvvm.annotations")
       ->addOperand(llvm::MDTuple::get(M.getContext(), KnownGroupSizeOperands));

--- a/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
+++ b/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
@@ -444,14 +444,15 @@ void LLVMToSpirvTranslator::applyKernelProperties(llvm::Function* F) {
 
   llvm::Module& M = *F->getParent();
 
+  auto SizeT = M.getDataLayout().getLargestLegalIntType(M.getContext());
   if (KnownGroupSizeX != 0 && KnownGroupSizeY != 0 && KnownGroupSizeZ != 0) {
     llvm::SmallVector<llvm::Metadata *> MDs;
     MDs.push_back(llvm::ConstantAsMetadata::get(
-        llvm::ConstantInt::get(llvm::Type::getInt32Ty(M.getContext()), KnownGroupSizeX)));
+        llvm::ConstantInt::get(SizeT, KnownGroupSizeX)));
     MDs.push_back(llvm::ConstantAsMetadata::get(
-        llvm::ConstantInt::get(llvm::Type::getInt32Ty(M.getContext()), KnownGroupSizeY)));
+        llvm::ConstantInt::get(SizeT, KnownGroupSizeY)));
     MDs.push_back(llvm::ConstantAsMetadata::get(
-        llvm::ConstantInt::get(llvm::Type::getInt32Ty(M.getContext()), KnownGroupSizeZ)));
+        llvm::ConstantInt::get(SizeT, KnownGroupSizeZ)));
 
     static const char *ReqdWGSize = "reqd_work_group_size";
     F->setMetadata(ReqdWGSize, llvm::MDNode::get(M.getContext(), MDs));


### PR DESCRIPTION
[According to the standard](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#api:info-device-max-work-group-size), the type of groupSize should be size_t. This pull request changes the type of KnownGroupSize variables from int to size_t. 

The max_group_size of any existing device should always be way smaller than UINTMAX+1, but since AdaptiveCpp is currently not verifying that the requested group size is lesser than the max_group_size of the device, this PR should prevent unexpected behavior before AdaptiveCpp transmits the kernel to the device. ( This should also remove this crash  that occur when requesting a group size > INTMAX  :

```
terminate called after throwing an instance of 'std::out_of_range'
  what():  stoi
```
)