### PR TITLE
Fix compilation error of vec::as<>() function

### DIFF
--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -353,13 +353,7 @@ public:
     static_assert(std::is_same_v<VectorStorage, detail::vec_storage<T, N>>,
                   "Reinterpreting swizzled vectors directly is not supported");
 
-    asT result;
-    
-    auto in_ptr = reinterpret_cast<const typename asT::element_type*>(&_data[0]);
-    for(int i = 0; i < N; ++i)
-      result[i] = in_ptr[i];
-
-    return result;
+    return sycl::bit_cast<asT>(*this);
   }
 
   template<int... SwizzleIndices>

--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -14,6 +14,7 @@
 #include "backend.hpp"
 #include "half.hpp"
 #include "multi_ptr.hpp"
+#include "bit_cast.hpp"
 
 #include <cstdint>
 #include <type_traits>

--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -355,7 +355,7 @@ public:
 
     asT result;
     
-    auto in_ptr = reinterpret_cast<typename asT::element_type*>(&_data[0]);
+    auto in_ptr = reinterpret_cast<const typename asT::element_type*>(&_data[0]);
     for(int i = 0; i < N; ++i)
       result[i] = in_ptr[i];
 

--- a/tests/sycl/vec.cpp
+++ b/tests/sycl/vec.cpp
@@ -133,5 +133,18 @@ BOOST_AUTO_TEST_CASE(vec_convert) {
   BOOST_TEST(floats_in.w() == floats_out.w());
 }
 
+// Regression test: as<>() would not compile due to casting from a const pointer to a non-const pointer
+BOOST_AUTO_TEST_CASE(vec_as) {
+  auto floats_in = sycl::float4{1.f, 2.f, 3.f, 4.f};
+  auto ints = floats_in.as<sycl::int4>();
+  auto floats_out = ints.as<sycl::float4>();
+  BOOST_TEST(floats_in.x() == floats_out.x());
+  BOOST_TEST(floats_in.y() == floats_out.y());
+  BOOST_TEST(floats_in.z() == floats_out.z());
+  BOOST_TEST(floats_in.w() == floats_out.w());
+}
+
+
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/sycl/vec.cpp
+++ b/tests/sycl/vec.cpp
@@ -144,7 +144,4 @@ BOOST_AUTO_TEST_CASE(vec_as) {
   BOOST_TEST(floats_in.w() == floats_out.w());
 }
 
-
-
-
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
as<>() function is const, so reinterpret_cast should cast to a `const asT` instead of `asT`

Also adding a regression tests for `vec_as` (mainly copy-pasted from the above `vec_convert` test).