### PR TITLE
[Metal] Fixes: fshl/fshr, bool sign expansion

### DIFF
--- a/src/compiler/llvm-to-backend/metal/Emitter.cpp
+++ b/src/compiler/llvm-to-backend/metal/Emitter.cpp
@@ -412,8 +412,9 @@ void MetalEmitter::emitIntrinsicHelpers() {
     return as_type<long>(value);
   }
 
-  inline bool __as_signed(bool value) {
-    return value;
+  // LLVM sext i1 true to iN yields all-ones (-1), so replicate that semantic
+  inline int __as_signed(bool value) {
+    return value ? -1 : 0;
   }
 )__";
 

--- a/src/compiler/llvm-to-backend/metal/HLTree.hpp
+++ b/src/compiler/llvm-to-backend/metal/HLTree.hpp
@@ -127,15 +127,6 @@ struct ReturnNode final : Node {
   {}
 };
 
-inline bool is(const Node& n, NodeKind k) {
-  return n.kind == k;
-}
-
-template <class T>
-inline T* as(Node* n) {
-  return (n && n->kind == T{}.kind) ? static_cast<T*>(n) : nullptr;
-}
-
 void dumpFunctionTree(llvm::raw_ostream& os, const llvm::Function& F, const Node& root);
 
 } // namespace hl

--- a/src/compiler/llvm-to-backend/metal/LLVMToMetal.cpp
+++ b/src/compiler/llvm-to-backend/metal/LLVMToMetal.cpp
@@ -378,17 +378,22 @@ struct ExpandIntrinsics : llvm::PassInfoMixin<ExpandIntrinsics> {
     llvm::Value* WmSh = B.CreateSub(WConst, Sh, "w_minus_sh");
 
     llvm::Value* ResShifted = nullptr;
+    llvm::Value* ZeroRes = nullptr;
     if (II->getIntrinsicID() == llvm::Intrinsic::fshl) {
+      // fshl(A, B, S) = msb_extract({A:B} << S) = (A << S) | (B >> (W-S))
       llvm::Value* L = B.CreateShl(A, Sh, "l");
       llvm::Value* R = B.CreateLShr(Bv, WmSh, "r");
       ResShifted = B.CreateOr(L, R, "fshl");
+      ZeroRes = A; // fshl(A, B, 0) = A
     } else { // fshr
-      llvm::Value* L = B.CreateLShr(A, Sh, "l");
-      llvm::Value* R = B.CreateShl(Bv, WmSh, "r");
+      // fshr(A, B, S) = lsb_extract({A:B} >> S) = (B >> S) | (A << (W-S))
+      llvm::Value* L = B.CreateLShr(Bv, Sh, "l");
+      llvm::Value* R = B.CreateShl(A, WmSh, "r");
       ResShifted = B.CreateOr(L, R, "fshr");
+      ZeroRes = Bv; // fshr(A, B, 0) = B
     }
 
-    llvm::Value* Res = B.CreateSelect(IsZero, A, ResShifted, "fsh");
+    llvm::Value* Res = B.CreateSelect(IsZero, ZeroRes, ResShifted, "fsh");
     II->replaceAllUsesWith(Res);
   }
 

--- a/tests/compiler/sscp/fshl_bool_sext.cpp
+++ b/tests/compiler/sscp/fshl_bool_sext.cpp
@@ -1,0 +1,85 @@
+// RUN: %acpp %s -o %t --acpp-targets=generic
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s -o %t --acpp-targets=generic -O3
+// RUN: %t | FileCheck %s
+
+#include <cstdint>
+#include <iostream>
+#include <sycl/sycl.hpp>
+#include "common.hpp"
+
+// likely expanded to @llvm.fshl.i32
+inline uint32_t rotate_left(uint32_t x, uint32_t n) {
+  return (x << n) | (x >> (32u - n));
+}
+
+// likely expanded to @llvm.fshr.i32
+inline uint32_t rotate_right(uint32_t x, uint32_t n) {
+  return (x >> n) | (x << (32u - n));
+}
+
+// likely expanded to @llvm.fshl.i32
+inline uint32_t funnel_left(uint32_t a, uint32_t b, uint32_t s) {
+  return (a << s) | (b >> (32u - s));
+}
+
+// likely expanded to @llvm.fshr.i32
+inline uint32_t funnel_right(uint32_t a, uint32_t b, uint32_t s) {
+  return (b >> s) | (a << (32u - s));
+}
+
+// likely expanded to sext i1 to i32
+inline int32_t bool_sign_mask(int32_t a, int32_t b) {
+  return -(int32_t)(a > b);
+}
+
+int main() {
+  sycl::queue q = get_queue();
+
+  uint32_t *data = sycl::malloc_shared<uint32_t>(8, q);
+  int32_t *sdata = sycl::malloc_shared<int32_t>(4, q);
+
+  data[0] = 0xDEADBEEFu;
+  data[1] = 12;
+  data[2] = 0xAAAAAAAAu;
+  data[3] = 0x55555555u;
+  data[4] = 8;
+
+  sdata[0] = 42;
+  sdata[1] = 10;
+  sdata[2] = 5;
+  sdata[3] = 100;
+
+  q.single_task([=]() {
+    uint32_t x = data[0];
+    uint32_t n = data[1];
+    uint32_t a = data[2];
+    uint32_t b = data[3];
+    uint32_t s = data[4];
+
+    data[5] = rotate_left(x, n);
+    data[6] = rotate_right(x, n);
+    data[7] = funnel_left(a, b, s);
+
+    sdata[2] = bool_sign_mask(sdata[0], sdata[1]);
+    sdata[3] = bool_sign_mask(sdata[1], sdata[0]);
+  }).wait();
+
+  uint32_t expected_rotl = rotate_left(0xDEADBEEFu, 12);
+  uint32_t expected_rotr = rotate_right(0xDEADBEEFu, 12);
+  uint32_t expected_fshl = funnel_left(0xAAAAAAAAu, 0x55555555u, 8);
+
+  // CHECK: rotl: 1
+  std::cout << "rotl: " << (data[5] == expected_rotl) << std::endl;
+  // CHECK: rotr: 1
+  std::cout << "rotr: " << (data[6] == expected_rotr) << std::endl;
+  // CHECK: fshl: 1
+  std::cout << "fshl: " << (data[7] == expected_fshl) << std::endl;
+  // CHECK: sext_true: -1
+  std::cout << "sext_true: " << sdata[2] << std::endl;
+  // CHECK: sext_false: 0
+  std::cout << "sext_false: " << sdata[3] << std::endl;
+
+  sycl::free(data, q);
+  sycl::free(sdata, q);
+}


### PR DESCRIPTION
  - Fix fshl/fshr intrinsic expansion: wrong operand order in fshr and wrong zero-shift result
  - Fix bool sign extension (sext i1): __as_signed(bool) now returns int with all-ones pattern

Started running acpp in CI for my project on apple hardware. Hit numerical mismatches traced back to incorrect fshl/fshr expansion and bool sign extension in the metal backend


