### PR TITLE
Change invalid CMake `INTEGER` type to regex-guarded `STRING`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,10 @@ endif()
 
 set(ACPP_EXPERIMENTAL_LLVM OFF CACHE BOOL "Whether to allow building AdaptiveCpp against unsupported LLVM versions")
 
-set(ACPP_SUBPROJECT_PARALLEL_JOBS 1 CACHE INTEGER "Specifies the number of parallel jobs to use when building subprojects")
+set(ACPP_SUBPROJECT_PARALLEL_JOBS "1" CACHE STRING "Specifies the number of parallel jobs to use when building subprojects")
+if(NOT ACPP_SUBPROJECT_PARALLEL_JOBS MATCHES "^[1-9][0-9]*$")
+  message(SEND_ERROR "ACPP_SUBPROJECT_PARALLEL_JOBS must be a positive integer.")
+endif()
 
 set(HIPSYCL_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(ACPP_SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
I do not believe `INTEGER` is a valid CMake type, but instead is automatically reinterpreted as a `STRING` type. This causes CMake warnings of the form:

```
CMake Warning (dev) at CMakeLists.txt:97 (set):
  implicitly converting 'INTEGER' to 'STRING' type.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

To address this, I have changed `ACPP_SUBPROJECT_PARALLEL_JOBS` to be set to a `STRING` type instead. To guard against values of `ACPP_SUBPROJECT_PARALLEL_JOBS`, which are not positive integers, I have added a regex-based check. Notably, this check will reject values of `ACPP_SUBPROJECT_PARALLEL_JOBS` with leading zeros (e.g. as in `01`), but I do not think this should be a problem in any real-world scenarios.