### PR TITLE
Implement rounding_mode in sycl::vec::convert

### DIFF
--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -339,7 +339,7 @@ public:
     vec<ConvertT, N> result;
 
     for(int i = 0; i < N; ++i) {
-// TODO handle float to float conversion. Here only float to short rounding is implemented
+// TODO handle float to float conversion. Here only float to integer rounding is implemented
       if constexpr (std::is_floating_point_v<T> &&
                        std::is_integral_v<ConvertT>) {
         if constexpr (RM == rounding_mode::rte || RM == rounding_mode::automatic) {

--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -339,8 +339,22 @@ public:
     vec<ConvertT, N> result;
 
     for(int i = 0; i < N; ++i) {
-      // TODO: Take rounding mode into account
-      result[i] = static_cast<ConvertT>(_data[i]);
+      if constexpr (std::is_floating_point_v<T> &&
+                       std::is_integral_v<ConvertT>) {
+        if constexpr (RM == rounding_mode::rte || RM == rounding_mode::automatic) {
+          result[i] = static_cast<ConvertT>(sycl::rint(_data[i]));          
+        } else if constexpr (RM == rounding_mode::rtz) {
+          result[i] = static_cast<ConvertT>(sycl::trunc(_data[i]));
+        } else if constexpr (RM == rounding_mode::rtp) {
+          result[i] = static_cast<ConvertT>(sycl::ceil(_data[i]));
+        } else if constexpr (RM == rounding_mode::rtn) {
+          result[i] = static_cast<ConvertT>(sycl::floor(_data[i]));
+        } else {
+          result[i] = static_cast<ConvertT>(_data[i]);
+        }
+      } else {
+        result[i] = static_cast<ConvertT>(_data[i]);
+      }
     }
 
     return result;

--- a/include/hipSYCL/sycl/libkernel/vec.hpp
+++ b/include/hipSYCL/sycl/libkernel/vec.hpp
@@ -339,6 +339,7 @@ public:
     vec<ConvertT, N> result;
 
     for(int i = 0; i < N; ++i) {
+// TODO handle float to float conversion. Here only float to short rounding is implemented
       if constexpr (std::is_floating_point_v<T> &&
                        std::is_integral_v<ConvertT>) {
         if constexpr (RM == rounding_mode::rte || RM == rounding_mode::automatic) {


### PR DESCRIPTION
Was marked as TODO
I made a very simple implementation.
At least it's better than silently ignoring the rounding parameter. Which can make users think that it's working fine but it's always doing a static cast.

Intel does a much more involved job:
https://github.com/intel/llvm/blob/sycl/sycl/include/sycl/detail/vector_convert.hpp

calling SPIRV and NVIDIA builtins but I think that's a more complicated story.