### PR TITLE
Use bracketed install(CODE) for LLVMSpirvTranslator install

### DIFF
--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -214,7 +214,9 @@ if(WITH_SSCP_COMPILER)
     )
 
     #install(TARGETS InstallLLVMSpirvTranslator)
-    install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} --build . --target InstallLLVMSpirvTranslator)")
+    install(CODE [[
+      execute_process(COMMAND "${CMAKE_COMMAND}" --build . --target InstallLLVMSpirvTranslator)
+    ]])
 
     add_dependencies(llvm-to-spirv LLVMSpirvTranslator)
     target_compile_definitions(llvm-to-spirv PRIVATE


### PR DESCRIPTION
This changes the `LLVMSpirvTranslator` install step from a quoted `install(CODE "...")` string to a bracketed `install(CODE [[ ... ]])` block.

In my testing on Windows, the original quoted form did not install `llvm-spirv.exe`, while the bracketed form does.

I think that the bracketed form should work just fine on Linux, so we don't need to add `WIN32` guard.