### PR TITLE
Fix narrowing conversion in __acpp_rootn (host and hiplike backends)

### DIFF
--- a/include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp
@@ -201,7 +201,7 @@ HIPSYCL_DEFINE_HIPLIKE_MATH_BUILTIN(__acpp_rint, rintf, rint)
 
 template<class T>
 HIPSYCL_HIPLIKE_BUILTIN T __acpp_rootn(T x, int y) noexcept {
-  return hiplike_builtins::__acpp_pow(x, T{1}/T{y});
+  return hiplike_builtins::__acpp_pow(x, T{1}/static_cast<T>(y));
 }
 
 HIPSYCL_DEFINE_HIPLIKE_MATH_BUILTIN(__acpp_round, roundf, round)

--- a/include/hipSYCL/sycl/libkernel/host/builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/host/builtins.hpp
@@ -306,7 +306,7 @@ HIPSYCL_BUILTIN T __acpp_rint(T x) noexcept {
 
 template<class T>
 HIPSYCL_BUILTIN T __acpp_rootn(T x, int y) noexcept {
-  return std::pow(x, T{1}/T{y});
+  return std::pow(x, T{1}/static_cast<T>(y));
 }
 
 template<class T>

--- a/tests/sycl/math.cpp
+++ b/tests/sycl/math.cpp
@@ -966,9 +966,16 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(math_rootn, T, math_test_genfloats) {
     auto outputs = out.get_host_access();
 
     for(int c = 0; c < std::max(D,1); ++c) {
+      // Reference is computed in double so the comparison happens at double
+      // precision. boost::unit_test::tolerance is type-keyed: tolerance(0.0001)
+      // registers a tolerance for `double` only, so a `float == float`
+      // comparison falls back to exact equality and any backend that returns
+      // a result differing by even one ULP from std::pow would fail. This
+      // matches the existing math_genfloat_genint pattern (line 906) and the
+      // DEFINE_*_MATH_TEST macros below.
       BOOST_TEST(comp(outputs[0], c) ==
-                 std::pow(comp(base_inputs[0], c),
-                          DT{1} / static_cast<DT>(comp(exp_inputs[0], c))));
+                 std::pow(static_cast<double>(comp(base_inputs[0], c)),
+                          1.0 / static_cast<double>(comp(exp_inputs[0], c))));
     }
   }
 }

--- a/tests/sycl/math.cpp
+++ b/tests/sycl/math.cpp
@@ -907,6 +907,72 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(math_genfloat_genint, T,
   }
 }
 
+// Focused test for rootn: positive bases with integer roots so the expected
+// results are exactly representable and visually verifiable (8^(1/3)=2,
+// 81^(1/4)=3, 125^(1/3)=5, 100^(1/2)=10, ...). Separate from
+// math_genfloat_genint so a rootn regression is immediately identifiable.
+BOOST_TEST_DECORATOR(*boost::unit_test::tolerance(0.0001))
+BOOST_AUTO_TEST_CASE_TEMPLATE(math_rootn, T, math_test_genfloats) {
+
+  constexpr int D = vector_length_v<T>;
+  using DT = vector_elem_t<T>;
+
+  namespace s = sycl;
+
+  using IntType = s::detail::builtin_input_intlike_t<T>;
+
+  s::queue queue;
+  if constexpr(std::is_same_v<DT, double>) {
+    if (!queue.get_device().has(sycl::aspect::fp64)) {
+      BOOST_TEST_MESSAGE("Skipping test for double since device has no fp64 support");
+      return;
+    }
+  }
+
+  // build inputs and allocate outputs
+
+  s::buffer<T> base_in{{1}};
+  s::buffer<IntType> exp_in{{1}};
+  s::buffer<T> out{{1}};
+  {
+    auto base_inputs = base_in.get_host_access();
+    auto exp_inputs = exp_in.get_host_access();
+    auto outputs = out.get_host_access();
+    s::vec<DT, 16> v1{8.0, 16.0, 27.0, 32.0, 81.0, 64.0, 125.0, 100.0,
+                      8.0, 16.0, 27.0, 32.0, 81.0, 64.0, 125.0, 100.0};
+    s::vec<int, 16> v2{3, 4, 3, 5, 4, 6, 3, 2,
+                       3, 4, 3, 5, 4, 6, 3, 2};
+    base_inputs[0] = get_math_input<DT, D>(v1);
+    exp_inputs[0] = get_math_input<int, D>(v2);
+    outputs[0] = T{DT{0}};
+  }
+
+  // run rootn
+
+  queue.submit([&](s::handler &cgh) {
+    auto base_inputs = base_in.template get_access<s::access::mode::read>(cgh);
+    auto exp_inputs = exp_in.template get_access<s::access::mode::read>(cgh);
+    auto outputs = out.template get_access<s::access::mode::write>(cgh);
+    cgh.single_task<kernel_name<class math_rootn, D, DT>>([=]() {
+      outputs[0] = s::rootn(base_inputs[0], exp_inputs[0]);
+    });
+  });
+
+  // check results
+
+  {
+    auto base_inputs = base_in.get_host_access();
+    auto exp_inputs = exp_in.get_host_access();
+    auto outputs = out.get_host_access();
+
+    for(int c = 0; c < std::max(D,1); ++c) {
+      BOOST_TEST(comp(outputs[0], c) ==
+                 std::pow(comp(base_inputs[0], c),
+                          DT{1} / static_cast<DT>(comp(exp_inputs[0], c))));
+    }
+  }
+}
+
 #define SKIP_IF_NO_FP64(queue, DT)                                              \
   if constexpr(std::is_same_v<DT, double>) {                                    \
     if (!(queue).get_device().has(sycl::aspect::fp64)) {                        \


### PR DESCRIPTION
Fixes #2032.

## Changes

- **`include/hipSYCL/sycl/libkernel/host/builtins.hpp`**: replace `T{y}`
  with `static_cast<T>(y)` in `__acpp_rootn`, keeping `T{1}` for the
  literal as you suggested.
- **`include/hipSYCL/sycl/libkernel/generic/hiplike/builtins.hpp`**:
  identical fix — the hiplike backend has the same construct. Although
  the narrowing diagnostic may not fire on the nvcc/hipcc paths, fixing
  both keeps the two backends consistent. Happy to drop this hunk if
  you'd rather leave the hiplike backend alone.
- **`tests/sycl/math.cpp`**: new `math_rootn` test case, inserted right
  after `math_genfloat_genint`. I noticed `rootn` is already touched
  indirectly from `math_genfloat_genint` (line 889 on develop), but a
  dedicated test makes regressions easier to diagnose, and the inputs
  are picked so that the expected results (2, 3, 5, 10, …) are visually
  checkable.

## Verification

Compiled the minimal reproducer from #2032 against this branch:

```console
$ clang++ --target=x86_64-pc-windows-msvc -c -std=c++17 \
    -I include issue2_rootn_narrowing.cpp
$ echo $?
0
```

Pre-fix, the same command on `origin/develop` fails with
`error: non-constant-expression cannot be narrowed from type 'int' to 'float'`
as described in the issue.

## Small observation (not blocking)

While preparing this, I noticed that the existing `math_genfloat_genint`
test already invokes `s::rootn` at line 889, yet the narrowing diagnostic
evidently slipped through. I couldn't determine from
`.github/workflows/windows-acppllvm.yml` why the Windows CI matrix
doesn't trip it on this existing call. Flagging in case it points to
something worth tightening elsewhere — no change from me, just an
observation.
