### PR TITLE
[Windows][SSCP][AMDGPU] Generate Windows AMDGPU libkernel bitcode with short wchar

### DIFF
--- a/src/libkernel/sscp/amdgpu/CMakeLists.txt
+++ b/src/libkernel/sscp/amdgpu/CMakeLists.txt
@@ -1,3 +1,10 @@
+set(amdgpu_libkernel_additional_args -nogpulib)
+
+if(WIN32)
+  list(APPEND amdgpu_libkernel_additional_args
+    -Xclang -fwchar-type=short)
+endif()
+
 if(WITH_LLVM_TO_AMDGPU_AMDHSA)
   libkernel_generate_bitcode_target(
       TARGETNAME amdgpu-amdhsa 
@@ -21,5 +28,5 @@ if(WITH_LLVM_TO_AMDGPU_AMDHSA)
       broadcast.cpp
       scan_inclusive.cpp
       scan_exclusive.cpp
-      ADDITIONAL_ARGS -nogpulib)
+      ADDITIONAL_ARGS ${amdgpu_libkernel_additional_args})
 endif()

--- a/src/libkernel/sscp/amdgpu/CMakeLists.txt
+++ b/src/libkernel/sscp/amdgpu/CMakeLists.txt
@@ -1,11 +1,11 @@
-set(amdgpu_libkernel_additional_args -nogpulib)
-
-if(WIN32)
-  list(APPEND amdgpu_libkernel_additional_args
-    -Xclang -fwchar-type=short)
-endif()
-
 if(WITH_LLVM_TO_AMDGPU_AMDHSA)
+  set(amdgpu_libkernel_additional_args -nogpulib)
+
+  if(WIN32)
+    list(APPEND amdgpu_libkernel_additional_args
+        -Xclang -fwchar-type=short)
+  endif()
+
   libkernel_generate_bitcode_target(
       TARGETNAME amdgpu-amdhsa 
       TRIPLE amdgcn-amd-amdhsa


### PR DESCRIPTION
On Windows, HIP device compilation emits LLVM IR with `wchar_size = 2`. AdaptiveCpp's generated AMDGPU libkernel bitcode used `wchar_size = 4`, which caused module flag conflicts during SSCP AMDGPU JIT linking.

This PR fixes this by generating AMDGPU libkernel bitcode on Windows with `-fwchar-type=short`.