### PR TITLE
Fix some naming mismatch of amath/armpl introduced in #1949

### DIFF
--- a/include/hipSYCL/compiler/llvm-to-backend/Utils.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/Utils.hpp
@@ -378,7 +378,7 @@ std::string getLLDPath();
 std::string getOptPath();
 std::string getLibSvmlDir();
 std::string getLibSleefDir();
-std::string getLibArmplDir();
+std::string getLibAmathDir();
 std::string getLibMvecDir();
 std::string getBitcodePath();
 std::string getRedistPackageBitcodePath(const std::string& backend);

--- a/src/compiler/llvm-to-backend/host/LLVMToHost.cpp
+++ b/src/compiler/llvm-to-backend/host/LLVMToHost.cpp
@@ -375,7 +375,7 @@ bool LLVMToHostTranslator::translateToBackendFormat(llvm::Module &FlavoredModule
       break;
 
     case host_vector_math_library::armpl:
-#ifdef ARMPL_AVAILABLE
+#ifdef AMATH_AVAILABLE
       amathDir = getLibAmathDir();
       if (!amathDir.empty()) {
         LldInvocation.push_back("-L");


### PR DESCRIPTION
While retesting changes introduced in #1949, I found that the amath veclib option is broken because I mixed up amath/armpl in the names of some function/macro.
This PR fix the `getLibAmathDir` function and the `AMATH_AVAILABLE` macro