### PR TITLE
[Metal] Fix address space inference; align with other backends

### DIFF
--- a/src/compiler/llvm-to-backend/metal/Emitter.cpp
+++ b/src/compiler/llvm-to-backend/metal/Emitter.cpp
@@ -82,7 +82,9 @@ std::optional<std::string> extractStringConstant(llvm::Value* V, std::string& er
   if (auto* gv = llvm::dyn_cast<llvm::GlobalVariable>(V)) {
     GV = gv;
   } else if (auto* CE = llvm::dyn_cast<llvm::ConstantExpr>(V)) {
-    if (CE->getOpcode() == llvm::Instruction::GetElementPtr) {
+    if (CE->getOpcode() == llvm::Instruction::AddrSpaceCast) {
+      return extractStringConstant(CE->getOperand(0), errorStr);
+    } else if (CE->getOpcode() == llvm::Instruction::GetElementPtr) {
       GV = llvm::dyn_cast<llvm::GlobalVariable>(CE->getOperand(0));
     }
   }
@@ -1510,7 +1512,8 @@ unsigned MetalEmitter::getPhysicalPointerAddressSpace(const Value* V) {
     return it->second;
   }
 
-  // If the value is an addrspacecast, get the original address space
+  inferredPtrAS[V] = 0; // to break cycles in PHIs and Loads
+
   if (auto* Alloca = dyn_cast<AllocaInst>(V)) {
     return (inferredPtrAS[V] = 5 /* private */);
   }

--- a/src/compiler/llvm-to-backend/metal/LLVMToMetal.cpp
+++ b/src/compiler/llvm-to-backend/metal/LLVMToMetal.cpp
@@ -482,8 +482,12 @@ bool LLVMToMetalTranslator::prepareBackendFlavor(llvm::Module& M) {
 bool LLVMToMetalTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
   AddressSpaceMap ASMap = getAddressSpaceMap();
 
-  AddressSpaceInferencePass ASIPass{ASMap};
-  ASIPass.run(M, *PH.ModuleAnalysisManager);
+  KernelFunctionParameterRewriter ParamRewriter{
+      KernelFunctionParameterRewriter::ByValueArgAttribute::ByVal,
+      ASMap[AddressSpace::Generic],
+      ASMap[AddressSpace::Global]};
+
+  ParamRewriter.run(M, KernelNames, *PH.ModuleAnalysisManager);
 
   // First linking: provides __acpp_sscp_* definitions so that the base class inliner
   // (which runs after toBackendFlavor) can inline them. The inlined bodies then go through
@@ -495,12 +499,17 @@ bool LLVMToMetalTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
   if (!this->linkBitcodeFile(M, BuiltinBitcodeFile))
     return false;
 
+  AddressSpaceInferencePass ASIPass{ASMap};
+  ASIPass.run(M, *PH.ModuleAnalysisManager);
+
   llvm::StripDebugInfo(M);
 
   return true;
 }
 
 bool LLVMToMetalTranslator::translateToBackendFormat(llvm::Module& FlavoredModule, std::string& out) {
+  AddressSpaceMap ASMap = getAddressSpaceMap();
+
   auto ok = withPassBuilder([&](auto& PB, auto& LAM, auto& FAM, auto& CGAM, auto& MAM) {
     // Second ReplaceIntrinsics + link pass: the base class O3 pipeline (InstCombine etc.) may
     // have re-introduced LLVM intrinsics (llvm.minnum, llvm.maxnum, llvm.fmuladd) from the
@@ -530,8 +539,10 @@ bool LLVMToMetalTranslator::translateToBackendFormat(llvm::Module& FlavoredModul
     FPM.addPass(llvm::ADCEPass());
     FPM.addPass(llvm::StructurizeCFGPass());
     FPM.addPass(llvm::SimplifyCFGPass());
+    AddressSpaceInferencePass ASIPass{ASMap};
     llvm::ModulePassManager MPM;
     MPM.addPass(createModuleToFunctionPassAdaptor(std::move(FPM)));
+    MPM.addPass(std::move(ASIPass));
     MPM.run(FlavoredModule, MAM);
     return true;
   });
@@ -543,9 +554,9 @@ bool LLVMToMetalTranslator::translateToBackendFormat(llvm::Module& FlavoredModul
 
   std::unordered_set<std::string> kernelNames(KernelNames.begin(), KernelNames.end());
 
-#ifdef ACPP_PRINT_IR_BEFORE_EMIT
-  FlavoredModule.print(llvm::errs(), nullptr);
-#endif
+  if (getenv("__ACPP_PRINT_IR_BEFORE_EMIT")) {
+    FlavoredModule.print(llvm::errs(), nullptr);
+  }
 
   MetalEmitterOptions emitterOpts;
   if (MaxArgsForFlatMode.has_value()) {
@@ -559,9 +570,9 @@ bool LLVMToMetalTranslator::translateToBackendFormat(llvm::Module& FlavoredModul
     return false;
   }
 
-#ifdef ACPP_PRINT_METAL_CODE
-  std::cerr << "Generated Metal code:\n" << out << std::endl;
-#endif
+  if (getenv("__ACPP_PRINT_METAL_CODE")) {
+    llvm::errs() << "Generated Metal code:\n" << out << "\n";
+  }
   return true;
 }
 


### PR DESCRIPTION
- extractStringConstant: handle AddrSpaceCast ConstantExpr around string literals
- getPhysicalPointerAddressSpace: fix infinite recursion
- LLVMToMetal: run KernelFunctionParameterRewriter and AddressSpaceInferencePass after linking (as PTX/AMDGPU do), add a second ASI pass post-optimization so address spaces are correctly annotated before pointer-translation passes