### PR TITLE
[SSCP][OpenCL] Use SPIR-V global invocation id builtin when on CPU device

### DIFF
--- a/include/hipSYCL/sycl/libkernel/detail/thread_hierarchy.hpp
+++ b/include/hipSYCL/sycl/libkernel/detail/thread_hierarchy.hpp
@@ -148,16 +148,19 @@ HIPSYCL_DEFINE_BUILTIN_VARIABLE_QUERY(__acpp_get_ngroups_z,
 // must be reversed before it can be used in a performant manner!
 inline ACPP_KERNEL_TARGET size_t get_global_id_x()
 {
+  __acpp_if_target_sscp(return __acpp_sscp_get_global_id_x(););
   return __acpp_gid_x * __acpp_lsize_x + __acpp_lid_x;
 }
 
 inline ACPP_KERNEL_TARGET size_t get_global_id_y()
 {
+  __acpp_if_target_sscp(return __acpp_sscp_get_global_id_y(););
   return __acpp_gid_y * __acpp_lsize_y + __acpp_lid_y;
 }
 
 inline ACPP_KERNEL_TARGET size_t get_global_id_z()
 {
+  __acpp_if_target_sscp(return __acpp_sscp_get_global_id_z(););
   return __acpp_gid_z * __acpp_lsize_z + __acpp_lid_z;
 }
 

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/core_typed.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/core_typed.hpp
@@ -30,6 +30,34 @@ HIPSYCL_SSCP_BUILTIN __acpp_uint64 __acpp_sscp_get_num_groups_x();
 HIPSYCL_SSCP_BUILTIN __acpp_uint64 __acpp_sscp_get_num_groups_y();
 HIPSYCL_SSCP_BUILTIN __acpp_uint64 __acpp_sscp_get_num_groups_z();
 
+template<class T>
+T __acpp_sscp_typed_get_global_id_x() {
+  T lsize = (T)__acpp_sscp_get_local_size_x();
+  T lid = (T)__acpp_sscp_get_local_id_x();
+  T gid = (T)__acpp_sscp_get_group_id_x();
+
+  return gid * lsize + lid;
+}
+
+template<class T>
+T __acpp_sscp_typed_get_global_id_y() {
+  T lsize = (T)__acpp_sscp_get_local_size_y();
+  T lid = (T)__acpp_sscp_get_local_id_y();
+  T gid = (T)__acpp_sscp_get_group_id_y();
+
+  return gid * lsize + lid;
+}
+
+
+template<class T>
+T __acpp_sscp_typed_get_global_id_z() {
+  T lsize = (T)__acpp_sscp_get_local_size_z();
+  T lid = (T)__acpp_sscp_get_local_id_z();
+  T gid = (T)__acpp_sscp_get_group_id_z();
+
+  return gid * lsize + lid;
+}
+
 template<int Dim, class T>
 T __acpp_sscp_typed_get_global_linear_id() {
   if constexpr(Dim == 1) {

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/global_id.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/global_id.hpp
@@ -1,0 +1,77 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+
+// THIS FILE INCLUDES STANDARD LIBRARY HEADERS AND MUST NOT BE 
+// USED IN THE DEFINITION OF SSCP BUILTINS!
+
+#ifndef HIPSYCL_SSCP_BUILTINS_GLOBAL_ID_HPP
+#define HIPSYCL_SSCP_BUILTINS_GLOBAL_ID_HPP
+
+#include "core.hpp"
+#include "core_typed.hpp"
+#include "hipSYCL/glue/llvm-sscp/jit-reflection/queries.hpp"
+
+#include <stddef.h>
+
+// This is used to implement the optimization in llvm-to-backend to treat
+// all queries as fitting into int.
+// The implementation is provided by the compiler and does not need to be implemented
+// by backends.
+HIPSYCL_SSCP_BUILTIN bool
+__acpp_sscp_if_global_sizes_fit_in_int();
+
+// Used as backend-specific optimization. Need to manually use
+// Itanium mangling so that it also works when the host is on MSVC ABI.
+// Intel CPU OpenCL seems to be able to generate better code in some cases
+// if kernels only use global invocation id builtins, so we want to use
+// that builtin there.
+// For other backends/devices, we calculate global ids manually so that
+// we can benefit from our global-id-fits-in-int32 JIT optimization.
+extern "C" size_t _Z33__spirv_BuiltInGlobalInvocationIdi(int);
+
+#define ACPP_RETURN_SPIRV_GLOBAL_ID_IF_SPIRV_CPU_DEVICE(Dim)                   \
+  using namespace hipsycl::sycl::AdaptiveCpp_jit;                              \
+  if (__acpp_sscp_jit_reflect_compiler_backend() == compiler_backend::spirv) { \
+    if (__acpp_sscp_jit_reflect_target_is_cpu())                               \
+      return _Z33__spirv_BuiltInGlobalInvocationIdi(Dim);                      \
+  }
+
+inline size_t __acpp_sscp_get_global_id_x() {
+  ACPP_RETURN_SPIRV_GLOBAL_ID_IF_SPIRV_CPU_DEVICE(0)
+  if(__acpp_sscp_if_global_sizes_fit_in_int()) {
+    return __acpp_sscp_typed_get_global_id_x<int>();
+  } else {
+    return __acpp_sscp_typed_get_global_id_x<size_t>();
+  }
+}
+
+inline size_t __acpp_sscp_get_global_id_y() {
+  ACPP_RETURN_SPIRV_GLOBAL_ID_IF_SPIRV_CPU_DEVICE(1)
+  if(__acpp_sscp_if_global_sizes_fit_in_int()) {
+    return __acpp_sscp_typed_get_global_id_y<int>();
+  } else {
+    return __acpp_sscp_typed_get_global_id_y<size_t>();
+  }
+}
+
+inline size_t __acpp_sscp_get_global_id_z() {
+  ACPP_RETURN_SPIRV_GLOBAL_ID_IF_SPIRV_CPU_DEVICE(2)
+  if(__acpp_sscp_if_global_sizes_fit_in_int()) {
+    return __acpp_sscp_typed_get_global_id_z<int>();
+  } else {
+    return __acpp_sscp_typed_get_global_id_z<size_t>();
+  }
+}
+
+#undef ACPP_RETURN_SPIRV_GLOBAL_ID_IF_SPIRV_CPU_DEVICE
+
+#endif

--- a/include/hipSYCL/sycl/libkernel/sscp/sscp_backend.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/sscp_backend.hpp
@@ -57,6 +57,7 @@
  #include "hipSYCL/glue/llvm-sscp/ir_constants.hpp"
  #include "builtins/core.hpp"
  #include "builtins/linear_id.hpp"
+ #include "builtins/global_id.hpp"
  
 #else
  #define ACPP_LIBKERNEL_COMPILER_SUPPORTS_SSCP 0


### PR DESCRIPTION
It was found that on Intel CPU OpenCL, kernels may be faster if they use the SPIR-V GlobalInvocationId builtin instead of manually calculating the id as we currently do.
The latter has the advantage that it allows to enforce our global-size-fits-in-int32 optimizations globally.

This PR adds a code path to use the SPIR-V builtin when OpenCL CPU device is detected.

It also enables global-size-fits-in-int32 optimizations for `get_global_id()`, not just `get_global_linear_id()` as currently.

I still see calls to the local id/work group id builtins in the IR with this PR. However, these are only there to assert information about the structure of the parallel iteration space to the optimizer via `llvm.assume()` calls. Their return values are not actually used.
We might have to do some additional investigation whether it's worth cleaning up the IR further to get rid of any mention of these other builtins, or whether it's okay the way it is currently.

CC @blinkfrog 