### PR TITLE
[SSCP][acpp] Auto-include hcf_registration.hpp for improved C++ modules support

### DIFF
--- a/bin/acpp
+++ b/bin/acpp
@@ -2334,11 +2334,17 @@ class compiler:
       file_replacement_map[s] = outfile
 
     result_args = []
+    consume_next = False
     for arg in args:
       if arg in file_replacement_map:
         result_args.append(file_replacement_map[arg])
       else:
-        result_args.append(arg)
+        if arg == "-include":
+          consume_next = True
+        elif consume_next:
+          consume_next = False
+        else:
+          result_args.append(arg)
     
     return result_args
 

--- a/bin/acpp
+++ b/bin/acpp
@@ -1947,6 +1947,8 @@ class llvm_sscp_invocation:
 
   def get_cxx_flags(self):
     flags = ["-D__ACPP_ENABLE_LLVM_SSCP_TARGET__",
+            "-include", os.path.join(self._config.acpp_include_path, 
+                "hipSYCL", "glue", "llvm-sscp", "hcf_registration.hpp"),
             "-Xclang", "-disable-O0-optnone", "-mllvm", "-acpp-sscp"]
     
     if self._config.is_export_all:

--- a/include/hipSYCL/glue/llvm-sscp/hcf_registration.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/hcf_registration.hpp
@@ -9,26 +9,26 @@
  */
 // SPDX-License-Identifier: BSD-2-Clause
 
+// This file may be included early; avoid including std headers.
 #include "s1_ir_constants.hpp"
-#include <cstdlib>
 
 
 #ifndef ACPP_SSCP_HCF_REGISTRATION_HPP
 #define ACPP_SSCP_HCF_REGISTRATION_HPP
 
 // These functions are defined in the AdaptiveCpp runtime (kernel_cache.cpp)
-extern "C" void __acpp_register_hcf(const char* hcf, std::size_t size);
-extern "C" void __acpp_unregister_hcf(std::size_t hcf_object_id);
+extern "C" void __acpp_register_hcf(const char* hcf, unsigned long long size);
+extern "C" void __acpp_unregister_hcf(unsigned long long hcf_object_id);
 
 namespace hipsycl::glue::sscp {
 
 static const char* get_local_hcf_object() {
   return __acpp_local_sscp_hcf_content;
 }
-static std::size_t get_local_hcf_size() {
+static unsigned long long get_local_hcf_size() {
   return __acpp_local_sscp_hcf_object_size;
 }
-static std::size_t get_local_hcf_id() {
+static unsigned long long get_local_hcf_id() {
   return __acpp_local_sscp_hcf_object_id;
 }
 

--- a/include/hipSYCL/glue/llvm-sscp/hcf_registration.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/hcf_registration.hpp
@@ -9,7 +9,12 @@
  */
 // SPDX-License-Identifier: BSD-2-Clause
 
+
 // This file may be included early; avoid including std headers.
+// THIS FILE SHOULD NOT BE EXPLICITLY INCLUDED; THE COMPILER WILL DO
+// IT AUTOMATICALLY
+
+
 #include "s1_ir_constants.hpp"
 
 

--- a/include/hipSYCL/glue/llvm-sscp/sscp_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/sscp_kernel_launcher.hpp
@@ -29,7 +29,7 @@
 #include "hipSYCL/sycl/libkernel/sp_group.hpp"
 #include "hipSYCL/sycl/libkernel/group.hpp"
 #include "ir_constants.hpp"
-#include "hcf_registration.hpp"
+
 #include "../kernel_launcher_data.hpp"
 
 #include <array>

--- a/include/hipSYCL/pcuda/pcuda.hpp
+++ b/include/hipSYCL/pcuda/pcuda.hpp
@@ -14,7 +14,6 @@
 #define ACPP_PCUDA_HPP
 
 #include "hipSYCL/glue/llvm-sscp/s1_ir_constants.hpp"
-#include "hipSYCL/glue/llvm-sscp/hcf_registration.hpp"
 #include "hipSYCL/sycl/libkernel/backend.hpp"
 #include "hipSYCL/sycl/libkernel/sscp/builtins/core.hpp"
 #include "hipSYCL/sycl/libkernel/sscp/builtins/subgroup.hpp"

--- a/src/runtime/kernel_cache.cpp
+++ b/src/runtime/kernel_cache.cpp
@@ -46,12 +46,12 @@ void for_each_exported_symbol_list(const common::hcf_container& hcf, F&& handler
 
 }
 
-extern "C" void __acpp_register_hcf(const char* hcf, std::size_t size) {
+extern "C" void __acpp_register_hcf(const char* hcf, unsigned long long size) {
   std::string hcf_data{hcf, size};
   hcf_cache::get().register_hcf_object(common::hcf_container{hcf_data});
 }
 
-extern "C" void __acpp_unregister_hcf(std::size_t hcf_object_id) {
+extern "C" void __acpp_unregister_hcf(unsigned long long hcf_object_id) {
   hcf_cache::get().unregister_hcf_object(hcf_object_id);
 }
 


### PR DESCRIPTION
This is a workaround that fixes #2085

With C++ modules, it can happen that the instantiation site of a kernel is no longer guaranteed to have `hcf_registration.hpp` included. Without modules, this is the case because in order to submit a kernel, users must include `sycl.hpp`.
In the modules case, the missing include can cause the kernel not to be registered with the runtime.

This PR works around this problem by automatically including the registration header using `-include` for every source file.

Since the header is extremely small, this should not have measurable impact on compile times.

This can also fix issues with `--acpp-export-all`, which previously has also required that somewhere `sycl.hpp` was included. This should no longer be necessary.
