### PR TITLE
[unordered_dense] Make iter_t explicitly private to work around clang bug (?)

### DIFF
--- a/include/hipSYCL/common/unordered_dense.hpp
+++ b/include/hipSYCL/common/unordered_dense.hpp
@@ -501,6 +501,7 @@ struct base_table_type_set {};
 // linear and thus there is one more indirection necessary for indexing.
 template <typename T, typename Allocator = std::allocator<T>, size_t MaxSegmentSizeBytes = 4096>
 class segmented_vector {
+private:
     template <bool IsConst>
     class iter_t;
 


### PR DESCRIPTION
It was reported that `unordered_dense` causes compiler errors in the project https://github.com/SimonTrecca/Temper/ in the form of mismatches between public/private declarations of `iter_t` in `unordered_dense`.

It seems that clang incorrectly assumes public visibility for the forward declaration of `iter_t`. This error never surfaced before in either CI nor other projects, so a bug in the clang parser/sema seems likely.

This PR works around this by explicitly declaring `iter_t` private.