### PR TITLE
Temporary workaround for ASan deadlock on macOS Tahoe

### DIFF
--- a/tests/compiler/reflection/function_name.cpp
+++ b/tests/compiler/reflection/function_name.cpp
@@ -6,8 +6,7 @@
 // RUN: %t | FileCheck %s
 // RUN: %acpp %s -o %t --acpp-targets=generic -fsanitize=undefined
 // RUN: %t | FileCheck %s
-// RUN: %acpp %s -o %t --acpp-targets=generic -fsanitize=address
-// RUN: %t | FileCheck %s
+// RUN: %if !system-darwin %{ %acpp %s -o %t --acpp-targets=generic -fsanitize=address && %t | FileCheck %s %}
 
 #include <iostream>
 #include "hipSYCL/glue/reflection.hpp"

--- a/tests/compiler/reflection/introspect_struct.cpp
+++ b/tests/compiler/reflection/introspect_struct.cpp
@@ -6,8 +6,7 @@
 // RUN: %t | FileCheck %s
 // RUN: %acpp %s -o %t --acpp-targets=generic -fsanitize=undefined
 // RUN: %t | FileCheck %s
-// RUN: %acpp %s -o %t --acpp-targets=generic -fsanitize=address
-// RUN: %t | FileCheck %s
+// RUN: %if !system-darwin %{ %acpp %s -o %t --acpp-targets=generic -fsanitize=address && %t | FileCheck %s %}
 
 #include <iostream>
 #include "hipSYCL/glue/reflection.hpp"


### PR DESCRIPTION
In macOS Tahoe a new dyld (dyld-1376.6) broke compatibility with clang ASan. Details: https://raw.githubusercontent.com/Micro-Evaluation-Group/CrashRustler/main/apple-sanitizer-tahoe-bug.md

Temporarily disabling ASan in two reflection tests on macOS until Homebrew picks up the fix (https://github.com/llvm/llvm-project/commit/2e7d07a33725a82ecfc514e27f047ece3ff13d4c) in clang-20/21, or we migrate to clang-22

I already saw this hang in GitHub CI, apparently a too new macOS 26 image landed there

trace:
```
Executable binary set to "/Users/aozeritsky/Projects/AdaptiveCpp/build-tests/reflection/Output/function_name.cpp.tmp".
Architecture set to: arm64-apple-macosx-.
(lldb) bt
* thread #1, stop reason = signal SIGSTOP
  * frame #0: 0x00000001837c7c88 libsystem_kernel.dylib`swtch_pri + 8
    frame #1: 0x0000000183808c28 libsystem_pthread.dylib`cthread_yield + 36
    frame #2: 0x0000000104e29bbc libclang_rt.asan_osx_dynamic.dylib`__sanitizer::internal_sched_yield() + 12
    frame #3: 0x0000000104e2c8a0 libclang_rt.asan_osx_dynamic.dylib`__sanitizer::StaticSpinMutex::LockSlow() + 60
    frame #4: 0x0000000104e1a1f0 libclang_rt.asan_osx_dynamic.dylib`__asan::AsanInitFromRtl() + 88
    frame #5: 0x0000000104e0fa74 libclang_rt.asan_osx_dynamic.dylib`__sanitizer_mz_malloc + 32
    frame #6: 0x0000000183638178 libsystem_malloc.dylib`_malloc_zone_malloc_instrumented_or_legacy + 152
    frame #7: 0x000000018361c678 libsystem_malloc.dylib`_malloc_type_malloc_outlined + 96
    frame #8: 0x00000001834d6d94 libsystem_blocks.dylib`_Block_copy + 84
    frame #9: 0x0000000243766e10 Dyld`dyld_shared_cache_iterate_text_swift + 28
    frame #10: 0x0000000104e2ea54 libclang_rt.asan_osx_dynamic.dylib`__sanitizer::get_dyld_hdr() + 208
    frame #11: 0x0000000104e2edd8 libclang_rt.asan_osx_dynamic.dylib`__sanitizer::MemoryMappingLayout::Next(__sanitizer::MemoryMappedSegment*) + 120
    frame #12: 0x0000000104e2d614 libclang_rt.asan_osx_dynamic.dylib`__sanitizer::MemoryRangeIsAvailable(unsigned long, unsigned long) + 164
    frame #13: 0x0000000104e1ae08 libclang_rt.asan_osx_dynamic.dylib`__asan::InitializeShadowMemory() + 100
    frame #14: 0x0000000104e1a308 libclang_rt.asan_osx_dynamic.dylib`__asan::AsanInitInternal() + 260
    frame #15: 0x0000000104e1a1d4 libclang_rt.asan_osx_dynamic.dylib`__asan::AsanInitFromRtl() + 60
    frame #16: 0x0000000104e0f294 libclang_rt.asan_osx_dynamic.dylib`wrap_malloc_default_zone + 12
    frame #17: 0x000000018360c4ac libsystem_malloc.dylib`__malloc_init + 1524
    frame #18: 0x000000019362f328 libSystem.B.dylib`libSystem_initializer + 204
    frame #19: 0x0000000183477734 dyld`invocation function for block in dyld4::Loader::findAndRunAllInitializers(dyld4::RuntimeState&) const + 444
    frame #20: 0x0000000183487e90 dyld`invocation function for block in dyld3::MachOAnalyzer::forEachInitializer(Diagnostics&, dyld3::MachOAnalyzer::VMAddrConverter const&, void (unsigned int) block_pointer, void const*) const + 320
    frame #21: 0x00000001834be560 dyld`invocation function for block in mach_o::UnsafeHeader::forEachSection(void (mach_o::UnsafeHeader::SectionInfo const&, bool&) block_pointer) const + 312
    frame #22: 0x00000001834bb094 dyld`mach_o::UnsafeHeader::forEachLoadCommand(void (load_command const*, bool&) block_pointer) const + 208
    frame #23: 0x00000001834bc93c dyld`mach_o::UnsafeHeader::forEachSection(void (mach_o::UnsafeHeader::SectionInfo const&, bool&) block_pointer) const + 124
    frame #24: 0x0000000183487984 dyld`dyld3::MachOAnalyzer::forEachInitializer(Diagnostics&, dyld3::MachOAnalyzer::VMAddrConverter const&, void (unsigned int) block_pointer, void const*) const + 516
    frame #25: 0x00000001834774ec dyld`dyld4::Loader::findAndRunAllInitializers(dyld4::RuntimeState&) const + 172
    frame #26: 0x00000001834a0d34 dyld`dyld4::PrebuiltLoader::runInitializers(dyld4::RuntimeState&) const + 44
    frame #27: 0x0000000183444844 dyld`dyld4::APIs::runAllInitializersForMain() + 100
    frame #28: 0x0000000183451334 dyld`dyld4::prepare(dyld4::APIs&, mach_o::UnsafeHeader const*) + 3880
    frame #29: 0x00000001834503f0 dyld`dyld4::start(dyld4::KernelArgs*, void*, void*, unsigned long long)::$_1::operator()() const + 320
    frame #30: 0x000000018344fd4c dyld`start + 6904
(lldb) ^D
```