### PR TITLE
[SSCP][host] Fix subgroup ops

### DIFF
--- a/src/libkernel/sscp/host/shuffle.cpp
+++ b/src/libkernel/sscp/host/shuffle.cpp
@@ -32,7 +32,7 @@ SUBGROUP_SIZE_ONE_SHUFLLE(64, shr)
   HIPSYCL_SSCP_CONVERGENT_BUILTIN                                                                  \
   __acpp_int##int_size __acpp_sscp_sub_group_permute_i##int_size(__acpp_int##int_size value,       \
                                                                  __acpp_int32 mask) {              \
-    return mask xor 0 ? value : 0;                                                                 \
+    return mask == 0 ? value : 0;                                                                 \
   }
 
 SUBGROUP_SIZE_ONE_PERMUTE(8)

--- a/src/libkernel/sscp/host/subgroup.cpp
+++ b/src/libkernel/sscp/host/subgroup.cpp
@@ -26,8 +26,9 @@ HIPSYCL_SSCP_BUILTIN __acpp_uint32 __acpp_sscp_get_subgroup_max_size() {
 HIPSYCL_SSCP_BUILTIN __acpp_uint32 __acpp_sscp_get_subgroup_id() {
   __acpp_uint32 local_tid =
       __acpp_sscp_get_local_id_x() +
-      __acpp_sscp_get_local_id_y() * (__acpp_sscp_get_local_size_x() +
-      __acpp_sscp_get_local_id_z() * __acpp_sscp_get_local_size_x());
+      __acpp_sscp_get_local_id_y() * __acpp_sscp_get_local_size_x() +
+      __acpp_sscp_get_local_id_z() * __acpp_sscp_get_local_size_x() * 
+          __acpp_sscp_get_local_size_y();
   return local_tid;
 }
 


### PR DESCRIPTION
- `__acpp_sscp_get_subgroup_id` was a bit off
- `__acpp_sscp_sub_group_permute_i*` had inverted logic

I can add / expand tests, but not sure how useful that would be for these corner cases