### PR TITLE
[SSCP][llvm-to-host] libkernel: Don't enforce target triple, just use default host compilation

### DIFF
--- a/src/libkernel/sscp/CMakeLists.txt
+++ b/src/libkernel/sscp/CMakeLists.txt
@@ -30,9 +30,14 @@ function(libkernel_generate_bitcode_library)
     endif()
   endif()
 
+  set(target_flag "")
+  if(triple)
+    set(target_flag -target ${triple})
+  endif()
+
   add_custom_command(
       OUTPUT ${target_output_file}
-      COMMAND ${CLANG_EXECUTABLE_PATH} -target ${triple} -fno-exceptions -fno-rtti -O3 -emit-llvm -std=c++17 -DHIPSYCL_SSCP_LIBKERNEL_LIBRARY
+      COMMAND ${CLANG_EXECUTABLE_PATH} ${target_flag} -fno-exceptions -fno-rtti -O3 -emit-llvm -std=c++17 -DHIPSYCL_SSCP_LIBKERNEL_LIBRARY
                     -I ${HIPSYCL_SOURCE_DIR}/include ${additional} ${platform_specific} -o ${target_output_file} -c ${CMAKE_CURRENT_SOURCE_DIR}/${source}
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${source} ${target_depends}
       VERBATIM)

--- a/src/libkernel/sscp/host/CMakeLists.txt
+++ b/src/libkernel/sscp/host/CMakeLists.txt
@@ -25,12 +25,12 @@ if(WITH_LLVM_TO_HOST)
 
   libkernel_generate_bitcode_target(
       TARGETNAME host 
-      TRIPLE ${LLVM_TARGET_TRIPLE}
+      TRIPLE ""
       SOURCES ${HOST_LIBKERNEL_BITCODE_SOURCES})
 
   libkernel_generate_bitcode_target(
       TARGETNAME host-fast
-      TRIPLE ${LLVM_TARGET_TRIPLE}
+      TRIPLE ""
       SOURCES ${HOST_LIBKERNEL_BITCODE_SOURCES}
       ADDITIONAL_ARGS -ffast-math)
 endif()


### PR DESCRIPTION
It was reported in https://github.com/AdaptiveCpp/AdaptiveCpp/discussions/1935 that AdaptiveCpp with SSCP does not build correctly on aarch64 due to the bitcode libraries for host not building because C++ standard headers cannot be found.

This was reportedly fixed by not setting the target triple when generating the host bitcode libs, i.e. just let clang do what it does by default. My guess is that setting the triple might incorrectly hint to clang that it is in a cross-compilation scenario, even if the triple is the same as host (at least on some architectures, such issues were never encountered on x86).