### PR TITLE
fix: replace removed __amdgcn_get_dynamicgroupbaseptr with extern __shared__ for HIP dynamic LDS

### DIFF
--- a/include/hipSYCL/sycl/libkernel/detail/local_memory_allocator.hpp
+++ b/include/hipSYCL/sycl/libkernel/detail/local_memory_allocator.hpp
@@ -163,18 +163,11 @@ private:
 
 ACPP_KERNEL_TARGET
 inline void* hiplike_dynamic_local_memory() {
-  __acpp_if_target_cuda(
+  __acpp_if_target_hiplike(
     extern __shared__ int local_mem [];
     return static_cast<void*>(local_mem);
   );
-  __acpp_if_target_hip(
-    // __amdgcn_get_dynamicgroupbaseptr is an AMDGPU clang compiler builtin that is no
-    // longer available in newer ROCm/LLVM versions. Use extern __shared__ instead,
-    // which is the standard portable way to obtain the dynamic LDS base in HIP and CUDA.
-    extern __shared__ char _acpp_lds_base[];
-    return static_cast<void*>(_acpp_lds_base);
-  );
-  
+
   return nullptr;
 }
 

--- a/include/hipSYCL/sycl/libkernel/detail/local_memory_allocator.hpp
+++ b/include/hipSYCL/sycl/libkernel/detail/local_memory_allocator.hpp
@@ -168,7 +168,11 @@ inline void* hiplike_dynamic_local_memory() {
     return static_cast<void*>(local_mem);
   );
   __acpp_if_target_hip(
-    return __amdgcn_get_dynamicgroupbaseptr();
+    // __amdgcn_get_dynamicgroupbaseptr is an AMDGPU clang compiler builtin that is no
+    // longer available in newer ROCm/LLVM versions. Use extern __shared__ instead,
+    // which is the standard portable way to obtain the dynamic LDS base in HIP and CUDA.
+    extern __shared__ char _acpp_lds_base[];
+    return static_cast<void*>(_acpp_lds_base);
   );
   
   return nullptr;


### PR DESCRIPTION
## Problem
`__amdgcn_get_dynamicgroupbaseptr()` is an AMDGPU clang compiler builtin used to
obtain the dynamic LDS (local data store) base pointer in HIP device code. It is no
longer available in newer ROCm/LLVM versions, causing a build failure when targeting
HIP:

```bash
error: use of undeclared identifier '__amdgcn_get_dynamicgroupbaseptr'
return __amdgcn_get_dynamicgroupbaseptr();
```

## Fix
Replace with `extern __shared__ char[]`, which is the standard portable way to obtain
the dynamic shared memory base pointer in both HIP and CUDA. This is semantically
equivalent and already used in the CUDA path of the same function directly above.
The replacement is backwards-compatible with older ROCm versions.

## Testing
Tested by building AdaptiveCpp (develop branch) against ROCm 7.13.0 nightly
(TheRock prebuilt artifacts) targeting gfx90a (MI210), and subsequently building
GROMACS v2025.4 against it. The HIP target compiles and the SYCL compiler test in
the GROMACS cmake configuration passes successfully with additional unrelated fixes:

- AdaptiveCpp: Passes/PassPlugin.h include path
- llc not in TheRock artifacts, pass -DACPP_LLC_PATH to ROCm 7.2.0 location