### PR TITLE
[LLVM 21] More aggressive LLVM builtin remapping; introduce builtin remapping on amdgpu

### DIFF
--- a/include/hipSYCL/compiler/llvm-to-backend/Utils.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/Utils.hpp
@@ -14,6 +14,7 @@
 #include <atomic>
 #include <optional>
 #include <sstream>
+#include <array>
 
 #include "hipSYCL/compiler/llvm-to-backend/LLVMToBackend.hpp"
 #include "hipSYCL/common/debug.hpp"
@@ -382,6 +383,64 @@ std::string getLibAmathDir();
 std::string getLibMvecDir();
 std::string getBitcodePath();
 std::string getRedistPackageBitcodePath(const std::string& backend);
+
+// Some backends do not correctly lower LLVM intrinsics;
+// this function replaces them with acpp builtins.
+// This should be done before linking in AdaptiveCpp builtin
+// bitcode libraries.
+template <int N>
+inline void replaceLLVMIntrinsicsWithAcppBuiltins(
+    llvm::Module &M, const std::array<std::array<const char *, 2>, N> &IntrinsicReplacementMap) {
+  
+  for(auto& RM : IntrinsicReplacementMap) {
+    if(auto* F = M.getFunction(RM[0])) {
+      llvm::Function* Replacement = M.getFunction(RM[1]);
+
+      if(!Replacement) {
+        Replacement = llvm::Function::Create(F->getFunctionType(),
+                                             llvm::GlobalValue::ExternalLinkage, RM[1], M);
+        F->replaceAllUsesWith(Replacement);
+      }
+    }
+  }
+}
+
+inline void replaceLLVMIntrinsicsWithAcppBuiltins(llvm::Module& M) {
+  using IntrinsicMapping = std::array<const char*, 2>;
+  static constexpr std::array IntrinsicReplacementMap = {
+    IntrinsicMapping{"llvm.pow.f32", "__acpp_sscp_pow_f32"},
+    IntrinsicMapping{"llvm.pow.f64", "__acpp_sscp_pow_f64"},
+    IntrinsicMapping{"llvm.exp.f32", "__acpp_sscp_exp_f32"},
+    IntrinsicMapping{"llvm.exp.f64", "__acpp_sscp_exp_f64"},
+    IntrinsicMapping{"llvm.exp2.f32", "__acpp_sscp_exp2_f32"},
+    IntrinsicMapping{"llvm.exp2.f64", "__acpp_sscp_exp2_f64"},
+    IntrinsicMapping{"llvm.exp10.f32", "__acpp_sscp_exp10_f32"},
+    IntrinsicMapping{"llvm.exp10.f64", "__acpp_sscp_exp10_f64"},
+    IntrinsicMapping{"llvm.cos.f32", "__acpp_sscp_cos_f32"},
+    IntrinsicMapping{"llvm.cos.f64", "__acpp_sscp_cos_f64"},
+    IntrinsicMapping{"llvm.sin.f32", "__acpp_sscp_sin_f32"},
+    IntrinsicMapping{"llvm.sin.f64", "__acpp_sscp_sin_f64"},
+    // tan not fine in LLVM 21
+    IntrinsicMapping{"llvm.tan.f32", "__acpp_sscp_tan_f32"},
+    IntrinsicMapping{"llvm.tan.f64", "__acpp_sscp_tan_f64"},
+    IntrinsicMapping{"llvm.log.f32", "__acpp_sscp_log_f32"},
+    IntrinsicMapping{"llvm.log.f64", "__acpp_sscp_log_f64"},
+    IntrinsicMapping{"llvm.log2.f32", "__acpp_sscp_log2_f32"},
+    IntrinsicMapping{"llvm.log2.f64", "__acpp_sscp_log2_f64"},
+    IntrinsicMapping{"llvm.log10.f32", "__acpp_sscp_log10_f32"},
+    IntrinsicMapping{"llvm.log10.f64", "__acpp_sscp_log10_f64"},
+    // asin and a cos not fine in LLVM 21
+    IntrinsicMapping{"llvm.asin.f32", "__acpp_sscp_asin_f32"},
+    IntrinsicMapping{"llvm.asin.f64", "__acpp_sscp_asin_f64"},
+    IntrinsicMapping{"llvm.acos.f32", "__acpp_sscp_acos_f32"},
+    IntrinsicMapping{"llvm.acos.f64", "__acpp_sscp_acos_f64"},
+    // atan at least with LLVM 20 needs remapping
+    IntrinsicMapping{"llvm.atan.f32", "__acpp_sscp_atan_f32"},
+    IntrinsicMapping{"llvm.atan.f64", "__acpp_sscp_atan_f64"}
+  };
+
+  replaceLLVMIntrinsicsWithAcppBuiltins<IntrinsicReplacementMap.size()>(M, IntrinsicReplacementMap);
+}
 
 }
 }

--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -41,6 +41,7 @@
 #include <vector>
 #include <sstream>
 #include <fstream>
+#include <array>
 
 #ifdef ACPP_HIPRTC_LINK
 #define __HIP_PLATFORM_AMD__
@@ -130,6 +131,53 @@ std::string discardConfigurationFromTargetName(const std::string& TargetDevice) 
   if(ColonPos != std::string::npos)
     return TargetDevice.substr(0, ColonPos);
   return TargetDevice;
+}
+
+using IntrinsicMapping = std::array<const char*, 2>;
+static constexpr std::array IntrinsicReplacementMap = {
+  IntrinsicMapping{"llvm.pow.f32", "__acpp_sscp_pow_f32"},
+  IntrinsicMapping{"llvm.pow.f64", "__acpp_sscp_pow_f64"},
+  IntrinsicMapping{"llvm.exp.f32", "__acpp_sscp_exp_f32"},
+  IntrinsicMapping{"llvm.exp.f64", "__acpp_sscp_exp_f64"},
+  IntrinsicMapping{"llvm.exp2.f32", "__acpp_sscp_exp2_f32"},
+  IntrinsicMapping{"llvm.exp2.f64", "__acpp_sscp_exp2_f64"},
+  IntrinsicMapping{"llvm.exp10.f32", "__acpp_sscp_exp10_f32"},
+  IntrinsicMapping{"llvm.exp10.f64", "__acpp_sscp_exp10_f64"},
+  IntrinsicMapping{"llvm.cos.f32", "__acpp_sscp_cos_f32"},
+  IntrinsicMapping{"llvm.cos.f64", "__acpp_sscp_cos_f64"},
+  IntrinsicMapping{"llvm.sin.f32", "__acpp_sscp_sin_f32"},
+  IntrinsicMapping{"llvm.sin.f64", "__acpp_sscp_sin_f64"},
+  // tan not fine in LLVM 21
+  IntrinsicMapping{"llvm.tan.f32", "__acpp_sscp_tan_f32"},
+  IntrinsicMapping{"llvm.tan.f64", "__acpp_sscp_tan_f64"},
+  IntrinsicMapping{"llvm.log.f32", "__acpp_sscp_log_f32"},
+  IntrinsicMapping{"llvm.log.f64", "__acpp_sscp_log_f64"},
+  IntrinsicMapping{"llvm.log2.f32", "__acpp_sscp_log2_f32"},
+  IntrinsicMapping{"llvm.log2.f64", "__acpp_sscp_log2_f64"},
+  IntrinsicMapping{"llvm.log10.f32", "__acpp_sscp_log10_f32"},
+  IntrinsicMapping{"llvm.log10.f64", "__acpp_sscp_log10_f64"},
+  // asin and a cos not fine in LLVM 21
+  IntrinsicMapping{"llvm.asin.f32", "__acpp_sscp_asin_f32"},
+  IntrinsicMapping{"llvm.asin.f64", "__acpp_sscp_asin_f64"},
+  IntrinsicMapping{"llvm.acos.f32", "__acpp_sscp_acos_f32"},
+  IntrinsicMapping{"llvm.acos.f64", "__acpp_sscp_acos_f64"},
+  // atan at least with LLVM 20 needs remapping
+  IntrinsicMapping{"llvm.atan.f32", "__acpp_sscp_atan_f32"},
+  IntrinsicMapping{"llvm.atan.f64", "__acpp_sscp_atan_f64"}
+};
+
+void replaceBrokenLLVMIntrinsics(llvm::Module& M) {
+  for(auto& RM : IntrinsicReplacementMap) {
+    if(auto* F = M.getFunction(RM[0])) {
+      llvm::Function* Replacement = M.getFunction(RM[1]);
+
+      if(!Replacement) {
+        Replacement = llvm::Function::Create(F->getFunctionType(),
+                                             llvm::GlobalValue::ExternalLinkage, RM[1], M);
+        F->replaceAllUsesWith(Replacement);
+      }
+    }
+  }
 }
 
 }
@@ -308,6 +356,8 @@ bool LLVMToAmdgpuTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
       applyKernelProperties(F);
     }
   }
+
+  replaceBrokenLLVMIntrinsics(M);
 
   std::string BuiltinBitcodeFile = 
     common::filesystem::join_path(getBitcodePath(), "libkernel-sscp-amdgpu-amdhsa-full.bc");

--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -41,7 +41,6 @@
 #include <vector>
 #include <sstream>
 #include <fstream>
-#include <array>
 
 #ifdef ACPP_HIPRTC_LINK
 #define __HIP_PLATFORM_AMD__
@@ -131,53 +130,6 @@ std::string discardConfigurationFromTargetName(const std::string& TargetDevice) 
   if(ColonPos != std::string::npos)
     return TargetDevice.substr(0, ColonPos);
   return TargetDevice;
-}
-
-using IntrinsicMapping = std::array<const char*, 2>;
-static constexpr std::array IntrinsicReplacementMap = {
-  IntrinsicMapping{"llvm.pow.f32", "__acpp_sscp_pow_f32"},
-  IntrinsicMapping{"llvm.pow.f64", "__acpp_sscp_pow_f64"},
-  IntrinsicMapping{"llvm.exp.f32", "__acpp_sscp_exp_f32"},
-  IntrinsicMapping{"llvm.exp.f64", "__acpp_sscp_exp_f64"},
-  IntrinsicMapping{"llvm.exp2.f32", "__acpp_sscp_exp2_f32"},
-  IntrinsicMapping{"llvm.exp2.f64", "__acpp_sscp_exp2_f64"},
-  IntrinsicMapping{"llvm.exp10.f32", "__acpp_sscp_exp10_f32"},
-  IntrinsicMapping{"llvm.exp10.f64", "__acpp_sscp_exp10_f64"},
-  IntrinsicMapping{"llvm.cos.f32", "__acpp_sscp_cos_f32"},
-  IntrinsicMapping{"llvm.cos.f64", "__acpp_sscp_cos_f64"},
-  IntrinsicMapping{"llvm.sin.f32", "__acpp_sscp_sin_f32"},
-  IntrinsicMapping{"llvm.sin.f64", "__acpp_sscp_sin_f64"},
-  // tan not fine in LLVM 21
-  IntrinsicMapping{"llvm.tan.f32", "__acpp_sscp_tan_f32"},
-  IntrinsicMapping{"llvm.tan.f64", "__acpp_sscp_tan_f64"},
-  IntrinsicMapping{"llvm.log.f32", "__acpp_sscp_log_f32"},
-  IntrinsicMapping{"llvm.log.f64", "__acpp_sscp_log_f64"},
-  IntrinsicMapping{"llvm.log2.f32", "__acpp_sscp_log2_f32"},
-  IntrinsicMapping{"llvm.log2.f64", "__acpp_sscp_log2_f64"},
-  IntrinsicMapping{"llvm.log10.f32", "__acpp_sscp_log10_f32"},
-  IntrinsicMapping{"llvm.log10.f64", "__acpp_sscp_log10_f64"},
-  // asin and a cos not fine in LLVM 21
-  IntrinsicMapping{"llvm.asin.f32", "__acpp_sscp_asin_f32"},
-  IntrinsicMapping{"llvm.asin.f64", "__acpp_sscp_asin_f64"},
-  IntrinsicMapping{"llvm.acos.f32", "__acpp_sscp_acos_f32"},
-  IntrinsicMapping{"llvm.acos.f64", "__acpp_sscp_acos_f64"},
-  // atan at least with LLVM 20 needs remapping
-  IntrinsicMapping{"llvm.atan.f32", "__acpp_sscp_atan_f32"},
-  IntrinsicMapping{"llvm.atan.f64", "__acpp_sscp_atan_f64"}
-};
-
-void replaceBrokenLLVMIntrinsics(llvm::Module& M) {
-  for(auto& RM : IntrinsicReplacementMap) {
-    if(auto* F = M.getFunction(RM[0])) {
-      llvm::Function* Replacement = M.getFunction(RM[1]);
-
-      if(!Replacement) {
-        Replacement = llvm::Function::Create(F->getFunctionType(),
-                                             llvm::GlobalValue::ExternalLinkage, RM[1], M);
-        F->replaceAllUsesWith(Replacement);
-      }
-    }
-  }
 }
 
 }
@@ -357,7 +309,7 @@ bool LLVMToAmdgpuTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
     }
   }
 
-  replaceBrokenLLVMIntrinsics(M);
+  replaceLLVMIntrinsicsWithAcppBuiltins(M);
 
   std::string BuiltinBitcodeFile = 
     common::filesystem::join_path(getBitcodePath(), "libkernel-sscp-amdgpu-amdhsa-full.bc");

--- a/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
+++ b/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
@@ -104,14 +104,20 @@ static constexpr std::array IntrinsicReplacementMap = {
   IntrinsicMapping{"llvm.cos.f64", "__acpp_sscp_cos_f64"},
   IntrinsicMapping{"llvm.sin.f32", "__acpp_sscp_sin_f32"},
   IntrinsicMapping{"llvm.sin.f64", "__acpp_sscp_sin_f64"},
-  // tan seems fine
+  // tan not fine in LLVM 21
+  IntrinsicMapping{"llvm.tan.f32", "__acpp_sscp_tan_f32"},
+  IntrinsicMapping{"llvm.tan.f64", "__acpp_sscp_tan_f64"},
   IntrinsicMapping{"llvm.log.f32", "__acpp_sscp_log_f32"},
   IntrinsicMapping{"llvm.log.f64", "__acpp_sscp_log_f64"},
   IntrinsicMapping{"llvm.log2.f32", "__acpp_sscp_log2_f32"},
   IntrinsicMapping{"llvm.log2.f64", "__acpp_sscp_log2_f64"},
   IntrinsicMapping{"llvm.log10.f32", "__acpp_sscp_log10_f32"},
   IntrinsicMapping{"llvm.log10.f64", "__acpp_sscp_log10_f64"},
-  // asin seems fine (presumably acos well?)
+  // asin and a cos not fine in LLVM 21
+  IntrinsicMapping{"llvm.asin.f32", "__acpp_sscp_asin_f32"},
+  IntrinsicMapping{"llvm.asin.f64", "__acpp_sscp_asin_f64"},
+  IntrinsicMapping{"llvm.acos.f32", "__acpp_sscp_acos_f32"},
+  IntrinsicMapping{"llvm.acos.f64", "__acpp_sscp_acos_f64"},
   // atan at least with LLVM 20 needs remapping
   IntrinsicMapping{"llvm.atan.f32", "__acpp_sscp_atan_f32"},
   IntrinsicMapping{"llvm.atan.f64", "__acpp_sscp_atan_f64"}

--- a/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
+++ b/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
@@ -87,57 +87,6 @@ void setPrecSqrt(llvm::Module& M, int Mode) {
   setNVVMReflectParameter(M, "prec-sqrt", Mode);
 }
 
-
-using IntrinsicMapping = std::array<const char*, 2>;
-// These intrinsics seem to not be handled correctly by NVPTX backend,
-// so replace them with our own builtins.
-static constexpr std::array IntrinsicReplacementMap = {
-  IntrinsicMapping{"llvm.pow.f32", "__acpp_sscp_pow_f32"},
-  IntrinsicMapping{"llvm.pow.f64", "__acpp_sscp_pow_f64"},
-  IntrinsicMapping{"llvm.exp.f32", "__acpp_sscp_exp_f32"},
-  IntrinsicMapping{"llvm.exp.f64", "__acpp_sscp_exp_f64"},
-  IntrinsicMapping{"llvm.exp2.f32", "__acpp_sscp_exp2_f32"},
-  IntrinsicMapping{"llvm.exp2.f64", "__acpp_sscp_exp2_f64"},
-  IntrinsicMapping{"llvm.exp10.f32", "__acpp_sscp_exp10_f32"},
-  IntrinsicMapping{"llvm.exp10.f64", "__acpp_sscp_exp10_f64"},
-  IntrinsicMapping{"llvm.cos.f32", "__acpp_sscp_cos_f32"},
-  IntrinsicMapping{"llvm.cos.f64", "__acpp_sscp_cos_f64"},
-  IntrinsicMapping{"llvm.sin.f32", "__acpp_sscp_sin_f32"},
-  IntrinsicMapping{"llvm.sin.f64", "__acpp_sscp_sin_f64"},
-  // tan not fine in LLVM 21
-  IntrinsicMapping{"llvm.tan.f32", "__acpp_sscp_tan_f32"},
-  IntrinsicMapping{"llvm.tan.f64", "__acpp_sscp_tan_f64"},
-  IntrinsicMapping{"llvm.log.f32", "__acpp_sscp_log_f32"},
-  IntrinsicMapping{"llvm.log.f64", "__acpp_sscp_log_f64"},
-  IntrinsicMapping{"llvm.log2.f32", "__acpp_sscp_log2_f32"},
-  IntrinsicMapping{"llvm.log2.f64", "__acpp_sscp_log2_f64"},
-  IntrinsicMapping{"llvm.log10.f32", "__acpp_sscp_log10_f32"},
-  IntrinsicMapping{"llvm.log10.f64", "__acpp_sscp_log10_f64"},
-  // asin and a cos not fine in LLVM 21
-  IntrinsicMapping{"llvm.asin.f32", "__acpp_sscp_asin_f32"},
-  IntrinsicMapping{"llvm.asin.f64", "__acpp_sscp_asin_f64"},
-  IntrinsicMapping{"llvm.acos.f32", "__acpp_sscp_acos_f32"},
-  IntrinsicMapping{"llvm.acos.f64", "__acpp_sscp_acos_f64"},
-  // atan at least with LLVM 20 needs remapping
-  IntrinsicMapping{"llvm.atan.f32", "__acpp_sscp_atan_f32"},
-  IntrinsicMapping{"llvm.atan.f64", "__acpp_sscp_atan_f64"}
-  // sqrt seems fine
-};
-
-void replaceBrokenLLVMIntrinsics(llvm::Module& M) {
-  for(auto& RM : IntrinsicReplacementMap) {
-    if(auto* F = M.getFunction(RM[0])) {
-      llvm::Function* Replacement = M.getFunction(RM[1]);
-
-      if(!Replacement) {
-        Replacement = llvm::Function::Create(F->getFunctionType(),
-                                             llvm::GlobalValue::ExternalLinkage, RM[1], M);
-        F->replaceAllUsesWith(Replacement);
-      }
-    }
-  }
-}
-
 }
 
 LLVMToPtxTranslator::LLVMToPtxTranslator(const std::vector<std::string> &KN)
@@ -189,7 +138,7 @@ bool LLVMToPtxTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
     }
   }
 
-  replaceBrokenLLVMIntrinsics(M);
+  replaceLLVMIntrinsicsWithAcppBuiltins(M);
 
   std::string BuiltinBitcodeFile =
       common::filesystem::join_path(getBitcodePath(), "libkernel-sscp-ptx-full.bc");


### PR DESCRIPTION
Looks like in LLVM 21, LLVM intrinsics that previously worked fine in the nvptx backend now no longer work.
Similarly, previously there were no known cases of LLVM math intrinsics not working on amdgpu -- now there are.

This PR adds intrinsic remapping such that the `builtin_remapping.cpp` LIT test now passes with LLVM 21.

Currently, the PR has some code duplication, which is not nice. Also, since both nvptx and amdgpu now suffer from this (and LLVM as a whole seems unreliable, not just the nvptx backend), we should maybe think about whether we do want to address this globally after all -> draft PR.