### PR TITLE
[Metal] Add math functions

### DIFF
--- a/include/hipSYCL/sycl/libkernel/builtin_interface.hpp
+++ b/include/hipSYCL/sycl/libkernel/builtin_interface.hpp
@@ -182,7 +182,7 @@ HIPSYCL_BUILTIN T __acpp_fmod(T x, T y) noexcept {
 }
 
 template<class T>
-T __acpp_fract(T x, T* ptr) noexcept {
+HIPSYCL_BUILTIN T __acpp_fract(T x, T* ptr) noexcept {
   HIPSYCL_RETURN_DISPATCH_BUILTIN(__acpp_fract, x, ptr);
 }
 

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp
@@ -127,7 +127,8 @@ HIPSYCL_HIPLIKE_BUILTIN double __acpp_frexp(double x, int* y) noexcept {
 }
 
 HIPSYCL_DEFINE_HIPLIKE_MATH_BUILTIN2(__acpp_hypot, hypotf, hypot)
-HIPSYCL_DEFINE_HIPLIKE_MATH_BUILTIN(__acpp_ilogb, ilogbf, ilogb)
+HIPSYCL_HIPLIKE_BUILTIN int __acpp_ilogb(float x) noexcept { return ::ilogbf(x); }
+HIPSYCL_HIPLIKE_BUILTIN int __acpp_ilogb(double x) noexcept { return ::ilogb(x); }
 
 HIPSYCL_HIPLIKE_BUILTIN float __acpp_ldexp(float x, int k) noexcept {
   return ::ldexpf(x, k);

--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp
@@ -106,10 +106,17 @@ HIPSYCL_DEFINE_HIPLIKE_MATH_BUILTIN2(__acpp_fmax, fmaxf, fmax)
 HIPSYCL_DEFINE_HIPLIKE_MATH_BUILTIN2(__acpp_fmin, fminf, fmin)
 HIPSYCL_DEFINE_HIPLIKE_MATH_BUILTIN2(__acpp_fmod, fmodf, fmod)
 
-// Unsupported
-template<class T>
-HIPSYCL_HIPLIKE_BUILTIN
-T __acpp_fract(T x, T* ptr) noexcept;
+HIPSYCL_HIPLIKE_BUILTIN float __acpp_fract(float x, float* ptr) noexcept {
+  float y = ::floorf(x);
+  *ptr = y;
+  return ::fminf(x - y, ::nextafterf(1.0f, 0.0f));
+}
+
+HIPSYCL_HIPLIKE_BUILTIN double __acpp_fract(double x, double* ptr) noexcept {
+  double y = ::floor(x);
+  *ptr = y;
+  return ::fmin(x - y, ::nextafter(1.0, 0.0));
+}
 
 HIPSYCL_HIPLIKE_BUILTIN float __acpp_frexp(float x, int* y) noexcept {
   return ::frexpf(x, y);
@@ -393,14 +400,14 @@ template <class T,
               int> = 0>
 HIPSYCL_HIPLIKE_BUILTIN T __acpp_ctz(T x) noexcept {
 
-  //we convert to the unsigned type to avoid the typecast creating 
+  //we convert to the unsigned type to avoid the typecast creating
   //additional ones in front of the value if x is negative
   using Usigned = typename std::make_unsigned<T>::type;
 
   constexpr T size = CHAR_BIT*sizeof(Usigned);
 
   return x ? __clz(static_cast<__acpp_int32>(__brev(static_cast<Usigned>(x)))) : size;
-  
+
 }
 
 template <class T,
@@ -410,7 +417,7 @@ template <class T,
 HIPSYCL_HIPLIKE_BUILTIN T __acpp_ctz(T x) noexcept {
 
   return __clz(static_cast<__acpp_int32>(__brev(static_cast<__acpp_uint32>(x))));
-  
+
 }
 
 template <class T,
@@ -435,27 +442,27 @@ template <class T,
               int> = 0>
 HIPSYCL_HIPLIKE_BUILTIN T __acpp_clz(T x) noexcept {
 
-  //we convert to the unsigned type to avoid the typecast creating 
+  //we convert to the unsigned type to avoid the typecast creating
   //additional ones in front of the value if x is negative
-  using Usigned = typename std::make_unsigned<T>::type; 
+  using Usigned = typename std::make_unsigned<T>::type;
 
   constexpr T diff = CHAR_BIT*(sizeof(__acpp_int32) - sizeof(Usigned));
   constexpr T size = CHAR_BIT*sizeof(T);
 
   auto v = static_cast<__acpp_int32>(static_cast<Usigned>(x));
 
-  #if ACPP_LIBKERNEL_IS_DEVICE_PASS_CUDA 
+  #if ACPP_LIBKERNEL_IS_DEVICE_PASS_CUDA
     return v ? __builtin_clz(v)-diff : size;
   #else
     // on hip we have to circumvent the clz(0) bug
     // here we force noinline on clz to avoid the if(v) to be optimized away as
-    // llvm rightfully assume that clz(0) == bitsize. 
+    // llvm rightfully assume that clz(0) == bitsize.
     // However, in some LLVM versions, the amdgpu
     // backend does not seem to honor this guarantee from the LLVM LangRef.
     // see : https://llvm.org/docs/LangRef.html#llvm-ctlz-intrinsic
     return v ? __noinline_clz(v)-diff : size;
   #endif
-  
+
 }
 
 template <class T,
@@ -548,7 +555,7 @@ HIPSYCL_HIPLIKE_BUILTIN T __acpp_sign(T x) noexcept {
 }
 
 template <typename VecType>
-HIPSYCL_HIPLIKE_BUILTIN VecType 
+HIPSYCL_HIPLIKE_BUILTIN VecType
 __acpp_cross3(const VecType &a, const VecType &b) noexcept {
   return {a[1] * b[2] - a[2] * b[1],
           a[2] * b[0] - a[0] * b[2],
@@ -556,9 +563,9 @@ __acpp_cross3(const VecType &a, const VecType &b) noexcept {
 }
 
 template <typename VecType>
-HIPSYCL_HIPLIKE_BUILTIN VecType 
+HIPSYCL_HIPLIKE_BUILTIN VecType
 __acpp_cross4(const VecType &a, const VecType &b) noexcept {
-  return {a[1] * b[2] - a[2] * b[1], 
+  return {a[1] * b[2] - a[2] * b[1],
           a[2] * b[0] - a[0] * b[2],
           a[0] * b[1] - a[1] * b[0],
           typename VecType::value_type{0}};

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins.hpp
@@ -112,7 +112,12 @@ HIPSYCL_BUILTIN double __acpp_frexp(double x, int* ptr) noexcept {
 }
 
 HIPSYCL_DEFINE_SSCP_GENFLOAT_MATH_BUILTIN2(hypot)
-HIPSYCL_DEFINE_SSCP_GENFLOAT_MATH_BUILTIN(ilogb)
+HIPSYCL_BUILTIN int __acpp_ilogb(float x) noexcept {
+  return __acpp_sscp_ilogb_f32(x);
+}
+HIPSYCL_BUILTIN int __acpp_ilogb(double x) noexcept {
+  return __acpp_sscp_ilogb_f64(x);
+}
 
 HIPSYCL_BUILTIN float __acpp_ldexp(float x, int k) noexcept {
   return __acpp_sscp_ldexp_f32(x, static_cast<__acpp_int32>(k));

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/math.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/math.hpp
@@ -116,8 +116,8 @@ HIPSYCL_SSCP_BUILTIN double __acpp_sscp_frexp_f64(double, __acpp_int32*);
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_hypot_f32(float, float);
 HIPSYCL_SSCP_BUILTIN double __acpp_sscp_hypot_f64(double, double);
 
-HIPSYCL_SSCP_BUILTIN float __acpp_sscp_ilogb_f32(float);
-HIPSYCL_SSCP_BUILTIN double __acpp_sscp_ilogb_f64(double);
+HIPSYCL_SSCP_BUILTIN __acpp_int32 __acpp_sscp_ilogb_f32(float);
+HIPSYCL_SSCP_BUILTIN __acpp_int32 __acpp_sscp_ilogb_f64(double);
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_ldexp_f32(float, __acpp_int32);
 HIPSYCL_SSCP_BUILTIN double __acpp_sscp_ldexp_f64(double, __acpp_int32);

--- a/src/libkernel/sscp/amdgpu/math.cpp
+++ b/src/libkernel/sscp/amdgpu/math.cpp
@@ -123,7 +123,12 @@ HIPSYCL_SSCP_BUILTIN double __acpp_sscp_frexp_f64(double x, __acpp_int32 *y) {
 }
 
 HIPSYCL_SSCP_MAP_OCML_FLOAT_BUILTIN2(hypot, __ocml_hypot)
-HIPSYCL_SSCP_MAP_OCML_FLOAT_BUILTIN(ilogb, __ocml_ilogb)
+HIPSYCL_SSCP_BUILTIN __acpp_int32 __acpp_sscp_ilogb_f32(float x) {
+  return __ocml_ilogb_f32(x);
+}
+HIPSYCL_SSCP_BUILTIN __acpp_int32 __acpp_sscp_ilogb_f64(double x) {
+  return __ocml_ilogb_f64(x);
+}
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_ldexp_f32(float x, __acpp_int32 k) {
   return __ocml_ldexp_f32(x, k);

--- a/src/libkernel/sscp/host/math.cpp
+++ b/src/libkernel/sscp/host/math.cpp
@@ -162,7 +162,12 @@ HIPSYCL_SSCP_BUILTIN double __acpp_sscp_frexp_f64(double x,
 }
 
 HIPSYCL_SSCP_MAP_HOST_FLOAT_BUILTIN2(hypot)
-HIPSYCL_SSCP_MAP_HOST_FLOAT_BUILTIN(ilogb)
+HIPSYCL_SSCP_BUILTIN __acpp_int32 __acpp_sscp_ilogb_f32(float x) {
+  return ilogbf(x);
+}
+HIPSYCL_SSCP_BUILTIN __acpp_int32 __acpp_sscp_ilogb_f64(double x) {
+  return ilogb(x);
+}
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_ldexp_f32(float x,
                                                     __acpp_int32 k) {

--- a/src/libkernel/sscp/metal/math.cpp
+++ b/src/libkernel/sscp/metal/math.cpp
@@ -70,8 +70,149 @@ ACPP_SSCP_MAP_METAL_FLOAT_BUILTIN2(fmax)
 ACPP_SSCP_MAP_METAL_FLOAT_BUILTIN2(fmod)
 ACPP_SSCP_MAP_METAL_FLOAT_BUILTIN2(fdim)
 ACPP_SSCP_MAP_METAL_FLOAT_BUILTIN2(pow)
+ACPP_SSCP_MAP_METAL_FLOAT_BUILTIN2(nextafter)
+ACPP_SSCP_MAP_METAL_FLOAT_BUILTIN(acosh)
+ACPP_SSCP_MAP_METAL_FLOAT_BUILTIN(asinh)
+ACPP_SSCP_MAP_METAL_FLOAT_BUILTIN(atanh)
 
+// See: https://en.wikipedia.org/wiki/Gamma_function  (Log-gamma function)
+// log Gamma(z) = (z - 1/2) log(z) - z + 1/2 log(2pi) + 1/(12z) - 1/(360 z^3) + 1/(1260 z^5) + ....
+// log Gamma(z-m) = log Gamma(z) - sum_{k=1}^{m} log(z-k)
+// threshold: 1/(1260*(8^5)) ~ 2.4e-8
+static f32 lgamma_positive_f32(f32 z) {
+  static constexpr f32 log_2pi_2 = 0.9189385332046727f; // = 1/2 log(2pi)
+  f32 adj = 0.0f;
+  while (z < 8.0f) {
+    adj += __acpp_sscp_log_f32(z);
+    z += 1.0f;
+  }
+  f32 z2 = z*z;
+  f32 z3 = z2*z;
+
+  f32 lg = log_2pi_2 + (z - 0.5f) * __acpp_sscp_log_f32(z) - z
+           + 1.0f / (12.0f * z)
+           - 1.0f / (360.0f * z3);
+  return lg - adj;
+}
+
+HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_lgamma_f32(f32 x) {
+  if (x > 0.0f) {
+    return lgamma_positive_f32(x);
+  }
+  // reflection
+  return __acpp_sscp_log_f32((f32)M_PI / __acpp_sscp_fabs_f32(__acpp_sscp_sinpi_f32(x))) - lgamma_positive_f32(1.0f - x);
+}
+
+HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_cbrt_f32(f32 x) {
+  if (x == 0.0f) return 0.0f;
+  f32 ax = __acpp_sscp_fabs_f32(x);
+  f32 result = __acpp_sscp_pow_f32(ax, 1.0f / 3.0f);
+  return (x < 0.0f) ? -result : result;
+}
+
+// erf: Abramowitz & Stegun 7.1.26, max error 1.5e-7, see https://en.wikipedia.org/wiki/Error_function
+inline f32 __acpp_sscp_erfc_poly_f32(f32 x) {
+  f32 p = 0.3275911f;
+  f32 a1 = 0.254829592f, a2 = -0.284496736f, a3 = 1.421413741f, a4 = -1.453152027f, a5 = 1.061405429f;
+  f32 t = 1.0f / (1.0f + p * x);
+  return (((((a5*t + a4)*t + a3)*t) + a2)*t + a1)*t * __acpp_sscp_exp_f32(-x*x);
+}
+
+HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_erf_f32(f32 x) {
+  if (x < 0.0f) {
+    return __acpp_sscp_erfc_poly_f32(-x) - 1.0f;
+  } else {
+    return 1.0f - __acpp_sscp_erfc_poly_f32(x);
+  }
+}
+
+HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_erfc_f32(f32 x) {
+  if (x < 0.0f) {
+    return 2.0f - __acpp_sscp_erfc_poly_f32(-x);
+  } else {
+    return __acpp_sscp_erfc_poly_f32(x);
+  }
+}
+
+HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_tgamma_f32(f32 x) {
+  if (x > 0.0f) {
+    return __acpp_sscp_exp_f32(__acpp_sscp_lgamma_f32(x));
+  }
+  // reflection
+  return (f32)M_PI / (__acpp_sscp_sinpi_f32(x) * __acpp_sscp_exp_f32(__acpp_sscp_lgamma_f32(1.0f - x)));
+}
+
+HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_remainder_f32(f32 x, f32 y) {
+  return x - __acpp_sscp_rint_f32(x / y) * y;
+}
+
+HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_acospi_f32(f32 x) {
+  return __acpp_sscp_acos_f32(x) / (f32)M_PI;
+}
+
+HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_asinpi_f32(f32 x) {
+  return __acpp_sscp_asin_f32(x) / (f32)M_PI;
+}
+
+HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_atanpi_f32(f32 x) {
+  return __acpp_sscp_atan_f32(x) / (f32)M_PI;
+}
+
+HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_atan2pi_f32(f32 x, f32 y) {
+  return __acpp_sscp_atan2_f32(x, y) / (f32)M_PI;
+}
+
+// TODO: ilogb: Metal returns int, SSCP signature returns f32
 HIPSYCL_SSCP_BUILTIN i32 __acpp_sscp_metal_math_i32_f32(const char* name, f32 x);
+
+HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_ilogb_f32(f32 x) {
+  return (f32)__acpp_sscp_metal_math_i32_f32("ilogb", __acpp_sscp_fabs_f32(x));
+}
+
+HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_logb_f32(f32 x) {
+  return (f32)__acpp_sscp_metal_math_i32_f32("ilogb", __acpp_sscp_fabs_f32(x));
+}
+
+HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_maxmag_f32(f32 x, f32 y) {
+  f32 ax = __acpp_sscp_fabs_f32(x);
+  f32 ay = __acpp_sscp_fabs_f32(y);
+  if (ax == ay) return __acpp_sscp_fmax_f32(x, y);
+  return (ax > ay) ? x : y;
+}
+
+HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_minmag_f32(f32 x, f32 y) {
+  f32 ax = __acpp_sscp_fabs_f32(x);
+  f32 ay = __acpp_sscp_fabs_f32(y);
+  if (ax == ay) return __acpp_sscp_fmin_f32(x, y);
+  return (ax < ay) ? x : y;
+}
+
+HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_fract_f32(f32 x, f32* iptr) {
+  *iptr = __acpp_sscp_floor_f32(x);
+  return __acpp_sscp_fmin_f32(x - *iptr, __acpp_sscp_nextafter_f32(1.0f, 0.0f));
+}
+
+HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_metal_math_f32_f32_i32ptr(const char* name, f32 x, i32* p);
+HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_metal_math_f32_f32_f32ptr(const char* name, f32 x, f32* p);
+
+HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_frexp_f32(f32 x, i32* exp) {
+  return __acpp_sscp_metal_math_f32_f32_i32ptr("frexp(%s, *__pointer_cast<int>(%s))", x, exp);
+}
+
+HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_modf_f32(f32 x, f32* iptr) {
+  return __acpp_sscp_metal_math_f32_f32_f32ptr("modf(%s, *__pointer_cast<float>(%s))", x, iptr);
+}
+
+HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_lgamma_r_f32(f32 x, i32* signp) {
+  f32 r = __acpp_sscp_lgamma_f32(x);
+  if (x >= 0.0f) {
+    *signp = 1;
+  } else {
+    i32 n = (i32)__acpp_sscp_floor_f32(-x);
+    *signp = (n & 1) ? 1 : -1;
+  }
+  return r;
+}
 
 HIPSYCL_SSCP_BUILTIN i32 __acpp_sscp_isnan_f32(f32 x) {
   return __acpp_sscp_metal_math_i32_f32("isnan", x);

--- a/src/libkernel/sscp/metal/math.cpp
+++ b/src/libkernel/sscp/metal/math.cpp
@@ -162,11 +162,10 @@ HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_atan2pi_f32(f32 x, f32 y) {
   return __acpp_sscp_atan2_f32(x, y) / (f32)M_PI;
 }
 
-// TODO: ilogb: Metal returns int, SSCP signature returns f32
 HIPSYCL_SSCP_BUILTIN i32 __acpp_sscp_metal_math_i32_f32(const char* name, f32 x);
 
-HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_ilogb_f32(f32 x) {
-  return (f32)__acpp_sscp_metal_math_i32_f32("ilogb", __acpp_sscp_fabs_f32(x));
+HIPSYCL_SSCP_BUILTIN i32 __acpp_sscp_ilogb_f32(f32 x) {
+  return __acpp_sscp_metal_math_i32_f32("ilogb", __acpp_sscp_fabs_f32(x));
 }
 
 HIPSYCL_SSCP_BUILTIN f32 __acpp_sscp_logb_f32(f32 x) {

--- a/src/libkernel/sscp/ptx/math.cpp
+++ b/src/libkernel/sscp/ptx/math.cpp
@@ -106,7 +106,12 @@ HIPSYCL_SSCP_BUILTIN double __acpp_sscp_frexp_f64(double x,
 }
 
 HIPSYCL_SSCP_MAP_PTX_FLOAT_BUILTIN2(hypot, __nv_hypotf, __nv_hypot)
-HIPSYCL_SSCP_MAP_PTX_FLOAT_BUILTIN(ilogb, __nv_ilogbf, __nv_ilogb)
+HIPSYCL_SSCP_BUILTIN __acpp_int32 __acpp_sscp_ilogb_f32(float x) {
+  return __nv_ilogbf(x);
+}
+HIPSYCL_SSCP_BUILTIN __acpp_int32 __acpp_sscp_ilogb_f64(double x) {
+  return __nv_ilogb(x);
+}
 
 HIPSYCL_SSCP_BUILTIN float __acpp_sscp_ldexp_f32(float x,
                                                     __acpp_int32 k) {

--- a/src/libkernel/sscp/spirv/math.cpp
+++ b/src/libkernel/sscp/spirv/math.cpp
@@ -113,7 +113,14 @@ HIPSYCL_SSCP_BUILTIN float __acpp_sscp_frexp_f32(float x, __acpp_int32* y ) { re
 HIPSYCL_SSCP_BUILTIN double __acpp_sscp_frexp_f64(double x, __acpp_int32* y) { return __spirv_ocl_frexp(x, y); }
 
 HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN2(hypot)
-HIPSYCL_SSCP_MAP_BUILTIN_TO_SPIRV_BUILTIN(ilogb)
+__acpp_int32 __spirv_ocl_ilogb(float);
+__acpp_int32 __spirv_ocl_ilogb(double);
+HIPSYCL_SSCP_BUILTIN __acpp_int32 __acpp_sscp_ilogb_f32(float x) {
+  return __spirv_ocl_ilogb(x);
+}
+HIPSYCL_SSCP_BUILTIN __acpp_int32 __acpp_sscp_ilogb_f64(double x) {
+  return __spirv_ocl_ilogb(x);
+}
 
 float __spirv_ocl_ldexp(float x, __acpp_int32 k);
 double __spirv_ocl_ldexp(double x, __acpp_int32 k);

--- a/tests/sycl/math.cpp
+++ b/tests/sycl/math.cpp
@@ -907,414 +907,272 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_genint, T,
   }
 }
 
-BOOST_TEST_DECORATOR(*boost::unit_test::tolerance(0.0001))
-BOOST_AUTO_TEST_CASE_TEMPLATE(math_unary_extra, T, math_test_genfloats) {
+#define SKIP_IF_NO_FP64(queue, DT)                                              \
+  if constexpr(std::is_same_v<DT, double>) {                                    \
+    if (!(queue).get_device().has(sycl::aspect::fp64)) {                        \
+      BOOST_TEST_MESSAGE("Skipping test for double since device has no fp64");  \
+      return;                                                                    \
+    }                                                                            \
+  }
 
+#define INPUT_GT1()   1.5, 2.0, 1.25, 3.0, 1.1, 1.7, 2.5, 1.3, 1.5, 2.0, 1.25, 3.0, 1.1, 1.7, 2.5, 1.3
+#define INPUT_SMALL() 0.5, -0.3, 0.75, -0.1, 0.6, -0.5, 0.2, -0.8, 0.5, -0.3, 0.75, -0.1, 0.6, -0.5, 0.2, -0.8
+#define INPUT_TRIG()  0.4, -0.3, 0.75, -0.1, 0.6, -0.4, 0.2, -0.8, 0.4, -0.3, 0.75, -0.1, 0.6, -0.4, 0.2, -0.8
+#define INPUT_ERF()   -3.0, -1.0, -0.5, 0.0, 0.5, 1.0, 3.0, 2.0, -3.0, -1.0, -0.5, 0.0, 0.5, 1.0, 3.0, 2.0
+#define INPUT_GAMMA() 0.5, 1.5, 2.5, -0.5, 3.0, -1.5, 4.0, -2.1, 0.5, 1.5, 2.5, -0.5, 3.0, -1.5, 4.0, -2.1
+#define INPUT_FRAC()  0.75, 1.5, -2.25, 0.5, 3.125, -0.375, 1.0, 0.25, 0.75, 1.5, -2.25, 0.5, 3.125, -0.375, 1.0, 0.25
+#define INPUT_BIN0()  7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0
+#define INPUT_BIN1()  17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0
+#define INPUT_PI1()   7.0, -4.0, 2.0, 3.0, -5.0, 1.0, -3.0, 0.5, 7.0, -4.0, 2.0, 3.0, -5.0, 1.0, -3.0, 0.5
+
+#define DEFINE_UNARY_MATH_TEST(name, tol, ref_func, input_macro)                \
+BOOST_TEST_DECORATOR(*boost::unit_test::tolerance(tol))                         \
+BOOST_AUTO_TEST_CASE_TEMPLATE(math_##name, T, math_test_genfloats) {           \
+  constexpr int D = vector_length_v<T>;                                         \
+  using DT = vector_elem_t<T>;                                                  \
+  namespace s = sycl;                                                            \
+  s::queue queue;                                                                \
+  SKIP_IF_NO_FP64(queue, DT);                                                   \
+  s::buffer<T> float_in{{1}};                                                   \
+  s::buffer<T> out{{1}};                                                        \
+  {                                                                              \
+    auto inp = float_in.get_host_access();                                      \
+    inp[0] = get_math_input<DT, D>(s::vec<DT, 16>{input_macro()});             \
+  }                                                                              \
+  queue.submit([&](s::handler& cgh) {                                           \
+    auto in = float_in.template get_access<s::access::mode::read>(cgh);         \
+    auto o = out.template get_access<s::access::mode::write>(cgh);              \
+    cgh.single_task<kernel_name<class math_##name, D, DT>>([=]() {             \
+      o[0] = s::name(in[0]);                                                    \
+    });                                                                          \
+  });                                                                            \
+  {                                                                              \
+    auto inp = float_in.get_host_access();                                      \
+    auto o = out.get_host_access();                                             \
+    for(int c = 0; c < std::max(D, 1); ++c)                                    \
+      BOOST_TEST(comp(o[0], c) ==                                               \
+        ref_func(static_cast<double>(comp(inp[0], c))));                        \
+  }                                                                              \
+}
+
+#define DEFINE_BINARY_MATH_TEST(name, tol, ref_func, in0_macro, in1_macro)      \
+BOOST_TEST_DECORATOR(*boost::unit_test::tolerance(tol))                         \
+BOOST_AUTO_TEST_CASE_TEMPLATE(math_##name, T, math_test_genfloats) {           \
+  constexpr int D = vector_length_v<T>;                                         \
+  using DT = vector_elem_t<T>;                                                  \
+  namespace s = sycl;                                                            \
+  s::queue queue;                                                                \
+  SKIP_IF_NO_FP64(queue, DT);                                                   \
+  s::buffer<T> float_in{{2}};                                                   \
+  s::buffer<T> out{{1}};                                                        \
+  {                                                                              \
+    auto inp = float_in.get_host_access();                                      \
+    inp[0] = get_math_input<DT, D>(s::vec<DT, 16>{in0_macro()});               \
+    inp[1] = get_math_input<DT, D>(s::vec<DT, 16>{in1_macro()});               \
+  }                                                                              \
+  queue.submit([&](s::handler& cgh) {                                           \
+    auto in = float_in.template get_access<s::access::mode::read>(cgh);         \
+    auto o = out.template get_access<s::access::mode::write>(cgh);              \
+    cgh.single_task<kernel_name<class math_##name, D, DT>>([=]() {             \
+      o[0] = s::name(in[0], in[1]);                                             \
+    });                                                                          \
+  });                                                                            \
+  {                                                                              \
+    auto inp = float_in.get_host_access();                                      \
+    auto o = out.get_host_access();                                             \
+    for(int c = 0; c < std::max(D, 1); ++c) {                                  \
+      double x = static_cast<double>(comp(inp[0], c));                          \
+      double y = static_cast<double>(comp(inp[1], c));                          \
+      BOOST_TEST(comp(o[0], c) == ref_func(x, y));                             \
+    }                                                                            \
+  }                                                                              \
+}
+
+DEFINE_UNARY_MATH_TEST(acosh,  0.0001, ref_acosh,  INPUT_GT1)
+DEFINE_UNARY_MATH_TEST(asinh,  0.0001, ref_asinh,  INPUT_SMALL)
+DEFINE_UNARY_MATH_TEST(atanh,  0.0001, ref_atanh,  INPUT_SMALL)
+DEFINE_UNARY_MATH_TEST(cbrt,   0.0001, ref_cbrt,   INPUT_SMALL)
+DEFINE_UNARY_MATH_TEST(logb,   0.0001, ref_logb,   INPUT_SMALL)
+DEFINE_UNARY_MATH_TEST(acospi, 0.0001, ref_acospi, INPUT_TRIG)
+DEFINE_UNARY_MATH_TEST(asinpi, 0.0001, ref_asinpi, INPUT_TRIG)
+DEFINE_UNARY_MATH_TEST(atanpi, 0.0001, ref_atanpi, INPUT_TRIG)
+DEFINE_UNARY_MATH_TEST(cospi,  0.0001, ref_cospi,  INPUT_TRIG)
+DEFINE_UNARY_MATH_TEST(sinpi,  0.0001, ref_sinpi,  INPUT_TRIG)
+DEFINE_UNARY_MATH_TEST(erf,    0.0007, ref_erf,    INPUT_ERF)
+DEFINE_UNARY_MATH_TEST(erfc,   0.0007, ref_erfc,   INPUT_ERF)
+DEFINE_UNARY_MATH_TEST(lgamma, 0.001,  ref_lgamma, INPUT_GAMMA)
+DEFINE_UNARY_MATH_TEST(tgamma, 0.001,  ref_tgamma, INPUT_GAMMA)
+
+BOOST_TEST_DECORATOR(*boost::unit_test::tolerance(0.0001))
+BOOST_AUTO_TEST_CASE_TEMPLATE(math_ilogb, T, math_test_genfloats) {
   constexpr int D = vector_length_v<T>;
   using DT = vector_elem_t<T>;
   using IntType = vector_coerce_elem_t<int, T>;
-
   namespace s = sycl;
-
   s::queue queue;
-  if constexpr(std::is_same_v<DT, double>) {
-    if (!queue.get_device().has(sycl::aspect::fp64)) {
-      BOOST_TEST_MESSAGE("Skipping test for double since device has no fp64 support");
-      return;
-    }
-  }
-
-  // build inputs and allocate outputs
-
-  constexpr int FUN_COUNT = 5; // acosh, asinh, atanh, cbrt, logb
-
-  s::buffer<T> float_in{{2}};
-  s::buffer<T> out{{FUN_COUNT}};
-  s::buffer<IntType> ilogb_out{{1}};
-  {
-    auto inputs = float_in.get_host_access();
-    auto outputs = out.get_host_access();
-    inputs[0] = get_math_input<DT, D>(s::vec<DT, 16>{
-      1.5, 2.0, 1.25, 3.0, 1.1, 1.7, 2.5, 1.3, 1.5, 2.0, 1.25, 3.0, 1.1, 1.7, 2.5, 1.3});
-    inputs[1] = get_math_input<DT, D>(s::vec<DT, 16>{
-      0.5, -0.3,  0.75, -0.1, 0.6, -0.5, 0.2, -0.8, 0.5, -0.3, 0.75, -0.1, 0.6, -0.5, 0.2, -0.8});
-    for(int i = 0; i < FUN_COUNT; ++i) {
-      outputs[i] = T{DT{0}};
-    }
-  }
-
-  // run functions
-
-  queue.submit([&](s::handler& cgh) {
-    auto inputs = float_in.template  get_access<s::access::mode::read>(cgh);
-    auto outputs = out.template get_access<s::access::mode::write>(cgh);
-    auto ilogb = ilogb_out.template get_access<s::access::mode::write>(cgh);
-    cgh.single_task<kernel_name<class math_unary_extra, D, DT>>([=]() {
-      int i = 0;
-      outputs[i++] = s::acosh(inputs[0]);
-      outputs[i++] = s::asinh(inputs[1]);
-      outputs[i++] = s::atanh(inputs[1]);
-      outputs[i++] = s::cbrt(inputs[1]);
-      outputs[i++] = s::logb(inputs[1]);
-      ilogb[0] = s::ilogb(inputs[1]);
-    });
-  });
-
-  // check results
-
-  {
-    auto inputs = float_in.get_host_access();
-    auto outputs = out.get_host_access();
-    auto ilogb = ilogb_out.get_host_access();
-    for(int c = 0; c < std::max(D, 1); ++c) {
-      double x0 = static_cast<double>(comp(inputs[0], c));
-      double x1 = static_cast<double>(comp(inputs[1], c));
-      int i = 0;
-      BOOST_TEST(comp(outputs[i++], c) == ref_acosh(x0));
-      BOOST_TEST(comp(outputs[i++], c) == ref_asinh(x1));
-      BOOST_TEST(comp(outputs[i++], c) == ref_atanh(x1));
-      BOOST_TEST(comp(outputs[i++], c) == ref_cbrt(x1));
-      BOOST_TEST(comp(outputs[i++], c) == ref_logb(x1));
-      BOOST_TEST(comp(ilogb[0], c) == std::ilogb(comp(inputs[1], c)));
-    }
-  }
-}
-
-
-BOOST_TEST_DECORATOR(*boost::unit_test::tolerance(0.0001))
-BOOST_AUTO_TEST_CASE_TEMPLATE(math_binary_extra, T, math_test_genfloats) {
-
-  constexpr int D = vector_length_v<T>;
-  using DT = vector_elem_t<T>;
-
-  namespace s = sycl;
-
-  s::queue queue;
-  if constexpr(std::is_same_v<DT, double>) {
-    if (!queue.get_device().has(sycl::aspect::fp64)) {
-      BOOST_TEST_MESSAGE("Skipping test for double since device has no fp64 support");
-      return;
-    }
-  }
-
-  // build inputs and allocate outputs
-
-  constexpr int FUN_COUNT = 4; // nextafter, remainder, maxmag, minmag
-
-  s::buffer<T> float_in{{2}};
-  s::buffer<T> out{{FUN_COUNT}};
-  {
-    auto inputs = float_in.get_host_access();
-    auto outputs = out.get_host_access();
-    inputs[0] = get_math_input<DT, D>(s::vec<DT, 16>{
-      7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0});
-    inputs[1] = get_math_input<DT, D>(s::vec<DT, 16>{
-      17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0});
-    for(int i = 0; i < FUN_COUNT; ++i) {
-      outputs[i] = T{DT{0}};
-    }
-  }
-
-  // run functions
-
-  queue.submit([&](s::handler& cgh) {
-    auto inputs = float_in.template get_access<s::access::mode::read>(cgh);
-    auto outputs = out.template get_access<s::access::mode::write>(cgh);
-    cgh.single_task<kernel_name<class math_binary_extra, D, DT>>([=]() {
-      int i = 0;
-      outputs[i++] = s::nextafter(inputs[0], inputs[1]);
-      outputs[i++] = s::remainder(inputs[0], inputs[1]);
-      outputs[i++] = s::maxmag(inputs[0], inputs[1]);
-      outputs[i++] = s::minmag(inputs[0], inputs[1]);
-    });
-  });
-
-  // check results
-
-  {
-    auto inputs = float_in.get_host_access();
-    auto outputs = out.get_host_access();
-    for(int c = 0; c < std::max(D, 1); ++c) {
-      double x = static_cast<double>(comp(inputs[0], c));
-      double y = static_cast<double>(comp(inputs[1], c));
-      int i = 0;
-      BOOST_TEST(comp(outputs[i++], c) == ref_nextafter(x, y));
-      BOOST_TEST(comp(outputs[i++], c) == ref_remainder(x, y));
-      BOOST_TEST(comp(outputs[i++], c) == ref_maxmag(x, y));
-      BOOST_TEST(comp(outputs[i++], c) == ref_minmag(x, y));
-    }
-  }
-}
-
-
-BOOST_TEST_DECORATOR(*boost::unit_test::tolerance(0.0001))
-BOOST_AUTO_TEST_CASE_TEMPLATE(math_pi_functions, T, math_test_genfloats) {
-
-  constexpr int D = vector_length_v<T>;
-  using DT = vector_elem_t<T>;
-
-  namespace s = sycl;
-
-  s::queue queue;
-  if constexpr(std::is_same_v<DT, double>) {
-    if (!queue.get_device().has(sycl::aspect::fp64)) {
-      BOOST_TEST_MESSAGE("Skipping test for double since device has no fp64 support");
-      return;
-    }
-  }
-
-  // build inputs and allocate outputs
-
-  constexpr int FUN_COUNT = 6; // acospi, asinpi, atanpi, atan2pi, cospi, sinpi
-
-  s::buffer<T> float_in{{2}};
-  s::buffer<T> out{{FUN_COUNT}};
-  {
-    auto inputs  = float_in.get_host_access();
-    auto outputs = out.get_host_access();
-    inputs[0] = get_math_input<DT, D>(s::vec<DT, 16>{
-      0.4, -0.3, 0.75, -0.1, 0.6, -0.4, 0.2, -0.8, 0.4, -0.3, 0.75, -0.1, 0.6, -0.4, 0.2, -0.8});
-    inputs[1] = get_math_input<DT, D>(s::vec<DT, 16>{
-      7.0, -4.0, 2.0, 3.0, -5.0, 1.0, -3.0, 0.5, 7.0, -4.0, 2.0, 3.0, -5.0, 1.0, -3.0, 0.5});
-    for(int i = 0; i < FUN_COUNT; ++i) {
-      outputs[i] = T{DT{0}};
-    }
-  }
-
-  // run functions
-
-  queue.submit([&](s::handler& cgh) {
-    auto inputs = float_in.template get_access<s::access::mode::read>(cgh);
-    auto outputs = out.template get_access<s::access::mode::write>(cgh);
-    cgh.single_task<kernel_name<class math_pi_functions, D, DT>>([=]() {
-      int i = 0;
-      outputs[i++] = s::acospi(inputs[0]);
-      outputs[i++] = s::asinpi(inputs[0]);
-      outputs[i++] = s::atanpi(inputs[0]);
-      outputs[i++] = s::atan2pi(inputs[0], inputs[1]);
-      outputs[i++] = s::cospi(inputs[0]);
-      outputs[i++] = s::sinpi(inputs[0]);
-    });
-  });
-
-  // check results
-
-  {
-    auto inputs = float_in.get_host_access();
-    auto outputs = out.get_host_access();
-    for(int c = 0; c < std::max(D, 1); ++c) {
-      double x = static_cast<double>(comp(inputs[0], c));
-      double y = static_cast<double>(comp(inputs[1], c));
-      int i = 0;
-      BOOST_TEST(comp(outputs[i++], c) == ref_acospi(x));
-      BOOST_TEST(comp(outputs[i++], c) == ref_asinpi(x));
-      BOOST_TEST(comp(outputs[i++], c) == ref_atanpi(x));
-      BOOST_TEST(comp(outputs[i++], c) == ref_atan2pi(x, y));
-      BOOST_TEST(comp(outputs[i++], c) == ref_cospi(x));
-      BOOST_TEST(comp(outputs[i++], c) == ref_sinpi(x));
-    }
-  }
-}
-
-
-BOOST_TEST_DECORATOR(*boost::unit_test::tolerance(0.0007))
-BOOST_AUTO_TEST_CASE_TEMPLATE(math_erf_erfc, T, math_test_genfloats) {
-
-  constexpr int D = vector_length_v<T>;
-  using DT = vector_elem_t<T>;
-
-  namespace s = sycl;
-
-  s::queue queue;
-  if constexpr(std::is_same_v<DT, double>) {
-    if (!queue.get_device().has(sycl::aspect::fp64)) {
-      BOOST_TEST_MESSAGE("Skipping test for double since device has no fp64 support");
-      return;
-    }
-  }
-
-  // build inputs and allocate outputs
-
+  SKIP_IF_NO_FP64(queue, DT);
   s::buffer<T> float_in{{1}};
-  s::buffer<T> erf_out {{1}};
-  s::buffer<T> erfc_out{{1}};
+  s::buffer<IntType> out{{1}};
   {
-    auto inputs = float_in.get_host_access();
-    inputs[0] = get_math_input<DT, D>(s::vec<DT, 16>{
-      -3.0, -1.0, -0.5, 0.0, 0.5, 1.0, 3.0, 2.0, -3.0, -1.0, -0.5, 0.0, 0.5, 1.0, 3.0, 2.0});
+    auto inp = float_in.get_host_access();
+    inp[0] = get_math_input<DT, D>(s::vec<DT, 16>{INPUT_SMALL()});
   }
-
-  // run functions
-
   queue.submit([&](s::handler& cgh) {
-    auto inputs = float_in.template get_access<s::access::mode::read>(cgh);
-    auto eout = erf_out.template get_access<s::access::mode::write>(cgh);
-    auto ecout = erfc_out.template get_access<s::access::mode::write>(cgh);
-    cgh.single_task<kernel_name<class math_erf_erfc_detailed, D, DT>>([=]() {
-      eout[0] = s::erf(inputs[0]);
-      ecout[0] = s::erfc(inputs[0]);
+    auto in = float_in.template get_access<s::access::mode::read>(cgh);
+    auto o = out.template get_access<s::access::mode::write>(cgh);
+    cgh.single_task<kernel_name<class math_ilogb, D, DT>>([=]() {
+      o[0] = s::ilogb(in[0]);
     });
   });
-
-  // check results
-
   {
-    auto inputs = float_in.get_host_access();
-    auto eout = erf_out.get_host_access();
-    auto ecout = erfc_out.get_host_access();
-    for(int c = 0; c < std::max(D, 1); ++c) {
-      double x = static_cast<double>(comp(inputs[0], c));
-      BOOST_TEST(comp(eout[0], c) == ref_erf(x));
-      BOOST_TEST(comp(ecout[0], c) == ref_erfc(x));
-      // erf(x) + erfc(x) == 1
-      BOOST_TEST(comp(eout[0], c) + comp(ecout[0], c) == 1.0);
-    }
+    auto inp = float_in.get_host_access();
+    auto o = out.get_host_access();
+    for(int c = 0; c < std::max(D, 1); ++c)
+      BOOST_TEST(comp(o[0], c) == std::ilogb(comp(inp[0], c)));
   }
 }
 
+DEFINE_BINARY_MATH_TEST(nextafter, 0.0001, ref_nextafter, INPUT_BIN0, INPUT_BIN1)
+DEFINE_BINARY_MATH_TEST(remainder, 0.0001, ref_remainder, INPUT_BIN0, INPUT_BIN1)
+DEFINE_BINARY_MATH_TEST(maxmag,    0.0001, ref_maxmag,    INPUT_BIN0, INPUT_BIN1)
+DEFINE_BINARY_MATH_TEST(minmag,    0.0001, ref_minmag,    INPUT_BIN0, INPUT_BIN1)
+DEFINE_BINARY_MATH_TEST(atan2pi,   0.0001, ref_atan2pi,   INPUT_TRIG, INPUT_PI1)
 
 BOOST_TEST_DECORATOR(*boost::unit_test::tolerance(0.001))
-BOOST_AUTO_TEST_CASE_TEMPLATE(math_gamma, T, math_test_genfloats) {
-
+BOOST_AUTO_TEST_CASE_TEMPLATE(math_lgamma_r, T, math_test_genfloats) {
   constexpr int D = vector_length_v<T>;
   using DT = vector_elem_t<T>;
   using IntType = vector_coerce_elem_t<int, T>;
-
   namespace s = sycl;
-
   s::queue queue;
-  if constexpr(std::is_same_v<DT, double>) {
-    if (!queue.get_device().has(sycl::aspect::fp64)) {
-      BOOST_TEST_MESSAGE("Skipping test for double since device has no fp64 support");
-      return;
-    }
-  }
-
-  // build inputs and allocate outputs
-
-  constexpr int FUN_COUNT = 3; // lgamma, tgamma, lgamma_r
-
+  SKIP_IF_NO_FP64(queue, DT);
   s::buffer<T> float_in{{1}};
-  s::buffer<T> out{{FUN_COUNT}};
-  s::buffer<IntType> lgr_sgn {{1}};
+  s::buffer<T> out{{1}};
+  s::buffer<IntType> lgr_sgn{{1}};
   {
-    auto inputs = float_in.get_host_access();
-    auto outputs = out.get_host_access();
-    inputs[0] = get_math_input<DT, D>(s::vec<DT, 16>{
-      0.5, 1.5, 2.5, -0.5, 3.0, -1.5, 4.0, -2.1, 0.5, 1.5, 2.5, -0.5, 3.0, -1.5, 4.0, -2.1});
-    for(int i = 0; i < FUN_COUNT; ++i) {
-      outputs[i] = T{DT{0}};
-    }
+    auto inp = float_in.get_host_access();
+    inp[0] = get_math_input<DT, D>(s::vec<DT, 16>{INPUT_GAMMA()});
   }
-
-  // run functions
-
   queue.submit([&](s::handler& cgh) {
-    auto inputs = float_in.template get_access<s::access::mode::read>(cgh);
-    auto outputs = out.template get_access<s::access::mode::write>(cgh);
+    auto in = float_in.template get_access<s::access::mode::read>(cgh);
+    auto o = out.template get_access<s::access::mode::write>(cgh);
     auto sgn = lgr_sgn.template get_access<s::access::mode::write>(cgh);
-    cgh.single_task<kernel_name<class math_gamma, D, DT>>([=]() {
-      int i = 0;
-      outputs[i++] = s::lgamma(inputs[0]);
-      outputs[i++] = s::tgamma(inputs[0]);
+    cgh.single_task<kernel_name<class math_lgamma_r, D, DT>>([=]() {
       IntType s;
-      outputs[i++] = s::lgamma_r(inputs[0], &s);
+      o[0] = s::lgamma_r(in[0], &s);
       sgn[0] = s;
     });
   });
-
-  // check results
-
   {
-    auto inputs = float_in.get_host_access();
-    auto outputs = out.get_host_access();
+    auto inp = float_in.get_host_access();
+    auto o = out.get_host_access();
     auto sgn = lgr_sgn.get_host_access();
     for(int c = 0; c < std::max(D, 1); ++c) {
-      double x = static_cast<double>(comp(inputs[0], c));
-      int i = 0;
-      BOOST_TEST(comp(outputs[i++], c) == ref_lgamma(x));
-      BOOST_TEST(comp(outputs[i++], c) == ref_tgamma(x));
-      BOOST_TEST(comp(outputs[i++], c) == ref_lgamma(x));
+      double x = static_cast<double>(comp(inp[0], c));
+      BOOST_TEST(comp(o[0], c) == ref_lgamma(x));
       BOOST_TEST(comp(sgn[0], c) == ref_lgamma_r_sign(x));
     }
   }
 }
 
-
 BOOST_TEST_DECORATOR(*boost::unit_test::tolerance(0.0001))
-BOOST_AUTO_TEST_CASE_TEMPLATE(math_out_params, T, math_test_genfloats) {
-
+BOOST_AUTO_TEST_CASE_TEMPLATE(math_frexp, T, math_test_genfloats) {
   constexpr int D = vector_length_v<T>;
   using DT = vector_elem_t<T>;
   using IntType = vector_coerce_elem_t<int, T>;
-
   namespace s = sycl;
-
   s::queue queue;
-  if constexpr(std::is_same_v<DT, double>) {
-    if (!queue.get_device().has(sycl::aspect::fp64)) {
-      BOOST_TEST_MESSAGE("Skipping test for double since device has no fp64 support");
-      return;
-    }
-  }
-
-  // build inputs and allocate outputs
-
-  // out[0]=frexp mantissa, out[1]=modf frac, out[2]=modf ipart, out[3]=fract frac
-  constexpr int FUN_COUNT = 4;
-
+  SKIP_IF_NO_FP64(queue, DT);
   s::buffer<T> float_in{{1}};
-  s::buffer<T> out{{FUN_COUNT}};
+  s::buffer<T> out{{1}};
   s::buffer<IntType> frexp_exp{{1}};
   {
-    auto inputs = float_in.get_host_access();
-    auto outputs = out.get_host_access();
-    inputs[0] = get_math_input<DT, D>(s::vec<DT, 16>{
-      0.75, 1.5, -2.25, 0.5, 3.125, -0.375, 1.0, 0.25,
-      0.75, 1.5, -2.25, 0.5, 3.125, -0.375, 1.0, 0.25});
-    for(int i = 0; i < FUN_COUNT; ++i) {
-      outputs[i] = T{DT{0}};
-    }
+    auto inp = float_in.get_host_access();
+    inp[0] = get_math_input<DT, D>(s::vec<DT, 16>{INPUT_FRAC()});
   }
-
-  // run functions
-
   queue.submit([&](s::handler& cgh) {
-    auto inputs = float_in.template  get_access<s::access::mode::read>(cgh);
-    auto outputs = out.template get_access<s::access::mode::write>(cgh);
+    auto in = float_in.template get_access<s::access::mode::read>(cgh);
+    auto o = out.template get_access<s::access::mode::write>(cgh);
     auto exp = frexp_exp.template get_access<s::access::mode::write>(cgh);
-    cgh.single_task<kernel_name<class math_out_params, D, DT>>([=]() {
-      int i = 0;
+    cgh.single_task<kernel_name<class math_frexp, D, DT>>([=]() {
       IntType frexp_exp_val;
-      outputs[i++] = s::frexp(inputs[0], &frexp_exp_val);
+      o[0] = s::frexp(in[0], &frexp_exp_val);
       exp[0] = frexp_exp_val;
-
-      T modf_ipart;
-      outputs[i++] = s::modf(inputs[0], &modf_ipart);
-      outputs[i++] = modf_ipart;
-
-      T fract_ipart;
-      outputs[i++] = s::fract(inputs[0], &fract_ipart);
     });
   });
-
-  // check results
-
   {
-    auto inputs = float_in.get_host_access();
-    auto outputs = out.get_host_access();
+    auto inp = float_in.get_host_access();
+    auto o = out.get_host_access();
     auto exp = frexp_exp.get_host_access();
     for(int c = 0; c < std::max(D, 1); ++c) {
-      double x = static_cast<double>(comp(inputs[0], c));
-      int ref_frexp_exp; double ref_frexp_m = std::frexp(x, &ref_frexp_exp);
-      double ref_modf_ipart; double ref_modf_frac = std::modf(x, &ref_modf_ipart);
-      int i = 0;
-      BOOST_TEST(comp(outputs[i++], c) == ref_frexp_m);
-      BOOST_TEST(comp(exp[0], c) == ref_frexp_exp);
-      BOOST_TEST(comp(outputs[i++], c) == ref_modf_frac);
-      BOOST_TEST(comp(outputs[i++], c) == ref_modf_ipart);
-      BOOST_TEST(comp(outputs[i++], c) == ref_fract(x));
+      double x = static_cast<double>(comp(inp[0], c));
+      int ref_exp; double ref_m = std::frexp(x, &ref_exp);
+      BOOST_TEST(comp(o[0], c) == ref_m);
+      BOOST_TEST(comp(exp[0], c) == ref_exp);
     }
+  }
+}
+
+BOOST_TEST_DECORATOR(*boost::unit_test::tolerance(0.0001))
+BOOST_AUTO_TEST_CASE_TEMPLATE(math_modf, T, math_test_genfloats) {
+  constexpr int D = vector_length_v<T>;
+  using DT = vector_elem_t<T>;
+  namespace s = sycl;
+  s::queue queue;
+  SKIP_IF_NO_FP64(queue, DT);
+  s::buffer<T> float_in{{1}};
+  s::buffer<T> out{{2}};
+  {
+    auto inp = float_in.get_host_access();
+    inp[0] = get_math_input<DT, D>(s::vec<DT, 16>{INPUT_FRAC()});
+  }
+  queue.submit([&](s::handler& cgh) {
+    auto in = float_in.template get_access<s::access::mode::read>(cgh);
+    auto o = out.template get_access<s::access::mode::write>(cgh);
+    cgh.single_task<kernel_name<class math_modf, D, DT>>([=]() {
+      T ipart;
+      o[0] = s::modf(in[0], &ipart);
+      o[1] = ipart;
+    });
+  });
+  {
+    auto inp = float_in.get_host_access();
+    auto o = out.get_host_access();
+    for(int c = 0; c < std::max(D, 1); ++c) {
+      double x = static_cast<double>(comp(inp[0], c));
+      double ref_ipart; double ref_frac = std::modf(x, &ref_ipart);
+      BOOST_TEST(comp(o[0], c) == ref_frac);
+      BOOST_TEST(comp(o[1], c) == ref_ipart);
+    }
+  }
+}
+
+BOOST_TEST_DECORATOR(*boost::unit_test::tolerance(0.0001))
+BOOST_AUTO_TEST_CASE_TEMPLATE(math_fract, T, math_test_genfloats) {
+  constexpr int D = vector_length_v<T>;
+  using DT = vector_elem_t<T>;
+  namespace s = sycl;
+  s::queue queue;
+  SKIP_IF_NO_FP64(queue, DT);
+  s::buffer<T> float_in{{1}};
+  s::buffer<T> out{{1}};
+  {
+    auto inp = float_in.get_host_access();
+    inp[0] = get_math_input<DT, D>(s::vec<DT, 16>{INPUT_FRAC()});
+  }
+  queue.submit([&](s::handler& cgh) {
+    auto in = float_in.template get_access<s::access::mode::read>(cgh);
+    auto o = out.template get_access<s::access::mode::write>(cgh);
+    cgh.single_task<kernel_name<class math_fract, D, DT>>([=]() {
+      T ipart;
+      o[0] = s::fract(in[0], &ipart);
+    });
+  });
+  {
+    auto inp = float_in.get_host_access();
+    auto o = out.get_host_access();
+    for(int c = 0; c < std::max(D, 1); ++c)
+      BOOST_TEST(comp(o[0], c) == ref_fract(static_cast<double>(comp(inp[0], c))));
   }
 }
 

--- a/tests/sycl/math.cpp
+++ b/tests/sycl/math.cpp
@@ -221,6 +221,104 @@ namespace {
     std::bitset<sizeof(T)*CHAR_BIT> bset(x);
     return bset.count();
   }
+
+  double ref_acosh(double x) {
+    return std::acosh(x);
+  }
+
+  double ref_asinh(double x) {
+    return std::asinh(x);
+  }
+
+  double ref_atanh(double x) {
+    return std::atanh(x);
+  }
+
+  double ref_cbrt(double x) {
+    return std::cbrt(x);
+  }
+
+  double ref_erf(double x) {
+    return std::erf(x);
+  }
+
+  double ref_erfc(double x) {
+    return std::erfc(x);
+  }
+
+  double ref_logb(double x) {
+    return std::logb(x);
+  }
+
+  double ref_nextafter(double x, double y) {
+    return std::nextafter(x, y);
+  }
+
+  double ref_remainder(double x, double y) {
+    return std::remainder(x, y);
+  }
+
+  double ref_maxmag(double x, double y) {
+    double ax = std::abs(x), ay = std::abs(y);
+    if (ax > ay) {
+      return x;
+    }
+    if (ay > ax) {
+      return y;
+    }
+    return std::fmax(x, y);
+  }
+
+  double ref_minmag(double x, double y) {
+    double ax = std::abs(x), ay = std::abs(y);
+    if (ax < ay) {
+      return x;
+    }
+    if (ay < ax) {
+      return y;
+    }
+    return std::fmin(x, y);
+  }
+
+  double ref_acospi(double x) {
+    return std::acos(x) / pi;
+  }
+
+  double ref_asinpi(double x) {
+    return std::asin(x) / pi;
+  }
+
+  double ref_atanpi(double x) {
+    return std::atan(x) / pi;
+  }
+
+  double ref_atan2pi(double x, double y) {
+    return std::atan2(x, y) / pi;
+  }
+
+  double ref_cospi(double x) {
+    return std::cos(x * pi);
+  }
+
+  double ref_sinpi(double x) {
+    return std::sin(x * pi);
+  }
+
+  double ref_lgamma(double x) {
+    return std::lgamma(x);
+  }
+
+  double ref_tgamma(double x) {
+    return std::tgamma(x);
+  }
+
+  int ref_lgamma_r_sign(double x) {
+    return std::tgamma(x) >= 0.0 ? 1 : -1;
+  }
+
+  double ref_fract(double x) {
+    return std::min(x - std::floor(x), std::nextafter(1.0, 0.0));
+  }
 }
 
 BOOST_TEST_DECORATOR(*boost::unit_test::tolerance(0.0001))
@@ -805,6 +903,417 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_genint, T,
       BOOST_TEST(comp(outputs[i++], c) == std::ldexp(comp(float_inputs[0], c), comp(int_inputs[0], c)));
       BOOST_TEST(comp(outputs[i++], c) == std::pow(comp(float_inputs[0], c), comp(int_inputs[0], c)));
       BOOST_TEST(comp(outputs[i++], c) == std::pow(std::fabs(comp(float_inputs[0], c)), 1./comp(int_inputs[0], c)));
+    }
+  }
+}
+
+BOOST_TEST_DECORATOR(*boost::unit_test::tolerance(0.0001))
+BOOST_AUTO_TEST_CASE_TEMPLATE(math_unary_extra, T, math_test_genfloats) {
+
+  constexpr int D = vector_length_v<T>;
+  using DT = vector_elem_t<T>;
+  using IntType = vector_coerce_elem_t<int, T>;
+
+  namespace s = sycl;
+
+  s::queue queue;
+  if constexpr(std::is_same_v<DT, double>) {
+    if (!queue.get_device().has(sycl::aspect::fp64)) {
+      BOOST_TEST_MESSAGE("Skipping test for double since device has no fp64 support");
+      return;
+    }
+  }
+
+  // build inputs and allocate outputs
+
+  constexpr int FUN_COUNT = 5; // acosh, asinh, atanh, cbrt, logb
+
+  s::buffer<T> float_in{{2}};
+  s::buffer<T> out{{FUN_COUNT}};
+  s::buffer<IntType> ilogb_out{{1}};
+  {
+    auto inputs = float_in.get_host_access();
+    auto outputs = out.get_host_access();
+    inputs[0] = get_math_input<DT, D>(s::vec<DT, 16>{
+      1.5, 2.0, 1.25, 3.0, 1.1, 1.7, 2.5, 1.3, 1.5, 2.0, 1.25, 3.0, 1.1, 1.7, 2.5, 1.3});
+    inputs[1] = get_math_input<DT, D>(s::vec<DT, 16>{
+      0.5, -0.3,  0.75, -0.1, 0.6, -0.5, 0.2, -0.8, 0.5, -0.3, 0.75, -0.1, 0.6, -0.5, 0.2, -0.8});
+    for(int i = 0; i < FUN_COUNT; ++i) {
+      outputs[i] = T{DT{0}};
+    }
+  }
+
+  // run functions
+
+  queue.submit([&](s::handler& cgh) {
+    auto inputs = float_in.template  get_access<s::access::mode::read>(cgh);
+    auto outputs = out.template get_access<s::access::mode::write>(cgh);
+    auto ilogb = ilogb_out.template get_access<s::access::mode::write>(cgh);
+    cgh.single_task<kernel_name<class math_unary_extra, D, DT>>([=]() {
+      int i = 0;
+      outputs[i++] = s::acosh(inputs[0]);
+      outputs[i++] = s::asinh(inputs[1]);
+      outputs[i++] = s::atanh(inputs[1]);
+      outputs[i++] = s::cbrt(inputs[1]);
+      outputs[i++] = s::logb(inputs[1]);
+      ilogb[0] = s::ilogb(inputs[1]);
+    });
+  });
+
+  // check results
+
+  {
+    auto inputs = float_in.get_host_access();
+    auto outputs = out.get_host_access();
+    auto ilogb = ilogb_out.get_host_access();
+    for(int c = 0; c < std::max(D, 1); ++c) {
+      double x0 = static_cast<double>(comp(inputs[0], c));
+      double x1 = static_cast<double>(comp(inputs[1], c));
+      int i = 0;
+      BOOST_TEST(comp(outputs[i++], c) == ref_acosh(x0));
+      BOOST_TEST(comp(outputs[i++], c) == ref_asinh(x1));
+      BOOST_TEST(comp(outputs[i++], c) == ref_atanh(x1));
+      BOOST_TEST(comp(outputs[i++], c) == ref_cbrt(x1));
+      BOOST_TEST(comp(outputs[i++], c) == ref_logb(x1));
+      BOOST_TEST(comp(ilogb[0], c) == std::ilogb(comp(inputs[1], c)));
+    }
+  }
+}
+
+
+BOOST_TEST_DECORATOR(*boost::unit_test::tolerance(0.0001))
+BOOST_AUTO_TEST_CASE_TEMPLATE(math_binary_extra, T, math_test_genfloats) {
+
+  constexpr int D = vector_length_v<T>;
+  using DT = vector_elem_t<T>;
+
+  namespace s = sycl;
+
+  s::queue queue;
+  if constexpr(std::is_same_v<DT, double>) {
+    if (!queue.get_device().has(sycl::aspect::fp64)) {
+      BOOST_TEST_MESSAGE("Skipping test for double since device has no fp64 support");
+      return;
+    }
+  }
+
+  // build inputs and allocate outputs
+
+  constexpr int FUN_COUNT = 4; // nextafter, remainder, maxmag, minmag
+
+  s::buffer<T> float_in{{2}};
+  s::buffer<T> out{{FUN_COUNT}};
+  {
+    auto inputs = float_in.get_host_access();
+    auto outputs = out.get_host_access();
+    inputs[0] = get_math_input<DT, D>(s::vec<DT, 16>{
+      7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0});
+    inputs[1] = get_math_input<DT, D>(s::vec<DT, 16>{
+      17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0, 17.0, -4.0, -2.0, 3.0, 7.0, -8.0, 9.0, -1.0});
+    for(int i = 0; i < FUN_COUNT; ++i) {
+      outputs[i] = T{DT{0}};
+    }
+  }
+
+  // run functions
+
+  queue.submit([&](s::handler& cgh) {
+    auto inputs = float_in.template get_access<s::access::mode::read>(cgh);
+    auto outputs = out.template get_access<s::access::mode::write>(cgh);
+    cgh.single_task<kernel_name<class math_binary_extra, D, DT>>([=]() {
+      int i = 0;
+      outputs[i++] = s::nextafter(inputs[0], inputs[1]);
+      outputs[i++] = s::remainder(inputs[0], inputs[1]);
+      outputs[i++] = s::maxmag(inputs[0], inputs[1]);
+      outputs[i++] = s::minmag(inputs[0], inputs[1]);
+    });
+  });
+
+  // check results
+
+  {
+    auto inputs = float_in.get_host_access();
+    auto outputs = out.get_host_access();
+    for(int c = 0; c < std::max(D, 1); ++c) {
+      double x = static_cast<double>(comp(inputs[0], c));
+      double y = static_cast<double>(comp(inputs[1], c));
+      int i = 0;
+      BOOST_TEST(comp(outputs[i++], c) == ref_nextafter(x, y));
+      BOOST_TEST(comp(outputs[i++], c) == ref_remainder(x, y));
+      BOOST_TEST(comp(outputs[i++], c) == ref_maxmag(x, y));
+      BOOST_TEST(comp(outputs[i++], c) == ref_minmag(x, y));
+    }
+  }
+}
+
+
+BOOST_TEST_DECORATOR(*boost::unit_test::tolerance(0.0001))
+BOOST_AUTO_TEST_CASE_TEMPLATE(math_pi_functions, T, math_test_genfloats) {
+
+  constexpr int D = vector_length_v<T>;
+  using DT = vector_elem_t<T>;
+
+  namespace s = sycl;
+
+  s::queue queue;
+  if constexpr(std::is_same_v<DT, double>) {
+    if (!queue.get_device().has(sycl::aspect::fp64)) {
+      BOOST_TEST_MESSAGE("Skipping test for double since device has no fp64 support");
+      return;
+    }
+  }
+
+  // build inputs and allocate outputs
+
+  constexpr int FUN_COUNT = 6; // acospi, asinpi, atanpi, atan2pi, cospi, sinpi
+
+  s::buffer<T> float_in{{2}};
+  s::buffer<T> out{{FUN_COUNT}};
+  {
+    auto inputs  = float_in.get_host_access();
+    auto outputs = out.get_host_access();
+    inputs[0] = get_math_input<DT, D>(s::vec<DT, 16>{
+      0.4, -0.3, 0.75, -0.1, 0.6, -0.4, 0.2, -0.8, 0.4, -0.3, 0.75, -0.1, 0.6, -0.4, 0.2, -0.8});
+    inputs[1] = get_math_input<DT, D>(s::vec<DT, 16>{
+      7.0, -4.0, 2.0, 3.0, -5.0, 1.0, -3.0, 0.5, 7.0, -4.0, 2.0, 3.0, -5.0, 1.0, -3.0, 0.5});
+    for(int i = 0; i < FUN_COUNT; ++i) {
+      outputs[i] = T{DT{0}};
+    }
+  }
+
+  // run functions
+
+  queue.submit([&](s::handler& cgh) {
+    auto inputs = float_in.template get_access<s::access::mode::read>(cgh);
+    auto outputs = out.template get_access<s::access::mode::write>(cgh);
+    cgh.single_task<kernel_name<class math_pi_functions, D, DT>>([=]() {
+      int i = 0;
+      outputs[i++] = s::acospi(inputs[0]);
+      outputs[i++] = s::asinpi(inputs[0]);
+      outputs[i++] = s::atanpi(inputs[0]);
+      outputs[i++] = s::atan2pi(inputs[0], inputs[1]);
+      outputs[i++] = s::cospi(inputs[0]);
+      outputs[i++] = s::sinpi(inputs[0]);
+    });
+  });
+
+  // check results
+
+  {
+    auto inputs = float_in.get_host_access();
+    auto outputs = out.get_host_access();
+    for(int c = 0; c < std::max(D, 1); ++c) {
+      double x = static_cast<double>(comp(inputs[0], c));
+      double y = static_cast<double>(comp(inputs[1], c));
+      int i = 0;
+      BOOST_TEST(comp(outputs[i++], c) == ref_acospi(x));
+      BOOST_TEST(comp(outputs[i++], c) == ref_asinpi(x));
+      BOOST_TEST(comp(outputs[i++], c) == ref_atanpi(x));
+      BOOST_TEST(comp(outputs[i++], c) == ref_atan2pi(x, y));
+      BOOST_TEST(comp(outputs[i++], c) == ref_cospi(x));
+      BOOST_TEST(comp(outputs[i++], c) == ref_sinpi(x));
+    }
+  }
+}
+
+
+BOOST_TEST_DECORATOR(*boost::unit_test::tolerance(0.0007))
+BOOST_AUTO_TEST_CASE_TEMPLATE(math_erf_erfc, T, math_test_genfloats) {
+
+  constexpr int D = vector_length_v<T>;
+  using DT = vector_elem_t<T>;
+
+  namespace s = sycl;
+
+  s::queue queue;
+  if constexpr(std::is_same_v<DT, double>) {
+    if (!queue.get_device().has(sycl::aspect::fp64)) {
+      BOOST_TEST_MESSAGE("Skipping test for double since device has no fp64 support");
+      return;
+    }
+  }
+
+  // build inputs and allocate outputs
+
+  s::buffer<T> float_in{{1}};
+  s::buffer<T> erf_out {{1}};
+  s::buffer<T> erfc_out{{1}};
+  {
+    auto inputs = float_in.get_host_access();
+    inputs[0] = get_math_input<DT, D>(s::vec<DT, 16>{
+      -3.0, -1.0, -0.5, 0.0, 0.5, 1.0, 3.0, 2.0, -3.0, -1.0, -0.5, 0.0, 0.5, 1.0, 3.0, 2.0});
+  }
+
+  // run functions
+
+  queue.submit([&](s::handler& cgh) {
+    auto inputs = float_in.template get_access<s::access::mode::read>(cgh);
+    auto eout = erf_out.template get_access<s::access::mode::write>(cgh);
+    auto ecout = erfc_out.template get_access<s::access::mode::write>(cgh);
+    cgh.single_task<kernel_name<class math_erf_erfc_detailed, D, DT>>([=]() {
+      eout[0] = s::erf(inputs[0]);
+      ecout[0] = s::erfc(inputs[0]);
+    });
+  });
+
+  // check results
+
+  {
+    auto inputs = float_in.get_host_access();
+    auto eout = erf_out.get_host_access();
+    auto ecout = erfc_out.get_host_access();
+    for(int c = 0; c < std::max(D, 1); ++c) {
+      double x = static_cast<double>(comp(inputs[0], c));
+      BOOST_TEST(comp(eout[0], c) == ref_erf(x));
+      BOOST_TEST(comp(ecout[0], c) == ref_erfc(x));
+      // erf(x) + erfc(x) == 1
+      BOOST_TEST(comp(eout[0], c) + comp(ecout[0], c) == 1.0);
+    }
+  }
+}
+
+
+BOOST_TEST_DECORATOR(*boost::unit_test::tolerance(0.001))
+BOOST_AUTO_TEST_CASE_TEMPLATE(math_gamma, T, math_test_genfloats) {
+
+  constexpr int D = vector_length_v<T>;
+  using DT = vector_elem_t<T>;
+  using IntType = vector_coerce_elem_t<int, T>;
+
+  namespace s = sycl;
+
+  s::queue queue;
+  if constexpr(std::is_same_v<DT, double>) {
+    if (!queue.get_device().has(sycl::aspect::fp64)) {
+      BOOST_TEST_MESSAGE("Skipping test for double since device has no fp64 support");
+      return;
+    }
+  }
+
+  // build inputs and allocate outputs
+
+  constexpr int FUN_COUNT = 3; // lgamma, tgamma, lgamma_r
+
+  s::buffer<T> float_in{{1}};
+  s::buffer<T> out{{FUN_COUNT}};
+  s::buffer<IntType> lgr_sgn {{1}};
+  {
+    auto inputs = float_in.get_host_access();
+    auto outputs = out.get_host_access();
+    inputs[0] = get_math_input<DT, D>(s::vec<DT, 16>{
+      0.5, 1.5, 2.5, -0.5, 3.0, -1.5, 4.0, -2.1, 0.5, 1.5, 2.5, -0.5, 3.0, -1.5, 4.0, -2.1});
+    for(int i = 0; i < FUN_COUNT; ++i) {
+      outputs[i] = T{DT{0}};
+    }
+  }
+
+  // run functions
+
+  queue.submit([&](s::handler& cgh) {
+    auto inputs = float_in.template get_access<s::access::mode::read>(cgh);
+    auto outputs = out.template get_access<s::access::mode::write>(cgh);
+    auto sgn = lgr_sgn.template get_access<s::access::mode::write>(cgh);
+    cgh.single_task<kernel_name<class math_gamma, D, DT>>([=]() {
+      int i = 0;
+      outputs[i++] = s::lgamma(inputs[0]);
+      outputs[i++] = s::tgamma(inputs[0]);
+      IntType s;
+      outputs[i++] = s::lgamma_r(inputs[0], &s);
+      sgn[0] = s;
+    });
+  });
+
+  // check results
+
+  {
+    auto inputs = float_in.get_host_access();
+    auto outputs = out.get_host_access();
+    auto sgn = lgr_sgn.get_host_access();
+    for(int c = 0; c < std::max(D, 1); ++c) {
+      double x = static_cast<double>(comp(inputs[0], c));
+      int i = 0;
+      BOOST_TEST(comp(outputs[i++], c) == ref_lgamma(x));
+      BOOST_TEST(comp(outputs[i++], c) == ref_tgamma(x));
+      BOOST_TEST(comp(outputs[i++], c) == ref_lgamma(x));
+      BOOST_TEST(comp(sgn[0], c) == ref_lgamma_r_sign(x));
+    }
+  }
+}
+
+
+BOOST_TEST_DECORATOR(*boost::unit_test::tolerance(0.0001))
+BOOST_AUTO_TEST_CASE_TEMPLATE(math_out_params, T, math_test_genfloats) {
+
+  constexpr int D = vector_length_v<T>;
+  using DT = vector_elem_t<T>;
+  using IntType = vector_coerce_elem_t<int, T>;
+
+  namespace s = sycl;
+
+  s::queue queue;
+  if constexpr(std::is_same_v<DT, double>) {
+    if (!queue.get_device().has(sycl::aspect::fp64)) {
+      BOOST_TEST_MESSAGE("Skipping test for double since device has no fp64 support");
+      return;
+    }
+  }
+
+  // build inputs and allocate outputs
+
+  // out[0]=frexp mantissa, out[1]=modf frac, out[2]=modf ipart, out[3]=fract frac
+  constexpr int FUN_COUNT = 4;
+
+  s::buffer<T> float_in{{1}};
+  s::buffer<T> out{{FUN_COUNT}};
+  s::buffer<IntType> frexp_exp{{1}};
+  {
+    auto inputs = float_in.get_host_access();
+    auto outputs = out.get_host_access();
+    inputs[0] = get_math_input<DT, D>(s::vec<DT, 16>{
+      0.75, 1.5, -2.25, 0.5, 3.125, -0.375, 1.0, 0.25,
+      0.75, 1.5, -2.25, 0.5, 3.125, -0.375, 1.0, 0.25});
+    for(int i = 0; i < FUN_COUNT; ++i) {
+      outputs[i] = T{DT{0}};
+    }
+  }
+
+  // run functions
+
+  queue.submit([&](s::handler& cgh) {
+    auto inputs = float_in.template  get_access<s::access::mode::read>(cgh);
+    auto outputs = out.template get_access<s::access::mode::write>(cgh);
+    auto exp = frexp_exp.template get_access<s::access::mode::write>(cgh);
+    cgh.single_task<kernel_name<class math_out_params, D, DT>>([=]() {
+      int i = 0;
+      IntType frexp_exp_val;
+      outputs[i++] = s::frexp(inputs[0], &frexp_exp_val);
+      exp[0] = frexp_exp_val;
+
+      T modf_ipart;
+      outputs[i++] = s::modf(inputs[0], &modf_ipart);
+      outputs[i++] = modf_ipart;
+
+      T fract_ipart;
+      outputs[i++] = s::fract(inputs[0], &fract_ipart);
+    });
+  });
+
+  // check results
+
+  {
+    auto inputs = float_in.get_host_access();
+    auto outputs = out.get_host_access();
+    auto exp = frexp_exp.get_host_access();
+    for(int c = 0; c < std::max(D, 1); ++c) {
+      double x = static_cast<double>(comp(inputs[0], c));
+      int ref_frexp_exp; double ref_frexp_m = std::frexp(x, &ref_frexp_exp);
+      double ref_modf_ipart; double ref_modf_frac = std::modf(x, &ref_modf_ipart);
+      int i = 0;
+      BOOST_TEST(comp(outputs[i++], c) == ref_frexp_m);
+      BOOST_TEST(comp(exp[0], c) == ref_frexp_exp);
+      BOOST_TEST(comp(outputs[i++], c) == ref_modf_frac);
+      BOOST_TEST(comp(outputs[i++], c) == ref_modf_ipart);
+      BOOST_TEST(comp(outputs[i++], c) == ref_fract(x));
     }
   }
 }


### PR DESCRIPTION
This PR adds implementations of several missing math functions in the Metal backend
erf/erfc and lgamma/tgamma are implemented in a simple way using formulas from Wikipedia

erf/erfc work quite well, tgamma/lgamma are less accurate and may lose precision for some inputs 
The goal of this PR is not to provide a perfect implementation.

A fully robust implementation of tgamma/lgamma in math libraries is typically around ~300 lines of code, so this could be improved later if needed