### PR TITLE
Fix a few typos here and there

### DIFF
--- a/doc/algorithms.md
+++ b/doc/algorithms.md
@@ -32,7 +32,7 @@ void run_scan(sycl::queue& q, int* device_data_ptr, int* device_output_ptr,
 
 * All algorithms are exclusively supported for the SYCL 2020 USM memory management model (either `device`, `host` or `shared` allocations). The old SYCL `buffer` model is unsupported.
 * All algorithms take a `sycl::queue` to which they submit their operations. Both out-of-order and in-order queues are supported, but we recommend in-order queues for performance and since the library is better tested with in-order queues.
-* All algorithms operate asynchronously, i.e. it is the user's resposibility to synchronize appropriately before results are accessed.
+* All algorithms operate asynchronously, i.e. it is the user's responsibility to synchronize appropriately before results are accessed.
 * All algorithms take an optional `const std::vector<sycl::event>&` argument that can be used to express dependencies.
 * All algorithms return a `sycl::event` which can be used for synchronization. Note: If an algorithm is invoked for a problem size of 0, then for performance reasons it immediately returns a default-constructed `sycl::event` which has a `completed` status. This is the case even if the algorithms has dependencies that are not yet complete!
 * Some algorithms require temporary scratch memory. For performance reasons, this scratch memory is cached. The AdaptiveCpp algorithms library exposes control over allocation lifetime and allocation kind for this scratch memory to users (see below).

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -760,7 +760,7 @@ The following 'finalizers' are supported:
 ### `ACPP_EXT_TARGET_NUMA_NODE_PROPERTY`
 This extension allows a user to specify a set of NUMA nodes on which to allocate memory.
 This can be done by using the `AdaptiveCpp_target_numa_node` property on USM allocation functions.
-This extension is aonly available when using the OpenMP backend. Using this property with any other backend will have no effects.
+This extension is only available when using the OpenMP backend. Using this property with any other backend will have no effects.
 
 Example:
 ```

--- a/doc/generic-sscp.md
+++ b/doc/generic-sscp.md
@@ -14,7 +14,7 @@ Stage 1 IR constants are hard-wired. The following important S1 IR constants exi
 
 Stage 2 IR constants are intended to provide information that requires knowledge of the target device, such as backend, device, and so on. Stage 2 IR constants can also be programmatically added by the user.
 
-After AdaptiveCpp sets the value of an IR constant, it runs constant propagation and dead code elimination passes. This causes if statements depending entirely on IR constants to be trivially optimized away - causing either removal of the code contained in the if brach, or hardwiring the code.
+After AdaptiveCpp sets the value of an IR constant, it runs constant propagation and dead code elimination passes. This causes if statements depending entirely on IR constants to be trivially optimized away - causing either removal of the code contained in the if branch, or hardwiring the code.
 
 #### Stage 1: Kernel extraction
 

--- a/doc/pcuda.md
+++ b/doc/pcuda.md
@@ -41,7 +41,7 @@ Due to the single-pass nature of AdaptiveCpp's compiler, host and device code ar
 
 ### No compile-time knowledge of targets
 
-Due to the JIT nature, the target device is not known at compile-time. Therefore, it is not possible to specialize code paths for different devices using preprocesor macros.
+Due to the JIT nature, the target device is not known at compile-time. Therefore, it is not possible to specialize code paths for different devices using preprocessor macros.
 Instead, control flow and AdaptiveCpp's JIT reflection and `compile_if` functionality must be used (**Note**: This API is currently available in SYCL and can be used from PCUDA, however, a native PCUDA version will follow in the future).
 
 Another consequence of the JIT nature is that `warpSize` is not `constexpr`, since the target device and its warp size is not known at compile time.
@@ -55,7 +55,7 @@ AdaptiveCpp does not implement CUDA's legacy default stream semantics and only s
 AdaptiveCpp is a portable platform supporting multiple backends that might potentially also be used simultaneously.
 
 * Multiple backends may be available. The OpenMP host backend targeting the CPU is always available.
-* A backend may contain multiple platorms. This is primarily used on backends like OpenCL, where the backend itself might expose multiple available drivers. For example, a system might have the Intel OpenCL implementation for CPU installed as well as the Intel GPU OpenCL implementation.
+* A backend may contain multiple platforms. This is primarily used on backends like OpenCL, where the backend itself might expose multiple available drivers. For example, a system might have the Intel OpenCL implementation for CPU installed as well as the Intel GPU OpenCL implementation.
 * A platform may contain multiple devices.
 
 Because devices from different vendors in general do not know how to talk to each other, in general data transfers are only possible within devices of one platform (and the host).
@@ -345,7 +345,7 @@ pcudaSetDevice(device);
 
 ## Interoperability with SYCL or C++ standard parallelism in device code
 
-When using `--acpp-targets=generic`, all programming models supported by AdaptiveCpp are interchangable arbitrarily in device code.
+When using `--acpp-targets=generic`, all programming models supported by AdaptiveCpp are interchangeable arbitrarily in device code.
 You can mix-and-match code as needed with any of the programming models.
 
 Example:

--- a/src/runtime/cuda/cuda_hardware_manager.cpp
+++ b/src/runtime/cuda/cuda_hardware_manager.cpp
@@ -36,7 +36,7 @@ cuda_hardware_manager::cuda_hardware_manager(hardware_platform hw_platform)
         __acpp_here(),
         error_info{
             "cuda_hardware_manager: CUDA backend does not support device "
-            "visibility masks. Use CUDA_VISIBILE_DEVICES instead."});
+            "visibility masks. Use CUDA_VISIBLE_DEVICES instead."});
   }
 
   int num_devices = 0;

--- a/src/runtime/hip/hip_hardware_manager.cpp
+++ b/src/runtime/hip/hip_hardware_manager.cpp
@@ -60,7 +60,7 @@ hip_hardware_manager::hip_hardware_manager(hardware_platform hw_platform)
         __acpp_here(),
         error_info{
             "hip_hardware_manager: HIP backend does not support device "
-            "visibility masks. Use HIP_VISIBILE_DEVICES instead."});
+            "visibility masks. Use HIP_VISIBLE_DEVICES instead."});
   }
 
   int num_devices = 0;


### PR DESCRIPTION
Most notably, `CUDA_VISIBLE_DEVICES` in the device mask warning, since it is convenient to copy-paste it.