### PR TITLE
[CI] Add force option to prime-docker action.

### DIFF
--- a/.github/workflows/create-ci-docker/action.yml
+++ b/.github/workflows/create-ci-docker/action.yml
@@ -24,6 +24,8 @@ inputs:
     default: 'ubuntu-22.04'
   GITHUB_TOKEN:
     required: true
+  FORCE_BUILD:
+    default: false
   
 outputs:
   docker_image:
@@ -163,7 +165,7 @@ runs:
         fi
         
     - name: Build and push Docker images
-      if: (steps.filter-last-push.outputs.docker == 'true' || steps.tag-exists.outputs.tag == 'not found') && github.event_name != 'pull_request'
+      if: (steps.filter-last-push.outputs.docker == 'true' || steps.tag-exists.outputs.tag == 'not found' || inputs.FORCE_BUILD) && github.event_name != 'pull_request'
       uses: docker/build-push-action@v6
       id: build
       with:

--- a/.github/workflows/prime-docker.yml
+++ b/.github/workflows/prime-docker.yml
@@ -21,6 +21,9 @@ on:
         default: "2"
       rocm:
         description: 'ROCm Version (default 5.4.3)'
+      force:
+        description: 'Force build the image'
+        default: "false"
 
 jobs:
   prep-container:
@@ -43,3 +46,4 @@ jobs:
           CUDA_PATCH_VERSION: ${{ inputs.cuda_patch_version }}
           BASE_TAG: ${{ inputs.os }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FORCE_BUILD: ${{ inputs.force != 'false' }}


### PR DESCRIPTION
@illuhad 
Merging this, should (enable) rebuilding the images for 2 reasons:
- we changed sth in create-ci-docker, which automatically triggers a rebuild
- You now have the option to `force` with the prime-docker action.