### PR TITLE
Change some LLVM API calls when using LLVM 21

### DIFF
--- a/src/compiler/cbs/SubCfgFormation.cpp
+++ b/src/compiler/cbs/SubCfgFormation.cpp
@@ -1141,7 +1141,14 @@ bool fillUserHull(llvm::AllocaInst *Alloca, llvm::SmallVectorImpl<llvm::Instruct
             WL.push_back(UI);
           if (auto CI = llvm::dyn_cast<llvm::CallBase>(UI)) {
             auto OperandNo = U.getOperandNo();
-            if (!CI->dataOperandHasImpliedAttr(OperandNo, llvm::Attribute::NoCapture) &&
+#if LLVM_VERSION_MAJOR > 20
+            if (!CI->dataOperandHasImpliedAttr(
+                OperandNo, llvm::Attribute::getWithCaptureInfo(
+                      CI->getContext(),llvm::CaptureInfo::none()).getKindAsEnum()) &&
+#else
+            if (!CI->dataOperandHasImpliedAttr(
+                OperandNo, llvm::Attribute::NoCapture) &&
+#endif
                 !CI->dataOperandHasImpliedAttr(OperandNo, llvm::Attribute::StructRet)) {
               HIPSYCL_DEBUG_INFO << "[SubCFG] Found function call that captures " << *I << ": "
                                  << *CI << " OperandNo: " << OperandNo << "\n";

--- a/src/compiler/llvm-to-backend/LLVMToBackend.cpp
+++ b/src/compiler/llvm-to-backend/LLVMToBackend.cpp
@@ -137,7 +137,11 @@ bool linkBitcode(llvm::Module &M, std::unique_ptr<llvm::Module> OtherM,
                    const std::string &ForcedDataLayout = "",
                    llvm::Linker::Flags Flags = llvm::Linker::Flags::LinkOnlyNeeded) {
   if(!ForcedTriple.empty())
+#if LLVM_VERSION_MAJOR > 20
+    OtherM->setTargetTriple(llvm::Triple(ForcedTriple));
+#else
     OtherM->setTargetTriple(ForcedTriple);
+#endif
   if(!ForcedDataLayout.empty())
     OtherM->setDataLayout(ForcedDataLayout);
 

--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -263,7 +263,12 @@ LLVMToAmdgpuTranslator::LLVMToAmdgpuTranslator(const std::vector<std::string> &K
 
 bool LLVMToAmdgpuTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
   
+#if LLVM_VERSION_MAJOR > 20
+  M.setTargetTriple(llvm::Triple(TargetTriple));
+#else
   M.setTargetTriple(TargetTriple);
+#endif
+
 #if LLVM_VERSION_MAJOR >= 18
   M.setDataLayout("e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-p7:160:256:256:"
                   "32-p8:128:128-p9:192:256:256:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:"

--- a/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
+++ b/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
@@ -141,7 +141,12 @@ bool LLVMToPtxTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
       "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-i128:128:128-f32:32:32-"
       "f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64";
 
+#if LLVM_VERSION_MAJOR > 20
+  M.setTargetTriple(llvm::Triple(Triple));
+#else
   M.setTargetTriple(Triple);
+#endif
+
   M.setDataLayout(DataLayout);
 
   // Initialize libdevice parameters. These values are < 0 in case no explicit

--- a/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
+++ b/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
@@ -187,8 +187,12 @@ LLVMToSpirvTranslator::LLVMToSpirvTranslator(const std::vector<std::string> &KN)
       KernelNames{KN} {}
 
 bool LLVMToSpirvTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
-  
+
+#if LLVM_VERSION_MAJOR > 20
+  M.setTargetTriple(llvm::Triple("spir64-unknown-unknown"));
+#else
   M.setTargetTriple("spir64-unknown-unknown");
+#endif
   M.setDataLayout("e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:"
                   "1024-A4-n8:16:32:64");
 
@@ -226,7 +230,11 @@ bool LLVMToSpirvTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
     common::filesystem::join_path(common::filesystem::get_install_directory(),
       {"lib", "hipSYCL", "bitcode", "libkernel-sscp-spirv-full.bc"});
 
+#if LLVM_VERSION_MAJOR > 20
+  if (!this->linkBitcodeFile(M, BuiltinBitcodeFile, M.getTargetTriple().str(), M.getDataLayoutStr()))
+#else
   if (!this->linkBitcodeFile(M, BuiltinBitcodeFile, M.getTargetTriple(), M.getDataLayoutStr()))
+#endif
     return false;
 
   // Set up local memory


### PR DESCRIPTION
LLVM pre-release 21 is now out (pre-release available [here](https://github.com/llvm/llvm-project/releases/tag/llvmorg-21.1.0-rc1) ) and introduces some API changes.

This PR adds support for (yet to be released)  LLVM21 : 
 -  `setTargetTriple` now takes `llvm::Triple` instead of a string (https://github.com/llvm/llvm-project/pull/129868)  
 -  `Attribute::NoCapture` no longer exists, replace it with `llvm::CaptureInfo::none()`  (https://github.com/llvm/llvm-project/commit/29441e4f5fa5f5c7709f7cf180815ba97f611297)