### PR TITLE
fix: update PassPlugin.h include path for LLVM 23+

### DIFF
--- a/src/compiler/AdaptiveCppLlvmPasses.cpp
+++ b/src/compiler/AdaptiveCppLlvmPasses.cpp
@@ -39,7 +39,11 @@
 
 #include "llvm/Pass.h"
 #include "llvm/Passes/PassBuilder.h"
+#if LLVM_VERSION_MAJOR >= 23
+#include "llvm/Plugins/PassPlugin.h"
+#else
 #include "llvm/Passes/PassPlugin.h"
+#endif
 #include "llvm/Support/CommandLine.h"
 
 #if LLVM_VERSION_MAJOR < 16


### PR DESCRIPTION
## Problem

In LLVM 23, `PassPlugin.h` was moved from `llvm/Passes/` to a new dedicated
`llvm/Plugins/` library as part of a dependency restructure
(llvm/llvm-project@f54df0d09e19ec6b205cb0af45c7ecea2fd8aeff). This causes a
build failure when compiling against LLVM 23+:

```bash
fatal error: 'llvm/Passes/PassPlugin.h' file not found
#include "llvm/Passes/PassPlugin.h"
```

## Fix

Add a version guard to select the correct include path depending on the LLVM version:

```cpp
#if LLVM_VERSION_MAJOR >= 23
#include "llvm/Plugins/PassPlugin.h"
#else
#include "llvm/Passes/PassPlugin.h"
#endif
```

## Testing
Tested by building AdaptiveCpp (develop branch) against ROCm 7.13.0 nightly
(TheRock prebuilt artifacts, LLVM 23.0.0git) targeting gfx90a (MI210), and
subsequently building GROMACS v2025.4 against it. The build completes successfully