### PR TITLE
Add .ixx as source file extension

### DIFF
--- a/bin/acpp
+++ b/bin/acpp
@@ -1268,7 +1268,7 @@ class acpp_config:
 
   @property
   def source_file_arguments(self):
-    source_file_endings = set([".cpp", ".cxx", ".c++", ".cc", ".c", ".hip", ".cu", ".sycl", ".cppm", ".cxxm", ".ccm", ".c++m"])
+    source_file_endings = set([".cpp", ".cxx", ".c++", ".cc", ".c", ".hip", ".cu", ".sycl", ".cppm", ".cxxm", ".ccm", ".c++m", ".ixx"])
     source_files = []
     for arg in self.forwarded_compiler_arguments:
       if not arg.startswith("-"):


### PR DESCRIPTION
Adding  `.ixx` to the list of source file extensions recognized.
.ixx is default as a module interface unit in Jetbrain's CLION, and possibly also MSVC.
