### PR TITLE
[Metal] Fix high-level extraction skipping child region entry payload

### DIFF
--- a/src/compiler/llvm-to-backend/metal/HLExtractionPass.cpp
+++ b/src/compiler/llvm-to-backend/metal/HLExtractionPass.cpp
@@ -26,6 +26,7 @@
 
 #include "HLExtractionPass.hpp"
 
+#include <cassert>
 #include <deque>
 #include <iostream>
 
@@ -196,6 +197,65 @@ struct Extractor {
     }
   }
 
+  void collectEmittedBlocks(
+    const NodePtr& n,
+    std::unordered_set<const BasicBlock*>& emitted) const
+  {
+    if (!n) return;
+
+    if (n->kind == NodeKind::Block) {
+      auto bn = std::static_pointer_cast<BlockNode>(n);
+      if (bn->bb) {
+        emitted.emplace(bn->bb);
+      }
+      return;
+    }
+
+    if (n->kind == NodeKind::List) {
+      auto ln = std::static_pointer_cast<ListNode>(n);
+      for (const auto& item : ln->items) {
+        collectEmittedBlocks(item, emitted);
+      }
+      return;
+    }
+
+    if (n->kind == NodeKind::If) {
+      auto in = std::static_pointer_cast<IfNode>(n);
+      collectEmittedBlocks(in->then_branch, emitted);
+      collectEmittedBlocks(in->else_branch, emitted);
+      return;
+    }
+
+    if (n->kind == NodeKind::Loop) {
+      auto loop = std::static_pointer_cast<LoopNode>(n);
+      collectEmittedBlocks(loop->body, emitted);
+    }
+  }
+
+  bool nodeStartsWithBlock(const NodePtr& n, const BasicBlock* BB) const {
+    assert(n && "HLTree list items must not be null");
+    if (!BB) return false;
+
+    if (n->kind == NodeKind::Block) {
+      return std::static_pointer_cast<BlockNode>(n)->bb == BB;
+    }
+
+    if (n->kind == NodeKind::List) {
+      auto ln = std::static_pointer_cast<ListNode>(n);
+      if (ln->items.empty()) return false;
+      assert(ln->items.front() && "HLTree list items must not be null");
+      return nodeStartsWithBlock(ln->items.front(), BB);
+    }
+
+    if (n->kind == NodeKind::Loop) {
+      auto loop = std::static_pointer_cast<LoopNode>(n);
+      assert(loop->body && "HLTree loop nodes must have a body");
+      return nodeStartsWithBlock(loop->body, BB);
+    }
+
+    return false;
+  }
+
   // BFS from start, collecting all reachable blocks until stop (exclusive)
   std::unordered_set<const BasicBlock*> collectBranchBlocksUntil(
     const BasicBlock* start,
@@ -267,6 +327,15 @@ struct Extractor {
         NodePtr child = it->second;
         if (child) {
           extractConditions(child);
+          if (!nodeStartsWithBlock(child, BB)) {
+            localConsumed.emplace(BB);
+            globalConsumed.emplace(BB);
+
+            auto bn = std::make_shared<BlockNode>(BB);
+            bn->R = R;
+            bn->parentLoop = parentLoop;
+            seq->append(bn);
+          }
           seq->append(child);
           markRegionBlocksConsumed(child->R, globalConsumed);
           BB = child->R ? child->R->getExit() : nullptr;
@@ -490,8 +559,13 @@ struct Extractor {
       }
     }
 
+    std::unordered_set<const BasicBlock*> emittedBlocks;
+    for (const auto& item : ln.items) {
+      collectEmittedBlocks(item, emittedBlocks);
+    }
+
     for (auto* BB : regionBlocks) {
-      if (consumed.find(BB) == consumed.end()) {
+      if (emittedBlocks.find(BB) == emittedBlocks.end()) {
         std::cerr << "WARNING: Block not emitted in region: " << BB->getName().str() << "\n";
       }
     }


### PR DESCRIPTION
Fixes Metal HL extraction when a child region starts at a block that has both payload and a conditional terminator
Problem CFG:
  ```text
        A
       / \
      B   |
      |   |
      +---+
        |
        v
        C
     payload:
       x = ...
       cond = ...
     br cond
      /   \
     T     F
```

`buildSequence()` replaced C with its child region. The child region started with IfNode(cond from C), but did not emit BlockNode(C), so MSL used cond without assigning it

Fix: before appending a child region, emit BlockNode(C) if the child tree does not already start with C

Also fixes DEBUG_VERIFY_COMPLETENESS: it now checks actual BlockNodes in the final HL tree instead of the intermediate consumed bookkeeping set, which caused both false negatives and false positives

A reproducer is included below. The kernel snippet is taken from llama.cpp
```cpp
#include <sycl/sycl.hpp>

#include <cstdio>
#include <cstdlib>
#include <vector>

static int next_power_of_2(int n) {
  int p = 1;
  while (p < n) p *= 2;
  return p;
}

static void k_argsort_reduced(const float *x, int *dst, const int ncols,
                              int ncols_pad,
                              const int tasks_per_thread,
                              const sycl::nd_item<3> &item,
                              uint8_t *local_mem) {
  int col_index = item.get_local_id(2);
  int row = item.get_group(1);

  for (int i = 0; i < tasks_per_thread; ++i) {
    int col = col_index * tasks_per_thread + i;
    if (col >= ncols_pad) return;
  }

  const float *x_row = x + row * ncols;
  auto dst_row = (int *)local_mem;

  for (int i = 0; i < tasks_per_thread; ++i) {
    int col = col_index * tasks_per_thread + i;
    dst_row[col] = col;
  }
  item.barrier(sycl::access::fence_space::local_space);

  for (int k = 2; k <= ncols_pad; k *= 2) {
    int j = k / 2;
    for (int i = 0; i < tasks_per_thread; ++i) {
      int col = col_index * tasks_per_thread + i;
      int ixj = col ^ j;
      if (ixj > col) {
        if (x_row[dst_row[col]] < x_row[dst_row[ixj]]) {
          int tmp = dst_row[col];
          dst_row[col] = dst_row[ixj];
          dst_row[ixj] = tmp;
        }
      }

      item.barrier(sycl::access::fence_space::local_space);
    }
  }

  for (int i = 0; i < tasks_per_thread; ++i) {
    int col = col_index * tasks_per_thread + i;
    if (col < ncols) {
      dst[row * ncols + col] = dst_row[col];
    }
  }
}

int main(int argc, char **argv) {
  sycl::queue q;
  auto dev = q.get_device();
  std::printf("Device: %s\n", dev.get_info<sycl::info::device::name>().c_str());

  const int ncols = argc > 1 ? std::atoi(argv[1]) : 2;
  const int nrows = 1;
  const int ncols_pad = next_power_of_2(ncols);
  const int nth = ncols_pad;
  const int tasks_per_thread = ncols_pad / nth;

  std::printf("ncols=%d ncols_pad=%d nth=%d tasks_per_thread=%d\n",
              ncols, ncols_pad, nth, tasks_per_thread);

  std::vector<float> h_x(nrows * ncols);
  for (int r = 0; r < nrows; ++r) {
    for (int c = 0; c < ncols; ++c) {
      h_x[r * ncols + c] = static_cast<float>((c * 17 + r * 13) % ncols);
    }
  }

  float *d_x = sycl::malloc_device<float>(nrows * ncols, q);
  int *d_dst = sycl::malloc_device<int>(nrows * ncols, q);
  std::vector<int> init(nrows * ncols, -999);
  q.memcpy(d_x, h_x.data(), h_x.size() * sizeof(float)).wait();
  q.memcpy(d_dst, init.data(), init.size() * sizeof(int)).wait();

  const size_t shared_mem = ncols_pad * sizeof(int);
  const sycl::range<3> block_dims(1, 1, nth);
  const sycl::range<3> block_nums(1, nrows, 1);

  q.submit([&](sycl::handler &cgh) {
    sycl::local_accessor<uint8_t, 1> local_acc(sycl::range<1>(shared_mem),
                                               cgh);
    cgh.parallel_for(
        sycl::nd_range<3>(block_nums * block_dims, block_dims),
        [=](sycl::nd_item<3> item) {
          k_argsort_reduced(
              d_x, d_dst, ncols, ncols_pad, tasks_per_thread, item,
              local_acc.get_multi_ptr<sycl::access::decorated::no>().get());
        });
  }).wait();

  std::vector<int> out(nrows * ncols);
  q.memcpy(out.data(), d_dst, out.size() * sizeof(int)).wait();

  int unwritten = 0;
  int out_of_range = 0;
  for (int v : out) {
    if (v == -999) ++unwritten;
    if (v < 0 || v >= ncols) ++out_of_range;
  }

  std::printf("Total cells: %d, unwritten: %d, out_of_range: %d\n",
              nrows * ncols, unwritten, out_of_range);
  if (unwritten == 0 && out_of_range == 0) {
    std::printf("PASS: reduced argsort CFG wrote all cells\n");
  } else {
    std::printf("FAIL: reduced argsort CFG reproduced skipped writeback\n");
  }

  sycl::free(d_x, q);
  sycl::free(d_dst, q);
  return (unwritten == 0 && out_of_range == 0) ? 0 : 1;
}

```