### PR TITLE
[SSCP][Windows] Avoid console windows when launching JIT tools on Windows

### DIFF
--- a/include/hipSYCL/compiler/llvm-to-backend/Utils.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/Utils.hpp
@@ -383,6 +383,11 @@ std::string getLibAmathDir();
 std::string getLibMvecDir();
 std::string getBitcodePath();
 std::string getRedistPackageBitcodePath(const std::string& backend);
+int executeAndWait(
+    llvm::StringRef program,
+    llvm::ArrayRef<llvm::StringRef> args,
+    std::optional<llvm::ArrayRef<llvm::StringRef>> env = std::nullopt,
+    llvm::ArrayRef<std::optional<llvm::StringRef>> redirects = {});
 
 // Some backends do not correctly lower LLVM intrinsics;
 // this function replaces them with acpp builtins.

--- a/include/hipSYCL/compiler/llvm-to-backend/Utils.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/Utils.hpp
@@ -39,6 +39,10 @@
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Passes/PassBuilder.h>
 
+#if LLVM_VERSION_MAJOR < 16
+#include <llvm/ADT/Optional.h>
+#endif
+
 namespace hipsycl {
 namespace compiler {
 
@@ -383,11 +387,20 @@ std::string getLibAmathDir();
 std::string getLibMvecDir();
 std::string getBitcodePath();
 std::string getRedistPackageBitcodePath(const std::string& backend);
+
+#if LLVM_VERSION_MAJOR >= 16
 int executeAndWait(
-    llvm::StringRef program,
-    llvm::ArrayRef<llvm::StringRef> args,
-    std::optional<llvm::ArrayRef<llvm::StringRef>> env = std::nullopt,
-    llvm::ArrayRef<std::optional<llvm::StringRef>> redirects = {});
+    llvm::StringRef Program,
+    llvm::ArrayRef<llvm::StringRef> Args,
+    std::optional<llvm::ArrayRef<llvm::StringRef>> Env = std::nullopt,
+    llvm::ArrayRef<std::optional<llvm::StringRef>> Redirects = {});
+#else
+int executeAndWait(
+    llvm::StringRef Program,
+    llvm::ArrayRef<llvm::StringRef> Args,
+    llvm::Optional<llvm::ArrayRef<llvm::StringRef>> Env = llvm::None,
+    llvm::ArrayRef<llvm::Optional<llvm::StringRef>> Redirects = {});
+#endif
 
 // Some backends do not correctly lower LLVM intrinsics;
 // this function replaces them with acpp builtins.

--- a/src/compiler/llvm-to-backend/Utils.cpp
+++ b/src/compiler/llvm-to-backend/Utils.cpp
@@ -258,7 +258,14 @@ int executeAndWait(
     std::optional<llvm::ArrayRef<llvm::StringRef>> Env,
     llvm::ArrayRef<std::optional<llvm::StringRef>> Redirects) {
 #if !defined(_WIN32) || LLVM_VERSION_MAJOR < 19
+#if LLVM_VERSION_MAJOR < 16
+  llvm::Optional<llvm::ArrayRef<llvm::StringRef>> EnvLegacy;
+  if(Env)
+    EnvLegacy = *Env;
+  return llvm::sys::ExecuteAndWait(Program, Args, EnvLegacy, Redirects);
+#else
   return llvm::sys::ExecuteAndWait(Program, Args, Env, Redirects);
+#endif
 #else
   std::string ErrMsg;
   bool ExecutionFailed = false;

--- a/src/compiler/llvm-to-backend/Utils.cpp
+++ b/src/compiler/llvm-to-backend/Utils.cpp
@@ -12,6 +12,12 @@
 #include "hipSYCL/compiler/llvm-to-backend/Utils.hpp"
 #include "hipSYCL/common/filesystem.hpp"
 
+#include <llvm/Support/Program.h>
+
+#ifdef _WIN32
+#include <llvm/Support/FileSystem.h>
+#endif
+
 namespace hipsycl {
 namespace compiler {
 
@@ -244,6 +250,72 @@ std::string getBitcodePath() {
 std::string getRedistPackageBitcodePath(const std::string& backend) {
   return common::filesystem::join_path(getRedistributablePackagePath(),
                                        std::vector<std::string>{"bitcode", backend});
+}
+
+int executeAndWait(
+    llvm::StringRef Program,
+    llvm::ArrayRef<llvm::StringRef> Args,
+    std::optional<llvm::ArrayRef<llvm::StringRef>> Env,
+    llvm::ArrayRef<std::optional<llvm::StringRef>> Redirects) {
+#ifndef _WIN32
+  return llvm::sys::ExecuteAndWait(Program, Args, Env, Redirects);
+#else
+  std::string ErrMsg;
+  bool ExecutionFailed = false;
+
+  llvm::SmallVector<std::optional<llvm::StringRef>, 3> ActualRedirects;
+  llvm::SmallString<128> StdoutFile;
+  llvm::SmallString<128> StderrFile;
+
+  bool CaptureOutput = Redirects.empty();
+
+  if(CaptureOutput) {
+    if(auto E = llvm::sys::fs::createTemporaryFile(
+           "acpp-tool-stdout", "txt", StdoutFile, llvm::sys::fs::OF_None))
+      return -1;
+
+    if(auto E = llvm::sys::fs::createTemporaryFile(
+           "acpp-tool-stderr", "txt", StderrFile, llvm::sys::fs::OF_None)) {
+      llvm::sys::fs::remove(StdoutFile);
+      return -1;
+    }
+
+    ActualRedirects.push_back(llvm::StringRef{}); // stdin -> NUL
+    ActualRedirects.push_back(StdoutFile.str());  // stdout -> temp file
+    ActualRedirects.push_back(StderrFile.str());  // stderr -> temp file
+
+    Redirects = ActualRedirects;
+  }
+
+  auto cleanup = [&]() {
+    if(CaptureOutput) {
+      auto Err0 = llvm::sys::fs::remove(StdoutFile);
+      auto Err1 = llvm::sys::fs::remove(StderrFile);
+    }
+  };
+
+  auto ProcessInfo =
+      llvm::sys::ExecuteNoWait(Program, Args, Env, Redirects,
+                               0, &ErrMsg, &ExecutionFailed, nullptr, true);
+
+  if(ExecutionFailed) {
+    cleanup();
+    return -1;
+  }
+
+  auto Result = llvm::sys::Wait(ProcessInfo, std::nullopt);
+
+  if(CaptureOutput) {
+    if(auto StdoutBuffer = llvm::MemoryBuffer::getFile(StdoutFile))
+      llvm::outs() << StdoutBuffer.get()->getBuffer();
+
+    if(auto StderrBuffer = llvm::MemoryBuffer::getFile(StderrFile))
+      llvm::errs() << StderrBuffer.get()->getBuffer();
+  }
+
+  cleanup();
+  return Result.ReturnCode;
+#endif
 }
 
 } // namespace compiler

--- a/src/compiler/llvm-to-backend/Utils.cpp
+++ b/src/compiler/llvm-to-backend/Utils.cpp
@@ -252,20 +252,22 @@ std::string getRedistPackageBitcodePath(const std::string& backend) {
                                        std::vector<std::string>{"bitcode", backend});
 }
 
+#if LLVM_VERSION_MAJOR < 16
+int executeAndWait(
+    llvm::StringRef Program,
+    llvm::ArrayRef<llvm::StringRef> Args,
+    llvm::Optional<llvm::ArrayRef<llvm::StringRef>> Env,
+    llvm::ArrayRef<llvm::Optional<llvm::StringRef>> Redirects) {
+  return llvm::sys::ExecuteAndWait(Program, Args, Env, Redirects);
+}
+#else
 int executeAndWait(
     llvm::StringRef Program,
     llvm::ArrayRef<llvm::StringRef> Args,
     std::optional<llvm::ArrayRef<llvm::StringRef>> Env,
     llvm::ArrayRef<std::optional<llvm::StringRef>> Redirects) {
 #if !defined(_WIN32) || LLVM_VERSION_MAJOR < 19
-#if LLVM_VERSION_MAJOR < 16
-  llvm::Optional<llvm::ArrayRef<llvm::StringRef>> EnvLegacy;
-  if(Env)
-    EnvLegacy = *Env;
-  return llvm::sys::ExecuteAndWait(Program, Args, EnvLegacy, Redirects);
-#else
   return llvm::sys::ExecuteAndWait(Program, Args, Env, Redirects);
-#endif
 #else
   std::string ErrMsg;
   bool ExecutionFailed = false;
@@ -324,6 +326,8 @@ int executeAndWait(
   return Result.ReturnCode;
 #endif
 }
+#endif
+
 
 } // namespace compiler
 } // namespace hipsycl

--- a/src/compiler/llvm-to-backend/Utils.cpp
+++ b/src/compiler/llvm-to-backend/Utils.cpp
@@ -257,7 +257,7 @@ int executeAndWait(
     llvm::ArrayRef<llvm::StringRef> Args,
     std::optional<llvm::ArrayRef<llvm::StringRef>> Env,
     llvm::ArrayRef<std::optional<llvm::StringRef>> Redirects) {
-#ifndef _WIN32
+#if !defined(_WIN32) || LLVM_VERSION_MAJOR < 19
   return llvm::sys::ExecuteAndWait(Program, Args, Env, Redirects);
 #else
   std::string ErrMsg;

--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -113,7 +113,7 @@ bool getCommandOutput(const std::string &Program, const llvm::SmallVector<std::s
   Redirections.push_back(llvm::StringRef{RedirectedOutputFile});
   Redirections.push_back(llvm::StringRef{RedirectedOutputFile});
 
-  int R = llvm::sys::ExecuteAndWait(Program, InvocationRef, {}, Redirections); 
+  int R = executeAndWait(Program, InvocationRef, {}, Redirections); 
   if(R != 0)
     return false;
 
@@ -422,7 +422,7 @@ bool LLVMToAmdgpuTranslator::hiprtcJitLink(const std::string &Bitcode, std::stri
 
 
   int OptR =
-      llvm::sys::ExecuteAndWait(OptPath, OptInvocation);
+      executeAndWait(OptPath, OptInvocation);
   if(OptR != 0) {
     this->registerError("LLVMToAmdgpu: opt invocation failed with exit code " +
                         std::to_string(OptR));
@@ -592,7 +592,7 @@ bool LLVMToAmdgpuTranslator::clangJitLink(llvm::Module& FlavoredModule, std::str
   }
   HIPSYCL_DEBUG_INFO << "LLVMToAmdgpu: Invoking " << ArgString << "\n";
 
-  int R = llvm::sys::ExecuteAndWait(
+  int R = executeAndWait(
       InvocationRef[0], InvocationRef);
 
   if(R != 0) {

--- a/src/compiler/llvm-to-backend/host/LLVMToHost.cpp
+++ b/src/compiler/llvm-to-backend/host/LLVMToHost.cpp
@@ -90,7 +90,7 @@ std::string get_macos_sdk_path() {
     *xcrun, "--show-sdk-path"
   };
 
-  int rc = llvm::sys::ExecuteAndWait(*xcrun, args, std::nullopt, redirects);
+  int rc = executeAndWait(*xcrun, args, std::nullopt, redirects);
   if(rc != 0) {
     llvm::sys::fs::remove(tmpName);
     return {};
@@ -479,7 +479,7 @@ bool LLVMToHostTranslator::translateToBackendFormat(llvm::Module &FlavoredModule
   }
 
   HIPSYCL_DEBUG_INFO << "LLVMToHost: Invoking " << getInvocationAsString(OptInvocation) << "\n";
-  int R = llvm::sys::ExecuteAndWait(OptPath, OptInvocation, NULLOPT, Redirects);
+  int R = executeAndWait(OptPath, OptInvocation, NULLOPT, Redirects);
 
   if (R != 0) {
     this->registerError("LLVMToHost: opt invocation failed with exit code " + std::to_string(R));
@@ -487,7 +487,7 @@ bool LLVMToHostTranslator::translateToBackendFormat(llvm::Module &FlavoredModule
   }
 
   HIPSYCL_DEBUG_INFO << "LLVMToHost: Invoking " << getInvocationAsString(LlcInvocation) << "\n";
-  R = llvm::sys::ExecuteAndWait(LLCPath, LlcInvocation, NULLOPT, Redirects);
+  R = executeAndWait(LLCPath, LlcInvocation, NULLOPT, Redirects);
 
   if (R != 0) {
     this->registerError("LLVMToHost: llc invocation failed with exit code " + std::to_string(R));
@@ -495,7 +495,7 @@ bool LLVMToHostTranslator::translateToBackendFormat(llvm::Module &FlavoredModule
   }
 
   HIPSYCL_DEBUG_INFO << "LLVMToHost: Invoking " << getInvocationAsString(LldInvocation) << "\n";
-  R = llvm::sys::ExecuteAndWait(LLDPath, LldInvocation, NULLOPT, Redirects);
+  R = executeAndWait(LLDPath, LldInvocation, NULLOPT, Redirects);
 
   if (R != 0) {
     this->registerError("LLVMToHost: lld invocation failed with exit code " + std::to_string(R));

--- a/src/compiler/llvm-to-backend/host/LLVMToHost.cpp
+++ b/src/compiler/llvm-to-backend/host/LLVMToHost.cpp
@@ -90,7 +90,7 @@ std::string get_macos_sdk_path() {
     *xcrun, "--show-sdk-path"
   };
 
-  int rc = executeAndWait(*xcrun, args, std::nullopt, redirects);
+  int rc = hipsycl::compiler::executeAndWait(*xcrun, args, std::nullopt, redirects);
   if(rc != 0) {
     llvm::sys::fs::remove(tmpName);
     return {};

--- a/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
+++ b/src/compiler/llvm-to-backend/ptx/LLVMToPtx.cpp
@@ -210,7 +210,7 @@ bool LLVMToPtxTranslator::translateToBackendFormat(llvm::Module &FlavoredModule,
   std::string PtxTargetArg = "--mcpu=sm_" + std::to_string(PtxTarget);
 
   const std::string OptPath = getOptPath();
-  int OptR = llvm::sys::ExecuteAndWait(
+  int OptR = executeAndWait(
       OptPath, {OptPath, PtxTargetArg, "-O3", InputFileName, "-o", OptOutputFileName});
 
   if(OptR != 0) {
@@ -248,7 +248,7 @@ bool LLVMToPtxTranslator::translateToBackendFormat(llvm::Module &FlavoredModule,
   }
   HIPSYCL_DEBUG_INFO << "LLVMToPtx: Invoking " << ArgString << "\n";
   
-  int R = llvm::sys::ExecuteAndWait(LLCPath, Invocation);
+  int R = executeAndWait(LLCPath, Invocation);
   
   if(R != 0) {
     this->registerError("LLVMToPtx: llc invocation failed with exit code " +

--- a/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
+++ b/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
@@ -347,7 +347,7 @@ bool LLVMToSpirvTranslator::translateToBackendFormat(llvm::Module &FlavoredModul
   }
   HIPSYCL_DEBUG_INFO << "LLVMToSpirv: Invoking " << ArgString << "\n";
 
-  int R = llvm::sys::ExecuteAndWait(
+  int R = executeAndWait(
       LLVMSpirVTranslator, Invocation);
 
   if(R != 0) {


### PR DESCRIPTION
This PR replaces direct `ExecuteAndWait()` calls in `llvm-to-backend` tool invocations with a small wrapper.

On Windows, this wrapper uses `ExecuteNoWait(..., DetachProcess=true)` + `Wait()`, which avoids visible console windows when AdaptiveCpp is used in GUI-subsystem applications.

For invocations without explicit redirects, stdout/stderr are redirected to temporary files and restored to `llvm::outs()` / `llvm::errs()` after completion. This preserves the original behaviour where tools still could still output to the parent console, while also providing valid standard streams for detached processes.

On non-Windows platforms, this wrapper forwards to `llvm::sys::ExecuteAndWait()`.

Fixes #2089