### PR TITLE
usm: handle zero-sized allocations

### DIFF
--- a/include/hipSYCL/sycl/usm.hpp
+++ b/include/hipSYCL/sycl/usm.hpp
@@ -74,6 +74,8 @@ namespace {
 inline void *malloc_device(size_t num_bytes, const device &dev,
                            const context &ctx,
                            const property_list &propList = {}) {
+  if (num_bytes == 0)
+    return nullptr;
   rt::allocation_hints hints = create_hints_from_proplist(propList);
   return rt::allocate_device(detail::select_device_allocator(dev), 0,
                              num_bytes, hints);
@@ -100,6 +102,8 @@ T* malloc_device(std::size_t count, const queue &q,
 inline void *aligned_alloc_device(std::size_t alignment, std::size_t num_bytes,
                                   const device &dev, const context &ctx,
                                   const property_list &propList = {}) {
+  if (num_bytes == 0)
+    return nullptr;
   rt::allocation_hints hints = create_hints_from_proplist(propList);
   return rt::allocate_device(detail::select_device_allocator(dev), alignment,
                              num_bytes, hints);
@@ -132,6 +136,8 @@ T *aligned_alloc_device(std::size_t alignment, std::size_t count,
 
 inline void *malloc_host(std::size_t num_bytes, const context &ctx,
                          const property_list &propList = {}) {
+  if (num_bytes == 0)
+    return nullptr;
   rt::allocation_hints hints = create_hints_from_proplist(propList);
   return rt::allocate_host(detail::select_usm_allocator(ctx), 0, num_bytes,
                            hints);
@@ -155,6 +161,8 @@ template <typename T> T *malloc_host(std::size_t count, const queue &q,
 inline void *malloc_shared(std::size_t num_bytes, const device &dev,
                            const context &ctx,
                            const property_list &propList = {}) {
+  if (num_bytes == 0)
+    return nullptr;
   rt::allocation_hints hints = create_hints_from_proplist(propList);
   return rt::allocate_shared(detail::select_usm_allocator(ctx, dev), num_bytes,
                              hints);
@@ -180,6 +188,8 @@ template <typename T> T *malloc_shared(std::size_t count, const queue &q,
 inline void *aligned_alloc_host(std::size_t alignment, std::size_t num_bytes,
                                 const context &ctx,
                                 const property_list &propList = {}) {
+  if (num_bytes == 0)
+    return nullptr;
   rt::allocation_hints hints = create_hints_from_proplist(propList);
   return rt::allocate_host(detail::select_usm_allocator(ctx), alignment,
                            num_bytes, hints);
@@ -210,6 +220,8 @@ T *aligned_alloc_host(std::size_t alignment, std::size_t count,
 inline void *aligned_alloc_shared(std::size_t alignment, std::size_t num_bytes,
                                   const device &dev, const context &ctx,
                                   const property_list &propList = {}) {
+  if (num_bytes == 0)
+    return nullptr;
   rt::allocation_hints hints = create_hints_from_proplist(propList);
   return rt::allocate_shared(detail::select_usm_allocator(ctx, dev), num_bytes,
                              hints);

--- a/tests/sycl/usm.cpp
+++ b/tests/sycl/usm.cpp
@@ -438,5 +438,34 @@ BOOST_AUTO_TEST_CASE(prefetch) {
   
   sycl::free(shared_mem, q);
 }
+
+BOOST_AUTO_TEST_CASE(allocation_zero_bytes) {
+  // SYCL standard requires zero-byte allocations to be handled gracefully
+  // We just check that no errors are thrown
+  sycl::queue q;
+
+  int *device_mem_ptr = sycl::malloc_device<int>(0, q);
+  if (device_mem_ptr)
+    sycl::free(device_mem_ptr, q);
+  int *aligned_device_mem_ptr =
+      sycl::aligned_alloc_device<int>(sizeof(int), 0, q);
+  if (aligned_device_mem_ptr)
+    sycl::free(aligned_device_mem_ptr, q);
+  int *host_ptr = sycl::malloc_host<int>(0, q);
+  if (host_ptr)
+    sycl::free(host_ptr, q);
+  int *aligned_host_ptr =
+      sycl::aligned_alloc_host<int>(sizeof(int), 0, q);
+  if (aligned_host_ptr)
+    sycl::free(aligned_host_ptr, q);
+  int *shared_ptr = sycl::malloc_shared<int>(0, q);
+  if (shared_ptr)
+    sycl::free(shared_ptr, q);
+  int *aligned_shared_ptr =
+      sycl::aligned_alloc_shared<int>(sizeof(int), 0, q);
+  if (aligned_shared_ptr)
+    sycl::free(aligned_shared_ptr, q);
+}
+
 BOOST_AUTO_TEST_SUITE_END() // NOTE: Make sure not to add anything below this
                             // line


### PR DESCRIPTION
SYCL standard requires graceful handling of zero-sized USM allocations,
akin to `std::malloc`: return nullptr or a free'able pointer.
However, not all backends behave this way.
So, we now handle this case ourselves. Added tests too.