### PR TITLE
Warn by default if legacy compilation flows are used

### DIFF
--- a/bin/acpp
+++ b/bin/acpp
@@ -607,7 +607,7 @@ class acpp_config:
 """  (Experimental) Treat all functions implicitly as SYCL_EXTERNAL. Only supported with generic target.
   This currently only works with translation units that include the sycl.hpp header."""),
       'allow-legacy-flows' : option("--acpp-allow-legacy-flows", "ACPP_ALLOW_LEGACY_FLOWS", "default-allow-legacy-flows",
-"""  Do not warn when the old 'hip' and 'cuda' targets are used, even though they might not result in best performance."""),
+"""  Do not warn when the old 'hip' and 'cuda' targets are used."""),
       'pcuda' : option("--acpp-pcuda", "ACPP_PCUDA", "default-pcuda",
 """  Enable AdaptiveCpp portable CUDA (PCUDA) support as input language.
   This is *exclusively* supported with --acpp-targets=generic."""),

--- a/bin/acpp
+++ b/bin/acpp
@@ -526,7 +526,7 @@ class acpp_config:
                                    Uses Minicoro for nd_range parallel_for support.
                - omp.accelerated: Uses clang as host compiler to enable compiler support
                                   for nd_range parallel_for (see --acpp-use-accelerated-cpu).
-      * cuda - CUDA backend
+      * cuda - Legacy CUDA interoperability backend
                Requires specification of targets of the form sm_XY,
                e.g. sm_70 for Volta, sm_60 for Pascal
                Backend Flavors:
@@ -536,7 +536,7 @@ class acpp_config:
                                            multipass mode.
       * cuda-nvcxx - CUDA backend with nvc++. Target specification is optional;
                if given requires the format ccXY.
-      * hip  - HIP backend
+      * hip  - Legacy HIP interoperability backend
                Requires specification of targets of the form gfxXYZ,
                e.g. gfx906 for Vega 20, gfx900 for Vega 10
                Backend Flavors:
@@ -606,6 +606,8 @@ class acpp_config:
       'is-export-all' : option("--acpp-export-all", "ACPP_EXPORT_ALL", "default-export-all",
 """  (Experimental) Treat all functions implicitly as SYCL_EXTERNAL. Only supported with generic target.
   This currently only works with translation units that include the sycl.hpp header."""),
+      'allow-legacy-flows' : option("--acpp-allow-legacy-flows", "ACPP_ALLOW_LEGACY_FLOWS", "default-allow-legacy-flows",
+"""  Do not warn when the old 'hip' and 'cuda' targets are used, even though they might not result in best performance."""),
       'pcuda' : option("--acpp-pcuda", "ACPP_PCUDA", "default-pcuda",
 """  Enable AdaptiveCpp portable CUDA (PCUDA) support as input language.
   This is *exclusively* supported with --acpp-targets=generic."""),
@@ -1119,6 +1121,13 @@ class acpp_config:
   def is_dryrun(self):
     try:
       return self._is_flag_set("is-dryrun")
+    except OptionNotSet:
+      return False
+    
+  @property
+  def are_legacy_flows_allowed(self):
+    try:
+      return self._is_flag_set("allow-legacy-flows")
     except OptionNotSet:
       return False
 
@@ -2004,6 +2013,17 @@ class compiler:
                       "simultaneously in non-explicit multipass; enabling explicit "
                       "multipass compilation.")
         self._is_explicit_multipass = True
+    
+    if "hip" in self._targets or "cuda" in self._targets:
+      if config.has_plugin_sscp_compiler:
+        if not config.are_legacy_flows_allowed:
+          print_warning("The 'hip' and 'cuda' compilation flows are not useful outside "
+                        "of specific interoperability use cases or applications that have "
+                        "been engineered specifically around them (e.g. Gromacs)."
+                        "\n\nFor all other use cases, they may not result in best performance!\n\n"
+                        "Please use 'generic' target for better performance, portability, and usability!\n"
+                        "(use --acpp-allow-legacy-flows to silence this warning)")
+
     if self._is_pcuda and "generic" not in self._targets:
       raise RuntimeError("PCUDA support requires generic target.")
 

--- a/bin/acpp
+++ b/bin/acpp
@@ -2019,7 +2019,7 @@ class compiler:
         if not config.are_legacy_flows_allowed:
           print_warning("The 'hip' and 'cuda' compilation flows are not useful outside "
                         "of specific interoperability use cases or applications that have "
-                        "been engineered specifically around them (e.g. Gromacs)."
+                        "been engineered specifically around them (e.g. GROMACS)."
                         "\n\nFor all other use cases, they may not result in best performance!\n\n"
                         "Please use 'generic' target for better performance, portability, and usability!\n"
                         "(use --acpp-allow-legacy-flows to silence this warning)")

--- a/bin/acpp
+++ b/bin/acpp
@@ -2017,7 +2017,7 @@ class compiler:
     if "hip" in self._targets or "cuda" in self._targets:
       if config.has_plugin_sscp_compiler:
         if not config.no_warn_legacy_flows:
-          print_warning("The 'hip' and 'cuda' compilation flows are not useful outside "
+          print_warning("The 'hip' and 'cuda' compilation flows are not typically useful outside "
                         "of specific interoperability use cases or applications that have "
                         "been engineered specifically around them (e.g. GROMACS)."
                         "\n\nFor all other use cases, they may not result in best performance!\n\n"

--- a/bin/acpp
+++ b/bin/acpp
@@ -606,7 +606,7 @@ class acpp_config:
       'is-export-all' : option("--acpp-export-all", "ACPP_EXPORT_ALL", "default-export-all",
 """  (Experimental) Treat all functions implicitly as SYCL_EXTERNAL. Only supported with generic target.
   This currently only works with translation units that include the sycl.hpp header."""),
-      'allow-legacy-flows' : option("--acpp-allow-legacy-flows", "ACPP_ALLOW_LEGACY_FLOWS", "default-allow-legacy-flows",
+      'no-warn-legacy-flows' : option("--acpp-no-warn-legacy-flows", "ACPP_NO_WARN_LEGACY_FLOWS", "default-no-warn-legacy-flows",
 """  Do not warn when the old 'hip' and 'cuda' targets are used."""),
       'pcuda' : option("--acpp-pcuda", "ACPP_PCUDA", "default-pcuda",
 """  Enable AdaptiveCpp portable CUDA (PCUDA) support as input language.
@@ -1125,9 +1125,9 @@ class acpp_config:
       return False
     
   @property
-  def are_legacy_flows_allowed(self):
+  def no_warn_legacy_flows(self):
     try:
-      return self._is_flag_set("allow-legacy-flows")
+      return self._is_flag_set("no-warn-legacy-flows")
     except OptionNotSet:
       return False
 
@@ -2016,13 +2016,13 @@ class compiler:
     
     if "hip" in self._targets or "cuda" in self._targets:
       if config.has_plugin_sscp_compiler:
-        if not config.are_legacy_flows_allowed:
+        if not config.no_warn_legacy_flows:
           print_warning("The 'hip' and 'cuda' compilation flows are not useful outside "
                         "of specific interoperability use cases or applications that have "
                         "been engineered specifically around them (e.g. GROMACS)."
                         "\n\nFor all other use cases, they may not result in best performance!\n\n"
                         "Please use 'generic' target for better performance, portability, and usability!\n"
-                        "(use --acpp-allow-legacy-flows to silence this warning)")
+                        "(use --acpp-no-warn-legacy-flows to silence this warning)")
 
     if self._is_pcuda and "generic" not in self._targets:
       raise RuntimeError("PCUDA support requires generic target.")


### PR DESCRIPTION
I'm getting increasingly annoyed that people still publish results with the old `hip` and `cuda` flows, without a good reason to do so. Doing so typically:
- causes a more brittle setup because the set of LLVM versions compatible with a specific CUDA or ROCm version is narrower and less well-defined compared to `generic`
- may cause performance loss, because optimization for the last 3 years has focused on `generic`, and many optimizations (like the entire adaptivity stuff) is unavailable outside of `generic`
- some functionality like PCUDA is exclusively supported in `generic`

We already make it very clear in the documentation that people should just use `generic`. I don't want people to publish suboptimal results, or to have a poor experience.

So I think it's time to start emitting warning when people use `hip` or `cuda`. This PR causes `acpp` to emit a warning when `hip` or `cuda` targets are used.

We're not emitting warnings for `omp` yet because the use case there is still a bit wider (sanitizers, debugging, some clang features that are available in `omp.accelerated` but not necessarily in `generic` for now).

The warning can be deactivated using `--acpp-allow-legacy-flows`.

@al42and I've tried to be gentle with the Gromacs use case, and tried my best to not imply that Gromacs is doing something improperly. Please take a look if you are okay with it. Also, note that the warning is only active if AdaptiveCpp has been built with the generic compiler. So, in a typical Gromacs deployment where AdaptiveCpp is built against ROCm LLVM and SSCP is thus disabled, users should not even see it.