### PR TITLE
Use aspect selector for host USM SYCL test

### DIFF
--- a/tests/sycl/queue.cpp
+++ b/tests/sycl/queue.cpp
@@ -35,10 +35,8 @@ BOOST_AUTO_TEST_CASE(queue_wait) {
 }
 
 BOOST_AUTO_TEST_CASE(queue_memcpy_host_to_host) {
-  try {
-    sycl::queue q{sycl::aspect_selector(std::vector{sycl::aspect::usm_host_allocations}),
-                  sycl::property::queue::in_order{}};
-
+  sycl::queue q{sycl::property::queue::in_order{}};
+  if (q.get_device().has(sycl::aspect::usm_host_allocations)) {
     auto source = sycl::malloc_host(sizeof(int), q);
     auto dest = malloc(sizeof(int));
 
@@ -46,8 +44,6 @@ BOOST_AUTO_TEST_CASE(queue_memcpy_host_to_host) {
 
     sycl::free(source, q);
     free(dest);
-  } catch (sycl::exception e) {
-    BOOST_CHECK(true); // Skip the test if host USM not available
   }
 }
 

--- a/tests/sycl/queue.cpp
+++ b/tests/sycl/queue.cpp
@@ -36,7 +36,8 @@ BOOST_AUTO_TEST_CASE(queue_wait) {
 
 BOOST_AUTO_TEST_CASE(queue_memcpy_host_to_host) {
   try {
-    sycl::queue q{sycl::gpu_selector_v, sycl::property::queue::in_order{}};
+    sycl::queue q{sycl::aspect_selector(std::vector{sycl::aspect::usm_host_allocations}),
+                  sycl::property::queue::in_order{}};
 
     auto source = sycl::malloc_host(sizeof(int), q);
     auto dest = malloc(sizeof(int));
@@ -46,7 +47,7 @@ BOOST_AUTO_TEST_CASE(queue_memcpy_host_to_host) {
     sycl::free(source, q);
     free(dest);
   } catch (sycl::exception e) {
-    BOOST_CHECK(true); // Skip the test if no GPU available
+    BOOST_CHECK(true); // Skip the test if host USM not available
   }
 }
 


### PR DESCRIPTION
Rather than using the GPU device selector to enable a SYCL queue test that requires host USM, use a aspect selector for the asserting the host usm capability.

This change allows the test to run on USM enabled devices that aren't GPUs, in particular OpenCL CPU implementations with the  USM/SVM extension features.