### PR TITLE
Use SMCP equivalent memory scope for barriers

### DIFF
--- a/include/hipSYCL/sycl/libkernel/detail/device_barrier.hpp
+++ b/include/hipSYCL/sycl/libkernel/detail/device_barrier.hpp
@@ -31,7 +31,7 @@ inline void sscp_barrier(access::fence_space space) {
     __acpp_sscp_work_group_barrier(memory_scope::work_group,
                                       memory_order::seq_cst);
   } else {
-    __acpp_sscp_work_group_barrier(memory_scope::device,
+    __acpp_sscp_work_group_barrier(memory_scope::work_group,
                                       memory_order::seq_cst);
   }
 }


### PR DESCRIPTION
In case of HIP a `__syncthreads()` call will generate the follwing LLVM IR [godbolt](https://godbolt.org/z/16a9aP64r):

```
  fence syncscope("workgroup") release
  call void @llvm.amdgcn.s.barrier()
  fence syncscope("workgroup") acquire
```
Since in case of SMCP we call sync-threads directly, this PR makes SSCP also generate the same IR. This change has significantly improves the performance of the SSCP flow.