### PR TITLE
[CI] Disable ROCm version 6.3 for clang 17

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,12 +21,6 @@ jobs:
         cuda_patch_version: [2]
         rocm: [5.4.3]
         include:
-          - clang: 17
-            os: ubuntu-22.04
-            cuda_major_version: 11
-            cuda_minor_version: 0
-            cuda_patch_version: 2
-            rocm: 5.6.1
           - clang: 21
             os: ubuntu-22.04
             cuda_major_version: 11


### PR DESCRIPTION
Currently, we test ROCm 5.4 for LLVM < 21 and ROCm 6.3 for LLVM 21.

LLVM 17 is the outlier, because we seem to test it with both ROCm versions. I don't know what the background is, but it does seem like the ROCm 6.3 build with LLVM 17 causes hiccups in our CI pipeline (it seems like the wrong docker image is pulled?).

I don't have the time at the moment to figure out the exact problem, so I propose to just disable that test. It seems strange to me anyway that we have this special treatment for LLVM 17.

Note that both LLVM 17 and ROCm 6.3 continue to be tested, not just in that specific combination.