### PR TITLE
Remove broken interop_handle::get_native_queue overload

### DIFF
--- a/include/hipSYCL/glue/backend_interop.hpp
+++ b/include/hipSYCL/glue/backend_interop.hpp
@@ -31,7 +31,6 @@ template <sycl::backend b> struct backend_interop {
   //
   // For interop_handle, the following is required:
   // native_queue_type get_native_queue(rt::backend_kernel_launcher*)
-  // native_queue_type get_native_queue(rt::device_id, rt::backend_executor*)
   // 
   // In any case, the following should be defined:
   // static constexpr bool can_make_T = <whether make_T exists>

--- a/include/hipSYCL/glue/cuda/cuda_interop.hpp
+++ b/include/hipSYCL/glue/cuda/cuda_interop.hpp
@@ -55,26 +55,6 @@ template <> struct backend_interop<sycl::backend::cuda> {
     return static_cast<native_queue_type>(q->get_native_type());
   }
 
-  static native_queue_type
-  get_native_queue(rt::device_id dev, rt::backend_executor *executor) {
-    rt::multi_queue_executor *mqe =
-        dynamic_cast<rt::multi_queue_executor *>(executor);
-
-    if (!mqe) {
-      rt::register_error(
-          __acpp_here(),
-          rt::error_info{"Invalid argument to get_native_queue()"});
-      return native_queue_type{};
-    }
-
-    rt::inorder_queue *q = nullptr;
-    mqe->for_each_queue(
-        dev, [&](rt::inorder_queue *current_queue) { q = current_queue; });
-    assert(q);
-
-    return static_cast<native_queue_type>(q->get_native_type());
-  }
-      
   static sycl::device make_sycl_device(int device_id) {
     return sycl::device{
         rt::device_id{rt::backend_descriptor{rt::hardware_platform::cuda,

--- a/include/hipSYCL/glue/hip/hip_interop.hpp
+++ b/include/hipSYCL/glue/hip/hip_interop.hpp
@@ -60,27 +60,6 @@ template <> struct backend_interop<sycl::backend::hip> {
     return static_cast<native_queue_type>(q->get_native_type());
   }
 
-  static native_queue_type
-  get_native_queue(rt::device_id dev, rt::backend_executor *executor) {
-    rt::multi_queue_executor *mqe =
-        dynamic_cast<rt::multi_queue_executor *>(executor);
-
-    if (!mqe) {
-      rt::register_error(
-          __acpp_here(),
-          rt::error_info{"Invalid argument to get_native_queue()"});
-      return native_queue_type{};
-    }
-
-    rt::inorder_queue *q = nullptr;
-    mqe->for_each_queue(
-        dev, [&](rt::inorder_queue *current_queue) { q = current_queue; });
-    assert(q);
-
-    return static_cast<native_queue_type>(q->get_native_type());
-  }
-
-
   static sycl::device make_sycl_device(int device_id) {
     return sycl::device{
         rt::device_id{rt::backend_descriptor{rt::hardware_platform::rocm,

--- a/include/hipSYCL/sycl/interop_handle.hpp
+++ b/include/hipSYCL/sycl/interop_handle.hpp
@@ -15,21 +15,23 @@
 #include "backend.hpp"
 #include "backend_interop.hpp"
 
-#include "hipSYCL/runtime/executor.hpp"
+#include "hipSYCL/runtime/device_id.hpp"
 
 namespace hipsycl {
+namespace rt {
+class backend_executor;
+}
 namespace sycl {
 
 class interop_handle {
 public:
   interop_handle() = delete;
   interop_handle(rt::device_id assigned_device, void *kernel_launcher_params)
-      : _dev{assigned_device}, _launcher_params{kernel_launcher_params},
-        _executor{nullptr} {}
+      : _dev{assigned_device}, _launcher_params{kernel_launcher_params} {}
 
+  // Guard against accidentally binding backend_executor* to the void* constructor.
   interop_handle(rt::device_id assigned_device,
-                 rt::backend_executor *executor)
-      : _dev{assigned_device}, _launcher_params{nullptr}, _executor{executor} {}
+                 rt::backend_executor *executor) = delete;
   
   backend get_backend() const noexcept {
     return _dev.get_backend();
@@ -63,11 +65,9 @@ public:
     
     if(_launcher_params)
       return glue::backend_interop<Backend>::get_native_queue(_launcher_params);
-    else if (_executor)
-      return glue::backend_interop<Backend>::get_native_queue(_executor);
 
     HIPSYCL_DEBUG_WARNING
-        << "interop_handle: Neither executor nor kernel launcher was provided, "
+        << "interop_handle: Kernel launcher was not provided, "
            "cannot construct native queue"
         << std::endl;
     
@@ -87,7 +87,6 @@ public:
 private:
   rt::device_id _dev;
   void *_launcher_params;
-  rt::backend_executor *_executor;
 };
 } // namespace sycl
 } // namespace hipsycl

--- a/tests/sycl/interop_handle.cpp
+++ b/tests/sycl/interop_handle.cpp
@@ -20,13 +20,16 @@ BOOST_AUTO_TEST_CASE(interop_handle_api) {
   using namespace hipsycl;
 
   rt::device_id assigned_device{rt::backend_descriptor{rt::hardware_platform::cpu,
-                                rt::api_platform::omp}, 12345};
+                                rt::api_platform::omp}, 0};
+  s::queue q{s::device{assigned_device}};
 
-  rt::backend_executor *executor = nullptr;
-  s::interop_handle ih{assigned_device, executor};
-  s::backend b = ih.get_backend();
-
-  BOOST_CHECK(b == s::backend::omp);
+  q.submit([&](s::handler &cgh) {
+    cgh.AdaptiveCpp_enqueue_custom_operation([=](s::interop_handle &ih) {
+      s::backend b = ih.get_backend();
+      BOOST_CHECK(b == s::backend::omp);
+    });
+  });
+  q.wait_and_throw();
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The `glue::backend_interop::get_native_queue(_executor)` codepath was never used except in a single test.
Remove it to make the code easier to follow. Not part of any public API as far as I can tell.