### PR TITLE
Open bitcode files in binary

### DIFF
--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -538,7 +538,7 @@ bool LLVMToAmdgpuTranslator::clangJitLink(llvm::Module& FlavoredModule, std::str
   }
 
   auto ReadResult =
-      llvm::MemoryBuffer::getFile(OutputFileName, -1);
+      llvm::MemoryBuffer::getFile(OutputFileName);
 
   if(auto Err = ReadResult.getError()) {
     this->registerError("LLVMToAmdgpu: Could not read result file" + Err.message());

--- a/src/compiler/llvm-to-backend/host/LLVMToHost.cpp
+++ b/src/compiler/llvm-to-backend/host/LLVMToHost.cpp
@@ -344,7 +344,7 @@ bool LLVMToHostTranslator::translateToBackendFormat(llvm::Module &FlavoredModule
     return false;
   }
 
-  auto ReadResult = llvm::MemoryBuffer::getFile(OutputFileName, -1);
+  auto ReadResult = llvm::MemoryBuffer::getFile(OutputFileName);
 
   if (auto Err = ReadResult.getError()) {
     this->registerError("LLVMToHost: Could not read result file" + Err.message());

--- a/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
+++ b/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
@@ -290,7 +290,7 @@ bool LLVMToPtxTranslator::translateToBackendFormat(llvm::Module &FlavoredModule,
     return false;
   }
   
-  auto ReadResult = llvm::MemoryBuffer::getFile(OutputFileName, -1);
+  auto ReadResult = llvm::MemoryBuffer::getFile(OutputFileName);
   
   if(auto Err = ReadResult.getError()) {
     this->registerError("LLVMToPtx: Could not read result file" + Err.message());

--- a/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
+++ b/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
@@ -358,7 +358,7 @@ bool LLVMToSpirvTranslator::translateToBackendFormat(llvm::Module &FlavoredModul
   }
   
   auto ReadResult =
-      llvm::MemoryBuffer::getFile(OutputFileName, -1);
+      llvm::MemoryBuffer::getFile(OutputFileName);
   
   if(auto Err = ReadResult.getError()) {
     this->registerError("LLVMToSpirv: Could not read result file"+Err.message());


### PR DESCRIPTION
Since LLVM 13 (c83cd8feef7eb8319131d968bb8c94fdc8dbb6a6), the second argument of `llvm::MemoryBuffer::getFile` was changed to `bool IsText = false` from `int64_t FileSize = -1`.

However, the `-1` was left in some invocations of this function, causing the file to be opened in text mode.

Harmless on Linux, but I guess it's not good