### PR TITLE
Replaced calloc for malloc in minicoro allocation approaches.

### DIFF
--- a/src/runtime/support/minicoro_wrapper.cpp
+++ b/src/runtime/support/minicoro_wrapper.cpp
@@ -13,6 +13,16 @@
 
 #include "hipSYCL/runtime/support/minicoro_wrapper.hpp"
 
+/**
+ * Defines MCO_ALLOC as malloc to avoid performance issues when the compiler
+ * issues a malloc + memset for a calloc. The coroutines allocate more space
+ * than they touch. Hence if the compiler issues a malloc + memset then all the
+ * requested space written to and hence allocated in physical memory which is
+ * slow. See AdaptiveCpp GitHub issue 1931. @edubart advises that this
+ * substitution is safe.
+ */
+#include <stdlib.h>
+#define MCO_ALLOC(size) malloc(size)
 #define MINICORO_IMPL
 #include "minicoro.h"
 

--- a/src/runtime/support/minicoro_wrapper.cpp
+++ b/src/runtime/support/minicoro_wrapper.cpp
@@ -23,6 +23,7 @@
  */
 #include <stdlib.h>
 #define MCO_ALLOC(size) malloc(size)
+#define MCO_DEALLOC(ptr, size) free(ptr)
 #define MINICORO_IMPL
 #include "minicoro.h"
 


### PR DESCRIPTION
Implements the replacement of calloc for malloc as discussed in issue 1931 [1].

[1] https://github.com/AdaptiveCpp/AdaptiveCpp/issues/1931
Closes #1931