### PR TITLE
[llvm-to-backend] Need to set eh/rtti depending on LLVM's build.

### DIFF
--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -52,6 +52,13 @@ function(create_llvm_based_library)
   endif()
   # We need symbolic functions for stdpar
   target_link_libraries(${target} PRIVATE ${HIPSYCL_STDPAR_RT_LINKER_FLAGS})
+  
+  if(NOT LLVM_ENABLE_EH)
+    target_compile_options(${target} PRIVATE -fno-exceptions)
+  endif()
+  if(NOT LLVM_ENABLE_RTTI)
+    target_compile_options(${target} PRIVATE -fno-rtti)
+  endif()
 
   if(ACPP_LLVM_COMPONENT)
     add_dependencies(${target} intrinsics_gen)


### PR DESCRIPTION
No clue why it worked without this so far... :)
My local build with LLVM 22-dev definitely didn't like it.