### PR TITLE
[SSCP][llvm-to-amdgpu][llvm-to-ptx] Forward target architectures to opt

### DIFF
--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -124,6 +124,14 @@ bool getCommandOutput(const std::string &Program, const llvm::SmallVector<std::s
   return true;
 }
 
+// From a string like gfxABC:flag+:flag2- only returns gfxABC
+std::string discardConfigurationFromTargetName(const std::string& TargetDevice) {
+  auto ColonPos = TargetDevice.find(":");
+  if(ColonPos != std::string::npos)
+    return TargetDevice.substr(0, ColonPos);
+  return TargetDevice;
+}
+
 }
 
 
@@ -132,12 +140,9 @@ bool getCommandOutput(const std::string &Program, const llvm::SmallVector<std::s
 class RocmDeviceLibs {
 private:
   static std::string extractISAAsString(const std::string &TargetDevice) {
-    std::string Result = TargetDevice;
     // First remove the subtarget in strings like gfxABC:xnack-:sramecc-
     // So, find first : and throw away the stuff afterwards to obtain gfxABC
-    auto ColonPos = Result.find(":");
-    if(ColonPos != std::string::npos)
-      Result = Result.substr(0, ColonPos);
+    std::string Result = discardConfigurationFromTargetName(TargetDevice);
 
     // Remove gfx prefix
     if(Result.find("gfx") != 0)
@@ -398,8 +403,20 @@ bool LLVMToAmdgpuTranslator::hiprtcJitLink(const std::string &Bitcode, std::stri
     bcfile.write(Bitcode.data(), Bitcode.size());
   }
   const std::string OptPath = getOptPath();
+  
+  llvm::SmallVector<llvm::StringRef, 16> OptInvocation {
+    OptPath,
+    "-O3", 
+    InputFileName, 
+    "-o", OptOutputFileName};
+
+  std::string OptTargetFlag = "--mcpu="+discardConfigurationFromTargetName(TargetDevice);
+  if(!TargetDevice.empty())
+    OptInvocation.push_back(OptTargetFlag);
+
+
   int OptR =
-      llvm::sys::ExecuteAndWait(OptPath, {OptPath, "-O3", InputFileName, "-o", OptOutputFileName});
+      llvm::sys::ExecuteAndWait(OptPath, OptInvocation);
   if(OptR != 0) {
     this->registerError("LLVMToAmdgpu: opt invocation failed with exit code " +
                         std::to_string(OptR));

--- a/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
+++ b/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
@@ -243,9 +243,11 @@ bool LLVMToPtxTranslator::translateToBackendFormat(llvm::Module &FlavoredModule,
     if(InputStream.error()) {HIPSYCL_DEBUG_ERROR << "Error while flushing" << InputStream.error().message() << '\n'; }
   }
 
+  std::string PtxTargetArg = "--mcpu=sm_" + std::to_string(PtxTarget);
+
   const std::string OptPath = getOptPath();
-  int OptR =
-      llvm::sys::ExecuteAndWait(OptPath, {OptPath, "-O3", InputFileName, "-o", OptOutputFileName});
+  int OptR = llvm::sys::ExecuteAndWait(
+      OptPath, {OptPath, PtxTargetArg, "-O3", InputFileName, "-o", OptOutputFileName});
 
   if(OptR != 0) {
     this->registerError("LLVMToPtx: opt invocation failed with exit code " +
@@ -256,7 +258,7 @@ bool LLVMToPtxTranslator::translateToBackendFormat(llvm::Module &FlavoredModule,
   const std::string LLCPath = getLLCPath();
 
   std::string PtxVersionArg = "--mattr=+ptx" + std::to_string(PtxVersion);
-  std::string PtxTargetArg = "--mcpu=sm_" + std::to_string(PtxTarget);
+  
   llvm::SmallVector<llvm::StringRef, 16> Invocation{LLCPath,
                                                     "--mtriple=nvptx64-nvidia-cuda",
                                                     "--march=nvptx64",


### PR DESCRIPTION
We now do explicit calls to `opt` as part of the JIT process. With this PR, the target architecture is also forwarded to these calls. This fixes a few (rare) performance regressions that I found.