### PR TITLE
Remove wchar_size module flag during target separation

### DIFF
--- a/src/compiler/sscp/TargetSeparationPass.cpp
+++ b/src/compiler/sscp/TargetSeparationPass.cpp
@@ -216,6 +216,24 @@ void replaceInvalidMSABICharsInSymbolNames(llvm::Module &M) {
 }
 #endif
 
+void removeModuleFlag(llvm::Module& M, llvm::StringRef Name) {
+  llvm::SmallVector<llvm::Module::ModuleFlagEntry, 8> Flags;
+  M.getModuleFlagsMetadata(Flags);
+
+  if(Flags.empty())
+    return;
+
+  if(auto* NMD = M.getNamedMetadata("llvm.module.flags"))
+    M.eraseNamedMetadata(NMD);
+
+  for(const auto& Flag : Flags) {
+    if(Flag.Key->getString() == Name)
+      continue;
+
+    M.addModuleFlag(Flag.Behavior, Flag.Key->getString(), Flag.Val);
+  }
+}
+
 std::unique_ptr<llvm::Module> generateDeviceIR(llvm::Module &M,
                                                const std::vector<std::string>& DynamicFunctions,
                                                std::vector<KernelInfo> &KernelInfoOutput,
@@ -274,6 +292,9 @@ std::unique_ptr<llvm::Module> generateDeviceIR(llvm::Module &M,
   StringAttrsToRemove.push_back("target-cpu");
   StringAttrsToRemove.push_back("target-features");
   StringAttrsToRemove.push_back("tune-cpu");
+  
+  // Remove host-specific module flags that should not leak into generic device IR
+  removeModuleFlag(*DeviceModule, "wchar_size");  
 
   llvm::SmallSet<llvm::Function *, 16> AcppNoInlineFunctions;
   utils::findFunctionsWithStringAnnotations(


### PR DESCRIPTION
This removes the `wchar_size` module flag from device module during SSCP target separation.

As device IR is derived from host IR, it may inherit host-specific module flags. On Windows, this causes a later conflict involving `wchar_size` during IR->SPIR-V JIT compilation.

This implementation follows the earlier suggestion that host-specific flags likely should be erased. (https://github.com/AdaptiveCpp/AdaptiveCpp/discussions/2014)

This change is intentionally generic and is not guarded by `_WIN32` or `_MSC_VER`, since this appears to be a wider target-separation issue: host-specific module flags should not be preserved and should not leak into generic device IR.

Tested on Windows with OpenCL backend, where this resolves the conflict on my side.

If preferred, I can instead switch this to the backend-side workaround (in `LLVMToSpirv.cpp`) discussed earlier.