### PR TITLE
[SSCP][SPIR-V] Lower collective predicates to SPIR-V

### DIFF
--- a/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
+++ b/src/compiler/llvm-to-backend/spirv/LLVMToSpirv.cpp
@@ -134,7 +134,7 @@ void rewriteZeroSizeArrayGEPs(llvm::Module& M) {
       for(auto& I : BB) {
         if(auto* GEPInst = llvm::dyn_cast<llvm::GetElementPtrInst>(&I)){
           auto* SourceTy =  GEPInst->getSourceElementType();
-          
+
           if(GEPInst->getNumIndices() > 0 && SourceTy->isArrayTy()) {
             llvm::Value* FirstIndex = GEPInst->idx_begin()->get();
             int64_t FirstIndexVal = -1;
@@ -198,7 +198,7 @@ bool LLVMToSpirvTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
 
   // llvm-spirv translator does not like GEPs into 0-size arrays.
   rewriteZeroSizeArrayGEPs(M);
-  
+
   AddressSpaceMap ASMap = getAddressSpaceMap();
   KernelFunctionParameterRewriter ParamRewriter{
     // llvm-spirv wants ByVal attribute for all aggregates passed in by-value
@@ -225,7 +225,7 @@ bool LLVMToSpirvTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
     }
   }
 
-  std::string BuiltinBitcodeFile = 
+  std::string BuiltinBitcodeFile =
     common::filesystem::join_path(getBitcodePath(), "libkernel-sscp-spirv-full.bc");
 
 #if LLVM_VERSION_MAJOR > 20
@@ -292,9 +292,9 @@ bool LLVMToSpirvTranslator::translateToBackendFormat(llvm::Module &FlavoredModul
   auto consumeError = [&](std::error_code EC) {
     if(EC) {
       if(Create)
-        this->registerError("LLVMToPtx: Could not create temp file: " + EC.message());
+        this->registerError("LLVMToSpirv: Could not create temp file: " + EC.message());
       else
-        this->registerError("LLVMToPtx: Could not remove temp file: " + EC.message());
+        this->registerError("LLVMToSpirv: Could not remove temp file: " + EC.message());
       return false;
     }
     return true;
@@ -361,15 +361,15 @@ bool LLVMToSpirvTranslator::translateToBackendFormat(llvm::Module &FlavoredModul
                         std::to_string(R));
     return false;
   }
-  
+
   auto ReadResult =
       llvm::MemoryBuffer::getFile(OutputFileName);
-  
+
   if(auto Err = ReadResult.getError()) {
     this->registerError("LLVMToSpirv: Could not read result file"+Err.message());
     return false;
   }
-  
+
   out = ReadResult->get()->getBuffer();
 
   return true;
@@ -446,7 +446,7 @@ bool LLVMToSpirvTranslator::optimizeFlavoredIR(llvm::Module& M, PassHandler& PH)
   }
   for(auto* I : InstsToRemove)
     I->eraseFromParent();
-  
+
   return Result;
 }
 

--- a/src/libkernel/sscp/spirv/collpredicate.cpp
+++ b/src/libkernel/sscp/spirv/collpredicate.cpp
@@ -10,38 +10,37 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
  #include "hipSYCL/sycl/libkernel/sscp/builtins/collpredicate.hpp"
- #include "hipSYCL/sycl/libkernel/sscp/builtins/reduction.hpp"
- #include "hipSYCL/sycl/libkernel/sscp/builtins/amdgpu/ockl.hpp"
+ #include "hipSYCL/sycl/libkernel/sscp/builtins/spirv/spirv_common.hpp"
 
+bool __spirv_GroupAny(__spv::ScopeFlag scope, bool pred) noexcept;
+bool __spirv_GroupAll(__spv::ScopeFlag scope, bool pred) noexcept;
 
 HIPSYCL_SSCP_CONVERGENT_BUILTIN
 bool __acpp_sscp_work_group_any(bool pred){
-    return __acpp_sscp_work_group_reduce_i8(__acpp_sscp_algorithm_op::logical_or, pred);
+    return __spirv_GroupAny(__spv::ScopeFlag::Workgroup, pred);
 }
 
 HIPSYCL_SSCP_CONVERGENT_BUILTIN
 bool __acpp_sscp_work_group_all(bool pred){
-    return __acpp_sscp_work_group_reduce_i8(__acpp_sscp_algorithm_op::logical_and, pred);
+    return __spirv_GroupAll(__spv::ScopeFlag::Workgroup, pred);
 }
 
 HIPSYCL_SSCP_CONVERGENT_BUILTIN
 bool __acpp_sscp_work_group_none(bool pred){
-    bool result_or = __acpp_sscp_work_group_reduce_i8(__acpp_sscp_algorithm_op::logical_or, pred);
-    return !result_or;
-}
-
-HIPSYCL_SSCP_CONVERGENT_BUILTIN
-bool __acpp_sscp_sub_group_all(bool pred){
-    return __acpp_sscp_sub_group_reduce_i8(__acpp_sscp_algorithm_op::logical_and, pred);
+    return !__spirv_GroupAny(__spv::ScopeFlag::Workgroup, pred);
 }
 
 HIPSYCL_SSCP_CONVERGENT_BUILTIN
 bool __acpp_sscp_sub_group_any(bool pred){
-    return __acpp_sscp_sub_group_reduce_i8(__acpp_sscp_algorithm_op::logical_or, pred);
+    return __spirv_GroupAny(__spv::ScopeFlag::Subgroup, pred);
+}
+
+HIPSYCL_SSCP_CONVERGENT_BUILTIN
+bool __acpp_sscp_sub_group_all(bool pred){
+    return __spirv_GroupAll(__spv::ScopeFlag::Subgroup, pred);
 }
 
 HIPSYCL_SSCP_CONVERGENT_BUILTIN
 bool __acpp_sscp_sub_group_none(bool pred){
-    bool result_or = __acpp_sscp_sub_group_reduce_i8(__acpp_sscp_algorithm_op::logical_or, pred);
-    return !result_or;
+    return !__spirv_GroupAny(__spv::ScopeFlag::Subgroup, pred);
 }


### PR DESCRIPTION
This patch relates on how the SYCL collective predicates `any_of_group`, `all_of_group`, and `none_of_group` are lowered on the SSCP SPIR-V JIT path. Currently, the lowering is carried out using ACpp builtins. This is not ideal, as the low level implementation decision is carried over to the backends, which can complicate backend optimizations.

By lowering directly to corresponding SPIR-V function calls, optimization freedom is preserved for the backends.

- Observed noticeable perf improvements on PoCL CPU. 

- Verified with OpenCL CPU (PoCL) and OpenCL GPU (Intel ARC A770).