### PR TITLE
[SSCP] Use correct barrier ordering

### DIFF
--- a/include/hipSYCL/pcuda/pcuda.hpp
+++ b/include/hipSYCL/pcuda/pcuda.hpp
@@ -161,12 +161,12 @@ inline int __pcuda_warp_size() {
 
 inline void __syncthreads() {
   PCUDA_BUILTIN_CALL(__acpp_sscp_work_group_barrier(
-      __acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed));
+      __acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel));
 }
 
 inline void __syncwarp() {
   PCUDA_BUILTIN_CALL(__acpp_sscp_sub_group_barrier(
-      __acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed));
+      __acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel));
 }
 
 inline void __threadfence() {

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/detail/broadcast.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/detail/broadcast.hpp
@@ -29,10 +29,10 @@ template <typename T, typename V> T wg_broadcast(__acpp_int32 sender, T x, V shr
     shrd_memory[0] = x;
   };
   __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group,
-                                 __acpp_sscp_memory_order::relaxed);
+                                 __acpp_sscp_memory_order::acq_rel);
   x = shrd_memory[0];
   __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group,
-                                 __acpp_sscp_memory_order::relaxed);
+                                 __acpp_sscp_memory_order::acq_rel);
   return x;
 }
 

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/detail/reduction.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/detail/reduction.hpp
@@ -65,7 +65,7 @@ OutType wg_reduce(OutType x, BinaryOperation op, MemoryType *shrd_mem) {
     shrd_mem[subgroup_id] = local_reduce_result;
   }
   __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group,
-                                 __acpp_sscp_memory_order::relaxed);
+                                 __acpp_sscp_memory_order::acq_rel);
 
   for (int i = shmem_array_length; i < num_subgroups; i += shmem_array_length) {
     if (subgroup_id >= i && subgroup_id < i + shmem_array_length) {
@@ -73,7 +73,7 @@ OutType wg_reduce(OutType x, BinaryOperation op, MemoryType *shrd_mem) {
           op(local_reduce_result, shrd_mem[subgroup_id % shmem_array_length]);
     }
     __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group,
-                                   __acpp_sscp_memory_order::relaxed);
+                                   __acpp_sscp_memory_order::acq_rel);
   }
 
   // Now we are filled up shared memory with the results of all the subgroups
@@ -85,7 +85,7 @@ OutType wg_reduce(OutType x, BinaryOperation op, MemoryType *shrd_mem) {
       shrd_mem[wg_lid] = op(shrd_mem[wg_lid + i], shrd_mem[wg_lid]);
     }
     __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group,
-                                   __acpp_sscp_memory_order::relaxed);
+                                   __acpp_sscp_memory_order::acq_rel);
   }
 
   // Now we load the data into registers

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/detail/scan_generic.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/detail/scan_generic.hpp
@@ -60,7 +60,7 @@ OutType wg_generic_scan(OutType x, BinaryOperation op, MemoryType shrd_mem, OutT
       }
     }
     __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group,
-                                   __acpp_sscp_memory_order::relaxed);
+                                   __acpp_sscp_memory_order::acq_rel);
     // First shmem_array_length number of threads exclusive scan in shared memory
     auto local_x = shrd_mem[relative_thread_id];
     for (__acpp_int32 j = 1; j < shmem_array_length; j *= 2) {
@@ -73,10 +73,10 @@ OutType wg_generic_scan(OutType x, BinaryOperation op, MemoryType shrd_mem, OutT
         }
       }
       __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group,
-                                     __acpp_sscp_memory_order::relaxed);
+                                     __acpp_sscp_memory_order::acq_rel);
     }
     __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group,
-                                   __acpp_sscp_memory_order::relaxed);
+                                   __acpp_sscp_memory_order::acq_rel);
 
     if (subgroup_id > 0) {
       auto current_segment_update = shrd_mem[(subgroup_id % shmem_array_length) - 1];
@@ -86,7 +86,7 @@ OutType wg_generic_scan(OutType x, BinaryOperation op, MemoryType shrd_mem, OutT
       sg_scan_result = op(shrd_mem[shmem_array_length], sg_scan_result);
     }
     __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group,
-                                   __acpp_sscp_memory_order::relaxed);
+                                   __acpp_sscp_memory_order::acq_rel);
     shrd_mem[shmem_array_length] = sg_scan_result;
   }
   return sg_scan_result;

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/detail/scan_hiplike.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/detail/scan_hiplike.hpp
@@ -47,12 +47,12 @@ OutType wg_hiplike_scan(OutType x, BinaryOperation op, MemoryType shrd_mem, OutT
     }
   }
   __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group,
-                                 __acpp_sscp_memory_order::relaxed);
+                                 __acpp_sscp_memory_order::acq_rel);
   if (subgroup_id == 0) {
     shrd_mem[wg_lid] = sg_inclusive_scan(shrd_mem[wg_lid], op);
   }
   __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group,
-                                 __acpp_sscp_memory_order::relaxed);
+                                 __acpp_sscp_memory_order::acq_rel);
   return subgroup_id > 0 ? op(shrd_mem[subgroup_id - 1], sg_scan_result) : sg_scan_result;
 }
 

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/detail/scan_host.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/detail/scan_host.hpp
@@ -40,12 +40,12 @@ OutType wg_host_scan(OutType x, BinaryOperation op, MemoryType shrd_mem, OutType
       shrd_mem[0] = init;
     }
     __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group,
-                                   __acpp_sscp_memory_order::relaxed);
+                                   __acpp_sscp_memory_order::acq_rel);
     local_x = shrd_mem[wg_lid];
   } else {
     shrd_mem[wg_lid] = x;
     __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group,
-                                   __acpp_sscp_memory_order::relaxed);
+                                   __acpp_sscp_memory_order::acq_rel);
     local_x = x;
   }
 
@@ -59,14 +59,14 @@ OutType wg_host_scan(OutType x, BinaryOperation op, MemoryType shrd_mem, OutType
       other_x = shrd_mem[next_id];
     }
     __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group,
-                                   __acpp_sscp_memory_order::relaxed);
+                                   __acpp_sscp_memory_order::acq_rel);
 
     if (is_nextid_valid) {
       local_x = op(local_x, other_x);
       shrd_mem[wg_lid] = local_x;
     }
     __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group,
-                                   __acpp_sscp_memory_order::relaxed);
+                                   __acpp_sscp_memory_order::acq_rel);
   }
   return local_x;
 }

--- a/src/libkernel/sscp/metal/collpredicate.cpp
+++ b/src/libkernel/sscp/metal/collpredicate.cpp
@@ -59,7 +59,7 @@ bool __acpp_sscp_work_group_any(bool predicate) {
   if (lane_id == 0) {
     scratch[group_id] = sg_any;
   }
-  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
 
   if (group_id == 0) {
     bool v = false;
@@ -71,7 +71,7 @@ bool __acpp_sscp_work_group_any(bool predicate) {
       scratch[0] = wg_any;
     }
   }
-  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
   bool tmp = scratch[0];
   __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
   return tmp;
@@ -100,7 +100,7 @@ bool __acpp_sscp_work_group_all(bool predicate) {
   if (lane_id == 0) {
     scratch[group_id] = sg_all;
   }
-  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
 
   if (group_id == 0) {
     bool v = true;
@@ -112,7 +112,7 @@ bool __acpp_sscp_work_group_all(bool predicate) {
       scratch[0] = wg_all;
     }
   }
-  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
   bool tmp = scratch[0];
   __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
   return tmp;

--- a/src/libkernel/sscp/metal/reduction.cpp
+++ b/src/libkernel/sscp/metal/reduction.cpp
@@ -163,7 +163,7 @@ inline T __acpp_sscp_work_group_reduce(T value) {
   const T sg_reduced = reduce_op(v);
 
   if(lane_id == 0) scratch[group_id] = sg_reduced;
-  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
 
   if(group_id == 0) {
     T result = identity();
@@ -192,7 +192,7 @@ inline T __acpp_sscp_work_group_reduce(T value) {
 
       if(lane_id == 0) scratch[0] = r0;
       if(lane_id == 1) scratch[1] = r1;
-      __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+      __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
 
       T y = identity();
       if(lid < 2) y = scratch[lid];
@@ -209,14 +209,14 @@ inline T __acpp_sscp_work_group_reduce(T value) {
           if(j < active_ngroups)
             scratch[lid] = binary_op(scratch[lid], scratch[j]);
         }
-        __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+        __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
         active_ngroups = offset;
       }
       if(lane_id == 0) scratch[0] = scratch[0];
     }
   }
 
-  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
   T tmp = scratch[0];
   __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
   return tmp;

--- a/src/libkernel/sscp/metal/scan_exclusive.cpp
+++ b/src/libkernel/sscp/metal/scan_exclusive.cpp
@@ -101,38 +101,38 @@ inline T __acpp_sscp_work_group_exclusive_scan(T value, T init) {
   if(lane_id == 0) excl = init;
 
   if(lane_id == last_lane) scratch[group_id] = incl;
-  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
 
   if(ngroups <= subgroup_size) {
     if(lid < ngroups) {
       T s = scratch[lid];
       scratch[lid] = prefix_incl_op(s);
     }
-    __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+    __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
   } else if(ngroups <= 2u * subgroup_size) {
     if(lid < ngroups) {
       T s = scratch[lid];
       scratch[lid] = prefix_incl_op(s);
     }
-    __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+    __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
 
     if(lid < ngroups) {
       T add = (lid >= subgroup_size) ? scratch[subgroup_size - 1u] : init;
       scratch[lid] = binary_op(scratch[lid], add);
     }
-    __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+    __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
   } else {
     for(uint offset = 1; offset < ngroups; offset <<= 1) {
       T addend = init;
       if(lid < ngroups && lid >= offset) addend = scratch[lid - offset];
 
-      __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+      __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
 
       if(lid < ngroups && lid >= offset) scratch[lid] = binary_op(scratch[lid], addend);
 
-      __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+      __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
     }
-    __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+    __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
   }
 
   const T group_offset = (group_id > 0) ? scratch[group_id - 1] : init;

--- a/src/libkernel/sscp/metal/scan_inclusive.cpp
+++ b/src/libkernel/sscp/metal/scan_inclusive.cpp
@@ -97,7 +97,7 @@ inline T __acpp_sscp_work_group_inclusive_scan(T value) {
   if(lane_id == last_lane) {
     scratch[group_id] = prefix;
   }
-  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
 
   if(ngroups <= subgroup_size) {
     if(lid < ngroups) {
@@ -105,20 +105,20 @@ inline T __acpp_sscp_work_group_inclusive_scan(T value) {
       T p = prefix_op(v);
       scratch[lid] = p;
     }
-    __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+    __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
   } else if(ngroups <= 2u * subgroup_size) {
     if(lid < ngroups) {
       T v = scratch[lid];
       T p = prefix_op(v);
       scratch[lid] = p;
     }
-    __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+    __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
 
     if(lid < ngroups) {
       T add = (lid >= subgroup_size) ? scratch[subgroup_size - 1u] : initial_value();
       scratch[lid] = binary_op(scratch[lid], add);
     }
-    __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+    __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
   } else {
     for(uint offset = 1; offset < ngroups; offset <<= 1) {
       T addend = initial_value();
@@ -126,15 +126,15 @@ inline T __acpp_sscp_work_group_inclusive_scan(T value) {
         addend = scratch[lid - offset];
       }
 
-      __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+      __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
 
       if(lid < ngroups && lid >= offset) {
         scratch[lid] = binary_op(scratch[lid], addend);
       }
 
-      __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+      __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
     }
-    __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+    __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
   }
 
   const T group_offset = (group_id > 0) ? scratch[group_id - 1] : initial_value();

--- a/src/libkernel/sscp/metal/shuffle.cpp
+++ b/src/libkernel/sscp/metal/shuffle.cpp
@@ -137,7 +137,7 @@ inline T __acpp_sscp_work_group_shl(T value, u32 delta) {
   const uint local_size = __acpp_sscp_typed_get_local_size<3, uint>();
 
   scratch[lid] = value;
-  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
 
   T result = (lid + delta < local_size) ? scratch[lid + delta] : T{};
   __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
@@ -160,7 +160,7 @@ inline T __acpp_sscp_work_group_shr(T value, u32 delta) {
   const uint lid = __acpp_sscp_typed_get_local_linear_id<3, uint>();
 
   scratch[lid] = value;
-  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
 
   T result = (lid >= delta) ? scratch[lid - delta] : T{};
   __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
@@ -184,7 +184,7 @@ inline T __acpp_sscp_work_group_permute(T value, i32 mask) {
   const uint local_size = __acpp_sscp_typed_get_local_size<3, uint>();
 
   scratch[lid] = value;
-  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
 
   const uint target = lid ^ (uint)mask;
   T result = (target < local_size) ? scratch[target] : T{};
@@ -209,7 +209,7 @@ inline T __acpp_sscp_work_group_select(T value, i32 id) {
   const uint local_size = __acpp_sscp_typed_get_local_size<3, uint>();
 
   scratch[lid] = value;
-  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);
+  __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::acq_rel);
 
   T result = ((uint)id < local_size) ? scratch[id] : T{};
   __acpp_sscp_work_group_barrier(__acpp_sscp_memory_scope::work_group, __acpp_sscp_memory_order::relaxed);


### PR DESCRIPTION
A `relaxed` barrier does not actually guarantee visibility, so stronger semantics are needed.

Also add trailing barriers to some Metal operations, to avoid races between two scans one after another.

This was causing issues on Intel A770 with SPIR-V.

Potentially also affects Metal and Host.

CUDA, HIP, and Vulkan don't bother with barrier memory ordering, so there no impact is expected.