### PR TITLE
[CI] Update NVC++ to 26.3

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -142,8 +142,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        nvhpc: [23.9]
-        cuda: [12.2]
+        nvhpc: [26.3]
+        cuda: [13.1]
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Update nvc++ in CI to 26.3. This hopefully fixes the spurious nvc++ compiler crashes that we've seen in CI.