### PR TITLE
Fix UB in decoupled lookback scan (caused by uninitialized dummy_init)

### DIFF
--- a/include/hipSYCL/algorithms/scan/decoupled_lookback_scan.hpp
+++ b/include/hipSYCL/algorithms/scan/decoupled_lookback_scan.hpp
@@ -429,11 +429,11 @@ void scan_kernel(sycl::nd_item<1> idx, T *local_memory, scratch_data<T> scratch,
     sycl::group_barrier(idx.get_group());
 
     // All groups except group 0 need to perform lookback to find their prefix
-    T exclusive_prefix;
+    T exclusive_prefix = local_inclusive_prefix; // avoid UB: must be initialized
     if(effective_group_id != 0) {
       if(local_id == 0) {
         exclusive_prefix = exclusive_prefix_look_back(
-            exclusive_prefix, effective_group_id, scratch.group_status,
+            local_inclusive_prefix, effective_group_id, scratch.group_status,
             scratch.group_aggregate, scratch.inclusive_prefix, op);
       }
       exclusive_prefix = collective_broadcast<T, BinaryOp>(


### PR DESCRIPTION
`exclusive_prefix_look_back()` takes a `dummy_init` argument, which is used to construct a valid `T` object before it is conditionally updated.
However, `scan_kernel` passed an uninitialized variable, which results in undefined behavior.

This led to incorrect results under SMCP (`cuda` target), while SSCP appears to work by accident.

Fixed by initializing `exclusive_prefix` with `local_inclusive_prefix` and passing `local_inclusive_prefix` as `dummy_init`.

(`local_inclusive_prefix` is passed explicitly instead of reusing `exclusive_prefix` to make the dummy role clear and avoid implying data dependency on the output variable)