### PR TITLE
Add runtime install destination for OpenCL and ZE backends

### DIFF
--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -232,6 +232,7 @@ if(WITH_LEVEL_ZERO_BACKEND)
   endif()
 
   install(TARGETS rt-backend-ze
+        RUNTIME DESTINATION bin/hipSYCL
         LIBRARY DESTINATION lib/hipSYCL
         ARCHIVE DESTINATION lib/hipSYCL)
 endif()
@@ -287,6 +288,7 @@ if(WITH_OPENCL_BACKEND)
   endif()
 
   install(TARGETS rt-backend-ocl
+        RUNTIME DESTINATION bin/hipSYCL
         LIBRARY DESTINATION lib/hipSYCL
         ARCHIVE DESTINATION lib/hipSYCL)
 endif()


### PR DESCRIPTION
This PR adds `RUNTIME DESTINATION bin/hipSYCL` to the install rules for `rt-backend-ocl` and `rt-backend-ze`.

These targets already specify `LIBRARY` and `ARCHIVE` destinations, which is sufficient on Linux, but on Windows the DLL is treated as a runtime artifact. Without `RUNTIME` destination, backend DLL is built but not installed.

This makes the install rules consistent with the other runtime backends which include `RUNTIME`.