### PR TITLE
Fix out-of-bounds write in `ze_queue::get_enqueued_event_handles()`

### DIFF
--- a/src/runtime/ze/ze_queue.cpp
+++ b/src/runtime/ze/ze_queue.cpp
@@ -412,8 +412,8 @@ ze_queue::get_enqueued_event_handles() const {
   if(!wait_events.empty()) {
     evts.reserve(wait_events.size());
     for(std::size_t i = 0; i < wait_events.size(); ++i) {
-      evts[i] = static_cast<ze_node_event *>(wait_events[i].get())
-                    ->get_event_handle();
+      evts.emplace_back(static_cast<ze_node_event *>(wait_events[i].get())
+                    ->get_event_handle());
     }
   }
   return evts;


### PR DESCRIPTION
## Description

This PR fixes a bug in `ze_queue::get_enqueued_event_handles()`.
Previously, the code called `reserve()` on the `std::vector<ze_event_handle_t>` and then attempted to assign values via `evts[i]` without actually resizing or inserting elements. This resulted in out-of-bounds writes.

The fix replaces the assignment with `emplace_back()`, which correctly appends elements to the `std::vector`.

## Changes

Replace `evts[i] = ...` with `evts.emplace_back(...)` after reserving capacity.

## Impact

Prevents undefined behavior from writing to an empty vector.

Ensures `get_enqueued_event_handles()` returns the correct list of event handles.

## Notes

An alternative would be to replace `reserve()` with `resize()` and keep the `evts[i] = ...` assignment. This works today since `ze_event_handle_t` is an alias for a raw pointer type, afaik, and default-initialized elements would just be `nullptr`. However, I chose `emplace_back()` instead because it does not rely on `ze_event_handle_t` remaining a raw pointer type in future revisions.