### PR TITLE
Increase score granularity in CPU device selector

### DIFF
--- a/include/hipSYCL/sycl/device_selector.hpp
+++ b/include/hipSYCL/sycl/device_selector.hpp
@@ -85,8 +85,15 @@ inline int select_accelerator(const device& dev) {
 }
 
 inline int select_cpu(const device& dev) {
-  if(dev.is_cpu())
-    return 1;
+  if(dev.is_cpu()) {
+    // Prefer non-OpenMP CPU device since the OpenMP backend cannot be disabled,
+    // so there would be no way to select e.g. an OpenCL CPU device
+    // using ACPP_VISIBILITY_MASK otherwise.
+    if(dev.get_backend() != sycl::backend::omp)
+      return 1;
+    else
+      return 0;
+  }
   return -1;
 }
 


### PR DESCRIPTION
The current CPU device selection logic for gives devices a score of either `1` or `-1` depending on if they are a CPU device or not.

However, if a user has multiple CPU backends in their build this does not allow for flexibility in selecting a specific CPU device with `ACPP_VISIBILITY_MASK` because the OpenMP device will also always be enabled and have the same score, leading to an undefined device being returned from the two devices with the same score. This patch favors the non-OpenMP device as is done in the default selector.

I experienced this when running hecbench executables compiled to use `sycl::cpu_selector_v` against an AdaptiveCpp library with 3 CPU backends enabled: OpenMP, OpenCL CPU, and Vulkan llvmpipe. In such a situation it's helpful to be able to use `ACPP_VISIBILITY_MASK` to specify which of 3 backhands to use.