### PR TITLE
Make Markdown bullet points render correctly in Material for MkDocs

### DIFF
--- a/doc/accessor-variants.md
+++ b/doc/accessor-variants.md
@@ -3,6 +3,7 @@
 ## Terminology
 
 In the following, we will use the following terminology:
+
 * A *placeholder* accessor is an accessor that was constructed without providing a SYCL `handler` object. Placeholder need to be bound to a `handler` by calling `handler::require()` at a later point.
 * A *ranged* accessor is an accessor that is constructed by specifying an access range consisting of a `sycl::range` and optionally a `sycl::id` describing the access offset. Ranged accessors may be used if only a subset of the buffer is accessed.
 * An *unranged* accessor is an accessor that is not a ranged accessor.
@@ -10,6 +11,7 @@ In the following, we will use the following terminology:
 ## Motivation
 
 SYCL accessors need to store several different kinds of information, depending on their use case. In general, this includes:
+
 * A data pointer
 * The n-dimensional shape of the allocation
 * the access offset and access range
@@ -48,6 +50,7 @@ For example, an unranged accessor does not have to store access offset and an ad
 With SYCL 2020 deduction guides and C++17 class template argument deduction, these additional template parameters can even be deduced automatically.
 
 AdaptiveCpp introduces the following accessor variants, which are described by the `sycl::accessor_variant` enumeration:
+
 * `ranged_placeholder` - ranged placeholder accessor.
 * `unranged_placeholder` - unranged placeholder accessor
 * `ranged` - ranged non-placeholder accessor
@@ -102,6 +105,7 @@ However, note that using distinct accessor variants might potentially break cert
 ## Constructing AdaptiveCpp accessor variants
 
 hipSYCL accessor variants can be constructed in the following way:
+
 1. By explicitly setting the `accessor_variant` template parameter of the accessor to a value that differs from the standard `access::placeholder::false_t` and `access::placeholder::true_t`.
 2. By using the `sycl::raw_accessor`, `sycl::ranged_accessor`, `sycl::unranged_accessor`, `sycl::ranged_placeholder_accessor`, `sycl::unranged_placeholder_accessor` type aliases (see API reference below)
 3. For raw accessors, by using the new `read_only_raw`, `read_write_raw` and `write_only_raw` deduction tags
@@ -150,6 +154,7 @@ There are certain restrictions with respect to the functionality of individual a
 
 ### Conversion rules
 Two accessor objects of different accessor variant can be implicitly converted, unless one of the following conditions is met:
+
 * the source accessor is a raw accessor. In that case the destination accessor would expose more information than the source could provide.
 * the destination accessor is unranged for a ranged source accessor, or a standard SYCL 2020 accessor. In that case, the destination accessor might expose access to regions of the buffer that are not guaranteed to be in a consistent state on the target device, if they are outside of the original access range of the source accessor.
 * the destination accessor is a placeholder accessor for a non-placeholder source accessor.
@@ -160,6 +165,7 @@ The opposite direction is currently allowed for compatibility reasons, but might
 ### Raw accessors
 
 Raw accessors additionally obey the following restrictions:
+
 * They cannot be constructed as placeholders
 * They do not expose range and size queries
 * They only expose `operator[]` for 0 and 1-dimensional accessors

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -23,6 +23,7 @@ These four components are strictly separated both in terms of the directory stru
 ## SYCL interface
 
 The SYCL interface provides the SYCL classes and functions that the user actually interacts with, i.e. everything inside the `sycl::` namespace. It can be seen as divided in two parts: 
+
 1. SYCL host API: This part of the SYCL interface is written in regular C++, only runs on the host and provides mechanisms for task submission, task management, platform and device management etc. For example `sycl::queue`, `sycl::event`, `sycl::device` belong to the host API. The SYCL host API is mainly just an interface to the SYCL runtime, which actually implements most of these features. *Backend-specific code is not allowed in the host API as a rule of thumb. Non-standard C++ code (e.g. CUDA) is absolutely not allowed in the host API.*
 2. SYCL kernel library: The kernel library contains all SYCL classes and functions that are available from kernels. In general, the kernel library will make use of backend-specific functionality and may even need to be written in a backend-specific C++ dialect such as CUDA. This means that in general, a regular C++ compiler may not be able to parse the kernel library code.
   Note that there are some classes such as `sycl::accessor`, `sycl::id`, `sycl::range` that are needed both inside and outside kernel code.

--- a/doc/compilation.md
+++ b/doc/compilation.md
@@ -25,10 +25,12 @@ The following illustration shows the complete stack and its capabilities to targ
 **Note:** This flow is AdaptiveCpp's default compilation flow, and for good reason: It compiles faster, typically generates faster code, and creates portable binaries. It is one of the focal points of our work, and development is thus moving quickly.
 
 AdaptiveCpp supports a generic single-pass compiler flow, where a single compiler invocation generates both host and device code. The SSCP compilation consists of two stages:
+
 1. Stage 1 happens at compile time: During the regular C++ host compilation, AdaptiveCpp extracts LLVM IR for kernels with backend-independent representations of builtins, kernel annotations etc. This LLVM IR is embedded in the host code. During stage 1, it is not yet known on which device(s) the code will ultimately run.
 2. Stage 2 typically happens at runtime: The embedded device IR is passed to AdaptiveCpp's `llvm-to-backend` infrastructure, which lowers the IR to backend-specific formats, such as NVIDIA's PTX, SPIR-V or amdgcn code. Unlike stage 1, stage 2 assumes that the target device is known. While stage 2 typically happens at runtime, support for precompiling to particular devices and formats could be added in the future.
 
 The generic SSCP design has several advantages over other implementation choices:
+
 * There is a single code representation across all backends, which allows implementing JIT-based features such as runtime kernel fusion in a backend-independent way;
 * Code is only parsed a single time, which can result is significant compilation speedups especially for template-heavy code;
 * Binaries inherently run on a wide range of hardware, without the user having to precompile for particular devices, and hence making assumptions where the binary will ultimately be executed ("Compile once, run anywhere").
@@ -92,6 +94,7 @@ Not all backends necessarily support all models. The following compilation flows
 | `generic` | (see below) | Generic SSCP | Generic single-pass flow |
 
 **Note:** 
+
 * Explicit multipass requires building AdaptiveCpp against a clang that supports `__builtin_unique_stable_name()` (available in clang 11), or clang 13 or newer as described in the [installation documentation](installing.md). `hip.explicit-multipass` requires clang 13 or newer.
 * Generic SSCP requires clang 14 or newer.
 

--- a/doc/enqueue-custom-operation.md
+++ b/doc/enqueue-custom-operation.md
@@ -12,6 +12,7 @@ Only asynchronous operations operating on the target device from the backend are
 ## host task vs enqueuing custom operations for interoperability
 
 Use a host task when
+
 * You want to execute work on the host
 * You want input data in a well defined state when your function object is evaluated
 * You want to run synchronous backend operations that depend on when they are executed during DAG execution
@@ -19,6 +20,7 @@ Use a host task when
 * You don't mind introducing synchronization between host and device
 
 Use a custom operation when
+
 * You want to submit additional asynchronous tasks to the backend
 * You care about latency.
 

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -208,6 +208,7 @@ int main() {
 The AdaptiveCpp runtime maintains a kernel cache that automatically distinguishes the same kernel invoked with different dynamic function configuration. JIT compilation is only triggered when a new configuration is requested that is not yet present in the cache.
 
 **Important notes**
+
 * `dynamic_function_config::apply()` is a very light-weight operation, but constructing a new `dynamic_function_config` object may have some overhead due to initializing the required data structures. It is therefore recommended to reuse a preexisting `dynamic_function_config` object when the same kernel is submitted multiple times with the same configuration.
 * Only a single `dynamic_function_config` object may be applied at a given kernel launch.
 * It is the user's responsibility to ensure that the `dynamic_function_config` object is kept alive at least until all kernels using it have completed.
@@ -445,6 +446,7 @@ See [here](accessor-variants.md) for more details.
 ### `ACPP_EXT_UPDATE_DEVICE`
 
 An extension that adds `handler::update()` for device accessors in analogy to `update_host()`. While `update_host()` makes sure that the host allocation of the buffer is updated, `update()` updates the allocation on the device to which the operation is submitted. This can be used
+
 * To preallocate memory if the buffer is uninitialized;
 * To separate potential data transfers from kernel execution, e.g. for benchmarking;
 * To control buffer data state when using buffer-USM interoperability(`ACPP_EXT_BUFFER_USM_INTEROP`);
@@ -491,6 +493,7 @@ For example, a coarse grained event for a backend based on in-order queues (e.g.
 Coarse-grained events support the same functionality as regular events.
 
 Coarse-grained events can be requested in two ways: 
+
 1. By passing a property to `queue` which instructs the `queue` to construct coarse-grained events for all operations that it processes, and 
 2. by passing in a property to an individual command group (see `ACPP_EXT_CG_PROPERTY_*`). In this case, coarse-grained events can be enabled selectively only for some command groups submitted to a queue.
 
@@ -717,6 +720,7 @@ q.submit([&] (cl::sycl::handler& cgh) {
 ```
 
 This extension serves two purposes:
+
 1. Avoid having to call `require()` again and again if the same accessor is used in many subsequent kernels. This can lead to a significant reduction of boilerplate code.
 2. Simplify code when working with SYCL libraries that accept lambda functions or function objects. For example, for a `sort()` function in a SYCL library a custom comparator may be desired. Currently, there is no easy way to access some independent data in that comparator because accessors must be requested in the command group handler. This would not be possible in that case since the command group would be spawned internally by `sort`, and the user has no means of accessing it.
 

--- a/doc/generic-sscp.md
+++ b/doc/generic-sscp.md
@@ -7,6 +7,7 @@
 The SSCP kernel extraction relies on the concept of what we refer to as IR constants. IR constants are global variables, that are non-const and without defined value when parsing the code, but will be turned into constants later during the processing of LLVM IR. This is a similar idea to e.g. SYCL 2020 specialization constants, and indeed specialization constants could be implemented on top of IR constants.
 
 Stage 1 IR constants are hard-wired. The following important S1 IR constants exist:
+
 * A string containing the device LLVM IR bitcode
 * Whether the LLVM module contains the host code
 * Whether the LLVM module contains the device code.
@@ -28,6 +29,7 @@ The final LLVM IR device bitcode is then embedded into a stage 1 IR constant str
 #### Stage 2: llvm-to-backend
 
 During stage 2, the `llvm-to-backend` infrastructure is responsible for turning the generic LLVM IR into something that a backend can actually execute. This means in particular:
+
 - Flavoring the LLVM IR such that the appropriate LLVM backend can handle the code; e.g. by correctly mapping address spaces, attaching information to mark kernels as entry points, correctly setting target triple, data layout, and function calling conventions etc.
 - Mapping `__acpp_sscp_*` builtins to backend builtins. This typically happens by linking backend-specific bitcode libraries.
 - Running optimization passes on the finalized IR.

--- a/doc/install-cuda.md
+++ b/doc/install-cuda.md
@@ -9,6 +9,7 @@ clang usually produces CUDA programs with very competitive performance compared 
 If you use a very recent CUDA version, you might get a warning when compiling with AdaptiveCpp that clang does not support your CUDA version and treats like an older version. This warning can usually safely be ignored.
 
 CMake variables:
+
 * `-DCUDA_TOOLKIT_ROOT_DIR=/path/to/cuda` to point AdaptiveCpp to the CUDA root installation directory (e.g. `/usr/local/cuda`), if cmake doesn't find the right CUDA installation.
 * `-DWITH_CUDA_BACKEND=ON` if AdaptiveCpp does not automatically enable the CUDA backend 
 
@@ -18,6 +19,7 @@ Please install the latest release of the NVIDIA HPC SDK and make sure to point A
 Please install CUDA 10.0 or later. You can also rely on the CUDA bundled with the NVIDIA HPC SDK
 
 CMake variables:
+
 * `-DNVCXX_COMPILER=/path/to/nvc++`
 * You can use the CUDA bundled with nvc++. Make sure to point AdaptiveCpp to the right CUDA installation using `-DCUDA_TOOLKIT_ROOT_DIR=/path/to/cuda`. 
 * `-DWITH_CUDA_BACKEND=ON` if AdaptiveCpp does not automatically enable the CUDA backend

--- a/doc/install-llvm.md
+++ b/doc/install-llvm.md
@@ -12,6 +12,7 @@ Usually, the clang/LLVM versions provided in Linux distribution repositories are
 If you are using Ubuntu or Debian, we can also recommend the package repositories at `http://apt.llvm.org` if you wish to obtain a newer LLVM.
 
 Install
+
 * clang (including development headers)
 * LLVM (including development headers)
 * libomp (including development headers)
@@ -72,6 +73,7 @@ make install
 When invoking cmake, the AdaptiveCpp build infrastructure will attempt to find LLVM automatically (see below for how to invoke cmake).
 
 If AdaptiveCpp does not automatically configure the build for the desired clang/LLVM installation, the following cmake variables can be used to point AdaptiveCpp to the right one:
+
 * `-DLLVM_DIR=/path/to/llvm/cmake` must be pointed to your LLVM installation, specifically, the **subdirectory containing the LLVM cmake files**. Note that different LLVM installations may have the LLVM cmake files in different subdirectories that don't necessarily end with `cmake` (e.g. it might also be `/path/to/llvm/lib/cmake/llvm`). Alternatively, you can try `-DLLVM_ROOT` which might be more forgiving.
 
 Verify from the cmake that the selected `clang++` and include headers match the LLVM that you have requested. Example output:
@@ -108,6 +110,7 @@ In that case, clang can be informed about the location of the GCC toolchain usin
 *Note:* This flag is very picky about the directory!. It needs to be provided with the parent directory that contains the `lib/gcc/<arch>/<version>` subdirectories. On a Cray system, this might e.g. be `--gcc-toolchain=/opt/cray/pe/gcc/12.2.0/snos`. If an incorrect path is provided, clang may silently ignore the argument. Use `clang++ -v /dev/null` as described above to check that it has accepted the GCC installation.
 
 While in theory AdaptiveCpp can be made to use that flag when compiling, a simpler solution to make that change permanent is to use clang configuration files ([details in the clang documentation](https://clang.llvm.org/docs/UsersManual.html#id25)):
+
 1. In the directory where `clang++` lives (e.g. some `bin` directory), create a new file `<name>.cfg`, replacing `<name>` with something of your choice.
 2. Put any flags that you want clang to use by default into this file, such as the `--gcc-toolchain=...` flag.
 3. Create a symlink to clang in the same directory that `clang++` and the config file exist in: `ln -s clang++ <name>-clang++`, again replacing `<name>` with the name of your config file.

--- a/doc/install-rocm.md
+++ b/doc/install-rocm.md
@@ -15,6 +15,7 @@ When using AdaptiveCpp's hip interoperability compiler (`--acpp-targets=hip`), n
 ## Using AdaptiveCpp with LLVM bundled from ROCm (not recommended)
 
 Instead of building AdaptiveCpp against a regular clang/LLVM, it is also possible (but not necessarily recommended, see below) to build AdaptiveCpp against the clang/LLVM that ships with ROCm. This can be interesting if other available clang/LLVM installations are not new enough to work with the ROCm installation.
+
 * **Such configurations may work, but are generally less tested.**
 * Also note that the LLVM distributions shipping with ROCm are not official LLVM releases, and depending on when the upstream development was last merged, may have slightly diverging functionality. There are multiple known cases where this causes problems: 
   * the clang 14 from ROCm 5.0 lacks functionality that is present in official clang 14 releases. You can work around those issues by setting `-DACPP_COMPILER_FEATURE_PROFILE=minimal` at the expense of missing features, such as reduced kernel performance on CPUs and lack of [SSCP](compilation.md) support.

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -182,6 +182,7 @@ In this scenario, a remedy can be to use a 2-stage compilation process to build 
 In compiler land this is known as [bootstrapping](https://llvm.org/docs/AdvancedBuilds.html#bootstrap-builds).
 
 To get an AdaptiveCpp build on MacOS that supports the generic JIT compiler, we recommend a 2-stage build process that proceeds as follows:
+
 1. ensure `ninja`, `cmake` and `boost` are available. For Mac you may use `brew`:
 ```bash
 # force CMake 3.31.6 (CMake 4.0 seems to break LLVM's compiler-rt build)

--- a/doc/pcuda.md
+++ b/doc/pcuda.md
@@ -6,6 +6,7 @@ AdaptiveCpp supports a dialect of the CUDA/HIP language called portable CUDA (PC
 Similarly to using `--acpp-targets=generic` with SYCL or C++ standard parallelism code (stdpar), AdaptiveCpp can JIT-compile the input PCUDA code for any target from a single binary, including CPUs, NVIDIA GPUs, AMD GPUs, and Intel GPUs.
 
 Possible use cases for PCUDA include:
+
 * Working with existing CUDA/HIP code bases;
 * Iterative porting of existing CUDA/HIP code bases;
 * Fairer compiler comparisons between AdaptiveCpp and nvcc or hipcc, since the exact same (or at least very similar) input code can be used for benchmarks;
@@ -52,6 +53,7 @@ AdaptiveCpp does not implement CUDA's legacy default stream semantics and only s
 ### Multi-backend device topology and device management
 
 AdaptiveCpp is a portable platform supporting multiple backends that might potentially also be used simultaneously.
+
 * Multiple backends may be available. The OpenMP host backend targeting the CPU is always available.
 * A backend may contain multiple platorms. This is primarily used on backends like OpenCL, where the backend itself might expose multiple available drivers. For example, a system might have the Intel OpenCL implementation for CPU installed as well as the Intel GPU OpenCL implementation.
 * A platform may contain multiple devices.
@@ -392,6 +394,7 @@ sycl::queue q = sycl::AdaptiveCpp_pcuda::make_queue(stream);
 ```
 
 **Note:** 
+
 1. During the lifetime of the queue, the underlying backend queue is shared between the PCUDA stream and the SYCL queue. The underlying backend queue will be freed once *both* PCUDA stream and SYCL queue are no longer alive.
 2. The queue returned from `make_queue` will always be an in-order queue. However, SYCL may queue up work to perform batched submission in certain cases. This can cause SYCL work dispatched before PCUDA work to be executed *after* PCUDA work even if both submit to the same underlying queue. To avoid this, use the AdaptiveCpp instant submission mode in SYCL (see [here](macros.md)) and avoid using the buffer-accessor data management model.
 3. You can get a SYCL queue for the PCUDA default stream for the current PCUDA device using `make_queue(0)`.

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -45,12 +45,14 @@ AdaptiveCpp supports all forms of USM universally on all backends and supported 
 Additionally, SYCL provides the `sycl::buffer`/`sycl::accessor` model.
 
 Generally, SYCL buffers are inferior to USM when it comes to performance:
+
 * **All types of USM have significantly lower host-side runtime overhead compared to buffers**, and can substantially outperform buffers, especially for short running kernels where submission latencies matter. This is especially true when in-order queues are used (See e.g. this paper for details: https://dl.acm.org/doi/fullHtml/10.1145/3648115.3648120)
     * With USM, the programmer can express dependencies statically, while the SYCL buffer-accessor model must figure out dependencies at runtime. Similarly, USM allows to statically express allocation/deallocation and data transfers, while with buffers non-trivial mechanisms in the SYCL runtime need to automatically manage these operations. This can add overhead.
 * Buffer accessors are not lightweight objects, and can increase register pressure in kernels compared to USM pointers.
 * Buffers may behave in unexpected ways that can silently introduce performance issues, for example buffer destructors synchronize in certain cases to wait for work to complete.
 
 For shared USM specifically:
+
 * Performance of shared USM typically depends on memory access patterns and driver quality. Depending on the operating system and hardware, very good performance is also possible with shared USM.
   * On CPU, shared USM is identical to device USM by design, and consequently there is no performance overhead
   * Performance on NVIDIA GPUs is typically excellent
@@ -63,6 +65,7 @@ Shared USM is the most productive memory management model that SYCL has, and can
 
 
 In summary:
+
 * **When control and maximum performance is needed, use device USM (`sycl::malloc_device`)**
 * **When maximum productivity is needed, use shared USM (`sycl::malloc_shared`)**
 * **Never use buffers. They do not bring significant advantages compared to USM, but can introduce substantial drawbacks!**
@@ -99,6 +102,7 @@ Note: Applications that are highly latency-sensitive may notice a slightly incre
 **For peak performance, you should not disable adaptivity, and run the application until the warning above is no longer printed.**
 
 We recommend:
+
 * Experiment with `ACPP_ADAPTIVITY_LEVEL=1` and `ACPP_ADAPTIVITY_LEVEL=2`
 * Experiment with `ACPP_ALLOCATION_TRACKING=1` and `ACPP_ALLOCATION_TRACKING=0`.
 

--- a/doc/scoped-parallelism.md
+++ b/doc/scoped-parallelism.md
@@ -3,6 +3,7 @@
 ## Introduction
 
 Scoped parallelism provides a novel way to formulate kernels in a hierarchical and performance-portable way. It contributes the following features to the SYCL world:
+
 * Hierarchical kernels with arbitrary nesting depth, while avoid the implementation and performance pitfalls from old SYCL 1.2.1 hierarchical parallelism by giving the implementation more freedom;
 * Performance portability (`nd_range` parallel for is notoriously difficult to implement efficiently in library-only CPU implementations);
 * Multi-dimensional (potentially nested) subgroups;
@@ -80,12 +81,14 @@ sycl::queue{}.parallel(num_work_groups, logical_group_size,
 ```
 
 There are three different group categories in scoped parallelism. They can be distinguished using the `static constexpr sycl::memory_scope fence_scope` member.
+
 1. The work group. For this group, it holds that `Group::fence_scope == sycl::memory_scope::work_group`. Represents the entire work group.
 2. A subgroup. For subgroups it holds that `Group::fence_scope == sycl::memory_scope::sub_group`. A sub group is a collection of logical work items below the granularity of the full work group. A backend or device might support multiple levels of nested sub groups.
 3. A scalar group. For scalar groups it holds that `Group::fence_scope == sycl::memory_scope::work_item`. Scalar groups contain a single logical work item.
 
  
 Invoking `distribute_groups()` on a group may result in the following group types provided in the next nesting level:
+
 1. Work group subdivision may result in subgroup or a scalar group.
 2. Subdivision of a subgroup may result in another, smaller subgroup or a scalar group
 3. Subdivision of a scalar group will result in a scalar group.
@@ -96,6 +99,7 @@ The user then expresses the kernel using calls to `distribute_groups` and `distr
 ## Scoped parallelism nesting rules
 
 Any program not obeying any of the following rules is **illegal**.
+
 1. The group object passed to `distribute_items(), distribute_groups(), single_item()`, their `*_and_wait` counterparts as well as group algorithms (e.g. `group_barrier()`) must be the smallest available group subunit available at that point in the code. In other words, it must be the group object that is "closest" in the nesting hierarchy. Otherwise the code would request execution within a parent group from a subunit of the parent group, at which point not all items from the parent group might participate anymore.
 2. `distribute_items(), distribute_groups(), single_item()`, their `*_and_wait` counterparts as well as group algorithms (e.g. `group_barrier()`) may not be called from within `distribute_items()` calls. `s_private_memory` objects may not be declared inside `distribute_items()` calls.
 3. `distribute_items(), distribute_groups(), single_item()`, their `*_and_wait` counterparts as well as group algorithms (e.g. `group_barrier()`) are collective with respect to the physical work items of the group object they operate on. The user must guarantee that each physical work item of the provided group object reaches their callsite. As soon as one physical item of a group invokes those functions, all others from the same group need to invoke it as well. There are no requirements regarding other, independent groups.
@@ -163,6 +167,7 @@ sycl::queue{}.parallel(num_work_groups, logical_group_size,
 ## Synchronization
 
 There are two ways of synchronizing:
+
 * `distribute_items_and_wait()`, `distribute_groups_and_wait()`, `single_item_and_wait()` automatically insert a barrier on the group provided as argument to those functions after executing the user-provided callable.
 * alternatively, `group_barrier()` can be invoked directly outside of `distribute_items` and in the appropriate scope of the group. This can provide more control as the fence scope can also be specified in this way.
 
@@ -171,6 +176,7 @@ There are two ways of synchronizing:
 ## Memory placement rules
 
 In the scoped parallelism model, the following memory placement rules apply:
+
 * Variables declared inside a `distribute_items()` call will be allocated in private memory of the logical work item.
 * Variables declared outside of `distribute_items()` calls will be allocated in the private memory of the executing physical work item.
 * Variables can be explicitly but into either local memory or the private memory of logical work items using `sycl::memory_environment()`
@@ -618,6 +624,7 @@ class ScopedGroup {
 ## Supported group algorithms
 
 The following group algorithms are supported for scoped parallelism groups:
+
 * `group_barrier()`
 * `joint_*` functions (not yet implemented)
 * `*_over_group` functions for arguments of private memory wrapper type obtained from `sycl::memory_environment()` (not yet implemented)

--- a/doc/stdpar.md
+++ b/doc/stdpar.md
@@ -16,6 +16,7 @@ AdaptiveCpp by default uses some experimental heuristics to determine if a probl
 ## Algorithms and policies supported for offloading
 
 Currently, the following execution policies qualify for offloading:
+
 * `par_unseq`
 * `par` (experimental; will only be offloaded on hardware that provides independent work item forward progress guarantees such as recent NVIDIA GPUs)
 


### PR DESCRIPTION
Material for MkDocs appears to be more sensitive to empty lines between body text and lists than GitHub-flavoured Markdown. In particular, it will not correctly render lists when there is no empty line separating them from the body text immediately preceding them. This pull request adds empty lines to the Markdown documentation at appropriate positions to correct the rendering of previously incorrectly rendered lists in the Material for MkDocs-based documentation pages (see below for an example).

---

![](https://github.com/user-attachments/assets/f49dd4fc-1613-4012-a0a4-3af0751518ca)

***Top:** Part of the compilation.md file rendered with Material for MkDocs prior to this pull request.*
***Bottom:** The same part of the compilation.md file rendered with Material for MkDocs after incorporation of this pull request.*

---