### PR TITLE
Refactor the group algorithms to work in-place

### DIFF
--- a/include/hipSYCL/algorithms/numeric.hpp
+++ b/include/hipSYCL/algorithms/numeric.hpp
@@ -32,32 +32,12 @@ namespace hipsycl::algorithms {
 
 namespace detail {
 
-template<class T, class Op>
-struct identity {
-  static constexpr bool is_known() { return false; }
-};
-
-#define HIPSYCL_ALGORITHMS_DEFINE_KNOWN_IDENTITY(op, value)                    \
-  template <class T> struct identity<T, op> {                                  \
-    static constexpr bool is_known() { return true; }                          \
-    static T get_identity() { return value; }                                  \
-  };
-
-// TODO: Need to restrict this to fundamental types
-HIPSYCL_ALGORITHMS_DEFINE_KNOWN_IDENTITY(std::plus<T>, T{})
-HIPSYCL_ALGORITHMS_DEFINE_KNOWN_IDENTITY(std::multiplies<T>, T{1})
-
-HIPSYCL_ALGORITHMS_DEFINE_KNOWN_IDENTITY(sycl::plus<T>, T{})
-HIPSYCL_ALGORITHMS_DEFINE_KNOWN_IDENTITY(sycl::multiplies<T>, T{1})
-HIPSYCL_ALGORITHMS_DEFINE_KNOWN_IDENTITY(sycl::minimum<T>, std::numeric_limits<T>::max())
-HIPSYCL_ALGORITHMS_DEFINE_KNOWN_IDENTITY(sycl::maximum<T>, std::numeric_limits<T>::min())
-
 
 template<class T, class BinaryOp>
 auto get_reduction_operator_configuration(const BinaryOp& op) {
-  if constexpr(detail::identity<T, BinaryOp>::is_known()) {
+  if constexpr(sycl::has_known_identity_v<BinaryOp, T>) {
     return reduction::reduction_binary_operator<T, BinaryOp, true>{
-        op, detail::identity<T, BinaryOp>::get_identity()};
+        op, sycl::known_identity_v<BinaryOp, T>};
   } else {
     return reduction::reduction_binary_operator<T, BinaryOp, false>{op};
   }

--- a/include/hipSYCL/sycl/libkernel/backend.hpp
+++ b/include/hipSYCL/sycl/libkernel/backend.hpp
@@ -93,17 +93,27 @@
 
 #ifndef __acpp_if_target_host
  #if !ACPP_LIBKERNEL_IS_DEVICE_PASS
-  #define __acpp_if_target_host(...) __VA_ARGS__
+  #define __acpp_if_target_host(...)                                         \
+   if constexpr (true) {                                                     \
+     __VA_ARGS__                                                             \
+   }
  #else
-  #define __acpp_if_target_host(...)
+  #define __acpp_if_target_host(...)                                         \
+   if constexpr (false) {                                                    \
+   }
  #endif
 #endif
 
 #ifndef __acpp_if_target_device
  #if ACPP_LIBKERNEL_IS_DEVICE_PASS
-  #define __acpp_if_target_device(...) __VA_ARGS__
+  #define __acpp_if_target_device(...)                                       \
+   if constexpr (true) {                                                     \
+     __VA_ARGS__                                                             \
+   }
  #else
-  #define __acpp_if_target_device(...)
+  #define __acpp_if_target_device(...)                                       \
+   if constexpr (false) {                                                    \
+   }
  #endif
 #endif
 

--- a/include/hipSYCL/sycl/libkernel/cuda/cuda_backend.hpp
+++ b/include/hipSYCL/sycl/libkernel/cuda/cuda_backend.hpp
@@ -60,13 +60,13 @@
 #ifdef ACPP_LIBKERNEL_CUDA_NVCXX
  #define ACPP_LIBKERNEL_IS_UNIFIED_HOST_DEVICE_PASS 1
 
-#define __acpp_if_target_host(...)                                          \
-  if target (nv::target::is_host) {                                            \
-    __VA_ARGS__                                                                \
+ #define __acpp_if_target_host(...)                                         \
+  if target (nv::target::is_host) {                                         \
+    __VA_ARGS__                                                             \
   }
 #define __acpp_if_target_device(...)                                        \
-  if target (nv::target::is_device) {                                          \
-    __VA_ARGS__                                                                \
+  if target (nv::target::is_device) {                                       \
+    __VA_ARGS__                                                             \
   }
 #else
  #define ACPP_LIBKERNEL_IS_UNIFIED_HOST_DEVICE_PASS 0

--- a/include/hipSYCL/sycl/libkernel/functional.hpp
+++ b/include/hipSYCL/sycl/libkernel/functional.hpp
@@ -19,61 +19,23 @@
 namespace hipsycl {
 namespace sycl {
 
+template <typename, std::size_t>
+class marray;
+
+template <typename, int, class>
+class vec;
+
 // TODO We might want to alias these to std:: types?
-template <typename T = void> struct plus {
-  ACPP_KERNEL_TARGET
-  T operator()(const T &x, const T &y) const { return x + y; }
-};
-
-template <> struct plus<void> {
-  template<class T>
-  ACPP_KERNEL_TARGET
-  T operator()(const T &x, const T &y) const { return x + y; }
-};
-
-template <typename T = void> struct multiplies {
-  ACPP_KERNEL_TARGET
-  T operator()(const T &x, const T &y) const { return x * y; }
-};
-
-template<> struct multiplies<void> {
-  template<class T>
-  ACPP_KERNEL_TARGET
-  T operator()(const T &x, const T &y) const { return x * y; }
-};
-
-template <typename T = void> struct bit_and {
-  ACPP_KERNEL_TARGET
-  T operator()(const T &x, const T &y) const { return x & y; }
-};
-
-template<> struct bit_and <void>{
-  template<class T>
-  ACPP_KERNEL_TARGET
-  T operator()(const T &x, const T &y) const { return x & y; }
-};
-
-template <typename T = void> struct bit_or {
-  ACPP_KERNEL_TARGET
-  T operator()(const T &x, const T &y) const { return x | y; }
-};
-
-template<> struct bit_or <void>{
-  template<class T>
-  ACPP_KERNEL_TARGET
-  T operator()(const T &x, const T &y) const { return x | y; }
-};
-
-template <typename T = void> struct bit_xor {
-  ACPP_KERNEL_TARGET
-  T operator()(const T &x, const T &y) const { return x ^ y; }
-};
-
-template<> struct bit_xor <void>{
-  template<class T>
-  ACPP_KERNEL_TARGET
-  T operator()(const T &x, const T &y) const { return x ^ y; }
-};
+template <typename T = void>
+using plus = std::plus<T>;
+template <typename T = void>
+using multiplies = std::multiplies<T>;
+template <typename T = void>
+using bit_and = std::bit_and<T>;
+template <typename T = void>
+using bit_or = std::bit_or<T>;
+template <typename T = void>
+using bit_xor = std::bit_xor<T>;
 
 template <typename T = void> struct logical_and {
   ACPP_KERNEL_TARGET
@@ -119,134 +81,119 @@ template<> struct maximum <void>{
   T operator()(const T &x, const T &y) const { return (x > y) ? x : y; }
 };
 
+namespace detail {
+template <typename BinaryOperation, typename AccumulatorT, typename = void>
+struct known_identity_impl;
+}
+
 template <typename BinaryOperation, typename AccumulatorT>
-struct known_identity {};
+struct known_identity : detail::known_identity_impl<BinaryOperation, std::decay_t<AccumulatorT>> {};
 
 template <typename BinaryOperation, typename AccumulatorT>
 inline constexpr AccumulatorT known_identity_v =
     known_identity<BinaryOperation, AccumulatorT>::value;
 
+namespace detail {
+template <typename BinaryOperation, typename AccumulatorT, typename = void>
+struct has_known_identity_impl : std::false_type {};
+
 template <typename BinaryOperation, typename AccumulatorT>
-struct has_known_identity : public std::false_type {};
+struct has_known_identity_impl<BinaryOperation, AccumulatorT, std::void_t<decltype(known_identity<BinaryOperation, AccumulatorT>::value)>> : std::true_type {};
+}
 
-template <class U, class AccumulatorT>
-struct has_known_identity<plus<U>, AccumulatorT> {
-  static constexpr bool value =
-      std::is_arithmetic_v<AccumulatorT> ||
-      std::is_same_v<std::remove_cv_t<AccumulatorT>, sycl::half>;
-};
-
-template <class U, class AccumulatorT>
-struct has_known_identity<multiplies<U>, AccumulatorT> {
-  static constexpr bool value =
-      std::is_arithmetic_v<AccumulatorT> ||
-      std::is_same_v<std::remove_cv_t<AccumulatorT>, sycl::half>;
-};
-
-template <class U, class AccumulatorT>
-struct has_known_identity<bit_and<U>, AccumulatorT> {
-  static constexpr bool value = std::is_integral_v<AccumulatorT>;
-};
-
-template <class U, class AccumulatorT>
-struct has_known_identity<bit_or<U>, AccumulatorT> {
-  static constexpr bool value = std::is_integral_v<AccumulatorT>;
-};
-
-template <class U, class AccumulatorT>
-struct has_known_identity<bit_xor<U>, AccumulatorT> {
-  static constexpr bool value = std::is_integral_v<AccumulatorT>;
-};
-
-template <class U, class AccumulatorT>
-struct has_known_identity<logical_and<U>, AccumulatorT> {
-  static constexpr bool value = std::is_same_v<std::remove_cv_t<AccumulatorT>, bool>;
-};
-
-template <class U, class AccumulatorT>
-struct has_known_identity<logical_or<U>, AccumulatorT> {
-  static constexpr bool value = std::is_same_v<std::remove_cv_t<AccumulatorT>, bool>;
-};
-
-template <class U, class AccumulatorT>
-struct has_known_identity<minimum<U>, AccumulatorT> {
-  static constexpr bool value =
-      std::is_integral_v<AccumulatorT> ||
-      std::is_floating_point_v<AccumulatorT> ||
-      std::is_same_v<std::remove_cv_t<AccumulatorT>, sycl::half>;
-};
-
-template <class U, class AccumulatorT>
-struct has_known_identity<maximum<U>, AccumulatorT> {
-  static constexpr bool value =
-      std::is_integral_v<AccumulatorT> ||
-      std::is_floating_point_v<AccumulatorT> ||
-      std::is_same_v<std::remove_cv_t<AccumulatorT>, sycl::half>;
-};
-
-template<class U, class AccumulatorT>
-struct known_identity<plus<U>, AccumulatorT> {
-  static constexpr AccumulatorT value = AccumulatorT{};
-};
-
-template<class U, class AccumulatorT>
-struct known_identity<multiplies<U>, AccumulatorT> {
-  static constexpr AccumulatorT value = AccumulatorT{1};
-};
-
-template<class U, class AccumulatorT>
-struct known_identity<bit_and<U>, AccumulatorT> {
-  static constexpr AccumulatorT value = ~AccumulatorT{};
-};
-
-template<class U, class AccumulatorT>
-struct known_identity<bit_or<U>, AccumulatorT> {
-  static constexpr AccumulatorT value = AccumulatorT{};
-};
-
-template<class U, class AccumulatorT>
-struct known_identity<bit_xor<U>, AccumulatorT> {
-  static constexpr AccumulatorT value = AccumulatorT{};
-};
-
-template<class U, class AccumulatorT>
-struct known_identity<logical_and<U>, AccumulatorT> {
-  static constexpr AccumulatorT value = true;
-};
-
-template<class U, class AccumulatorT>
-struct known_identity<logical_or<U>, AccumulatorT> {
-  static constexpr AccumulatorT value = false;
-};
-
-template<class U, class AccumulatorT>
-struct known_identity<minimum<U>, AccumulatorT> {
-private:
-  static constexpr auto get() {
-    if constexpr(std::is_integral_v<AccumulatorT>)
-      return std::numeric_limits<AccumulatorT>::max();
-    else return std::numeric_limits<AccumulatorT>::infinity();
-  }
-public:
-  static constexpr AccumulatorT value = get();
-};
-
-template<class U, class AccumulatorT>
-struct known_identity<maximum<U>, AccumulatorT> {
-private:
-  static constexpr auto get() {
-    if constexpr(std::is_integral_v<AccumulatorT>)
-      return std::numeric_limits<AccumulatorT>::lowest();
-    else return -std::numeric_limits<AccumulatorT>::infinity();
-  }
-public:
-  static constexpr AccumulatorT value = get();
-};
+template <typename BinaryOperation, typename AccumulatorT>
+struct has_known_identity : detail::has_known_identity_impl<BinaryOperation, AccumulatorT> {};
 
 template <typename BinaryOperation, typename AccumulatorT>
 inline constexpr bool has_known_identity_v =
     has_known_identity<BinaryOperation, AccumulatorT>::value;
 
+namespace detail {
+template <typename BinaryOperation, typename AccumulatorT, typename >
+struct known_identity_impl{};
+
+template<class U, class AccumulatorT>
+struct known_identity_impl<plus<U>, AccumulatorT,
+  std::enable_if_t<std::is_arithmetic_v<AccumulatorT> ||
+    std::is_same_v<std::remove_cv_t<AccumulatorT>, sycl::half>>> {
+  static constexpr AccumulatorT value = AccumulatorT{};
+};
+
+template<class U, class AccumulatorT>
+struct known_identity_impl<multiplies<U>, AccumulatorT,
+  std::enable_if_t<std::is_arithmetic_v<AccumulatorT> ||
+    std::is_same_v<std::remove_cv_t<AccumulatorT>, sycl::half>>> {
+  static constexpr AccumulatorT value = AccumulatorT{1};
+};
+
+template<class U, class AccumulatorT>
+struct known_identity_impl<bit_and<U>, AccumulatorT,
+  std::enable_if_t<std::is_integral_v<AccumulatorT>>> {
+  static constexpr AccumulatorT value = ~AccumulatorT{};
+};
+
+template<class U, class AccumulatorT>
+struct known_identity_impl<bit_or<U>, AccumulatorT,
+  std::enable_if_t<std::is_integral_v<AccumulatorT>>> {
+  static constexpr AccumulatorT value = AccumulatorT{};
+};
+
+template<class U, class AccumulatorT>
+struct known_identity_impl<bit_xor<U>, AccumulatorT,
+  std::enable_if_t<std::is_integral_v<AccumulatorT>>> {
+  static constexpr AccumulatorT value = AccumulatorT{};
+};
+
+template<class U, class AccumulatorT>
+struct known_identity_impl<logical_and<U>, AccumulatorT,
+  std::enable_if_t<std::is_same_v<std::remove_cv_t<AccumulatorT>, bool>>> {
+  static constexpr AccumulatorT value = true;
+};
+
+template<class U, class AccumulatorT>
+struct known_identity_impl<logical_or<U>, AccumulatorT,
+  std::enable_if_t<std::is_same_v<std::remove_cv_t<AccumulatorT>, bool>>> {
+  static constexpr AccumulatorT value = false;
+};
+
+template<class U, class AccumulatorT>
+struct known_identity_impl<minimum<U>, AccumulatorT,
+  std::enable_if_t<std::is_integral_v<AccumulatorT>>> {
+  static constexpr AccumulatorT value = std::numeric_limits<AccumulatorT>::max();
+};
+
+template<class U, class AccumulatorT>
+struct known_identity_impl<minimum<U>, AccumulatorT,
+  std::enable_if_t<std::is_floating_point_v<AccumulatorT> ||
+    std::is_same_v<std::remove_cv_t<AccumulatorT>, sycl::half>>> {
+  static constexpr AccumulatorT value = std::numeric_limits<AccumulatorT>::infinity();
+};
+
+template<class U, class AccumulatorT>
+struct known_identity_impl<maximum<U>, AccumulatorT,
+  std::enable_if_t<std::is_integral_v<AccumulatorT>>> {
+  static constexpr AccumulatorT value = std::numeric_limits<AccumulatorT>::lowest();
+};
+
+template<class U, class AccumulatorT>
+struct known_identity_impl<maximum<U>, AccumulatorT,
+  std::enable_if_t<std::is_floating_point_v<AccumulatorT> ||
+    std::is_same_v<std::remove_cv_t<AccumulatorT>, sycl::half>>> {
+  static constexpr AccumulatorT value = -std::numeric_limits<AccumulatorT>::infinity();
+};
+
+template <typename BinaryOperation, typename AccumulatorT, std::size_t NumElements>
+struct known_identity_impl<BinaryOperation, marray<AccumulatorT, NumElements>,
+  std::enable_if_t<has_known_identity_v<BinaryOperation, AccumulatorT>>> {
+  static constexpr auto value = marray<AccumulatorT, NumElements>(known_identity_v<BinaryOperation, AccumulatorT>);
+};
+
+template <typename BinaryOperation, typename AccumulatorT, int N, class VectorStorage>
+struct known_identity_impl<BinaryOperation, vec<AccumulatorT, N, VectorStorage>,
+  std::enable_if_t<has_known_identity_v<BinaryOperation, AccumulatorT>>> {
+  static constexpr auto value = vec<AccumulatorT, N, VectorStorage>(known_identity_v<BinaryOperation, AccumulatorT>);
+};
+}
 
 
 } // namespace sycl

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/group_functions.hpp
@@ -218,9 +218,9 @@ __device__ T __acpp_shift_group_right(
   scratch[lid] = x;
   __acpp_group_barrier(g);
 
-  // checking for both larger and smaller in case 'group<Dim>::linear_id_type' is not unsigned
-  if (target_lid > g.get_local_range().size() || target_lid < 0)
+  if (target_lid > g.get_local_range().size()) {
     target_lid = 0;
+  }
 
   return scratch[target_lid];
 }
@@ -473,9 +473,9 @@ __device__ T __acpp_permute_group_by_xor(
   scratch[lid] = x;
   __acpp_group_barrier(g);
 
-  // checking for both larger and smaller in case 'group<Dim>::linear_id_type' is not unsigned
-  if (target_lid > g.get_local_range().size() || target_lid < 0)
+  if (target_lid > g.get_local_range().size()) {
     target_lid = 0;
+  }
 
   return scratch[target_lid];
 }
@@ -502,9 +502,9 @@ __device__ T __acpp_select_from_group(
   scratch[lid] = x;
   __acpp_group_barrier(g);
 
-  // checking for both larger and smaller in case 'group<Dim>::linear_id_type' is not unsigned
-  if (target_lid > g.get_local_range().size() || target_lid < 0)
+  if (target_lid > g.get_local_range().size()) {
     target_lid = 0;
+  }
 
   return scratch[target_lid];
 }

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/group_functions.hpp
@@ -15,6 +15,7 @@
 #include "../../backend.hpp"
 #include "../../detail/data_layout.hpp"
 #include "../../detail/thread_hierarchy.hpp"
+#include "../../functional.hpp"
 #include "../../id.hpp"
 #include "../../sub_group.hpp"
 #include "../../vec.hpp"
@@ -177,6 +178,58 @@ bool __acpp_leader_all_of(Group g, T *first, T *last, Predicate pred) {
 }
 }
 
+// shift_left
+template <int Dim, typename T>
+__device__ T __acpp_shift_group_left(
+    group<Dim> g, T x, typename group<Dim>::linear_id_type delta = 1) {
+  __shared__ std::aligned_storage_t<sizeof(T) * detail::max_group_size, alignof(T)>
+             scratch_storage;
+  T *        scratch = reinterpret_cast<T *>(&scratch_storage);
+
+  typename group<Dim>::linear_id_type lid        = g.get_local_linear_id();
+  typename group<Dim>::linear_id_type target_lid = lid + delta;
+
+  scratch[lid] = x;
+  __acpp_group_barrier(g);
+
+  if (target_lid > g.get_local_range().size())
+    target_lid = 0;
+
+  return scratch[target_lid];
+}
+
+template <typename T>
+__device__ T __acpp_shift_group_left(
+    sub_group g, T x, typename sub_group::linear_id_type delta = 1) {
+  return detail::__acpp_shuffle_down_impl(x, delta);
+}
+
+// shift_right
+template <int Dim, typename T>
+__device__ T __acpp_shift_group_right(
+    group<Dim> g, T x, typename group<Dim>::linear_id_type delta = 1) {
+  __shared__ std::aligned_storage_t<sizeof(T) * detail::max_group_size, alignof(T)>
+             scratch_storage;
+  T *        scratch = reinterpret_cast<T *>(&scratch_storage);
+
+  typename group<Dim>::linear_id_type lid        = g.get_local_linear_id();
+  typename group<Dim>::linear_id_type target_lid = lid - delta;
+
+  scratch[lid] = x;
+  __acpp_group_barrier(g);
+
+  // checking for both larger and smaller in case 'group<Dim>::linear_id_type' is not unsigned
+  if (target_lid > g.get_local_range().size() || target_lid < 0)
+    target_lid = 0;
+
+  return scratch[target_lid];
+}
+
+template <typename T>
+__device__ T __acpp_shift_group_right(
+    sub_group g, T x, typename sub_group::linear_id_type delta = 1) {
+  return detail::__acpp_shuffle_up_impl(x, delta);
+}
 
 // none_of
 template<int Dim>
@@ -352,102 +405,10 @@ __device__ T __acpp_inclusive_scan_over_group(group<Dim> g, T x,
 
 template <typename Group, typename V, typename T, typename BinaryOperation,
           std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-__device__ T __acpp_inclusive_scan_over_group(Group g, V x, T init,
-                                                 BinaryOperation binary_op) {
+__device__ T __acpp_inclusive_scan_over_group(Group g, V x,
+                                                 BinaryOperation binary_op, T init) {
   T scan = __acpp_inclusive_scan_over_group(g, T{x}, binary_op);
   return binary_op(scan, init);
-}
-
-template <typename Group, typename InPtr, typename OutPtr, typename T,
-          typename BinaryOperation,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-__device__ OutPtr __acpp_joint_inclusive_scan(Group g, InPtr first,
-                                                 InPtr last, OutPtr result,
-                                                 BinaryOperation binary_op,
-                                                 T init) {
-  using OutT = std::remove_reference_t<decltype(*result)>;
-
-  auto         lid          = g.get_local_linear_id();
-  auto         wid          = lid / __acpp_warp_size;
-  size_t       lrange       = g.get_local_range().size();
-  const size_t num_elements = last - first;
-  const size_t iterations   = (num_elements + lrange - 1) / lrange;
-
-  const size_t warp_size =
-      (wid == lrange / __acpp_warp_size && lrange % __acpp_warp_size != 0) ? lrange % __acpp_warp_size : __acpp_warp_size;
-
-  size_t offset     = lid;
-  OutT      carry_over = init;
-  OutT      local_x;
-
-  for (int i = 0; i < iterations; ++i) {
-    const size_t offset = lid + i * lrange;
-    local_x = (offset < num_elements) ? first[offset] : OutT{};
-    local_x =
-        __acpp_inclusive_scan_over_group(g, local_x, carry_over, binary_op);
-
-    if (offset < num_elements)
-      result[offset] = local_x;
-
-    carry_over = __acpp_group_broadcast(g, local_x, lrange - 1);
-  }
-
-  return result + num_elements;
-}
-
-template <typename Group, typename InPtr, typename OutPtr,
-          typename BinaryOperation,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-__device__ OutPtr __acpp_joint_inclusive_scan(Group g, InPtr first,
-                                                 InPtr last, OutPtr result,
-                                                 BinaryOperation binary_op) {
-  using OutT = std::remove_reference_t<decltype(*result)>;
-
-  auto         lid          = g.get_local_linear_id();
-  auto         wid          = lid / __acpp_warp_size;
-  size_t       lrange       = g.get_local_range().size();
-  const size_t num_elements = last - first;
-  const size_t iterations   = (num_elements + lrange - 1) / lrange;
-
-  OutT carry_over;
-  OutT local_x;
-
-  for (int i = 0; i < iterations; ++i) {
-    const size_t offset = lid + i * lrange;
-    local_x             = (offset < num_elements) ? first[offset] : OutT{};
-    if (i > 0) {
-      local_x =
-          __acpp_inclusive_scan_over_group(g, local_x, carry_over, binary_op);
-    } else {
-      local_x = __acpp_inclusive_scan_over_group(g, local_x, binary_op);
-    }
-
-    if (offset < num_elements)
-      result[offset] = local_x;
-
-    carry_over = __acpp_group_broadcast(g, local_x, lrange - 1);
-  }
-
-  return result + num_elements;
-}
-
-namespace detail { // until scoped-parallelism can be detected
-template <typename Group, typename V, typename T, typename BinaryOperation,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-__device__ T *
-__acpp_leader_inclusive_scan(Group g, V *first, V *last, T *result,
-                                BinaryOperation binary_op, T init) {
-  return __acpp_joint_inclusive_scan(g, first, last, result, binary_op,
-                                        init);
-}
-
-template<typename Group, typename V, typename T, typename BinaryOperation,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-__device__
-T *__acpp_leader_inclusive_scan(Group g, V *first, V *last, T *result,
-                         BinaryOperation binary_op) {
-  return __acpp_joint_inclusive_scan(g, first, last, result, binary_op);
-}
 }
 
 // exclusive_scan
@@ -495,105 +456,7 @@ template<typename Group, typename T, typename BinaryOperation,
           std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
 __device__
 T __acpp_exclusive_scan_over_group(Group g, T x, BinaryOperation binary_op) {
-  return __acpp_exclusive_scan_over_group(g, x, T{}, binary_op);
-}
-
-template <typename Group, typename InPtr, typename OutPtr, typename T,
-          typename BinaryOperation,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-__device__ OutPtr __acpp_joint_exclusive_scan(Group g, InPtr first,
-                                                 InPtr last, OutPtr result,
-                                                 T init,
-                                                 BinaryOperation binary_op) {
-  auto lid = g.get_local_linear_id();
-  if (lid == 0 && last - first > 0)
-    result[0] = init;
-  return __acpp_joint_inclusive_scan(g, first, last - 1, result + 1,
-                                        binary_op, init);
-}
-
-template <typename Group, typename InPtr, typename OutPtr,
-          typename BinaryOperation,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-__device__ OutPtr __acpp_joint_exclusive_scan(Group g, InPtr first,
-                                                 InPtr last, OutPtr result,
-                                                 BinaryOperation binary_op) {
-  using OutT = std::remove_reference_t<decltype(*result)>;
-  return __acpp_joint_exclusive_scan(
-      g, first, last, result, OutT{},
-      binary_op);
-}
-
-namespace detail { // until scoped-parallelism can be detected
-template <typename Group, typename V, typename T, typename BinaryOperation,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-__device__ T *__acpp_leader_exclusive_scan(Group g, V *first, V *last,
-                                              T *result, T init,
-                                              BinaryOperation binary_op) {
-  return __acpp_joint_exclusive_scan(g, first, last, result, init,
-                                        binary_op);
-}
-
-template <typename Group, typename V, typename T, typename BinaryOperation,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-__device__ T *__acpp_leader_exclusive_scan(Group g, V *first, V *last,
-                                              T *result,
-                                              BinaryOperation binary_op) {
-  return __acpp_joint_exclusive_scan(g, first, last, result, binary_op);
-}
-}
-
-// shift_left
-template <int Dim, typename T>
-__device__ T __acpp_shift_group_left(
-    group<Dim> g, T x, typename group<Dim>::linear_id_type delta = 1) {
-  __shared__ std::aligned_storage_t<sizeof(T) * detail::max_group_size, alignof(T)>
-             scratch_storage;
-  T *        scratch = reinterpret_cast<T *>(&scratch_storage);
-
-  typename group<Dim>::linear_id_type lid        = g.get_local_linear_id();
-  typename group<Dim>::linear_id_type target_lid = lid + delta;
-
-  scratch[lid] = x;
-  __acpp_group_barrier(g);
-
-  if (target_lid > g.get_local_range().size())
-    target_lid = 0;
-
-  return scratch[target_lid];
-}
-
-template <typename T>
-__device__ T __acpp_shift_group_left(
-    sub_group g, T x, typename sub_group::linear_id_type delta = 1) {
-  return detail::__acpp_shuffle_down_impl(x, delta);
-}
-
-// shift_right
-template <int Dim, typename T>
-__device__ T __acpp_shift_group_right(
-    group<Dim> g, T x, typename group<Dim>::linear_id_type delta = 1) {
-  __shared__ std::aligned_storage_t<sizeof(T) * detail::max_group_size, alignof(T)>
-             scratch_storage;
-  T *        scratch = reinterpret_cast<T *>(&scratch_storage);
-
-  typename group<Dim>::linear_id_type lid        = g.get_local_linear_id();
-  typename group<Dim>::linear_id_type target_lid = lid - delta;
-
-  scratch[lid] = x;
-  __acpp_group_barrier(g);
-
-  // checking for both larger and smaller in case 'group<Dim>::linear_id_type' is not unsigned
-  if (target_lid > g.get_local_range().size() || target_lid < 0)
-    target_lid = 0;
-
-  return scratch[target_lid];
-}
-
-template <typename T>
-__device__ T __acpp_shift_group_right(
-    sub_group g, T x, typename sub_group::linear_id_type delta = 1) {
-  return detail::__acpp_shuffle_up_impl(x, delta);
+  return __acpp_exclusive_scan_over_group(g, x, sycl::known_identity_v<BinaryOperation, std::decay_t<T>>, binary_op);
 }
 
 // permute_group_by_xor

--- a/include/hipSYCL/sycl/libkernel/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/group_functions.hpp
@@ -277,7 +277,7 @@ template <typename Group, typename InPtr, typename OutPtr, typename T,
 HIPSYCL_BUILTIN OutPtr joint_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
                                                    T init, BinaryOperation binary_op) {
   static_assert(std::is_same_v<decltype(binary_op(init, *first)), T>);
-  static constexpr auto identity = known_identity_v<BinaryOperation, T>;
+  constexpr auto identity = known_identity_v<BinaryOperation, T>;
 
   size_t num_elements = last - first;
   T carry_over = init;
@@ -319,7 +319,7 @@ HIPSYCL_BUILTIN OutPtr joint_exclusive_scan(Group g, InPtr first, InPtr last, Ou
   using value_type = typename std::iterator_traits<OutPtr>::value_type;
   static_assert(std::is_same_v<decltype(binary_op(*first, *first)), value_type>);
   
-  static constexpr auto identity = known_identity_v<BinaryOperation, value_type>;
+  constexpr auto identity = known_identity_v<BinaryOperation, value_type>;
   return joint_exclusive_scan(g, first, last, result, identity, binary_op);
 }
 
@@ -330,7 +330,7 @@ template <typename Group, typename InPtr, typename OutPtr, typename T,
 HIPSYCL_BUILTIN OutPtr joint_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
                                                    BinaryOperation binary_op, T init) {
   static_assert(std::is_same_v<decltype(binary_op(init, *first)), T>);
-  static constexpr auto identity = known_identity_v<BinaryOperation, T>;
+  constexpr auto identity = known_identity_v<BinaryOperation, T>;
 
   size_t num_elements = last - first;
   T carry_over = init;
@@ -371,7 +371,7 @@ HIPSYCL_BUILTIN OutPtr joint_inclusive_scan(Group g, InPtr first, InPtr last, Ou
   using value_type = typename std::iterator_traits<OutPtr>::value_type;
   static_assert(std::is_same_v<decltype(binary_op(*first, *first)), value_type>);
   
-  static constexpr auto identity = known_identity_v<BinaryOperation, value_type>;
+  constexpr auto identity = known_identity_v<BinaryOperation, value_type>;
   return joint_inclusive_scan(g, first, last, result, binary_op, identity);
 }
 

--- a/include/hipSYCL/sycl/libkernel/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/group_functions.hpp
@@ -19,6 +19,7 @@
 #include "vec.hpp"
 #include "detail/builtin_dispatch.hpp"
 
+#include <iterator>
 #include <type_traits>
 
 
@@ -165,27 +166,6 @@ HIPSYCL_BUILTIN T reduce_over_group(Group g, T x, BinaryOperation binary_op) {
                                           binary_op);
 }
 
-// exclusive_scan
-template <typename Group, typename InPtr, typename OutPtr, typename T,
-          typename BinaryOperation,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-HIPSYCL_BUILTIN
-OutPtr joint_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result, T init,
-                       BinaryOperation binary_op) {
-  HIPSYCL_RETURN_DISPATCH_GROUP_ALGORITHM(__acpp_joint_exclusive_scan, g,
-                                          first, last, result, init, binary_op);
-}
-
-template <typename Group, typename InPtr, typename OutPtr,
-          typename BinaryOperation,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-HIPSYCL_BUILTIN
-OutPtr joint_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
-                            BinaryOperation binary_op) {
-  HIPSYCL_RETURN_DISPATCH_GROUP_ALGORITHM(__acpp_joint_exclusive_scan, g,
-                                          first, last, result, binary_op);
-}
-
 template<class Group, typename V, typename T, typename BinaryOperation,
           std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
 HIPSYCL_BUILTIN
@@ -202,26 +182,6 @@ T exclusive_scan_over_group(Group g, T x, BinaryOperation binary_op) {
                                           g, x, binary_op);
 }
 
-template <typename Group, typename InPtr, typename OutPtr, typename T,
-          typename BinaryOperation,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-HIPSYCL_BUILTIN
-OutPtr joint_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
-                       BinaryOperation binary_op, T init) {
-  HIPSYCL_RETURN_DISPATCH_GROUP_ALGORITHM(__acpp_joint_inclusive_scan, g,
-                                          first, last, result, binary_op, init);
-}
-
-template <typename Group, typename InPtr, typename OutPtr,
-          typename BinaryOperation,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-HIPSYCL_BUILTIN
-OutPtr joint_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
-                            BinaryOperation binary_op) {
-  HIPSYCL_RETURN_DISPATCH_GROUP_ALGORITHM(__acpp_joint_inclusive_scan, g,
-                                          first, last, result, binary_op);
-}
-
 template<class Group, class T, typename BinaryOperation,
           std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
 HIPSYCL_BUILTIN
@@ -233,9 +193,9 @@ T inclusive_scan_over_group(Group g, T x, BinaryOperation binary_op) {
 template<typename Group, typename V, typename T, typename BinaryOperation,
           std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
 HIPSYCL_BUILTIN
-T inclusive_scan_over_group(Group g, V x, T init, BinaryOperation binary_op) {
+T inclusive_scan_over_group(Group g, V x, BinaryOperation binary_op, T init) {
   HIPSYCL_RETURN_DISPATCH_GROUP_ALGORITHM(__acpp_inclusive_scan_over_group,
-                                          g, x, init, binary_op);
+                                          g, x, binary_op, init);
 }
 
 // shift_left
@@ -310,6 +270,110 @@ T reduce_over_group(Group g, V x, T init, BinaryOperation binary_op) {
   return binary_op(reduction, init);
 }
 
+// exclusive_scan
+template <typename Group, typename InPtr, typename OutPtr, typename T,
+          typename BinaryOperation,
+          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
+HIPSYCL_BUILTIN OutPtr joint_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
+                                                   T init, BinaryOperation binary_op) {
+  static_assert(std::is_same_v<decltype(binary_op(init, *first)), T>);
+  static constexpr auto identity = known_identity_v<BinaryOperation, T>;
+
+  size_t num_elements = last - first;
+  T carry_over = init;
+
+  __acpp_if_target_host(
+    if (g.leader()) {
+      for (size_t i = 0; i < num_elements; i++) {
+        T next = first[i];
+        result[i] = carry_over;
+        carry_over = binary_op(carry_over, next);
+      }
+    }
+    group_barrier(g);
+  ) else {
+    size_t lrange = g.get_local_range().size();
+    size_t lid = g.get_local_linear_id();
+    size_t num_segments = (num_elements + lrange - 1) / lrange;
+
+    for (size_t segment = 0; segment < num_segments; segment++) {
+      size_t element_idx = segment * lrange + lid;
+      auto local_element = element_idx < num_elements ? first[element_idx] : identity;
+
+      T segment_result = exclusive_scan_over_group(g, local_element, carry_over, binary_op);
+      if (element_idx < num_elements) {
+        result[element_idx] = segment_result;
+      }
+      carry_over = group_broadcast(g, binary_op(segment_result, local_element), lrange - 1);
+    }
+  }
+  return result + num_elements;
+}
+
+template <typename Group, typename InPtr, typename OutPtr,
+          typename BinaryOperation,
+          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
+HIPSYCL_BUILTIN OutPtr joint_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
+                                                   BinaryOperation binary_op) {
+  
+  using value_type = typename std::iterator_traits<OutPtr>::value_type;
+  static_assert(std::is_same_v<decltype(binary_op(*first, *first)), value_type>);
+  
+  static constexpr auto identity = known_identity_v<BinaryOperation, value_type>;
+  return joint_exclusive_scan(g, first, last, result, identity, binary_op);
+}
+
+// inclusive_scan
+template <typename Group, typename InPtr, typename OutPtr, typename T,
+          typename BinaryOperation,
+          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
+HIPSYCL_BUILTIN OutPtr joint_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
+                                                   BinaryOperation binary_op, T init) {
+  static_assert(std::is_same_v<decltype(binary_op(init, *first)), T>);
+  static constexpr auto identity = known_identity_v<BinaryOperation, T>;
+
+  size_t num_elements = last - first;
+  T carry_over = init;
+
+  __acpp_if_target_host(
+    if (g.leader()) {
+      for (size_t i = 0; i < num_elements; i++) {
+        carry_over = binary_op(carry_over, first[i]);
+        result[i] = carry_over;
+      }
+    }
+    group_barrier(g);
+  ) else {
+    size_t lrange = g.get_local_range().size();
+    size_t lid = g.get_local_linear_id();
+    size_t num_segments = (num_elements + lrange - 1) / lrange;
+
+    for (size_t segment = 0; segment < num_segments; segment++) {
+      size_t element_idx = segment * lrange + lid;
+      auto local_element = element_idx < num_elements ? first[element_idx] : identity;
+
+      T segment_result = inclusive_scan_over_group(g, local_element, binary_op, carry_over);
+      if (element_idx < num_elements) {
+        result[element_idx] = segment_result;
+      }
+      carry_over = group_broadcast(g, segment_result, lrange - 1);
+    }
+  }
+  return result + num_elements;
+}
+
+template <typename Group, typename InPtr, typename OutPtr,
+          typename BinaryOperation,
+          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
+HIPSYCL_BUILTIN OutPtr joint_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
+                                                   BinaryOperation binary_op) {
+  
+  using value_type = typename std::iterator_traits<OutPtr>::value_type;
+  static_assert(std::is_same_v<decltype(binary_op(*first, *first)), value_type>);
+  
+  static constexpr auto identity = known_identity_v<BinaryOperation, value_type>;
+  return joint_inclusive_scan(g, first, last, result, binary_op, identity);
+}
 
 
 } // namespace sycl

--- a/include/hipSYCL/sycl/libkernel/group_functions_alias.hpp
+++ b/include/hipSYCL/sycl/libkernel/group_functions_alias.hpp
@@ -93,7 +93,7 @@ template<typename Group, typename V, typename T, typename BinaryOperation>
 [[deprecated("renamed to 'inclusive_scan_over_group' in SYCL 2020 Specification")]]
 ACPP_KERNEL_TARGET
 T group_inclusive_scan(Group g, V x, T init, BinaryOperation binary_op) {
-  return inclusive_scan_over_group(g, x, init, binary_op);
+  return inclusive_scan_over_group(g, x, binary_op, init);
 }
 template<typename Group, typename T, typename BinaryOperation>
 [[deprecated("renamed to 'inclusive_scan_over_group' in SYCL 2020 Specification")]]

--- a/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
@@ -497,9 +497,9 @@ ACPP_KERNEL_TARGET T __acpp_shift_group_right(
   scratch[lid] = x;
   __acpp_group_barrier(g);
 
-  // checking for both larger and smaller in case 'group<Dim>::linear_id_type' is not unsigned
-  if (target_lid > g.get_local_range().size() || target_lid < 0)
+  if (target_lid > g.get_local_range().size()) {
     target_lid = 0;
+  }
 
   x = scratch[target_lid];
   __acpp_group_barrier(g);
@@ -525,9 +525,9 @@ ACPP_KERNEL_TARGET T __acpp_permute_group_by_xor(
   scratch[lid] = x;
   __acpp_group_barrier(g);
 
-  // checking for both larger and smaller in case 'group<Dim>::linear_id_type' is not unsigned
-  if (target_lid > g.get_local_range().size() || target_lid < 0)
+  if (target_lid > g.get_local_range().size()) {
     target_lid = 0;
+  }
 
   x = scratch[target_lid];
   __acpp_group_barrier(g);
@@ -556,8 +556,9 @@ ACPP_KERNEL_TARGET T __acpp_select_from_group(
   __acpp_group_barrier(g);
 
   // checking for both larger and smaller in case 'group<Dim>::linear_id_type' is not unsigned
-  if (target_lid > g.get_local_range().size() || target_lid < 0)
+  if (target_lid > g.get_local_range().size()) {
     target_lid = 0;
+  }
 
   x = scratch[target_lid];
   __acpp_group_barrier(g);

--- a/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/host/group_functions.hpp
@@ -358,69 +358,32 @@ template<typename Group, typename InPtr, typename OutPtr, typename T, typename B
           std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
 ACPP_KERNEL_TARGET
 OutPtr __acpp_leader_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result, T init,
-                                   BinaryOperation binary_op) {
-
+                                   BinaryOperation binary_op) {  
   if (g.leader()) {
-    *(result++) = init;
-    while (first != last - 1) {
-      *result = binary_op(*(result - 1), *(first++));
-      result++;
+    T acc = init;
+    while (first != last) {
+        T next = binary_op(acc, *(first++));
+        *(result++) = acc;
+        acc = next;
     }
   }
   return result;
 }
-
-template<typename Group, typename InPtr, typename OutPtr, typename BinaryOperation,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-ACPP_KERNEL_TARGET
-OutPtr __acpp_leader_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
-                                   BinaryOperation binary_op) {
-  using value_type = std::remove_reference_t<decltype(*result)>;
-  return __acpp_leader_exclusive_scan(g, first, last, result, value_type{},
-                                         binary_op);
-}
-}
-
-template <typename Group, typename InPtr, typename OutPtr, typename T,
-          typename BinaryOperation,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-ACPP_KERNEL_TARGET OutPtr
-__acpp_joint_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
-                               T init, BinaryOperation binary_op) {
-  const auto ret = detail::__acpp_leader_exclusive_scan(
-      g, first, last, result, init, binary_op);
-  return group_broadcast(g, ret);
-}
-
-template <typename Group, typename InPtr, typename OutPtr,
-          typename BinaryOperation,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-ACPP_KERNEL_TARGET OutPtr
-__acpp_joint_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
-                               BinaryOperation binary_op) {
-  using value_type = std::remove_reference_t<decltype(*result)>;
-  return host_builtins::__acpp_joint_exclusive_scan(
-      g, first, last, result, value_type{},
-      binary_op);
 }
 
 template <int Dim, typename V, typename T, typename BinaryOperation>
 ACPP_KERNEL_TARGET T __acpp_exclusive_scan_over_group(
     group<Dim> g, V x, T init, BinaryOperation binary_op) {
-  T *          scratch = static_cast<T *>(g.get_local_memory_ptr());
-  const size_t lid     = g.get_local_linear_id();
+  V * input = static_cast<V *>(g.get_local_memory_ptr());
+  T * scratch = reinterpret_cast<T *>(static_cast<char *>(g.get_local_memory_ptr()) + g.get_local_range().size() * sizeof(V));
+  const size_t lid = g.get_local_linear_id();
 
-  if (lid + 1 < 1024)
-    scratch[lid + 1] = x;
+  input[lid] = x;
   __acpp_group_barrier(g);
 
-  if (g.leader()) {
-    scratch[0] = init;
-    for (int i = 1; i < g.get_local_range().size(); ++i)
-      scratch[i] = binary_op(scratch[i], scratch[i - 1]);
-  }
-
+  detail::__acpp_leader_exclusive_scan(g, input, input + g.get_local_range().size(), scratch, init, binary_op);
   __acpp_group_barrier(g);
+  
   T tmp = scratch[lid];
   __acpp_group_barrier(g);
 
@@ -430,14 +393,14 @@ ACPP_KERNEL_TARGET T __acpp_exclusive_scan_over_group(
 template <typename V, typename T, typename BinaryOperation>
 ACPP_KERNEL_TARGET T __acpp_exclusive_scan_over_group(
     sub_group g, V x, T init, BinaryOperation binary_op) {
-  return binary_op(x, init);
+  return init;
 }
 
 template <typename Group, typename T, typename BinaryOperation,
           std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-ACPP_KERNEL_TARGET T
-__acpp_exclusive_scan_over_group(Group g, T x, BinaryOperation binary_op) {
-  return __acpp_exclusive_scan_over_group(g, x, T{}, binary_op);
+ACPP_KERNEL_TARGET T __acpp_exclusive_scan_over_group(
+    Group g, T x, BinaryOperation binary_op) {
+  return __acpp_exclusive_scan_over_group(g, x, sycl::known_identity_v<BinaryOperation, std::decay_t<T>>, binary_op);
 }
 
 // inclusive_scan
@@ -451,81 +414,47 @@ __acpp_leader_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
     return result;
 
   if (g.leader()) {
-    *(result++) = binary_op(init, *(first++));
+    T acc = binary_op(init, *(first++));
+    *(result++) = acc;
     while (first != last) {
-      *result = binary_op(*(result - 1), *(first++));
-      result++;
+      acc = binary_op(acc, *(first++));
+      *(result++) = acc;
     }
   }
   return result;
 }
-
-template <typename Group, typename InPtr, typename OutPtr, typename BinaryOperation,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-ACPP_KERNEL_TARGET OutPtr
-__acpp_leader_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
-                                BinaryOperation binary_op) {
-  using value_type = std::remove_reference_t<decltype(*result)>;
-  return __acpp_leader_inclusive_scan(g, first, last, result, binary_op, value_type{});
-}
 }
 
-template <typename Group, typename InPtr, typename OutPtr, typename T,
-          typename BinaryOperation,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-ACPP_KERNEL_TARGET OutPtr
-__acpp_joint_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
-                               BinaryOperation binary_op, T init) {
-  auto ret = detail::__acpp_leader_inclusive_scan(g, first, last, result,
-                                                     binary_op, init);
-  return __acpp_group_broadcast(g, ret);
-}
+template <int Dim, typename V, typename T, typename BinaryOperation>
+ACPP_KERNEL_TARGET T __acpp_inclusive_scan_over_group(
+    group<Dim> g, V x, BinaryOperation binary_op, T init) {
+  V * input = static_cast<V *>(g.get_local_memory_ptr());
+  T * scratch = reinterpret_cast<T *>(static_cast<char *>(g.get_local_memory_ptr()) + g.get_local_range().size() * sizeof(V));
+  const size_t lid = g.get_local_linear_id();
 
-template <typename Group, typename InPtr, typename OutPtr,
-          typename BinaryOperation,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-ACPP_KERNEL_TARGET OutPtr
-__acpp_joint_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
-                               BinaryOperation binary_op) {
-  using value_type = std::remove_reference_t<decltype(*result)>;
-  return __acpp_joint_inclusive_scan(
-      g, first, last, result, binary_op,
-      value_type{});
-}
-template <int Dim, typename T, typename BinaryOperation>
-ACPP_KERNEL_TARGET
-T __acpp_inclusive_scan_over_group(
-    group<Dim> g, T x, BinaryOperation binary_op) {
-  T *          scratch = static_cast<T *>(g.get_local_memory_ptr());
-  const size_t lid     = g.get_local_linear_id();
-
-  scratch[lid] = x;
+  input[lid] = x;
   __acpp_group_barrier(g);
 
-  if (g.leader()) {
-    for (int i = 1; i < g.get_local_range().size(); ++i)
-      scratch[i] = binary_op(scratch[i], scratch[i - 1]);
-  }
-
+  detail::__acpp_leader_inclusive_scan(g, input, input + g.get_local_range().size(), scratch, binary_op, init);
   __acpp_group_barrier(g);
+  
   T tmp = scratch[lid];
   __acpp_group_barrier(g);
 
   return tmp;
 }
 
-template <typename T, typename BinaryOperation>
+template <typename V, typename T, typename BinaryOperation>
 ACPP_KERNEL_TARGET T __acpp_inclusive_scan_over_group(
-    sub_group g, T x, BinaryOperation binary_op) {
-  return x;
+    sub_group g, V x, BinaryOperation binary_op, T init) {
+  return binary_op(init, x);
 }
 
-template <typename Group, typename V, typename T, typename BinaryOperation,
+template <typename Group, typename T, typename BinaryOperation,
           std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
 ACPP_KERNEL_TARGET T __acpp_inclusive_scan_over_group(
-    Group g, V x, T init, BinaryOperation binary_op) {
-  T scan = __acpp_inclusive_scan_over_group(g, T{x}, binary_op);
-  return binary_op(scan, init);
+    Group g, T x, BinaryOperation binary_op) {
+  return __acpp_inclusive_scan_over_group(g, x, binary_op, sycl::known_identity_v<BinaryOperation, std::decay_t<T>>);
 }
 
 // shift_left

--- a/include/hipSYCL/sycl/libkernel/sscp/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/group_functions.hpp
@@ -68,6 +68,136 @@ __acpp_group_barrier(sub_group g,
   __acpp_sscp_sub_group_barrier(fence_scope, memory_order::seq_cst);
 }
 
+// shift_left
+template <int Dim, typename T>
+HIPSYCL_BUILTIN
+std::enable_if_t<(sizeof(T) <= 8), T> __acpp_shift_group_left(
+    group<Dim> g, T x, typename group<Dim>::linear_id_type delta = 1) {
+
+  if constexpr(sizeof(T) == 1) {
+    return maybe_bit_cast<T>(__acpp_sscp_work_group_shl_i8(
+        maybe_bit_cast<__acpp_int8>(x), static_cast<__acpp_uint32>(delta)));
+  } else if constexpr(sizeof(T) == 2) {
+    return maybe_bit_cast<T>(__acpp_sscp_work_group_shl_i16(
+        maybe_bit_cast<__acpp_int16>(x), static_cast<__acpp_uint32>(delta)));
+  } else if constexpr(sizeof(T) == 4) {
+    return maybe_bit_cast<T>(__acpp_sscp_work_group_shl_i32(
+        maybe_bit_cast<__acpp_int32>(x), static_cast<__acpp_uint32>(delta)));
+  } else {
+    return maybe_bit_cast<T>(__acpp_sscp_work_group_shl_i64(
+        maybe_bit_cast<__acpp_int64>(x), static_cast<__acpp_uint32>(delta)));
+  }
+}
+
+template <typename T>
+HIPSYCL_BUILTIN std::enable_if_t<(sizeof(T) <= 8), T> __acpp_shift_group_left(
+    sub_group g, T x, typename sub_group::linear_id_type delta = 1) {
+
+  if constexpr(sizeof(T) == 1) {
+    return maybe_bit_cast<T>(__acpp_sscp_sub_group_shl_i8(
+        maybe_bit_cast<__acpp_int8>(x), static_cast<__acpp_uint32>(delta)));
+  } else if constexpr(sizeof(T) == 2) {
+    return maybe_bit_cast<T>(__acpp_sscp_sub_group_shl_i16(
+        maybe_bit_cast<__acpp_int16>(x), static_cast<__acpp_uint32>(delta)));
+  } else if constexpr(sizeof(T) == 4) {
+    return maybe_bit_cast<T>(__acpp_sscp_sub_group_shl_i32(
+        maybe_bit_cast<__acpp_int32>(x), static_cast<__acpp_uint32>(delta)));
+  } else {
+    return maybe_bit_cast<T>(__acpp_sscp_sub_group_shl_i64(
+        maybe_bit_cast<__acpp_int64>(x), static_cast<__acpp_uint32>(delta)));
+  }
+}
+
+template <class Group, typename T, int N,
+          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
+HIPSYCL_BUILTIN
+std::enable_if_t<(sizeof(vec<T, N>) > 8), vec<T,N>>
+__acpp_shift_group_left(Group g, vec<T,N> x, typename Group::linear_id_type delta = 1) {
+  vec<T,N> result;
+  for(int i = 0; i < N; ++i) {
+    result[i] = __acpp_shift_group_left(g, x[i], delta);
+    __acpp_group_barrier(g);
+  }
+  return result;
+}
+
+template <class Group, typename T, size_t N,
+          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
+HIPSYCL_BUILTIN
+std::enable_if_t<(sizeof(marray<T, N>) > 8), marray<T,N>>
+__acpp_shift_group_left(Group g, marray<T,N> x, typename Group::linear_id_type delta = 1) {
+  marray<T,N> result;
+  for(int i = 0; i < N; ++i) {
+    result[i] = __acpp_shift_group_left(g, x[i], delta);
+    __acpp_group_barrier(g);
+  }
+  return result;
+}
+
+// shift_right
+template <int Dim, typename T>
+HIPSYCL_BUILTIN std::enable_if_t<(sizeof(T) <= 8), T> __acpp_shift_group_right(
+    group<Dim> g, T x, typename group<Dim>::linear_id_type delta = 1) {
+  if constexpr(sizeof(T) == 1) {
+    return maybe_bit_cast<T>(__acpp_sscp_work_group_shr_i8(
+        maybe_bit_cast<__acpp_int8>(x), static_cast<__acpp_uint32>(delta)));
+  } else if constexpr(sizeof(T) == 2) {
+    return maybe_bit_cast<T>(__acpp_sscp_work_group_shr_i16(
+        maybe_bit_cast<__acpp_int16>(x), static_cast<__acpp_uint32>(delta)));
+  } else if constexpr(sizeof(T) == 4) {
+    return maybe_bit_cast<T>(__acpp_sscp_work_group_shr_i32(
+        maybe_bit_cast<__acpp_int32>(x), static_cast<__acpp_uint32>(delta)));
+  } else {
+    return maybe_bit_cast<T>(__acpp_sscp_work_group_shr_i64(
+        maybe_bit_cast<__acpp_int64>(x), static_cast<__acpp_uint32>(delta)));
+  }
+}
+
+template <typename T>
+HIPSYCL_BUILTIN std::enable_if_t<(sizeof(T) <= 8), T> __acpp_shift_group_right(
+    sub_group g, T x, typename sub_group::linear_id_type delta = 1) {
+  if constexpr(sizeof(T) == 1) {
+    return maybe_bit_cast<T>(__acpp_sscp_sub_group_shr_i8(
+        maybe_bit_cast<__acpp_int8>(x), static_cast<__acpp_uint32>(delta)));
+  } else if constexpr(sizeof(T) == 2) {
+    return maybe_bit_cast<T>(__acpp_sscp_sub_group_shr_i16(
+        maybe_bit_cast<__acpp_int16>(x), static_cast<__acpp_uint32>(delta)));
+  } else if constexpr(sizeof(T) == 4) {
+    return maybe_bit_cast<T>(__acpp_sscp_sub_group_shr_i32(
+        maybe_bit_cast<__acpp_int32>(x), static_cast<__acpp_uint32>(delta)));
+  } else {
+    return maybe_bit_cast<T>(__acpp_sscp_sub_group_shr_i64(
+        maybe_bit_cast<__acpp_int64>(x), static_cast<__acpp_uint32>(delta)));
+  }
+}
+
+
+template <class Group, typename T, int N,
+          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
+HIPSYCL_BUILTIN
+std::enable_if_t<(sizeof(vec<T, N>) > 8), vec<T,N>>
+__acpp_shift_group_right(Group g, vec<T,N> x, typename Group::linear_id_type delta = 1) {
+  vec<T,N> result;
+  for(int i = 0; i < N; ++i) {
+    result[i] = __acpp_shift_group_right(g, x[i], delta);
+    __acpp_group_barrier(g);
+  }
+  return result;
+}
+
+template <class Group, typename T, size_t N,
+          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
+HIPSYCL_BUILTIN
+std::enable_if_t<(sizeof(marray<T, N>) > 8), marray<T,N>>
+__acpp_shift_group_right(Group g, marray<T,N> x, typename Group::linear_id_type delta = 1) {
+  marray<T,N> result;
+  for(int i = 0; i < N; ++i) {
+    result[i] = __acpp_shift_group_right(g, x[i], delta);
+    __acpp_group_barrier(g);
+  }
+  return result;
+}
+
 // broadcast
 
 // Separate all of the ID conversion shenaigans
@@ -285,20 +415,11 @@ struct sscp_binary_operation {};
     static constexpr __acpp_sscp_algorithm_op value = SSCPOp;               \
   };
 
-HIPSYCL_SSCP_MAP_GROUP_BINARY_OPERATION(sycl::plus,
-                                        __acpp_sscp_algorithm_op::plus)
-HIPSYCL_SSCP_MAP_GROUP_BINARY_OPERATION(sycl::multiplies,
-                                        __acpp_sscp_algorithm_op::multiply)
+
 HIPSYCL_SSCP_MAP_GROUP_BINARY_OPERATION(sycl::minimum,
                                         __acpp_sscp_algorithm_op::min)
 HIPSYCL_SSCP_MAP_GROUP_BINARY_OPERATION(sycl::maximum,
                                         __acpp_sscp_algorithm_op::max)
-HIPSYCL_SSCP_MAP_GROUP_BINARY_OPERATION(sycl::bit_and,
-                                        __acpp_sscp_algorithm_op::bit_and)
-HIPSYCL_SSCP_MAP_GROUP_BINARY_OPERATION(sycl::bit_or,
-                                        __acpp_sscp_algorithm_op::bit_or)
-HIPSYCL_SSCP_MAP_GROUP_BINARY_OPERATION(sycl::bit_xor,
-                                        __acpp_sscp_algorithm_op::bit_xor)
 HIPSYCL_SSCP_MAP_GROUP_BINARY_OPERATION(sycl::logical_and,
                                         __acpp_sscp_algorithm_op::logical_and)
 HIPSYCL_SSCP_MAP_GROUP_BINARY_OPERATION(sycl::logical_or,
@@ -716,69 +837,15 @@ HIPSYCL_BUILTIN marray<T, N> __acpp_inclusive_scan_over_group(Group g, marray<T,
 
 template <class Group, typename V, typename T, typename BinaryOperation,
           std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-HIPSYCL_BUILTIN T __acpp_inclusive_scan_over_group(Group g, V x, T init,
-                                                   BinaryOperation binary_op) {
+HIPSYCL_BUILTIN T __acpp_inclusive_scan_over_group(Group g, V x,
+                                                   BinaryOperation binary_op,
+                                                   T init) {
   const size_t lid = g.get_local_linear_id();
   x = lid == 0 ? binary_op(init, x) : x;
   __acpp_group_barrier(g);
   x = __acpp_inclusive_scan_over_group(g, x, binary_op);
   __acpp_group_barrier(g);
   return x;
-}
-
-template <typename Group, typename InPtr, typename OutPtr, typename T, typename BinaryOperation,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-HIPSYCL_BUILTIN OutPtr __acpp_joint_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
-                                                   BinaryOperation binary_op, T init) {
-
-  const size_t lrange = g.get_local_range().size();
-  const size_t num_elements = last - first;
-  const size_t lid = g.get_local_linear_id();
-  using value_type = std::remove_cv_t<std::remove_reference_t<decltype(*first)>>;
-
-  auto identity = sscp_binary_operation_identity<std::decay_t<value_type>,
-                                                 sscp_binary_operation_v<BinaryOperation>>::get();
-
-  if (num_elements == 0)
-    return result;
-
-  if (num_elements == 1) {
-    *result = *first;
-    return result;
-  }
-
-
-  size_t segment = 0;
-  size_t num_segments = (num_elements + lrange - 1) / lrange;
-
-  for (size_t segment = 0; segment < num_segments; segment++) {
-    size_t element_idx = segment * lrange + lid;
-    auto local_element = element_idx < num_elements ? first[element_idx] : identity;
-    value_type segment_result;
-    if (segment > 0) {
-      segment_result = __acpp_inclusive_scan_over_group(g, local_element, result[segment*lrange-1], binary_op);
-    } else {
-      segment_result = __acpp_inclusive_scan_over_group(g, local_element, init, binary_op);
-    }
-    if (element_idx < num_elements) {
-      result[element_idx] = segment_result;
-    }
-    __acpp_group_barrier(g);
-  }
-  return result;
-}
-
-template <typename Group, typename InPtr, typename OutPtr, typename BinaryOperation,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-HIPSYCL_BUILTIN OutPtr __acpp_joint_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
-                                                   BinaryOperation binary_op) {
-  using value_type = std::remove_cv_t<std::remove_reference_t<decltype(*first)>>;
-
-  auto identity = sscp_binary_operation_identity<std::decay_t<value_type>,
-                                                 sscp_binary_operation_v<BinaryOperation>>::get();
-  OutPtr updated_result = __acpp_joint_inclusive_scan(g, first, last, result, binary_op, identity);
-  __acpp_group_barrier(g);
-  return updated_result;
 }
 
 // exclusive_scan -- subgroup
@@ -852,7 +919,7 @@ HIPSYCL_BUILTIN float __acpp_exclusive_scan_over_group(sub_group g, double x,
                                                   identity);
 }
 
-// // exclusive scan group
+// exclusive scan -- group
 
 template <
     typename T, int Dim, typename BinaryOperation,
@@ -962,164 +1029,6 @@ HIPSYCL_BUILTIN T __acpp_exclusive_scan_over_group(Group g, V x, T init,
     x = init;
   }
   return x;
-}
-template <typename Group, typename InPtr, typename OutPtr, typename T, typename BinaryOperation,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-HIPSYCL_BUILTIN OutPtr __acpp_joint_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
-                                                   T init, BinaryOperation binary_op) {
-  const size_t lid = g.get_local_linear_id();
-  __acpp_joint_inclusive_scan(g, first, last - 1, result + 1, binary_op, init);
-
-  if (lid == 0) {
-    result[0] = init;
-  }
-  __acpp_group_barrier(g);
-  return result;
-}
-
-template <typename Group, typename InPtr, typename OutPtr, typename BinaryOperation,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-HIPSYCL_BUILTIN OutPtr __acpp_joint_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
-                                                   BinaryOperation binary_op) {
-  const size_t lrange = g.get_local_range().size();
-  const size_t num_elements = last - first;
-  const size_t lid = g.get_local_linear_id();
-  using value_type = std::remove_cv_t<std::remove_reference_t<decltype(*first)>>;
-  auto identity = sscp_binary_operation_identity<std::decay_t<value_type>,
-                                                 sscp_binary_operation_v<BinaryOperation>>::get();
-  OutPtr updated_result = __acpp_joint_inclusive_scan(g, first, last - 1, result + 1, binary_op, identity);
-  __acpp_group_barrier(g);
-  return updated_result;
-}
-
-// shift_left
-template <int Dim, typename T>
-HIPSYCL_BUILTIN
-std::enable_if_t<(sizeof(T) <= 8), T> __acpp_shift_group_left(
-    group<Dim> g, T x, typename group<Dim>::linear_id_type delta = 1) {
-
-  if constexpr(sizeof(T) == 1) {
-    return maybe_bit_cast<T>(__acpp_sscp_work_group_shl_i8(
-        maybe_bit_cast<__acpp_int8>(x), static_cast<__acpp_uint32>(delta)));
-  } else if constexpr(sizeof(T) == 2) {
-    return maybe_bit_cast<T>(__acpp_sscp_work_group_shl_i16(
-        maybe_bit_cast<__acpp_int16>(x), static_cast<__acpp_uint32>(delta)));
-  } else if constexpr(sizeof(T) == 4) {
-    return maybe_bit_cast<T>(__acpp_sscp_work_group_shl_i32(
-        maybe_bit_cast<__acpp_int32>(x), static_cast<__acpp_uint32>(delta)));
-  } else {
-    return maybe_bit_cast<T>(__acpp_sscp_work_group_shl_i64(
-        maybe_bit_cast<__acpp_int64>(x), static_cast<__acpp_uint32>(delta)));
-  }
-}
-
-template <typename T>
-HIPSYCL_BUILTIN std::enable_if_t<(sizeof(T) <= 8), T> __acpp_shift_group_left(
-    sub_group g, T x, typename sub_group::linear_id_type delta = 1) {
-
-  if constexpr(sizeof(T) == 1) {
-    return maybe_bit_cast<T>(__acpp_sscp_sub_group_shl_i8(
-        maybe_bit_cast<__acpp_int8>(x), static_cast<__acpp_uint32>(delta)));
-  } else if constexpr(sizeof(T) == 2) {
-    return maybe_bit_cast<T>(__acpp_sscp_sub_group_shl_i16(
-        maybe_bit_cast<__acpp_int16>(x), static_cast<__acpp_uint32>(delta)));
-  } else if constexpr(sizeof(T) == 4) {
-    return maybe_bit_cast<T>(__acpp_sscp_sub_group_shl_i32(
-        maybe_bit_cast<__acpp_int32>(x), static_cast<__acpp_uint32>(delta)));
-  } else {
-    return maybe_bit_cast<T>(__acpp_sscp_sub_group_shl_i64(
-        maybe_bit_cast<__acpp_int64>(x), static_cast<__acpp_uint32>(delta)));
-  }
-}
-
-template <class Group, typename T, int N,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-HIPSYCL_BUILTIN
-std::enable_if_t<(sizeof(vec<T, N>) > 8), vec<T,N>>
-__acpp_shift_group_left(Group g, vec<T,N> x, typename Group::linear_id_type delta = 1) {
-  vec<T,N> result;
-  for(int i = 0; i < N; ++i) {
-    result[i] = __acpp_shift_group_left(g, x[i], delta);
-    __acpp_group_barrier(g);
-  }
-  return result;
-}
-
-template <class Group, typename T, size_t N,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-HIPSYCL_BUILTIN
-std::enable_if_t<(sizeof(marray<T, N>) > 8), marray<T,N>>
-__acpp_shift_group_left(Group g, marray<T,N> x, typename Group::linear_id_type delta = 1) {
-  marray<T,N> result;
-  for(int i = 0; i < N; ++i) {
-    result[i] = __acpp_shift_group_left(g, x[i], delta);
-    __acpp_group_barrier(g);
-  }
-  return result;
-}
-
-// shift_right
-template <int Dim, typename T>
-HIPSYCL_BUILTIN std::enable_if_t<(sizeof(T) <= 8), T> __acpp_shift_group_right(
-    group<Dim> g, T x, typename group<Dim>::linear_id_type delta = 1) {
-  if constexpr(sizeof(T) == 1) {
-    return maybe_bit_cast<T>(__acpp_sscp_work_group_shr_i8(
-        maybe_bit_cast<__acpp_int8>(x), static_cast<__acpp_uint32>(delta)));
-  } else if constexpr(sizeof(T) == 2) {
-    return maybe_bit_cast<T>(__acpp_sscp_work_group_shr_i16(
-        maybe_bit_cast<__acpp_int16>(x), static_cast<__acpp_uint32>(delta)));
-  } else if constexpr(sizeof(T) == 4) {
-    return maybe_bit_cast<T>(__acpp_sscp_work_group_shr_i32(
-        maybe_bit_cast<__acpp_int32>(x), static_cast<__acpp_uint32>(delta)));
-  } else {
-    return maybe_bit_cast<T>(__acpp_sscp_work_group_shr_i64(
-        maybe_bit_cast<__acpp_int64>(x), static_cast<__acpp_uint32>(delta)));
-  }
-}
-
-template <typename T>
-HIPSYCL_BUILTIN std::enable_if_t<(sizeof(T) <= 8), T> __acpp_shift_group_right(
-    sub_group g, T x, typename sub_group::linear_id_type delta = 1) {
-  if constexpr(sizeof(T) == 1) {
-    return maybe_bit_cast<T>(__acpp_sscp_sub_group_shr_i8(
-        maybe_bit_cast<__acpp_int8>(x), static_cast<__acpp_uint32>(delta)));
-  } else if constexpr(sizeof(T) == 2) {
-    return maybe_bit_cast<T>(__acpp_sscp_sub_group_shr_i16(
-        maybe_bit_cast<__acpp_int16>(x), static_cast<__acpp_uint32>(delta)));
-  } else if constexpr(sizeof(T) == 4) {
-    return maybe_bit_cast<T>(__acpp_sscp_sub_group_shr_i32(
-        maybe_bit_cast<__acpp_int32>(x), static_cast<__acpp_uint32>(delta)));
-  } else {
-    return maybe_bit_cast<T>(__acpp_sscp_sub_group_shr_i64(
-        maybe_bit_cast<__acpp_int64>(x), static_cast<__acpp_uint32>(delta)));
-  }
-}
-
-
-template <class Group, typename T, int N,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-HIPSYCL_BUILTIN
-std::enable_if_t<(sizeof(vec<T, N>) > 8), vec<T,N>>
-__acpp_shift_group_right(Group g, vec<T,N> x, typename Group::linear_id_type delta = 1) {
-  vec<T,N> result;
-  for(int i = 0; i < N; ++i) {
-    result[i] = __acpp_shift_group_right(g, x[i], delta);
-    __acpp_group_barrier(g);
-  }
-  return result;
-}
-
-template <class Group, typename T, size_t N,
-          std::enable_if_t<is_group_v<std::decay_t<Group>>, bool> = true>
-HIPSYCL_BUILTIN
-std::enable_if_t<(sizeof(marray<T, N>) > 8), marray<T,N>>
-__acpp_shift_group_right(Group g, marray<T,N> x, typename Group::linear_id_type delta = 1) {
-  marray<T,N> result;
-  for(int i = 0; i < N; ++i) {
-    result[i] = __acpp_shift_group_right(g, x[i], delta);
-    __acpp_group_barrier(g);
-  }
-  return result;
 }
 
 // permute_group_by_xor

--- a/include/hipSYCL/sycl/libkernel/sscp/group_functions.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/group_functions.hpp
@@ -425,6 +425,8 @@ HIPSYCL_SSCP_MAP_GROUP_BINARY_OPERATION(sycl::logical_and,
 HIPSYCL_SSCP_MAP_GROUP_BINARY_OPERATION(sycl::logical_or,
                                         __acpp_sscp_algorithm_op::logical_or)
 
+// This assumes that sycl::plus, sycl::multiplies, and so on
+// are aliases to their std equivalents.
 HIPSYCL_SSCP_MAP_GROUP_BINARY_OPERATION(std::plus,
                                         __acpp_sscp_algorithm_op::plus)
 HIPSYCL_SSCP_MAP_GROUP_BINARY_OPERATION(std::multiplies,

--- a/include/hipSYCL/sycl/libkernel/sscp/sscp_backend.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/sscp_backend.hpp
@@ -33,11 +33,11 @@
 
  #define __acpp_if_target_host(...)                                         \
   if (__acpp_sscp_is_host) {                                                \
-    __VA_ARGS__                                                                \
+    __VA_ARGS__                                                             \
   }
  #define __acpp_if_target_device(...)                                       \
   if (__acpp_sscp_is_device) {                                              \
-    __VA_ARGS__                                                                \
+    __VA_ARGS__                                                             \
   }
 
 

--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -32,45 +32,47 @@ public:
   using interop_type = vec_storage<T,N>;
   using value_type = T;
 
-  ACPP_UNIVERSAL_TARGET
-  T& operator[](int i) { return _storage[i]; }
+  constexpr vec_storage() = default;
 
   ACPP_UNIVERSAL_TARGET
-  const T& operator[](int i) const { return _storage[i]; }
+  constexpr T& operator[](int i) { return _storage[i]; }
+
+  ACPP_UNIVERSAL_TARGET
+  constexpr const T& operator[](int i) const { return _storage[i]; }
 
   template<int Index>
   ACPP_UNIVERSAL_TARGET
-  T& get() {
+  constexpr T& get() {
     return _storage[Index];
   }
 
   template<int Index>
   ACPP_UNIVERSAL_TARGET
-  const T& get() const {
+  constexpr const T& get() const {
     return _storage[Index];
   }
 
   template<class F>
   ACPP_UNIVERSAL_TARGET
-  void for_each(F&& f) {
+  constexpr void for_each(F&& f) {
     for(int i = 0; i < N; ++i)
       f(i, _storage[i]);
   }
 
   template<class F>
   ACPP_UNIVERSAL_TARGET
-  void for_each(F&& f) const {
+  constexpr void for_each(F&& f) const {
     for(int i = 0; i < N; ++i)
       f(i, _storage[i]);
   }
 
   ACPP_UNIVERSAL_TARGET
-  interop_type interop() const {
+  constexpr interop_type interop() const {
     return *this;
   }
 
 private:
-  alignas(alignment) T _storage [effective_size];
+  alignas(alignment) T _storage [effective_size]{};
 };
 
 // An alternative implementation of the vec_storage concept
@@ -78,7 +80,6 @@ private:
 template<class TargetStorage, int... SwizzleIndices>
 class swizzled_view_storage {
 public:
-
   using interop_type = typename TargetStorage::interop_type;
   using value_type = typename TargetStorage::value_type;
 
@@ -267,7 +268,7 @@ public:
             std::enable_if_t<std::is_same_v<S, detail::vec_storage<T, N>>,
                              bool> = true>
   ACPP_UNIVERSAL_TARGET
-  vec() {
+  constexpr vec() {
     for(int i = 0; i < N; ++i)
       _data[i] = T{};
   }
@@ -275,7 +276,7 @@ public:
   template <class S = VectorStorage,
             std::enable_if_t<std::is_same_v<S, detail::vec_storage<T, N>>,
                              bool> = true>
-  ACPP_UNIVERSAL_TARGET explicit vec(const T &value) {
+  ACPP_UNIVERSAL_TARGET constexpr explicit vec(const T &value) {
     for(int i = 0; i < N; ++i)
       _data[i] = value;
   }
@@ -286,7 +287,7 @@ public:
                              bool> = true,
             std::enable_if_t<(detail::count_num_elements<Args, T> + ...) == N,
                              bool> = true>
-  ACPP_UNIVERSAL_TARGET vec(const Args &...args) {
+  ACPP_UNIVERSAL_TARGET constexpr vec(const Args &...args) {
     int current_init_index = 0;
     (partial_initialization(current_init_index, args), ...);
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,6 +89,7 @@ add_executable(sycl_tests
   sycl/fill.cpp
   sycl/group_functions/group_functions_misc.cpp
   sycl/group_functions/group_functions_binary_reduce.cpp
+  sycl/group_functions/group_functions_known_identity.cpp
   sycl/group_functions/group_functions_reduce.cpp
   sycl/group_functions/group_functions_scan.cpp
   sycl/half.cpp

--- a/tests/sycl/group_functions/group_functions_known_identity.cpp
+++ b/tests/sycl/group_functions/group_functions_known_identity.cpp
@@ -1,0 +1,39 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "../sycl_test_suite.hpp"
+#include "group_functions.hpp"
+
+#ifdef HIPSYCL_ENABLE_GROUP_ALGORITHM_TESTS
+
+
+using all_ops = boost::mp11::mp_list<
+    sycl::plus<>,
+    sycl::multiplies<>,
+    sycl::bit_and<>,
+    sycl::bit_or<>,
+    sycl::bit_xor<>,
+    sycl::logical_and<>,
+    sycl::logical_or<>,
+    sycl::minimum<>,
+    sycl::maximum<>
+>;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(group_known_identity, T, test_types) {
+    
+    boost::mp11::mp_for_each<all_ops>([&](auto op){
+        static constexpr auto HAS_KNOWN_IDENTITY = sycl::has_known_identity_v<decltype(op), T>;
+        if constexpr (HAS_KNOWN_IDENTITY) {
+            static_assert(std::is_same_v<decltype(sycl::known_identity_v<decltype(op), T>), const T>);
+        }
+    });
+}
+#endif

--- a/tests/sycl/group_functions/group_functions_scan.cpp
+++ b/tests/sycl/group_functions/group_functions_scan.cpp
@@ -418,7 +418,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(group_inclusive_scan, T, test_types) {
     const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
                                     auto g, T local_value) {
       acc[global_linear_id] = sycl::inclusive_scan_over_group(
-          g, local_value, detail::initialize_type<T>(10), std::plus<T>());
+          g, local_value, std::plus<T>(), detail::initialize_type<T>(10));
     };
     const auto validation_function = [](const std::vector<T> &vIn,
                                         const std::vector<T> &vOrig,size_t, size_t local_size,
@@ -597,7 +597,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(sub_group_inclusive_scan, T, test_types) {
       const auto tested_function = [](auto acc, size_t global_linear_id, sycl::sub_group sg,
                                       auto g, T local_value) {
         acc[global_linear_id] = sycl::inclusive_scan_over_group(
-            sg, local_value, detail::initialize_type<T>(10), std::plus<T>());
+            sg, local_value, std::plus<T>(), detail::initialize_type<T>(10));
       };
       const auto validation_function = [](const std::vector<T> &vIn,
                                           const std::vector<T> &vOrig, size_t subgroup_size, size_t local_size,


### PR DESCRIPTION
This refactors the group algorithms, mainly `joint_exclusive_scan`, to work in-place. This change also fixes `inclusive_scan_over_group` signature to take the init parameter last, which is a breaking change.

Please let me know if I should add a compatibility wrapper for the old parameter order.

Fixes #1440, #1899, #1900