### PR TITLE
[OpenCL][llvm-to-spirv] Disable pointer kernel argument wrapping

### DIFF
--- a/.github/workflows/linux-lit.yml
+++ b/.github/workflows/linux-lit.yml
@@ -119,7 +119,7 @@ jobs:
           wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
           echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list
           apt-get update
-          apt-get install -y intel-oneapi-runtime-opencl intel-oneapi-runtime-compilers ocl-icd-libopencl1 ocl-icd-opencl-dev
+          apt-get install -y intel-oneapi-runtime-opencl-2024 intel-oneapi-runtime-compilers-2024 ocl-icd-libopencl1 ocl-icd-opencl-dev
       - name: build AdaptiveCpp
         run: |
           mkdir build && cd build

--- a/.github/workflows/linux-lit.yml
+++ b/.github/workflows/linux-lit.yml
@@ -119,7 +119,7 @@ jobs:
           wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
           echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list
           apt-get update
-          apt-get install -y intel-oneapi-runtime-opencl-2024 intel-oneapi-runtime-compilers-2024 ocl-icd-libopencl1 ocl-icd-opencl-dev
+          apt-get install -y intel-oneapi-runtime-opencl intel-oneapi-runtime-compilers ocl-icd-libopencl1 ocl-icd-opencl-dev
       - name: build AdaptiveCpp
         run: |
           mkdir build && cd build

--- a/include/hipSYCL/compiler/llvm-to-backend/spirv/LLVMToSpirv.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/spirv/LLVMToSpirv.hpp
@@ -43,6 +43,7 @@ private:
   std::vector<std::string> KernelNames;
   unsigned DynamicLocalMemSize = 0;
   bool UseIntelLLVMSpirvArgs = false;
+  bool WrapPointerArguments = false;
 };
 
 }

--- a/include/hipSYCL/runtime/kernel_configuration.hpp
+++ b/include/hipSYCL/runtime/kernel_configuration.hpp
@@ -69,7 +69,8 @@ enum class kernel_build_flag : int {
   ptx_approx_div,
   ptx_approx_sqrt,
 
-  spirv_enable_intel_llvm_spirv_options
+  spirv_enable_intel_llvm_spirv_options,
+  spirv_enable_pointer_wrapping
 };
 
 enum class kernel_param_flag : int {

--- a/include/hipSYCL/runtime/ocl/ocl_queue.hpp
+++ b/include/hipSYCL/runtime/ocl/ocl_queue.hpp
@@ -102,6 +102,7 @@ private:
   };
 
   protected_state _state;
+  bool _api_accepts_arbirary_pointers;
 
   // SSCP submission data
   common::spin_lock _sscp_submission_spin_lock;

--- a/include/hipSYCL/runtime/ocl/ocl_usm.hpp
+++ b/include/hipSYCL/runtime/ocl/ocl_usm.hpp
@@ -56,6 +56,19 @@ public:
 
   virtual cl_int enable_indirect_usm_access(cl::Kernel&) = 0;
 
+  // SYCL requires that arbitrary pointers are accepted as kernel arguments
+  // (e.g. nullptr, host pointers) as long as they are not accessed. Some APIs
+  // may validate pointers more strictly, in which case AdaptiveCpp may have to
+  // fallback to another strategy (wrapping pointers in structs to hide them
+  // from the OpenCL driver).
+  virtual bool accepts_arbitrary_pointer_kernel_arguments() const = 0;
+
+  // If AdaptiveCpp passes in raw pointer arguments
+  // (accepts_arbitrary_pointer_kernel_arguments() is true), uses to set the
+  // argument.
+  virtual cl_int set_kernel_pointer_arg(cl::Kernel &, unsigned i,
+                                        const void *ptr) = 0;
+
   static std::unique_ptr<ocl_usm> from_intel_extension(ocl_hardware_manager* hw_mgr, int device_index);
   static std::unique_ptr<ocl_usm> from_fine_grained_system_svm(ocl_hardware_manager* hw_mgr, int device_index);
 };

--- a/include/hipSYCL/runtime/ocl/ocl_usm.hpp
+++ b/include/hipSYCL/runtime/ocl/ocl_usm.hpp
@@ -61,11 +61,13 @@ public:
   // may validate pointers more strictly, in which case AdaptiveCpp may have to
   // fallback to another strategy (wrapping pointers in structs to hide them
   // from the OpenCL driver).
+  // This function returns whether the API accepts any pointer arguments, and
+  // we can thus pass them in directly, without wrapping them in structs.
   virtual bool accepts_arbitrary_pointer_kernel_arguments() const = 0;
 
   // If AdaptiveCpp passes in raw pointer arguments
-  // (accepts_arbitrary_pointer_kernel_arguments() is true), uses to set the
-  // argument.
+  // (accepts_arbitrary_pointer_kernel_arguments() is true), it uses this to set
+  // kernel pointer arguments.
   virtual cl_int set_kernel_pointer_arg(cl::Kernel &, unsigned i,
                                         const void *ptr) = 0;
 

--- a/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
+++ b/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
@@ -212,7 +212,7 @@ bool LLVMToSpirvTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
     ASMap[AddressSpace::Private],
     // Actual pointers should be in global memory
     ASMap[AddressSpace::Global],
-    false};
+    WrapPointerArguments};
 
   ParamRewriter.run(M, KernelNames, *PH.ModuleAnalysisManager);
 
@@ -386,6 +386,10 @@ bool LLVMToSpirvTranslator::applyBuildOption(const std::string &Option, const st
 bool LLVMToSpirvTranslator::applyBuildFlag(const std::string& Flag) {
   if(Flag == "spirv-enable-intel-llvm-spirv-options") {
     UseIntelLLVMSpirvArgs = true;
+    return true;
+  }
+  if(Flag == "spirv-enable-pointer-wrapping") {
+    WrapPointerArguments = true;
     return true;
   }
   return false;

--- a/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
+++ b/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
@@ -198,12 +198,7 @@ bool LLVMToSpirvTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
 
   // llvm-spirv translator does not like GEPs into 0-size arrays.
   rewriteZeroSizeArrayGEPs(M);
-  if(M.getModuleFlag("wchar_size")) {
-    // not sure if the right value is 4 or 2, please check.
-    auto* WcharSize = llvm::ConstantInt::get(M.getContext(), llvm::APInt{32, 4});
-    M.setModuleFlag(llvm::Module::ModFlagBehavior::Override, "wchar_size",
-                    llvm::ConstantAsMetadata::get(WcharSize));
-  }
+  
   AddressSpaceMap ASMap = getAddressSpaceMap();
   KernelFunctionParameterRewriter ParamRewriter{
     // llvm-spirv wants ByVal attribute for all aggregates passed in by-value

--- a/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
+++ b/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
@@ -198,7 +198,12 @@ bool LLVMToSpirvTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
 
   // llvm-spirv translator does not like GEPs into 0-size arrays.
   rewriteZeroSizeArrayGEPs(M);
-  
+  if(M.getModuleFlag("wchar_size")) {
+    // not sure if the right value is 4 or 2, please check.
+    auto* WcharSize = llvm::ConstantInt::get(M.getContext(), llvm::APInt{32, 4});
+    M.setModuleFlag(llvm::Module::ModFlagBehavior::Override, "wchar_size",
+                    llvm::ConstantAsMetadata::get(WcharSize));
+  }
   AddressSpaceMap ASMap = getAddressSpaceMap();
   KernelFunctionParameterRewriter ParamRewriter{
     // llvm-spirv wants ByVal attribute for all aggregates passed in by-value
@@ -207,8 +212,7 @@ bool LLVMToSpirvTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
     ASMap[AddressSpace::Private],
     // Actual pointers should be in global memory
     ASMap[AddressSpace::Global],
-    // We need to wrap pointer types
-    true};
+    false};
 
   ParamRewriter.run(M, KernelNames, *PH.ModuleAnalysisManager);
 

--- a/src/runtime/kernel_configuration.cpp
+++ b/src/runtime/kernel_configuration.cpp
@@ -37,7 +37,8 @@ public:
       {"ptx-ftz", kernel_build_flag::ptx_ftz},
       {"ptx-approx-div", kernel_build_flag::ptx_approx_div},
       {"ptx-approx-sqrt", kernel_build_flag::ptx_approx_sqrt},
-      {"spirv-enable-intel-llvm-spirv-options", kernel_build_flag::spirv_enable_intel_llvm_spirv_options}
+      {"spirv-enable-intel-llvm-spirv-options", kernel_build_flag::spirv_enable_intel_llvm_spirv_options},
+      {"spirv-enable-pointer-wrapping", kernel_build_flag::spirv_enable_pointer_wrapping}
     };
 
     for(const auto& elem : _options) {

--- a/src/runtime/ocl/ocl_queue.cpp
+++ b/src/runtime/ocl/ocl_queue.cpp
@@ -46,22 +46,35 @@ result submit_ocl_kernel(cl::Kernel& kernel,
                         const std::size_t *arg_sizes, std::size_t num_args,
                         ocl_usm* usm,
                         const hcf_kernel_info *info,
+                        const std::optional<std::vector<int>>& dae_retained_arguments_mask,
                         cl::Event* evt_out = nullptr) {
 
+  // We assume that if this returns true, then the JIT compiler was configured
+  // to not wrap pointers, so that we can pass them directly.
+  bool can_submit_arbitrary_pointer_arguments =
+      usm->accepts_arbitrary_pointer_kernel_arguments();
+
   cl_int err = 0;
+
   for(std::size_t i = 0; i < num_args; ++i ){
     HIPSYCL_DEBUG_INFO << "ocl_queue: Setting kernel argument " << i
                        << " of size " << arg_sizes[i] << " at " << kernel_args[i]
                        << std::endl;
 
-    if(info->get_argument_type(i) == hcf_kernel_info::argument_type::pointer &&
-      usm->accepts_arbitrary_pointer_kernel_arguments()) {
+    std::size_t original_index = i;
+    if(dae_retained_arguments_mask.has_value()) {
+      original_index = dae_retained_arguments_mask.value()[i];
+    }
+    
+    if (can_submit_arbitrary_pointer_arguments &&
+        info->get_argument_type(original_index) ==
+            hcf_kernel_info::argument_type::pointer) {
 
       const void* arg_location = kernel_args[i];
       void* ptr;
       std::memcpy(&ptr, arg_location, sizeof(void*));
+      
       err = usm->set_kernel_pointer_arg(kernel, static_cast<unsigned>(i), ptr);
-
     } else {
       // If we don't have arbitrary pointer argument support, the JIT compiler
       // should have been configured to wrap pointers, so that we can always
@@ -622,6 +635,7 @@ result ocl_queue::submit_sscp_kernel_from_code_object(
       kernel, _queue, group_size, num_groups, _arg_mapper.get_mapped_args(),
       const_cast<std::size_t *>(_arg_mapper.get_mapped_arg_sizes()),
       _arg_mapper.get_mapped_num_args(), hw_ctx->get_usm_provider(), kernel_info,
+      obj->get_jit_output_metadata().kernel_retained_arguments_indices,
       &completion_evt);
 
   if(!submission_err.is_success())

--- a/src/runtime/ocl/ocl_queue.cpp
+++ b/src/runtime/ocl/ocl_queue.cpp
@@ -54,9 +54,17 @@ result submit_ocl_kernel(cl::Kernel& kernel,
                        << " of size " << arg_sizes[i] << " at " << kernel_args[i]
                        << std::endl;
 
-    if(info->get_argument_type(i) == hcf_kernel_info::argument_type::pointer) {
-      err = kernel.setArg(i, *reinterpret_cast<void**>(kernel_args[i]));
+    if(info->get_argument_type(i) == hcf_kernel_info::argument_type::pointer &&
+      usm->accepts_arbitrary_pointer_kernel_arguments()) {
+
+      void* arg_location = kernel_args[i];
+      const void* ptr = *reinterpret_cast<void**>(arg_location);
+      usm->set_kernel_pointer_arg(kernel, static_cast<unsigned>(i), ptr);
+
     } else {
+      // If we don't have arbitrary pointer argument support, the JIT compiler
+      // should have been configured to wrap pointers, so that we can always
+      // safely execute this branch.
       err = kernel.setArg(i, static_cast<std::size_t>(arg_sizes[i]), kernel_args[i]);
     }
 
@@ -121,6 +129,9 @@ ocl_queue::ocl_queue(ocl_hardware_manager* hw_manager, std::size_t device_index,
       static_cast<ocl_hardware_context *>(hw_manager->get_device(device_index));
   cl::Device cl_dev = dev_ctx->get_cl_device();
   cl::Context cl_ctx = dev_ctx->get_cl_context();
+
+  this->_api_accepts_arbirary_pointers =
+      dev_ctx->get_usm_provider()->accepts_arbitrary_pointer_kernel_arguments();
 
   cl_int err;
   if(priority != 0 && dev_ctx->has_cl_khr_priority_hints_extension()) {
@@ -517,7 +528,9 @@ result ocl_queue::submit_sscp_kernel_from_code_object(
   // with OpenCL implementations that are not from Intel.
   _config.set_build_flag(
     kernel_build_flag::spirv_enable_intel_llvm_spirv_options);
-
+  if(!this->_api_accepts_arbirary_pointers) {
+    _config.set_build_flag(kernel_build_flag::spirv_enable_pointer_wrapping);
+  }
 
   // TODO: Enable this if we are on Intel
   // config.set_build_flag(kernel_build_flag::spirv_enable_intel_llvm_spirv_options);

--- a/src/runtime/ocl/ocl_queue.cpp
+++ b/src/runtime/ocl/ocl_queue.cpp
@@ -57,8 +57,9 @@ result submit_ocl_kernel(cl::Kernel& kernel,
     if(info->get_argument_type(i) == hcf_kernel_info::argument_type::pointer &&
       usm->accepts_arbitrary_pointer_kernel_arguments()) {
 
-      void* arg_location = kernel_args[i];
-      const void* ptr = *reinterpret_cast<void**>(arg_location);
+      const void* arg_location = kernel_args[i];
+      void* ptr;
+      std::memcpy(&ptr, arg_location, sizeof(void*));
       usm->set_kernel_pointer_arg(kernel, static_cast<unsigned>(i), ptr);
 
     } else {

--- a/src/runtime/ocl/ocl_queue.cpp
+++ b/src/runtime/ocl/ocl_queue.cpp
@@ -54,7 +54,11 @@ result submit_ocl_kernel(cl::Kernel& kernel,
                        << " of size " << arg_sizes[i] << " at " << kernel_args[i]
                        << std::endl;
 
-    err = kernel.setArg(i, static_cast<std::size_t>(arg_sizes[i]), kernel_args[i]);
+    if(info->get_argument_type(i) == hcf_kernel_info::argument_type::pointer) {
+      err = kernel.setArg(i, *reinterpret_cast<void**>(kernel_args[i]));
+    } else {
+      err = kernel.setArg(i, static_cast<std::size_t>(arg_sizes[i]), kernel_args[i]);
+    }
 
     if(err != CL_SUCCESS) {
       return make_error(

--- a/src/runtime/ocl/ocl_queue.cpp
+++ b/src/runtime/ocl/ocl_queue.cpp
@@ -60,7 +60,7 @@ result submit_ocl_kernel(cl::Kernel& kernel,
       const void* arg_location = kernel_args[i];
       void* ptr;
       std::memcpy(&ptr, arg_location, sizeof(void*));
-      usm->set_kernel_pointer_arg(kernel, static_cast<unsigned>(i), ptr);
+      err = usm->set_kernel_pointer_arg(kernel, static_cast<unsigned>(i), ptr);
 
     } else {
       // If we don't have arbitrary pointer argument support, the JIT compiler

--- a/src/runtime/ocl/ocl_usm.cpp
+++ b/src/runtime/ocl/ocl_usm.cpp
@@ -285,6 +285,16 @@ public:
     return err;
   }
 
+  bool accepts_arbitrary_pointer_kernel_arguments() const override {
+    // TODO Only for USM extension version >= 1.1
+    return true;
+  }
+
+  cl_int set_kernel_pointer_arg(cl::Kernel &k, unsigned i,
+                                const void *ptr) override {
+    return _set_kernel_arg_mem_pointer(k.get(), i, ptr);
+  }
+
 private:
   template <class Func>
   void initialize_func(Func &out, const char *name, cl_platform_id id) {
@@ -462,6 +472,15 @@ public:
 
   cl_int enable_indirect_usm_access(cl::Kernel& k) override {
     return k.setExecInfo(CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM, cl_bool{true});
+  }
+
+  bool accepts_arbitrary_pointer_kernel_arguments() const override {
+    return false;
+  }
+
+  cl_int set_kernel_pointer_arg(cl::Kernel &k, unsigned i,
+                                const void *ptr) override {
+    return k.setArg(i, ptr);
   }
 
 private:

--- a/src/runtime/ocl/ocl_usm.cpp
+++ b/src/runtime/ocl/ocl_usm.cpp
@@ -67,6 +67,11 @@ public:
       // On CPU, we can be more relaxed in a couple of places as
       // USM will generally "just work"
       _is_cpu = _hw_mgr->get_device(device_index)->is_cpu();
+
+      // USM spec says that we can pass in arbitrary pointers
+      // if we also have shared USM. This was further relaxed in
+      // USM 1.1, however, not all implementations support that yet.
+      _supports_arbitrary_pointer_args = has_usm_shared_allocations();
     }
   }
 
@@ -286,8 +291,7 @@ public:
   }
 
   bool accepts_arbitrary_pointer_kernel_arguments() const override {
-    // TODO Only for USM extension version >= 1.1
-    return true;
+    return _supports_arbitrary_pointer_args;
   }
 
   cl_int set_kernel_pointer_arg(cl::Kernel &k, unsigned i,
@@ -325,6 +329,7 @@ private:
   cl::Device _dev;
   ocl_hardware_manager* _hw_mgr;
   bool _is_cpu = false;
+  bool _supports_arbitrary_pointer_args;
 };
 
 

--- a/src/runtime/ze/ze_queue.cpp
+++ b/src/runtime/ze/ze_queue.cpp
@@ -480,6 +480,8 @@ result ze_queue::submit_sscp_kernel_from_code_object(
       local_mem_size);
   _config.set_build_flag(
       kernel_build_flag::spirv_enable_intel_llvm_spirv_options);
+  _config.set_build_flag(
+      kernel_build_flag::spirv_enable_pointer_wrapping);
 
   auto binary_configuration_id = adaptivity_engine.finalize_binary_configuration(_config);
   auto code_object_configuration_id = binary_configuration_id;

--- a/tests/sycl/usm.cpp
+++ b/tests/sycl/usm.cpp
@@ -66,6 +66,28 @@ BOOST_AUTO_TEST_CASE(device_allocation_functions) {
   sycl::free(aligned_device_mem_ptr, q);
 }
 
+BOOST_AUTO_TEST_CASE(invalid_pointer_argument) {
+  sycl::queue q;
+
+  void** data_in = sycl::malloc_device<void*>(1, q);
+  void** data_out = sycl::malloc_device<void*>(1, q);
+
+  void* data = reinterpret_cast<void*>(0x1);
+  q.memcpy(data_in, &data, sizeof(void*)).wait();
+
+  q.single_task([=](){
+    *data_out = *data_in;
+  }).wait();
+
+  void* data_result = nullptr;
+  q.memcpy(&data_result, data_out, sizeof(void*)).wait();
+  BOOST_CHECK(data_result == reinterpret_cast<void*>(0x1));
+
+  sycl::free(data_in, q);
+  sycl::free(data_out, q);
+
+}
+
 BOOST_AUTO_TEST_CASE(host_allocation_functions) {
   // Basic check that allocations work
   sycl::queue q;


### PR DESCRIPTION
Currently we wrap kernel pointer arguments in a struct in llvm-to-spirv.
This is because older L0 versions and some OpenCL SVM APIs strictly validate all pointer arguments, and error if a nullptr or host pointer is passed in. In SYCL (or stdpar or PCUDA) this is however legal as long as the pointer is not dereferenced on the device. The pointer wrapping hides the pointer from the driver, and we can just pass it in as a blob without additional validation.

A downside of this approach is that, since the kernel no longer has pointer arguments, optimizations like automatic noalias inference at JIT time no longer work, because those need pointers. It also poses additional challenges for address space inference.

This approach therefore relaxes pointer wrapping such that it is no longer done in APIs that do not perform this undesired validation (OpenCL+Intel USM extensions). In the future, we could also relax it for more cases (newer Level Zero versions?).


Pointer wrapping is still done in all other cases so that hopefully nothing breaks.