### PR TITLE
[Metal] Introduce metal_mmap_region for USM allocations

### DIFF
--- a/include/hipSYCL/runtime/metal/metal_allocator.hpp
+++ b/include/hipSYCL/runtime/metal/metal_allocator.hpp
@@ -26,6 +26,12 @@ class Buffer;
 namespace hipsycl {
 namespace rt {
 
+struct metal_mmap_region;
+
+// Metal USM allocator. Reserves a large VA range via mmap and wraps sub-regions
+// with newBuffer(ptr,...) so that all shared/host buffers satisfy:
+//   buffer->gpuAddress() - (uintptr_t)buffer->contents() == _delta (constant).
+// _delta is used for pointer translation between CPU and GPU address spaces.
 class metal_allocator : public backend_allocator
 {
 public:
@@ -63,16 +69,21 @@ public:
   // Returns the Metal buffer and offset for a given USM pointer
   std::tuple<MTL::Buffer*, size_t, usm_alloc_type> get_usm_block(const void* ptr) const;
 private:
+  MTL::Buffer* alloc_buffer(size_t size_bytes);
+  void calibrate();
+
   MTL::Device* _device = nullptr;
   device_id _device_id;
+  const size_t _page_size;
+  size_t _delta;
 
   struct usm_block {
     MTL::Buffer* buffer;
-    size_t size;
     usm_alloc_type alloc_type;
   };
   std::map<void*, usm_block> _ptr_to_block;
   mutable std::mutex _mutex;
+  std::unique_ptr<metal_mmap_region> _mmap_region;
 };
 
 

--- a/src/runtime/metal/metal_allocator.cpp
+++ b/src/runtime/metal/metal_allocator.cpp
@@ -12,15 +12,190 @@
 #include "hipSYCL/runtime/metal/metal_allocator.hpp"
 
 #include <Metal/Metal.hpp>
+#include <sys/mman.h>
+#include <sys/sysctl.h>
+#include <unistd.h>
+
+#include <iostream>
 
 namespace hipsycl {
 namespace rt {
 
-metal_allocator::metal_allocator(MTL::Device* device, const device_id &id)
-  : _device{device}, _device_id{id}
-{}
+namespace {
+  uintptr_t align_up(uintptr_t v, size_t align) {
+    return (v + align - 1) & ~(uintptr_t)(align - 1);
+  }
 
-metal_allocator::~metal_allocator() = default;
+  size_t get_total_ram() {
+    uint64_t mem = 0;
+    std::size_t len = sizeof(mem);
+    if (sysctlbyname("hw.memsize", &mem, &len, nullptr, 0) == 0)
+      return static_cast<std::size_t>(mem);
+    return 8ULL << 30; // fallback: 8 GiB
+  }
+
+  // Metal allocates MTL::Buffer storage in page_size units and always appends
+  // one extra gap page after the user data.  The total page count must be even,
+  // so we round up (sz + 1 gap page) to the next multiple of 2 pages.
+  size_t metal_gpu_stride(size_t sz, size_t page_size) {
+    const size_t two_pages = 2 * page_size;
+    return (sz + page_size + two_pages - 1) & ~(two_pages - 1);
+  }
+}
+
+static constexpr double mmap_region_size_fraction = 10.0;
+
+struct metal_mmap_region {
+  metal_mmap_region(size_t capacity, size_t alignment)
+    : _mmap_size(capacity), _capacity(capacity), _alignment(alignment)
+  {
+    void* ptr = mmap(nullptr, capacity, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    if (ptr == MAP_FAILED) {
+      throw std::runtime_error("metal_mmap_region: mmap failed");
+    }
+
+    _base = static_cast<char*>(ptr);
+    auto current = reinterpret_cast<char*>(align_up(reinterpret_cast<uintptr_t>(_base), _alignment));
+    capacity = capacity - (current - _base);
+    _midpoint = reinterpret_cast<char*>(align_up(reinterpret_cast<uintptr_t>(current + capacity / 2), _alignment));
+
+    madvise(current, _capacity, MADV_FREE_REUSABLE);
+    _free_blocks.emplace(current, _capacity);
+  }
+
+  ~metal_mmap_region() {
+    if (_base) {
+      munmap(_base, _mmap_size);
+    }
+  }
+
+  void* midpoint() {
+    return static_cast<void*>(_midpoint);
+  }
+
+  void* alloc(size_t size) {
+    if (size == 0) {
+      return nullptr;
+    }
+    size = align_up(size, _alignment);
+
+    std::lock_guard<std::mutex> lock{_mutex};
+
+    for (auto it = _free_blocks.begin(); it != _free_blocks.end(); ++it) {
+      if (it->second >= size) {
+        void* ptr = it->first;
+        size_t remaining = it->second - size;
+        _free_blocks.erase(it);
+        if (remaining > 0) {
+          _free_blocks.emplace(static_cast<char*>(ptr) + size, remaining);
+        }
+        madvise(ptr, size, MADV_FREE_REUSE);
+        return ptr;
+      }
+    }
+
+    return nullptr;
+  }
+
+  void* alloc_at(void* addr, size_t size) {
+    if (addr == nullptr) {
+      return alloc(size);
+    }
+    if (size == 0) {
+      return nullptr;
+    }
+    size = align_up(size, _alignment);
+
+    std::lock_guard<std::mutex> lock{_mutex};
+
+    uintptr_t aligned_addr = align_up(reinterpret_cast<uintptr_t>(addr), _alignment);
+    if (aligned_addr != reinterpret_cast<uintptr_t>(addr)) {
+      return nullptr;
+    }
+
+    auto it = _free_blocks.upper_bound(addr);
+    if (it == _free_blocks.begin()) {
+      return nullptr;
+    }
+    --it;
+    char* ptr = static_cast<char*>(it->first);
+    if (ptr + it->second <= static_cast<char*>(addr)) {
+      // addr is after the end of the free block
+      return nullptr;
+    }
+    if (static_cast<char*>(addr) + size > ptr + it->second) {
+      // addr + size exceeds the end of the free block
+      return nullptr;
+    }
+    size_t remaining = (ptr + it->second) - (static_cast<char*>(addr) + size);
+    _free_blocks.erase(it);
+    if (remaining > 0) {
+      madvise(static_cast<char*>(addr) + size, remaining, MADV_FREE_REUSABLE);
+      _free_blocks.emplace(static_cast<char*>(addr) + size, remaining);
+    }
+    if (ptr < static_cast<char*>(addr)) {
+      madvise(ptr, static_cast<char*>(addr) - ptr, MADV_FREE_REUSABLE);
+      _free_blocks.emplace(ptr, static_cast<char*>(addr) - ptr);
+    }
+    madvise(addr, size, MADV_FREE_REUSE);
+    return addr;
+  }
+
+  void free(void* ptr, size_t size) {
+    if (!ptr || size == 0) {
+      return;
+    }
+
+    void* end = static_cast<char*>(ptr) + size;
+
+    std::lock_guard<std::mutex> lock{_mutex};
+
+    madvise(ptr, size, MADV_FREE_REUSABLE);
+    auto [it, _] = _free_blocks.emplace(ptr, size);
+
+    auto next = std::next(it);
+    if (next != _free_blocks.end() && next->first == end) {
+      it->second += next->second;
+      _free_blocks.erase(next);
+    }
+
+    if (it != _free_blocks.begin()) {
+      auto prev = std::prev(it);
+      if (static_cast<char*>(prev->first) + prev->second == it->first) {
+        prev->second += it->second;
+        _free_blocks.erase(it);
+      }
+    }
+  }
+
+  char* _base;
+  char* _midpoint;
+  size_t _mmap_size;
+  size_t _capacity;
+  size_t _alignment;
+
+  std::mutex _mutex;
+  std::map<void*, size_t> _free_blocks;
+};
+
+metal_allocator::metal_allocator(MTL::Device* device, const device_id &id)
+  : _device{device}
+  , _device_id{id}
+  , _page_size{static_cast<size_t>(getpagesize())}
+  , _delta{(size_t)-1}
+  , _mmap_region(std::make_unique<metal_mmap_region>(
+      static_cast<size_t>(get_total_ram() * mmap_region_size_fraction), _page_size))
+{
+  calibrate();
+}
+
+metal_allocator::~metal_allocator() {
+  for (auto& [ptr, block] : _ptr_to_block) {
+    if (block.buffer) {
+      block.buffer->release();
+    }
+  }
+}
 
 void* metal_allocator::raw_allocate(
   size_t min_alignment, size_t size_bytes,
@@ -31,7 +206,6 @@ void* metal_allocator::raw_allocate(
   void* gpu_ptr = reinterpret_cast<void*>(buffer->gpuAddress());
   auto block = usm_block{
     .buffer = buffer,
-    .size = size_bytes,
     .alloc_type = usm_alloc_type::device
   };
   std::lock_guard<std::mutex> lock{_mutex};
@@ -43,13 +217,14 @@ void *metal_allocator::raw_allocate_usm(
   size_t size_bytes,
   const allocation_hints &hints)
 {
-  auto storage_mode = MTL::ResourceStorageModeShared;
-  auto buffer = _device->newBuffer(size_bytes, storage_mode);
+  auto buffer = alloc_buffer(size_bytes);
+  if (!buffer) {
+    return nullptr;
+  }
   void* host_ptr = buffer->contents();
   auto block = usm_block{
     .buffer = buffer,
-    .size = size_bytes,
-    .alloc_type = usm_alloc_type::shared
+    .alloc_type = usm_alloc_type::shared,
   };
   std::lock_guard<std::mutex> lock{_mutex};
   _ptr_to_block[host_ptr] = block;
@@ -61,13 +236,14 @@ metal_allocator::raw_allocate_optimized_host(
   size_t min_alignment, size_t size_bytes,
   const allocation_hints &hints)
 {
-  auto storage_mode = MTL::ResourceStorageModeShared;
-  auto buffer = _device->newBuffer(size_bytes, storage_mode);
+  auto buffer = alloc_buffer(size_bytes);
+  if (!buffer) {
+    return nullptr;
+  }
   void* host_ptr = buffer->contents();
   auto block = usm_block{
     .buffer = buffer,
-    .size = size_bytes,
-    .alloc_type = usm_alloc_type::host
+    .alloc_type = usm_alloc_type::host,
   };
   std::lock_guard<std::mutex> lock{_mutex};
   _ptr_to_block[host_ptr] = block;
@@ -133,6 +309,63 @@ device_id metal_allocator::get_device() const {
   return _device_id;
 }
 
+MTL::Buffer* metal_allocator::alloc_buffer(size_t size_bytes) {
+  const size_t aligned = align_up(size_bytes, _page_size);
+  const size_t stride  = metal_gpu_stride(aligned, _page_size);
+  void* region_ptr = nullptr;
+  size_t delta = 0;
+  MTL::Buffer* buffer = nullptr;
+
+  auto make_buffer = [this, stride, aligned](MTL::Buffer* buffer, void* region_ptr) -> MTL::Buffer* {
+    if (buffer) {
+      region_ptr = reinterpret_cast<void*>(buffer->gpuAddress() - _delta);
+      buffer->release();
+    }
+    region_ptr = _mmap_region->alloc_at(region_ptr, stride);
+    if (!region_ptr) {
+      return nullptr;
+    }
+
+    buffer = _device->newBuffer(
+      region_ptr, aligned, MTL::ResourceStorageModeShared,
+      ^(void*, NS::UInteger) {
+        _mmap_region->free(region_ptr, stride);
+      });
+    if (!buffer) {
+      _mmap_region->free(region_ptr, stride);
+      return nullptr;
+    }
+
+    return buffer;
+  };
+
+  buffer = make_buffer(buffer, region_ptr);
+  if (!buffer) {
+    return nullptr;
+  }
+  delta = buffer->gpuAddress() - reinterpret_cast<uintptr_t>(buffer->contents());
+  int it = 0, max_iterations = 10;
+  while (delta != _delta) {
+    buffer = make_buffer(buffer, region_ptr);
+    if (!buffer) {
+      return nullptr;
+    }
+    delta = buffer->gpuAddress() - reinterpret_cast<uintptr_t>(buffer->contents());
+    if (++it > max_iterations) {
+      buffer->release();
+      return nullptr;
+    }
+  }
+  return buffer;
+}
+
+void metal_allocator::calibrate() {
+  auto* buffer = _device->newBuffer(_mmap_region->midpoint(), _page_size, MTL::ResourceStorageModeShared,
+    ^(void*, NS::UInteger) { });
+  _delta = buffer->gpuAddress() - reinterpret_cast<uintptr_t>(buffer->contents());
+  buffer->release();
+}
+
 std::tuple<MTL::Buffer*, size_t, metal_allocator::usm_alloc_type> metal_allocator::get_usm_block(const void* ptr) const {
   std::lock_guard<std::mutex> lock{_mutex};
   if (_ptr_to_block.empty()) {
@@ -146,7 +379,7 @@ std::tuple<MTL::Buffer*, size_t, metal_allocator::usm_alloc_type> metal_allocato
   const usm_block& block = it->second;
   size_t offset = static_cast<const char*>(ptr) -
           static_cast<const char*>(it->first);
-  if (offset < block.size) {
+  if (offset < block.buffer->length()) {
     return {block.buffer, offset, block.alloc_type};
   }
   return {nullptr, 0, usm_alloc_type::undefined};

--- a/src/runtime/metal/metal_queue.cpp
+++ b/src/runtime/metal/metal_queue.cpp
@@ -88,6 +88,10 @@ void encode_arguments_argbuffer(
       if (buffer) {
         arg_enc->setBuffer(buffer, offset, i);
         encoder->useResource(buffer, MTL::ResourceUsageRead | MTL::ResourceUsageWrite);
+      } else {
+        // Argument buffer memory may be reused (e.g. mmap-backed region), so
+        // stale pointer slots must be explicitly zeroed rather than left as-is.
+        arg_enc->setBuffer(nullptr, 0, i);
       }
     } else {
       auto* dst = arg_enc->constantData(i);

--- a/tests/sycl/usm.cpp
+++ b/tests/sycl/usm.cpp
@@ -368,7 +368,7 @@ BOOST_AUTO_TEST_CASE(memcpy) {
 
     for (std::size_t i = 0; i < test_size; ++i)
       BOOST_TEST(host_data[i] == initial_data[i]);
-    
+
     sycl::free(device_mem, q);
     sycl::free(device_mem2, q);
     sycl::free(shared_mem, q);
@@ -398,7 +398,7 @@ BOOST_AUTO_TEST_CASE(memcpy) {
     int *device_mem = sycl::malloc_device<int>(test_size, q);
     int *device_mem2 = sycl::malloc_device<int>(test_size, q);
     std::vector<int> host_data(test_size);
-    
+
     q.memcpy(device_mem, initial_data.data(), test_size * sizeof(int));
     q.memcpy(device_mem2, device_mem, test_size * sizeof(int));
     q.memcpy(host_data.data(), device_mem2, test_size * sizeof(int));
@@ -437,13 +437,13 @@ BOOST_AUTO_TEST_CASE(memcpy) {
 
     for (std::size_t i = 0; i < test_size; ++i)
       mem[i] = initial_data[i];
-    
+
     q.memcpy(mem2, mem, sizeof(int) * test_size);
     q.wait();
 
     for (std::size_t i = 0; i < test_size; ++i)
       BOOST_TEST(mem2[i] == initial_data[i]);
-    
+
     sycl::free(mem, ooo_q);
     sycl::free(mem2, ooo_q);
   }
@@ -509,7 +509,7 @@ BOOST_AUTO_TEST_CASE(prefetch) {
   q.parallel_for<class usm_prefetch_test_kernel>(
       sycl::range<1>{test_size},
       [=](sycl::id<1> idx) { shared_mem[idx.get(0)] += 1; });
-  
+
   q.wait();
 
   // Test prefetching to host using a host_queue
@@ -520,7 +520,7 @@ BOOST_AUTO_TEST_CASE(prefetch) {
   }
   for (std::size_t i = 0; i < test_size; ++i)
     BOOST_TEST(shared_mem[i] == i + 1);
-  
+
   sycl::free(shared_mem, q);
 }
 
@@ -652,6 +652,53 @@ BOOST_AUTO_TEST_CASE(linked_list_separate_alloc) {
   for (int i = 0; i < num_nodes; i++) {
     sycl::free(nodes[i], q);
   }
+}
+
+BOOST_AUTO_TEST_CASE(usm_shared_ptr_gpu_delta_constant) {
+  sycl::queue q{sycl::property::queue::in_order{}};
+
+  if (!q.get_device().has(sycl::aspect::usm_shared_allocations)) {
+    return;
+  }
+
+  static constexpr int K = 8;
+  static constexpr int sizes[K] = {4096, 8192, 1, 16384, 512, 32768, 2048, 65536};
+
+  int* a[K];
+  for (int k = 0; k < K; ++k)
+    a[k] = sycl::malloc_shared<int>(sizes[k], q);
+
+  uint64_t* gpu_addrs = sycl::malloc_shared<uint64_t>(K, q);
+
+  int *p0=a[0], *p1=a[1], *p2=a[2], *p3=a[3],
+      *p4=a[4], *p5=a[5], *p6=a[6], *p7=a[7];
+
+  q.single_task([=]() {
+    gpu_addrs[0] = reinterpret_cast<uint64_t>(p0);
+    gpu_addrs[1] = reinterpret_cast<uint64_t>(p1);
+    gpu_addrs[2] = reinterpret_cast<uint64_t>(p2);
+    gpu_addrs[3] = reinterpret_cast<uint64_t>(p3);
+    gpu_addrs[4] = reinterpret_cast<uint64_t>(p4);
+    gpu_addrs[5] = reinterpret_cast<uint64_t>(p5);
+    gpu_addrs[6] = reinterpret_cast<uint64_t>(p6);
+    gpu_addrs[7] = reinterpret_cast<uint64_t>(p7);
+  });
+  q.wait();
+
+  int64_t first_delta = static_cast<int64_t>(gpu_addrs[0] - reinterpret_cast<uint64_t>(a[0]));
+  bool all_same = true;
+  for (int k = 1; k < K; ++k) {
+    int64_t delta = static_cast<int64_t>(gpu_addrs[k] - reinterpret_cast<uint64_t>(a[k]));
+    if (delta != first_delta) {
+      all_same = false;
+      BOOST_TEST_MESSAGE("delta mismatch at k=" << k
+        << " expected=" << first_delta << " got=" << delta);
+    }
+  }
+  BOOST_CHECK(all_same);
+
+  for (int k = 0; k < K; ++k) sycl::free(a[k], q);
+  sycl::free(gpu_addrs, q);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // NOTE: Make sure not to add anything below this


### PR DESCRIPTION
Reserves a large VA range via mmap and uses newBuffer(ptr, ...) to back all shared/host MTL::Buffer allocations at controlled CPU addresses. A calibration step determines the fixed offset _delta between CPU and GPU virtual addresses, and a correction loop enforces it for every subsequent allocation:                                                                                                              

``` 
buffer->gpuAddress() - (uintptr_t)buffer->contents() == _delta  // constant
```
 
This is a prerequisite for full USM support on Metal. The approach was proposed by Philip Turner in https://github.com/philipturner/metal-usm