### PR TITLE
[LIT] Fix invalid device memory access in dynamic functions test

### DIFF
--- a/tests/compiler/sscp/dynamic_function.cpp
+++ b/tests/compiler/sscp/dynamic_function.cpp
@@ -51,7 +51,7 @@ int main() {
     q.memcpy(&host, data, sizeof(int)).wait();
 
     // CHECK: 1
-    std::cout << *data << std::endl;
+    std::cout << host << std::endl;
   }
 
   {
@@ -69,7 +69,7 @@ int main() {
     q.memcpy(&host, data, sizeof(int)).wait();
 
     // CHECK: 1
-    std::cout << *data << std::endl;
+    std::cout << host << std::endl;
   }
 
   {
@@ -87,7 +87,7 @@ int main() {
     q.memcpy(&host, data, sizeof(int)).wait();
 
     // CHECK: 1
-    std::cout << *data << std::endl;
+    std::cout << host << std::endl;
   }
 
   {
@@ -105,7 +105,7 @@ int main() {
     q.memcpy(&host, data, sizeof(int)).wait();
 
     // CHECK: 3
-    std::cout << *data << std::endl;
+    std::cout << host << std::endl;
   }
 
 


### PR DESCRIPTION
Presumably a regression that was introduced when we reduced shared USM usage in tests in favor of device USM.