### PR TITLE
[libkernel][host] Add glibc version check for fmaxmag/fminmag

### DIFF
--- a/src/libkernel/sscp/host/math.cpp
+++ b/src/libkernel/sscp/host/math.cpp
@@ -195,9 +195,11 @@ HIPSYCL_SSCP_MAP_HOST_FLOAT_BUILTIN(log1p)
 HIPSYCL_SSCP_MAP_HOST_FLOAT_BUILTIN(logb)
 HIPSYCL_SSCP_MAP_HOST_FLOAT_BUILTIN3_NAME(mad,fmaf,fma)
 
-#if !defined(_WIN32) && !defined(__APPLE__) && defined(__GLIBC__) && __GLIBC_PREREQ(2, 25)
+#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(__GLIBC__) || __GLIBC_PREREQ(2, 25)
 HIPSYCL_SSCP_MAP_HOST_FLOAT_BUILTIN2_NAME(maxmag,fmaxmagf,fmaxmag)
 HIPSYCL_SSCP_MAP_HOST_FLOAT_BUILTIN2_NAME(minmag,fmaxmagf,fmaxmag)
+#endif
 #endif
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_modf_f32(float x, float* y ) {

--- a/src/libkernel/sscp/host/math.cpp
+++ b/src/libkernel/sscp/host/math.cpp
@@ -195,7 +195,7 @@ HIPSYCL_SSCP_MAP_HOST_FLOAT_BUILTIN(log1p)
 HIPSYCL_SSCP_MAP_HOST_FLOAT_BUILTIN(logb)
 HIPSYCL_SSCP_MAP_HOST_FLOAT_BUILTIN3_NAME(mad,fmaf,fma)
 
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32) && !defined(__APPLE__) && defined(__GLIBC__) && __GLIBC_PREREQ(2, 25)
 HIPSYCL_SSCP_MAP_HOST_FLOAT_BUILTIN2_NAME(maxmag,fmaxmagf,fmaxmag)
 HIPSYCL_SSCP_MAP_HOST_FLOAT_BUILTIN2_NAME(minmag,fmaxmagf,fmaxmag)
 #endif


### PR DESCRIPTION
fmaxmag and fminmag were added in glibc 2.25. On older systems (e.g., RHEL 7 with glibc 2.17), these functions are not available, causing build failures.

Add __GLIBC_PREREQ(2, 25) check to skip these builtins on older glibc versions.