### PR TITLE
Use _WIN32 and lowercase <windows.h> in omp_queue.cpp

### DIFF
--- a/src/runtime/omp/omp_queue.cpp
+++ b/src/runtime/omp/omp_queue.cpp
@@ -34,16 +34,16 @@
 #include "hipSYCL/runtime/adaptivity_engine.hpp"
 #include "hipSYCL/runtime/omp/omp_code_object.hpp"
 
-#ifndef WIN32 // MSVC might not have #warning?
+#ifndef _WIN32 // MSVC might not have #warning?
 #ifndef _OPENMP
 #warning Building omp backend with JIT support, but OpenMP parallelization is not available - kernels will run sequentially! This points to an issue in the build system.
 #endif
 #endif
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #else
-#include <Windows.h>
+#include <windows.h>
 #endif
 #endif
 
@@ -184,7 +184,7 @@ private:
 #ifdef HIPSYCL_WITH_SSCP_COMPILER
 
 std::size_t get_page_size() {
-#ifndef WIN32
+#ifndef _WIN32
   return static_cast<std::size_t>(sysconf(_SC_PAGESIZE));
 #else
   SYSTEM_INFO si;


### PR DESCRIPTION
Fixes #2031.

## Changes

Replace `WIN32` (no underscore, not a predefined compiler macro) with the
official `_WIN32` throughout `src/runtime/omp/omp_queue.cpp`, and switch
`<Windows.h>` to lowercase `<windows.h>` so case-sensitive filesystems
find the header.

Four edits in one file:

- Line 37: `#ifndef WIN32` → `#ifndef _WIN32` (the JIT/OpenMP `#warning` guard)
- Line 43: `#ifndef WIN32` → `#ifndef _WIN32` (the `<unistd.h>` vs `<windows.h>` guard)
- Line 46: `#include <Windows.h>` → `#include <windows.h>`
- Line 187: `#ifndef WIN32` → `#ifndef _WIN32` (inside `get_page_size()`)

## Verification

**Pre-fix** (clean `origin/develop` @ `21a8df24`), the minimal pattern
reproducer from #2031 fails as expected:

```console
$ clang++ --target=x86_64-pc-windows-msvc -c -std=c++17 test.cpp
test.cpp:2:10: fatal error: 'unistd.h' file not found
    2 | #include <unistd.h>
      |          ^~~~~~~~~~
1 error generated.
```

**Post-fix**, compiling the actual patched `omp_queue.cpp` with the
CMake-equivalent compile flags succeeds with zero errors:

```console
$ clang++ --target=x86_64-pc-windows-msvc -c -std=c++17 \
    -DHIPSYCL_WITH_SSCP_COMPILER -DHIPSYCL_DEBUG_LEVEL=1 \
    -DNOMINMAX -DWIN32_LEAN_AND_MEAN -D_USE_MATH_DEFINES \
    -I include -I src/runtime -I boost/include \
    src/runtime/omp/omp_queue.cpp
$ echo $?
0
```

## Not in scope

- Investigating why the Windows CI path doesn't trip this with the
  current `WIN32` check. You mentioned in the issue that you don't know
  either. Not something I'd want to expand the scope of this PR to
  chase — flagging it as an open question you may want to look into
  independently.
- Auditing other source files for the same `WIN32` vs `_WIN32` pattern.
  A quick `grep -rn 'ifn\?def WIN32' src/` suggests `omp_queue.cpp` is
  the only offender on `develop`, but I haven't verified exhaustively.
  Happy to extend the PR if you find more.
