### PR TITLE
[VK] Re-fold instcombine byte-GEP chains before clspv

### DIFF
--- a/include/hipSYCL/compiler/llvm-to-backend/clspv/FoldChainedGEPsPass.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/clspv/FoldChainedGEPsPass.hpp
@@ -1,0 +1,41 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#pragma once
+
+#include <llvm/IR/PassManager.h>
+
+namespace hipsycl {
+namespace compiler {
+
+/// After O3 instcombine, GEP expressions of the form:
+///
+///   %inner = getelementptr T,  ptr %base, i64 %n
+///   %outer = getelementptr i8, ptr %inner, i64 C   ; C = constant byte offset
+///
+/// are folded back into a single typed GEP:
+///
+///   %combined = getelementptr T, ptr %base, i64 (%n + C/sizeof(T))
+///
+/// This is required because clspv --physical-storage-buffers cannot correctly
+/// lower byte-granularity GEPs with negative offsets (clspv issue #1292):
+/// it infers 'i8' as the element type and emits 4 separate byte loads instead
+/// of a single word load, producing wrong results or a device crash.
+///
+/// The fold is only applied when C is an exact multiple of sizeof(T), ensuring
+/// the result is representable as a typed index with no loss of precision.
+class FoldChainedGEPsPass : public llvm::PassInfoMixin<FoldChainedGEPsPass> {
+public:
+  llvm::PreservedAnalyses run(llvm::Function &F,
+                              llvm::FunctionAnalysisManager &FAM);
+};
+
+} // namespace compiler
+} // namespace hipsycl

--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -86,7 +86,7 @@ function(create_llvm_to_backend_library)
   set(sources ${CREATE_LLVM_LIBRARY_SOURCES})
 
   if(WIN32)
-  set(MODE STATIC)
+    set(MODE STATIC)
   endif()
   create_llvm_based_library(TARGET ${target} ${MODE} SOURCES ${sources})
   target_link_libraries(${target} PUBLIC llvm-to-backend)
@@ -323,6 +323,7 @@ if(WITH_SSCP_COMPILER)
       BACKEND clspv
       LIBRARY clspv/LLVMToCLSPV.cpp
       clspv/AddrSpaceCastRemovalPass.cpp
+      clspv/FoldChainedGEPsPass.cpp
       clspv/RemoveUnusedIntrinsicsPass.cpp
       clspv/MemsetLoweringPass.cpp
       clspv/ConstantAddrSpacePass.cpp

--- a/src/compiler/llvm-to-backend/clspv/FoldChainedGEPsPass.cpp
+++ b/src/compiler/llvm-to-backend/clspv/FoldChainedGEPsPass.cpp
@@ -1,0 +1,183 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This pass re-folds two-level GEP chains produced by LLVM's instcombine pass
+// back into a single typed GEP before the IR is handed to clspv.
+//
+// Background
+// ----------
+// LLVM O3's instcombine canonicalises `ptr[n - k]` (where k is a positive
+// constant) into a byte-granularity two-GEP chain:
+//
+//   %inner = getelementptr T,  ptr %base, i64 %n        ; past-end pointer
+//   %outer = getelementptr i8, ptr %inner, i64 -(k*sizeof(T))
+//
+// This form is valid LLVM IR (it avoids the `inbounds` UB that would arise
+// from a single `getelementptr inbounds T, ptr %base, i64 (%n-k)` when n==0),
+// but clspv --physical-storage-buffers miscompiles it (clspv issue #1292):
+// seeing an i8 source-element type, clspv infers 'char' as the pointee type
+// and emits four separate byte-wide OpLoads instead of one word-wide OpLoad,
+// which produces wrong results or a device crash on Vulkan.
+//
+// The fold is valid when the constant byte offset of the outer GEP is an exact
+// multiple of sizeof(T), which instcombine guarantees for this specific pattern.
+
+#include "hipSYCL/compiler/llvm-to-backend/clspv/FoldChainedGEPsPass.hpp"
+
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/DataLayout.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/PassManager.h>
+
+namespace hipsycl {
+namespace compiler {
+
+namespace {
+
+/// Try to fold a two-level GEP chain:
+///   outer = getelementptr i8, ptr inner, i64 C   (C = constant byte offset)
+///   inner = getelementptr T,  ptr base,  i64 n
+/// into:
+///   combined = getelementptr T, ptr base, i64 (n + C/sizeof(T))
+///
+/// Returns the new GEP on success, nullptr if the pattern does not match or
+/// the fold is not safe.
+static llvm::GetElementPtrInst *
+tryFoldChainedGEP(llvm::GetElementPtrInst *Outer, const llvm::DataLayout &DL) {
+  // The outer GEP must be a single-index byte-granularity GEP.
+  if (!Outer->getSourceElementType()->isIntegerTy(8))
+    return nullptr;
+  if (Outer->getNumIndices() != 1)
+    return nullptr;
+
+  auto *ByteOffsetCI =
+      llvm::dyn_cast<llvm::ConstantInt>(Outer->getOperand(1));
+  if (!ByteOffsetCI)
+    return nullptr;
+  int64_t ByteOffset = ByteOffsetCI->getSExtValue();
+
+  // The pointer operand of the outer GEP must itself be a single-index GEP
+  // on a concrete element type (the inner GEP).
+  auto *Inner =
+      llvm::dyn_cast<llvm::GetElementPtrInst>(Outer->getPointerOperand());
+  if (!Inner)
+    return nullptr;
+  if (Inner->getNumIndices() != 1)
+    return nullptr;
+
+  llvm::Type *ElemTy = Inner->getSourceElementType();
+  if (ElemTy->isVoidTy() || !ElemTy->isSized())
+    return nullptr;
+
+  llvm::TypeSize ElemTSz = DL.getTypeStoreSize(ElemTy);
+  if (ElemTSz.isScalable() || ElemTSz.getFixedValue() == 0)
+    return nullptr;
+
+  int64_t ElemBytes = static_cast<int64_t>(ElemTSz.getFixedValue());
+
+  // The fold is lossless only when ByteOffset is an exact multiple of the
+  // element size. (instcombine guarantees this for its specific transform.)
+  if (ByteOffset % ElemBytes != 0)
+    return nullptr;
+
+  int64_t IndexDelta = ByteOffset / ElemBytes; // may be negative
+
+  // Build the combined GEP immediately before the outer GEP so that
+  // dominance is maintained for the base pointer and original index.
+  llvm::IRBuilder<> Builder(Outer);
+  llvm::Value *OrigIndex = Inner->getOperand(1);
+
+  llvm::Value *NewIndex;
+  if (IndexDelta == 0) {
+    NewIndex = OrigIndex;
+  } else {
+    llvm::Type *IdxTy = OrigIndex->getType();
+    NewIndex =
+        Builder.CreateAdd(OrigIndex,
+                          llvm::ConstantInt::get(IdxTy,
+                                                 static_cast<uint64_t>(IndexDelta),
+                                                 /*isSigned=*/true),
+                          "gep.fold.idx");
+  }
+
+  llvm::Value *NewGEPVal = Builder.CreateGEP(ElemTy, Inner->getPointerOperand(),
+                                             {NewIndex}, Outer->getName());
+  auto *NewGEP = llvm::cast<llvm::GetElementPtrInst>(NewGEPVal);
+
+  // Only mark the combined GEP as inbounds when both source GEPs were inbounds.
+  // A negative byte offset means the outer GEP is not inbounds (it accesses
+  // memory before the inner pointer), so this is a conservative approach.
+  if (Inner->isInBounds() && Outer->isInBounds())
+    NewGEP->setIsInBounds(true);
+
+  return NewGEP;
+}
+
+} // namespace
+
+llvm::PreservedAnalyses
+FoldChainedGEPsPass::run(llvm::Function &F,
+                         llvm::FunctionAnalysisManager &) {
+  const llvm::DataLayout &DL = F.getParent()->getDataLayout();
+
+  // Collect GEPs to fold first to avoid iterator invalidation.
+  llvm::SmallVector<llvm::GetElementPtrInst *, 16> OuterGEPs;
+  for (auto &BB : F) {
+    for (auto &I : BB) {
+      if (auto *GEP = llvm::dyn_cast<llvm::GetElementPtrInst>(&I))
+        OuterGEPs.push_back(GEP);
+    }
+  }
+
+  llvm::SmallVector<llvm::GetElementPtrInst *, 16> ToErase;
+  bool Changed = false;
+
+  for (auto *Outer : OuterGEPs) {
+    // Skip if already erased (e.g. was an inner GEP of a previous fold).
+    if (!Outer->getParent())
+      continue;
+
+    // Remember the inner GEP before we replace Outer (so we can check if
+    // it becomes dead after the replacement).
+    auto *InnerGEP =
+        llvm::dyn_cast<llvm::GetElementPtrInst>(Outer->getPointerOperand());
+
+    auto *NewGEP = tryFoldChainedGEP(Outer, DL);
+    if (!NewGEP)
+      continue;
+
+    Outer->replaceAllUsesWith(NewGEP);
+    ToErase.push_back(Outer);
+
+    // If the inner GEP is now dead (Outer was its only user), schedule removal.
+    if (InnerGEP && InnerGEP->use_empty())
+      ToErase.push_back(InnerGEP);
+
+    Changed = true;
+  }
+
+  // Erase in reverse order so that a use is removed before its def when both
+  // Outer (use of Inner) and Inner are in ToErase.
+  for (auto It = ToErase.rbegin(); It != ToErase.rend(); ++It) {
+    auto *I = *It;
+    if (I->getParent() && I->use_empty())
+      I->eraseFromParent();
+  }
+
+  return Changed ? llvm::PreservedAnalyses::none()
+                 : llvm::PreservedAnalyses::all();
+}
+
+} // namespace compiler
+} // namespace hipsycl

--- a/src/compiler/llvm-to-backend/clspv/LLVMToCLSPV.cpp
+++ b/src/compiler/llvm-to-backend/clspv/LLVMToCLSPV.cpp
@@ -17,6 +17,7 @@
 #include "hipSYCL/compiler/llvm-to-backend/Utils.hpp"
 #include "hipSYCL/compiler/llvm-to-backend/clspv/AddrSpaceCastRemovalPass.hpp"
 #include "hipSYCL/compiler/llvm-to-backend/clspv/ConstantAddrSpacePass.hpp"
+#include "hipSYCL/compiler/llvm-to-backend/clspv/FoldChainedGEPsPass.hpp"
 #include "hipSYCL/compiler/llvm-to-backend/clspv/MemsetLoweringPass.hpp"
 #include "hipSYCL/compiler/llvm-to-backend/clspv/RemoveUnusedIntrinsicsPass.hpp"
 #include "hipSYCL/compiler/sscp/IRConstantReplacer.hpp"
@@ -400,6 +401,8 @@ bool LLVMToCLSPVTranslator::optimizeFlavoredIR(llvm::Module &M,
   MPM.addPass(
       llvm::createModuleToFunctionPassAdaptor(RemoveUnusedIntrinsicsPass()));
   MPM.addPass(llvm::createModuleToFunctionPassAdaptor(MemsetLoweringPass()));
+  MPM.addPass(
+      llvm::createModuleToFunctionPassAdaptor(FoldChainedGEPsPass()));
   MPM.addPass(
       llvm::createModuleToFunctionPassAdaptor(AddrSpaceCastRemovalPass()));
   MPM.addPass(ConstantAddrSpacePass());

--- a/src/compiler/llvm-to-backend/clspv/llvm-to-clspv.md
+++ b/src/compiler/llvm-to-backend/clspv/llvm-to-clspv.md
@@ -93,6 +93,33 @@ This pass handles this case by replacing memset intrinsics taking a dynamic leng
 parameter with a naive implementation of memset which uses a loop to copy chunks to
 the destination pointer based on the size of the data type being pointed to.
 
+### FoldChainedGEPsPass
+
+LLVM O3's `instcombine` canonicalises pointer arithmetic of the form
+`ptr[n - k]` (where `k` is a positive constant) into a two-level byte-GEP
+chain:
+
+```llvm
+%inner = getelementptr T,  ptr %base, i64 %n    ; past-end pointer
+%outer = getelementptr i8, ptr %inner, i64 -k*sizeof(T)
+```
+
+`clspv --physical-storage-buffers` miscompiles this pattern
+([clspv issue #1292](https://github.com/google/clspv/issues/1292)): seeing
+an `i8` source-element type it infers `char` as the pointee type and emits
+four separate byte-wide `OpLoad`s instead of a single word-wide `OpLoad`,
+producing wrong results or a device crash on Vulkan
+([AdaptiveCpp issue #2126](https://github.com/AdaptiveCpp/AdaptiveCpp/issues/2126)).
+
+This pass re-folds such chains back into a single typed GEP:
+
+```llvm
+%combined = getelementptr T, ptr %base, i64 (%n - k)
+```
+
+The fold is applied only when the byte offset is an exact multiple of
+`sizeof(T)`, which is always the case for the specific instcombine transform.
+
 ### AddrSpaceCastRemovalPass
 
 Remove casting away the address space from arguments, as otherwise

--- a/tests/compiler/sscp/array_index_subtract.cpp
+++ b/tests/compiler/sscp/array_index_subtract.cpp
@@ -3,9 +3,6 @@
 // RUN: %acpp %s -o %t --acpp-targets=generic -O3
 // RUN: %t | FileCheck %s
 
-// https://github.com/AdaptiveCpp/AdaptiveCpp/issues/2126
-// UNSUPPORTED: vulkan || vk
-
 #include "common.hpp"
 #include <iostream>
 


### PR DESCRIPTION
Fixes #2126.

## Problem

The `array_index_subtract` SSCP LIT test fails on the Vulkan backend with
incorrect results or device loss. The same pattern also reproduces with `clvk`
using an OpenCL kernel with `--physical-storage-buffers` / `spir64` addressing.

Root cause: LLVM O3 `instcombine` canonicalises `in_ptr[size - 1]` from a
single typed GEP into a two-level byte-offset chain:

```llvm
; Before instcombine (O0):
%gep = getelementptr inbounds i32, ptr %in_ptr, i64 (size - 1)

; After instcombine (O3):
%5 = getelementptr i32, ptr %in_ptr, i64 %size   ; past-end pointer
%6 = getelementptr i8,  ptr %5,      i64 -4      ; byte GEP, negative offset
```

`clspv --physical-storage-buffers` miscompiles this pattern
(clspv issue [#1292](https://github.com/google/clspv/issues/1292)): seeing `i8`
as the source element type it infers `char` as the pointee type and emits four
separate byte-wide `OpLoad`s instead of a single `i32` `OpLoad`, producing
wrong results or a GPU crash.

## Fix

Add `FoldChainedGEPsPass` — a new LLVM function pass in the clspv backend
pipeline that runs after O3 and before `clspv` invocation. It recognises the
pattern:

```
outer = getelementptr i8, ptr inner, i64 C   (C = constant byte offset)
inner = getelementptr T,  ptr base,  i64 n
```

and folds it into a single typed GEP when `C` is an exact multiple of
`sizeof(T)` (which instcombine always guarantees for this transform):

```
combined = getelementptr T, ptr base, i64 (n + C/sizeof(T))
```

The pass is inserted in `optimizeFlavoredIR()` between `MemsetLoweringPass`
and `AddrSpaceCastRemovalPass`.

The `// UNSUPPORTED: vulkan || vk` guard is removed from the LIT test.

## Testing

- Direct compilation of the new pass with `clang++ -std=c++17` against the
  project headers: passes cleanly.
- The LIT test `tests/compiler/sscp/array_index_subtract.cpp` should now pass
  on Vulkan. A Vulkan-capable build with `clspv` is required to run it
  end-to-end.

## References

- clspv issue: https://github.com/google/clspv/issues/1292
