### PR TITLE
[Metal] Move local memory ptr/size to global vars

### DIFF
--- a/src/compiler/llvm-to-backend/metal/Emitter.cpp
+++ b/src/compiler/llvm-to-backend/metal/Emitter.cpp
@@ -219,6 +219,9 @@ uint3 __acpp_sscp_metal_num_groups [[threadgroups_per_grid]];
 uint3 __acpp_sscp_metal_local_id [[thread_position_in_threadgroup]];
 uint3 __acpp_sscp_metal_local_size [[threads_per_threadgroup]];
 
+threadgroup void * constant __acpp_sscp_metal_dynamic_local_memory [[threadgroup(0)]];
+constant uint& constant __acpp_sscp_metal_dynamic_local_memory_size [[buffer(0)]];
+
 )__";
 
   emitTypes();
@@ -499,7 +502,6 @@ bool MetalEmitter::emitArgStruct(Function& F) {
 
 bool MetalEmitter::emitSignature(Function& F) {
   bool isKernel = kernelNames.count(F.getName().str()) > 0;
-  bool needDlm = needsDynamicLocalMemory.count(&F) > 0;
 
   bool useArgStruct = isKernel && F.arg_size() > opt.maxArgsForFlatMode;
   if (isKernel) {
@@ -510,7 +512,7 @@ bool MetalEmitter::emitSignature(Function& F) {
   os << returnType << " " << F.getName().str() << " (";
 
   bool first = true;
-  int bufIdx = 0;
+  int bufIdx = 1; // index=0 is reserved for dynamic local memory size if needed, so start from 1
   if (useArgStruct) {
     first = false;
     os << "device " << inputStructName << "& __args [[buffer(" << bufIdx++ << ")]]";
@@ -530,20 +532,6 @@ bool MetalEmitter::emitSignature(Function& F) {
       } else {
         os << typeName << " " << valueName(&A);
       }
-    }
-  }
-
-  if (needDlm) {
-    if (!first) {
-      os << ", ";
-    }
-
-    if (isKernel) {
-      os << "threadgroup void* __acpp_sscp_metal_dynamic_local_memory [[threadgroup(0)]], ";
-      os << "constant uint& __acpp_sscp_metal_dynamic_local_memory_size [[buffer(" << bufIdx++ << ")]]";
-    } else {
-      os << "threadgroup void* __acpp_sscp_metal_dynamic_local_memory, ";
-      os << "uint __acpp_sscp_metal_dynamic_local_memory_size";
     }
   }
 
@@ -1265,13 +1253,6 @@ bool MetalEmitter::emitCallInstruction(const CallInst* CI, const std::string& na
     }
     callExpr += emitExpr(CI->getArgOperand(i));
   }
-  if (needsDynamicLocalMemory.count(callee)) {
-    if (argsSize > 0) {
-      callExpr += ", ";
-    }
-    callExpr += "__acpp_sscp_metal_dynamic_local_memory, ";
-    callExpr += "__acpp_sscp_metal_dynamic_local_memory_size";
-  }
   callExpr += ")";
 
   if (!CI->getType()->isVoidTy()) {
@@ -1598,8 +1579,6 @@ unsigned MetalEmitter::getPhysicalPointerAddressSpace(const Value* V) {
 }
 
 void MetalEmitter::analyzeCallInsts() {
-  std::unordered_map<const Function*, std::vector<const Function*>> calls;
-
   for (auto& F : M) {
     if (F.isDeclaration()) {
       continue;
@@ -1621,30 +1600,6 @@ void MetalEmitter::analyzeCallInsts() {
         mapType(returnType);
         for (auto& Arg : Callee->args()) {
           mapType(Arg.getType());
-        }
-        const StringRef calleeName = Callee->getName();
-        if (calleeName == "__acpp_sscp_metal_symbol_local_memory" || calleeName == "__acpp_sscp_metal_symbol_local_memory_size") {
-          needsDynamicLocalMemory.insert(&F);
-        } else if (!Callee->isDeclaration()) {
-          calls[&F].push_back(Callee);
-        }
-      }
-    }
-  }
-
-  // transitive closure, TODO: union-find
-  bool changed = true;
-  while (changed) {
-    changed = false;
-    for (auto& [F, callees] : calls) {
-      if (needsDynamicLocalMemory.count(F)) {
-        continue;
-      }
-      for (auto* Callee : callees) {
-        if (needsDynamicLocalMemory.count(Callee)) {
-          needsDynamicLocalMemory.insert(F);
-          changed = true;
-          break;
         }
       }
     }

--- a/src/compiler/llvm-to-backend/metal/Emitter.hpp
+++ b/src/compiler/llvm-to-backend/metal/Emitter.hpp
@@ -108,7 +108,6 @@ private:
   //
   std::unordered_map<const llvm::Value*, unsigned> inferredPtrAS;
 
-  std::unordered_set<const llvm::Function*> needsDynamicLocalMemory;
   int inputStructCounter = 0;
   std::string inputStructName;
 

--- a/src/runtime/metal/metal_queue.cpp
+++ b/src/runtime/metal/metal_queue.cpp
@@ -45,17 +45,19 @@ void encode_arguments(
   void** args,
   std::size_t* arg_sizes,
   std::size_t num_args,
-  const std::vector<int>& is_pointer_arg
+  const std::vector<int>& is_pointer_arg,
+  NS::UInteger buf_offset = 0
 ) {
   for (std::size_t i = 0; i < num_args; ++i) {
+    NS::UInteger buf_idx = i + buf_offset;
     if (is_pointer_arg[i]) {
       void* usm_ptr = *(void**)args[i];
       auto [buffer, offset, _] = allocator->get_usm_block(usm_ptr);
       if (buffer) {
-        encoder->setBuffer(buffer, offset, i);
+        encoder->setBuffer(buffer, offset, buf_idx);
       }
     } else {
-      encoder->setBytes(args[i], arg_sizes[i], i);
+      encoder->setBytes(args[i], arg_sizes[i], buf_idx);
     }
   }
 }
@@ -69,9 +71,10 @@ void encode_arguments_argbuffer(
   std::size_t* arg_sizes,
   std::size_t num_args,
   const std::vector<int>& is_pointer_arg,
-  std::vector<NS::SharedPtr<MTL::Buffer>>& buffers_out
+  std::vector<NS::SharedPtr<MTL::Buffer>>& buffers_out,
+  NS::UInteger buf_offset = 0
 ) {
-  NS::SharedPtr<MTL::ArgumentEncoder> arg_enc = NS::TransferPtr(function->newArgumentEncoder(0));
+  NS::SharedPtr<MTL::ArgumentEncoder> arg_enc = NS::TransferPtr(function->newArgumentEncoder(buf_offset));
 
   const size_t arg_len = arg_enc->encodedLength();
   auto arg_buffer_out = buffers_out.emplace_back(NS::TransferPtr(device->newBuffer(arg_len, MTL::ResourceStorageModeShared)));
@@ -92,7 +95,7 @@ void encode_arguments_argbuffer(
     }
   }
 
-  encoder->setBuffer(arg_buffer_out.get(), 0, 0);
+  encoder->setBuffer(arg_buffer_out.get(), 0, buf_offset);
 }
 
 result launch_kernel_from_library(
@@ -118,6 +121,7 @@ result launch_kernel_from_library(
   auto entry = std::string(kernel_name);
   // Get the kernel function from library
   NS::String* function_name = NS::String::string(entry.c_str(), NS::UTF8StringEncoding);
+
   NS::SharedPtr<MTL::Function> function = NS::TransferPtr(library->newFunction(function_name));
 
   if (!function) {
@@ -159,7 +163,8 @@ result launch_kernel_from_library(
   }
 
   encoder->setComputePipelineState(pipeline_state.get());
-  auto user_local_mem_size = local_mem_size;
+  uint32_t user_local_mem_size = local_mem_size;
+
   auto threads_per_group = group_size[0] * group_size[1] * group_size[2];
   // Allocate scratch for workgroup algorithms (reduction, scan, shuffle).
   // Different algorithms have different scratch requirements:
@@ -170,20 +175,19 @@ result launch_kernel_from_library(
   // TODO: inspect kernel_info to determine which algorithms are actually used and only allocate
   // as much scratch as needed (e.g. reduction-only kernels need far less than local_size * 8 bytes).
   auto additional_local_mem = threads_per_group * sizeof(uint64_t);
-
   local_mem_size = user_local_mem_size + additional_local_mem;
-  if (local_mem_size != 0) {
-    encoder->setThreadgroupMemoryLength(align_up(local_mem_size, 16), 0);
-  }
 
+  encoder->setThreadgroupMemoryLength(align_up(local_mem_size, 16), 0);
+
+  const NS::UInteger buf_offset = 1; // buffer(0) is reserved for dynamic local memory size, so start from 1
+  encoder->setBytes(&user_local_mem_size, sizeof(uint32_t), 0);
   std::vector<NS::SharedPtr<MTL::Buffer>> buffers_out;
   if (!arg_buffer_used) {
-    encode_arguments(encoder, device, allocator, args, arg_sizes, num_args, is_pointer_arg);
+    encode_arguments(encoder, device, allocator, args, arg_sizes, num_args, is_pointer_arg, buf_offset);
   } else {
     encode_arguments_argbuffer(
-      encoder, device, allocator, function.get(), args, arg_sizes, num_args, is_pointer_arg, buffers_out);
+      encoder, device, allocator, function.get(), args, arg_sizes, num_args, is_pointer_arg, buffers_out, buf_offset);
   }
-  encoder->setBytes(&user_local_mem_size, sizeof(uint32_t), arg_buffer_used ? 1 : num_args);
 
   MTL::Size num_groups_size = MTL::Size::Make(
     num_groups[0],


### PR DESCRIPTION
Small refactoring to simplify the Metal pipeline and prepare for upcoming address translation support needed for indirection structures. The address translation parameters will also be passed via globals, so moving these values to globals now helps keep the pipeline and calling convention simpler