### PR TITLE
[Metal] Fix scratch buffer race in work-group reduce and predicates

### DIFF
--- a/src/libkernel/sscp/metal/collpredicate.cpp
+++ b/src/libkernel/sscp/metal/collpredicate.cpp
@@ -72,8 +72,9 @@ bool __acpp_sscp_work_group_any(bool predicate) {
     }
   }
   __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
-
-  return scratch[0];
+  bool tmp = scratch[0];
+  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+  return tmp;
 }
 
 HIPSYCL_SSCP_CONVERGENT_BUILTIN
@@ -112,8 +113,9 @@ bool __acpp_sscp_work_group_all(bool predicate) {
     }
   }
   __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
-
-  return scratch[0];
+  bool tmp = scratch[0];
+  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+  return tmp;
 }
 
 HIPSYCL_SSCP_CONVERGENT_BUILTIN

--- a/src/libkernel/sscp/metal/reduction.cpp
+++ b/src/libkernel/sscp/metal/reduction.cpp
@@ -217,7 +217,9 @@ inline T __acpp_sscp_work_group_reduce(T value) {
   }
 
   __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
-  return scratch[0];
+  T tmp = scratch[0];
+  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+  return tmp;
 }
 
 #define X(type) \


### PR DESCRIPTION
This should fix flaky metal reduction tests caused by a scratch buffer race between simd groups