### PR TITLE
Add checks for zero-sized nd_range kernels

### DIFF
--- a/include/hipSYCL/sycl/handler.hpp
+++ b/include/hipSYCL/sycl/handler.hpp
@@ -378,7 +378,7 @@ public:
             typename... ReductionsAndKernel, int dimensions>
   void parallel_for(nd_range<dimensions> executionRange,
                     const ReductionsAndKernel &... redu_kernel) {
-    if (executionRange.get_global_range() == 0)
+    if (executionRange.get_global_range().size() == 0)
       AdaptiveCpp_enqueue_custom_operation([](auto&){});
 
     else {
@@ -413,7 +413,7 @@ public:
   void parallel_for_work_group(range<dimensions> numWorkGroups,
                                range<dimensions> workGroupSize,
                                const ReductionsAndKernel &... redu_kernel) {
-    if (numWorkGroups == 0)
+    if (numWorkGroups.size() == 0)
       AdaptiveCpp_enqueue_custom_operation([](auto&){});
 
     else {
@@ -435,7 +435,7 @@ public:
                 range<dimensions> workGroupSize,
                 const ReductionsAndKernel& ... redu_kernel)
   {
-    if (numWorkGroups == 0)
+    if (numWorkGroups.size() == 0)
       AdaptiveCpp_enqueue_custom_operation([](auto&){});
 
     else {

--- a/include/hipSYCL/sycl/handler.hpp
+++ b/include/hipSYCL/sycl/handler.hpp
@@ -378,14 +378,19 @@ public:
             typename... ReductionsAndKernel, int dimensions>
   void parallel_for(nd_range<dimensions> executionRange,
                     const ReductionsAndKernel &... redu_kernel) {
-    auto invoker = [&](auto&& kernel, auto&& ... reductions) {
-      this->submit_kernel<KernelName, rt::kernel_type::ndrange_parallel_for>(
-        executionRange.get_offset(), executionRange.get_global_range(),
-        executionRange.get_local_range(),
-        kernel, reductions...);
-    };
+    if (executionRange.get_global_range() == 0)
+      AdaptiveCpp_enqueue_custom_operation([](auto&){});
 
-    detail::separate_last_argument_and_apply(invoker, redu_kernel...);
+    else {
+      auto invoker = [&](auto&& kernel, auto&& ... reductions) {
+        this->submit_kernel<KernelName, rt::kernel_type::ndrange_parallel_for>(
+          executionRange.get_offset(), executionRange.get_global_range(),
+          executionRange.get_local_range(),
+          kernel, reductions...);
+      };
+
+      detail::separate_last_argument_and_apply(invoker, redu_kernel...);
+    }
   }
 
   // Hierarchical kernel dispatch API
@@ -408,13 +413,18 @@ public:
   void parallel_for_work_group(range<dimensions> numWorkGroups,
                                range<dimensions> workGroupSize,
                                const ReductionsAndKernel &... redu_kernel) {
-    auto invoker = [&](auto &&kernel, auto &&... reductions) {
-      this->submit_kernel<KernelName,
-                          rt::kernel_type::hierarchical_parallel_for>(
-          sycl::id<dimensions>{}, numWorkGroups * workGroupSize, workGroupSize,
-          kernel, reductions...);
-    };
-    detail::separate_last_argument_and_apply(invoker, redu_kernel...);
+    if (numWorkGroups == 0)
+      AdaptiveCpp_enqueue_custom_operation([](auto&){});
+
+    else {
+      auto invoker = [&](auto &&kernel, auto &&... reductions) {
+        this->submit_kernel<KernelName,
+                            rt::kernel_type::hierarchical_parallel_for>(
+            sycl::id<dimensions>{}, numWorkGroups * workGroupSize, workGroupSize,
+            kernel, reductions...);
+      };
+      detail::separate_last_argument_and_apply(invoker, redu_kernel...);
+    }
   }
 
   // Scoped parallelism API
@@ -425,14 +435,19 @@ public:
                 range<dimensions> workGroupSize,
                 const ReductionsAndKernel& ... redu_kernel)
   {
-    auto invoker = [&](auto&& kernel, auto&&... reductions) {
-      this->submit_kernel<KernelName, rt::kernel_type::scoped_parallel_for>(
-          sycl::id<dimensions>{}, numWorkGroups * workGroupSize,
-          workGroupSize,
-          kernel, reductions...);
-    };
+    if (numWorkGroups == 0)
+      AdaptiveCpp_enqueue_custom_operation([](auto&){});
 
-    detail::separate_last_argument_and_apply(invoker, redu_kernel...);
+    else {
+      auto invoker = [&](auto&& kernel, auto&&... reductions) {
+        this->submit_kernel<KernelName, rt::kernel_type::scoped_parallel_for>(
+            sycl::id<dimensions>{}, numWorkGroups * workGroupSize,
+            workGroupSize,
+            kernel, reductions...);
+      };
+
+      detail::separate_last_argument_and_apply(invoker, redu_kernel...);
+    }
   }
 
   /*

--- a/tests/sycl/kernel_invocation.cpp
+++ b/tests/sycl/kernel_invocation.cpp
@@ -124,17 +124,17 @@ BOOST_AUTO_TEST_CASE(empty_kernel_submission) {
   }).wait_and_throw();
 
   q.submit([&](cl::sycl::handler &cgh) {
-    cgh.parallel(cl::sycl::range<1>{0}, cl::sycl::range<1>{0}, [=](auto& work_item) {
+    cgh.parallel(cl::sycl::range<1>{0}, cl::sycl::range<1>{0}, [=](auto work_item) {
     });
   }).wait_and_throw();
 
   q.submit([&](cl::sycl::handler &cgh) {
-    cgh.parallel(cl::sycl::range<2>{0, 0}, cl::sycl::range<2>{0, 0}, [=](auto& work_item) {
+    cgh.parallel(cl::sycl::range<2>{0, 0}, cl::sycl::range<2>{0, 0}, [=](auto work_item) {
     });
   }).wait_and_throw();
 
   q.submit([&](cl::sycl::handler &cgh) {
-    cgh.parallel(cl::sycl::range<3>{0, 0, 0}, cl::sycl::range<3>{0, 0, 0}, [=](auto& work_item) {
+    cgh.parallel(cl::sycl::range<3>{0, 0, 0}, cl::sycl::range<3>{0, 0, 0}, [=](auto work_item) {
     });
   }).wait_and_throw();
 }

--- a/tests/sycl/kernel_invocation.cpp
+++ b/tests/sycl/kernel_invocation.cpp
@@ -41,6 +41,13 @@ BOOST_AUTO_TEST_CASE(empty_kernel_submission) {
       }
     ).wait_and_throw();
 
+    q.parallel_for(
+      cl::sycl::nd_range<1>{{0}, {0}},
+      [=](cl::sycl::nd_item<1> idx) {
+        d_y[idx.get_global_linear_id()] = static_cast<int>(idx.get_global_linear_id());
+      }
+    ).wait_and_throw();
+
   // 2D check
   q.parallel_for(
     cl::sycl::range<2>(0,0),
@@ -48,11 +55,25 @@ BOOST_AUTO_TEST_CASE(empty_kernel_submission) {
     }
   ).wait_and_throw();
 
+  q.parallel_for(
+  cl::sycl::nd_range<2>{{0, 0}, {0, 0}},
+  [=](cl::sycl::nd_item<2> idx) {
+    d_y[idx.get_global_linear_id()] = static_cast<int>(idx.get_global_linear_id());
+  }
+  ).wait_and_throw();
+
   // 3D check
   q.parallel_for(
     cl::sycl::range<3>(0,0,0),
     [=](cl::sycl::id<3> idx) {
     }
+  ).wait_and_throw();
+
+  q.parallel_for(
+  cl::sycl::nd_range<3>{{0, 0, 0}, {0, 0, 0}},
+  [=](cl::sycl::nd_item<3> idx) {
+    d_y[idx.get_global_linear_id()] = static_cast<int>(idx.get_global_linear_id());
+  }
   ).wait_and_throw();
 
   // Checking for event & dependency handling
@@ -85,6 +106,37 @@ BOOST_AUTO_TEST_CASE(empty_kernel_submission) {
   });
 
   e3D.wait_and_throw();
+
+  // Check for hierarchical parallelism and scoped parallelism
+  q.submit([&](cl::sycl::handler &cgh) {
+    cgh.parallel_for_work_group(cl::sycl::range<1>{0}, cl::sycl::range<1>{0}, [=](auto& work_item) {
+    });
+  }).wait_and_throw();
+
+  q.submit([&](cl::sycl::handler &cgh) {
+    cgh.parallel_for_work_group(cl::sycl::range<2>{0, 0}, cl::sycl::range<2>{0, 0}, [=](auto& work_item) {
+    });
+  }).wait_and_throw();
+
+  q.submit([&](cl::sycl::handler &cgh) {
+    cgh.parallel_for_work_group(cl::sycl::range<3>{0, 0, 0}, cl::sycl::range<3>{0, 0, 0}, [=](auto& work_item) {
+    });
+  }).wait_and_throw();
+
+  q.submit([&](cl::sycl::handler &cgh) {
+    cgh.parallel(cl::sycl::range<1>{0}, cl::sycl::range<1>{0}, [=](auto& work_item) {
+    });
+  }).wait_and_throw();
+
+  q.submit([&](cl::sycl::handler &cgh) {
+    cgh.parallel(cl::sycl::range<2>{0, 0}, cl::sycl::range<2>{0, 0}, [=](auto& work_item) {
+    });
+  }).wait_and_throw();
+
+  q.submit([&](cl::sycl::handler &cgh) {
+    cgh.parallel(cl::sycl::range<3>{0, 0, 0}, cl::sycl::range<3>{0, 0, 0}, [=](auto& work_item) {
+    });
+  }).wait_and_throw();
 }
 
 BOOST_AUTO_TEST_CASE(basic_parallel_for) {


### PR DESCRIPTION
Issue #1764 and PR #1821 addressed submission of zero-sized kernels. A small oversight in the PR was that it only added checks for the standard range-based parallel_for, but not the nd_range parallel_for. 

This PR adds the remaining checks for nd_range parallel_for, as well as for hierarchical and scoped parallelism. 