### PR TITLE
[Windows][SSCP] Remove MSVC linker directives from generic device IR on Windows

### DIFF
--- a/src/compiler/sscp/TargetSeparationPass.cpp
+++ b/src/compiler/sscp/TargetSeparationPass.cpp
@@ -234,7 +234,6 @@ void removeModuleFlag(llvm::Module& M, llvm::StringRef Name) {
   }
 }
 
-#ifdef _WIN32
 void removeLinkerOptionsByPrefixes(
     llvm::Module& M,
     llvm::ArrayRef<llvm::StringRef> Prefixes) {
@@ -278,7 +277,6 @@ void removeLinkerOptionsByPrefixes(
       NewNMD->addOperand(OptionNode);
   }
 }
-#endif
 
 std::unique_ptr<llvm::Module> generateDeviceIR(llvm::Module &M,
                                                const std::vector<std::string>& DynamicFunctions,

--- a/src/compiler/sscp/TargetSeparationPass.cpp
+++ b/src/compiler/sscp/TargetSeparationPass.cpp
@@ -234,6 +234,52 @@ void removeModuleFlag(llvm::Module& M, llvm::StringRef Name) {
   }
 }
 
+#ifdef _WIN32
+void removeLinkerOptionsByPrefixes(
+    llvm::Module& M,
+    llvm::ArrayRef<llvm::StringRef> Prefixes) {
+
+  llvm::NamedMDNode* NMD = M.getNamedMetadata("llvm.linker.options");
+  if(!NMD)
+    return;
+
+  auto StartsWithPrefix = [&](llvm::StringRef Option) {
+    for(auto Prefix : Prefixes) {
+      if(Option.starts_with(Prefix))
+        return true;
+    }
+
+    return false;
+  };
+
+  llvm::SmallVector<llvm::MDNode*, 8> RemainingOptions;
+
+  for(unsigned i = 0; i < NMD->getNumOperands(); ++i) {
+    llvm::MDNode* OptionNode = NMD->getOperand(i);
+
+    bool Remove = false;
+    if(OptionNode && OptionNode->getNumOperands() > 0) {
+      if(auto* Option = llvm::dyn_cast<llvm::MDString>(OptionNode->getOperand(0))) {
+        Remove = StartsWithPrefix(Option->getString());
+      }
+    }
+
+    if(!Remove)
+      RemainingOptions.push_back(OptionNode);
+  }
+
+  M.eraseNamedMetadata(NMD);
+
+  if(!RemainingOptions.empty()) {
+    llvm::NamedMDNode* NewNMD =
+        M.getOrInsertNamedMetadata("llvm.linker.options");
+
+    for(llvm::MDNode* OptionNode : RemainingOptions)
+      NewNMD->addOperand(OptionNode);
+  }
+}
+#endif
+
 std::unique_ptr<llvm::Module> generateDeviceIR(llvm::Module &M,
                                                const std::vector<std::string>& DynamicFunctions,
                                                std::vector<KernelInfo> &KernelInfoOutput,
@@ -295,6 +341,11 @@ std::unique_ptr<llvm::Module> generateDeviceIR(llvm::Module &M,
   
   // Remove host-specific module flags that should not leak into generic device IR
   removeModuleFlag(*DeviceModule, "wchar_size");  
+
+#ifdef _WIN32
+  // Remove MSVC host linker directives from generic device IR
+  removeLinkerOptionsByPrefixes(*DeviceModule, {"/"});
+#endif
 
   llvm::SmallSet<llvm::Function *, 16> AcppNoInlineFunctions;
   utils::findFunctionsWithStringAnnotations(

--- a/src/compiler/sscp/TargetSeparationPass.cpp
+++ b/src/compiler/sscp/TargetSeparationPass.cpp
@@ -244,7 +244,7 @@ void removeLinkerOptionsByPrefixes(
 
   auto StartsWithPrefix = [&](llvm::StringRef Option) {
     for(auto Prefix : Prefixes) {
-      if(Option.starts_with(Prefix))
+      if(llvmutils::starts_with(Option, Prefix))
         return true;
     }
 


### PR DESCRIPTION
On Windows, MSVC linker directives are injected into `llvm.linker.options` metadata in generic device IR. These directives are host-specific and can break SSCP JIT flows, for example causing HIP/ROCm bitcode linking to fail.

This PR fixes it by removing MSVC-style linker options from device IR during TargetSeparationPass.

This fix is currently applied only on Windows and removes linker options starting with `/`, matching MSVC linker directive style.