### PR TITLE
Remove double overloads from SYCL native builtins

### DIFF
--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp
@@ -231,15 +231,11 @@ HIPSYCL_DEFINE_HIPLIKE_MATH_BUILTIN(__acpp_trunc, truncf, trunc)
 // ***************** native math builtins ******************
 
 #define HIPSYCL_DEFINE_HIPLIKE_NATIVE_MATH_BUILTIN(name, sp_impl, dp_impl)     \
-  HIPSYCL_HIPLIKE_BUILTIN float name(float x) noexcept { return sp_impl(x); }  \
-  HIPSYCL_HIPLIKE_BUILTIN double name(double x) noexcept { return dp_impl(x); }
+  HIPSYCL_HIPLIKE_BUILTIN float name(float x) noexcept { return sp_impl(x); }
 
 #define HIPSYCL_DEFINE_HIPLIKE_NATIVE_MATH_BUILTIN2(name, sp_impl, dp_impl)    \
   HIPSYCL_HIPLIKE_BUILTIN float name(float x, float y) noexcept {              \
     return sp_impl(x, y);                                                      \
-  }                                                                            \
-  HIPSYCL_HIPLIKE_BUILTIN double name(double x, double y) noexcept {           \
-    return dp_impl(x, y);                                                      \
   }
 
 HIPSYCL_DEFINE_HIPLIKE_NATIVE_MATH_BUILTIN(__acpp_native_cos, __cosf,

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins.hpp
@@ -218,17 +218,11 @@ HIPSYCL_DEFINE_SSCP_GENFLOAT_MATH_BUILTIN(trunc)
 #define HIPSYCL_DEFINE_SSCP_GENFLOAT_NATIVE_BUILTIN(name)                    \
   HIPSYCL_BUILTIN float __acpp_native_##name(float x) noexcept {             \
     return __acpp_sscp_native_##name##_f32(x);                               \
-  }                                                                          \
-  HIPSYCL_BUILTIN double __acpp_native_##name(double x) noexcept {           \
-    return __acpp_sscp_native_##name##_f64(x);                               \
   }
 
 #define HIPSYCL_DEFINE_SSCP_GENFLOAT_NATIVE_BUILTIN2(name)                   \
   HIPSYCL_BUILTIN float __acpp_native_##name(float x, float y) noexcept {    \
     return __acpp_sscp_native_##name##_f32(x, y);                            \
-  }                                                                          \
-  HIPSYCL_BUILTIN double __acpp_native_##name(double x, double y) noexcept { \
-    return __acpp_sscp_native_##name##_f64(x, y);                            \
   }
 
 

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/native.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/native.hpp
@@ -14,45 +14,31 @@
 #include "builtin_config.hpp"
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_cos_f32(float);
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_cos_f64(double);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_divide_f32(float, float);
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_divide_f64(double, double);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_exp_f32(float);
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_exp_f64(double);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_exp2_f32(float);
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_exp2_f64(double);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_exp10_f32(float);
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_exp10_f64(double);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_log_f32(float);
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_log_f64(double);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_log2_f32(float);
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_log2_f64(double);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_log10_f32(float);
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_log10_f64(double);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_powr_f32(float, float);
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_powr_f64(double, double);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_recip_f32(float);
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_recip_f64(double);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_rsqrt_f32(float);
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_rsqrt_f64(double);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_sin_f32(float);
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_sin_f64(double);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_sqrt_f32(float);
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_sqrt_f64(double);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_tan_f32(float);
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_tan_f64(double);
 
 #endif

--- a/src/libkernel/sscp/amdgpu/native.cpp
+++ b/src/libkernel/sscp/amdgpu/native.cpp
@@ -14,43 +14,29 @@
 #include "hipSYCL/sycl/libkernel/sscp/builtins/amdgpu/ocml.hpp"
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_cos_f32(float x) { return __ocml_native_cos_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_cos_f64(double x) { return __ocml_native_cos_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_divide_f32(float x, float y) { return x / y; }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_divide_f64(double x, double y) { return x / y; }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_exp_f32(float x) { return __ocml_native_exp_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_exp_f64(double x) { return __ocml_native_exp_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_exp2_f32(float x) { return __ocml_native_exp2_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_exp2_f64(double x) { return __ocml_native_exp2_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_exp10_f32(float x) { return __ocml_native_exp10_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_exp10_f64(double x) { return __acpp_sscp_exp10_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_log_f32(float x) { return __ocml_native_log_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_log_f64(double x) { return __ocml_native_log_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_log2_f32(float x) { return __ocml_native_log2_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_log2_f64(double x) { return __ocml_native_log2_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_log10_f32(float x) { return __ocml_native_log10_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_log10_f64(double x) { return __ocml_native_log10_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_powr_f32(float x, float y) { return __acpp_sscp_powr_f32(x, y); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_powr_f64(double x, double y) { return __acpp_sscp_powr_f64(x, y); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_recip_f32(float x) { return __ocml_native_recip_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_recip_f64(double x) { return __ocml_native_recip_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_rsqrt_f32(float x) { return __ocml_native_rsqrt_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_rsqrt_f64(double x) { return __ocml_native_rsqrt_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_sin_f32(float x) { return __ocml_native_sin_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_sin_f64(double x) { return __ocml_native_sin_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_sqrt_f32(float x) { return __ocml_native_sqrt_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_sqrt_f64(double x) { return __ocml_native_sqrt_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_tan_f32(float x) { return __acpp_sscp_tan_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_tan_f64(double x) { return __acpp_sscp_tan_f64(x); }

--- a/src/libkernel/sscp/host/native.cpp
+++ b/src/libkernel/sscp/host/native.cpp
@@ -13,43 +13,29 @@
 #include "hipSYCL/sycl/libkernel/sscp/builtins/native.hpp"
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_cos_f32(float x) { return __acpp_sscp_cos_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_cos_f64(double x) { return __acpp_sscp_cos_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_divide_f32(float x, float y) { return x / y; }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_divide_f64(double x, double y) { return x / y; }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_exp_f32(float x) { return __acpp_sscp_exp_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_exp_f64(double x) { return __acpp_sscp_exp_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_exp2_f32(float x) { return __acpp_sscp_exp2_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_exp2_f64(double x) { return __acpp_sscp_exp2_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_exp10_f32(float x) { return __acpp_sscp_exp10_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_exp10_f64(double x) { return __acpp_sscp_exp10_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_log_f32(float x) { return __acpp_sscp_log_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_log_f64(double x) { return __acpp_sscp_log_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_log2_f32(float x) { return __acpp_sscp_log2_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_log2_f64(double x) { return __acpp_sscp_log2_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_log10_f32(float x) { return __acpp_sscp_log10_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_log10_f64(double x) { return __acpp_sscp_log10_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_powr_f32(float x, float y) { return __acpp_sscp_powr_f32(x, y); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_powr_f64(double x, double y) { return __acpp_sscp_powr_f64(x, y); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_recip_f32(float x) { return __acpp_sscp_native_divide_f32(1.f, x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_recip_f64(double x) { return __acpp_sscp_native_divide_f64(1.f, x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_rsqrt_f32(float x) { return __acpp_sscp_rsqrt_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_rsqrt_f64(double x) { return __acpp_sscp_rsqrt_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_sin_f32(float x) { return __acpp_sscp_sin_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_sin_f64(double x) { return __acpp_sscp_sin_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_sqrt_f32(float x) { return __acpp_sscp_sqrt_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_sqrt_f64(double x) { return __acpp_sscp_sqrt_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_tan_f32(float x) { return __acpp_sscp_tan_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_tan_f64(double x) { return __acpp_sscp_tan_f64(x); }

--- a/src/libkernel/sscp/ptx/native.cpp
+++ b/src/libkernel/sscp/ptx/native.cpp
@@ -14,43 +14,29 @@
 #include "hipSYCL/sycl/libkernel/sscp/builtins/ptx/libdevice.hpp"
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_cos_f32(float x) { return __nv_fast_cosf(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_cos_f64(double x) { return __nv_cos(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_divide_f32(float x, float y) { return __nv_fast_fdividef(x, y); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_divide_f64(double x, double y) { return x / y; }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_exp_f32(float x) { return __nv_fast_expf(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_exp_f64(double x) { return __acpp_sscp_exp_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_exp2_f32(float x) { return __acpp_sscp_exp2_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_exp2_f64(double x) { return __acpp_sscp_exp2_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_exp10_f32(float x) { return __nv_fast_exp10f(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_exp10_f64(double x) { return __acpp_sscp_exp10_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_log_f32(float x) { return __nv_fast_logf(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_log_f64(double x) { return __acpp_sscp_log_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_log2_f32(float x) { return __nv_fast_log2f(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_log2_f64(double x) { return __acpp_sscp_log2_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_log10_f32(float x) { return __nv_fast_log10f(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_log10_f64(double x) { return __acpp_sscp_log10_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_powr_f32(float x, float y) { return __nv_fast_powf(x, y); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_powr_f64(double x, double y) { return __acpp_sscp_powr_f64(x, y); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_recip_f32(float x) { return 1.f / x; }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_recip_f64(double x) { return 1. / x; }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_rsqrt_f32(float x) { return __acpp_sscp_rsqrt_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_rsqrt_f64(double x) { return __acpp_sscp_rsqrt_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_sin_f32(float x) { return __nv_fast_sinf(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_sin_f64(double x) { return __acpp_sscp_sin_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_sqrt_f32(float x) { return __nvvm_sqrt_rn_f(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_sqrt_f64(double x) { return __nvvm_sqrt_rn_d(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_tan_f32(float x) { return __nv_fast_tanf(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_tan_f64(double x) { return __acpp_sscp_tan_f64(x); }

--- a/src/libkernel/sscp/spirv/native.cpp
+++ b/src/libkernel/sscp/spirv/native.cpp
@@ -13,43 +13,29 @@
 #include "hipSYCL/sycl/libkernel/sscp/builtins/native.hpp"
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_cos_f32(float x) { return __acpp_sscp_cos_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_cos_f64(double x) { return __acpp_sscp_cos_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_divide_f32(float x, float y) { return x / y; }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_divide_f64(double x, double y) { return x / y; }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_exp_f32(float x) { return __acpp_sscp_exp_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_exp_f64(double x) { return __acpp_sscp_exp_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_exp2_f32(float x) { return __acpp_sscp_exp2_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_exp2_f64(double x) { return __acpp_sscp_exp2_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_exp10_f32(float x) { return __acpp_sscp_exp10_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_exp10_f64(double x) { return __acpp_sscp_exp10_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_log_f32(float x) { return __acpp_sscp_log_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_log_f64(double x) { return __acpp_sscp_log_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_log2_f32(float x) { return __acpp_sscp_log2_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_log2_f64(double x) { return __acpp_sscp_log2_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_log10_f32(float x) { return __acpp_sscp_log10_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_log10_f64(double x) { return __acpp_sscp_log10_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_powr_f32(float x, float y) { return __acpp_sscp_powr_f32(x, y); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_powr_f64(double x, double y) { return __acpp_sscp_powr_f64(x, y); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_recip_f32(float x) { return 1.f / x; }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_recip_f64(double x) { return 1. / x; }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_rsqrt_f32(float x) { return __acpp_sscp_rsqrt_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_rsqrt_f64(double x) { return __acpp_sscp_rsqrt_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_sin_f32(float x) { return __acpp_sscp_sin_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_sin_f64(double x) { return __acpp_sscp_sin_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_sqrt_f32(float x) { return __acpp_sscp_sqrt_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_sqrt_f64(double x) { return __acpp_sscp_sqrt_f64(x); }
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_native_tan_f32(float x) { return __acpp_sscp_tan_f32(x); }
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_native_tan_f64(double x) { return __acpp_sscp_tan_f64(x); }


### PR DESCRIPTION
These are not in the SYCL standard, and can no longer even be called after the refactoring of the math builtins.

https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_native_precision_math_functions