### PR TITLE
[CUDA] Add support for CUDA 13

### DIFF
--- a/src/runtime/cuda/cuda_allocator.cpp
+++ b/src/runtime/cuda/cuda_allocator.cpp
@@ -147,8 +147,15 @@ result cuda_allocator::query_pointer(const void *ptr, pointer_info &out) const {
 result cuda_allocator::mem_advise(const void *addr, std::size_t num_bytes,
                             int advise) const {
 #ifndef _WIN32
+  #if CUDART_VERSION >= 13000
+  cudaMemLocation location;
+  location.id = _dev;
+  location.type = cudaMemLocationTypeDevice;
+  #else
+  int location = _dev;
+  #endif
   cudaError_t err = cudaMemAdvise(addr, num_bytes,
-                                  static_cast<cudaMemoryAdvise>(advise), _dev);
+                                  static_cast<cudaMemoryAdvise>(advise), location);
   if(err != cudaSuccess) {
     return make_error(
       __acpp_here(),

--- a/src/runtime/cuda/cuda_hardware_manager.cpp
+++ b/src/runtime/cuda/cuda_hardware_manager.cpp
@@ -329,7 +329,18 @@ cuda_hardware_context::get_property(device_uint_property prop) const {
     return 2;
     break;
   case device_uint_property::max_clock_speed:
+#if CUDART_VERSION >= 13000
+    {
+      int clockRate = 0;
+      auto err = cudaDeviceGetAttribute(&clockRate, cudaDevAttrClockRate, _dev);
+      if (err == cudaSuccess)
+        return clockRate / 1000;
+      else
+        return 0;
+    }
+#else
     return _properties->clockRate / 1000;
+#endif
     break;
   case device_uint_property::max_malloc_size:
     return _properties->totalGlobalMem;

--- a/src/runtime/cuda/cuda_queue.cpp
+++ b/src/runtime/cuda/cuda_queue.cpp
@@ -416,15 +416,24 @@ result cuda_queue::submit_prefetch(prefetch_operation& op, const dag_node_ptr& n
   cuda_instrumentation_guard instrumentation{this, op, node.get()};
 #ifndef _WIN32
   cudaError_t err = cudaSuccess;
-  
-  if (op.get_target().is_host()) {
-    err = cudaMemPrefetchAsync(op.get_pointer(), op.get_num_bytes(),
-                                        cudaCpuDeviceId, get_stream());
-  } else {
-    err = cudaMemPrefetchAsync(op.get_pointer(), op.get_num_bytes(),
-                                        _dev.get_id(), get_stream());
-  }
 
+  #if CUDART_VERSION >= 13000
+  cudaMemLocation location;
+  if (op.get_target().is_host()) {
+    location.id = 0; // ignored
+    location.type = cudaMemLocationTypeHostNumaCurrent;
+  } else {
+    location.id = _dev.get_id();
+    location.type = cudaMemLocationTypeDevice;
+  }
+  const unsigned int flags = 0;
+  err = cudaMemPrefetchAsync(op.get_pointer(), op.get_num_bytes(),
+                                    location, flags, get_stream());
+  #else
+  int location = op.get_target().is_host() ? cudaCpuDeviceId : _dev.get_id();
+  err = cudaMemPrefetchAsync(op.get_pointer(), op.get_num_bytes(),
+                                           location, get_stream());
+  #endif
 
   if (err != cudaSuccess) {
     return make_error(__acpp_here(),

--- a/src/runtime/cuda/cuda_queue.cpp
+++ b/src/runtime/cuda/cuda_queue.cpp
@@ -68,6 +68,7 @@ unsigned select_ptx_version(unsigned sm_version, unsigned& ptx_target) {
        {80, 70},
        {86, 71},
        {87, 74},
+       {88, 90},
        {89, 78},
        {90, 80},
        // some variants of 100, 101 need 8.6, some 8.8
@@ -75,6 +76,7 @@ unsigned select_ptx_version(unsigned sm_version, unsigned& ptx_target) {
        {100, 88},
        {101, 88},
        {103, 88},
+       {110, 90},
        {120, 88},
        {121, 88}};
 


### PR DESCRIPTION
Some runtime functions got removed.

Requires LLVM 22 (and thus #1887).

Release notes: https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html