### PR TITLE
[VK] Support SSCP generated LLVM memmove intrinsic

### DIFF
--- a/.github/workflows/linux-vulkan.yml
+++ b/.github/workflows/linux-vulkan.yml
@@ -51,6 +51,7 @@ jobs:
       matrix:
         docker: ${{fromJson(needs.prep-container.outputs.docker_matrix)}}
         clang_version: ['19', '21']
+        clspv_commit: ['88d8ff71000bf995493c8daaed865ec1ac216309']
       fail-fast: false
     steps:
     - uses: actions/checkout@v4
@@ -88,7 +89,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ${{github.workspace}}/clspv/build/install
-        key: 8286ad49be1fa8708f07aa6852e1b84ed4dd0861
+        key: ${{matrix.clspv_commit}}
 
     - name: checkout clspv
       if: steps.cache-clspv.outputs.cache-hit != 'true'
@@ -96,7 +97,7 @@ jobs:
       with:
         repository: google/clspv
         path: clspv
-        ref: 8286ad49be1fa8708f07aa6852e1b84ed4dd0861
+        ref: ${{matrix.clspv_commit}}
 
     - name: build clspv
       if: steps.cache-clspv.outputs.cache-hit != 'true'

--- a/.github/workflows/macos-vulkan.yml
+++ b/.github/workflows/macos-vulkan.yml
@@ -1,7 +1,8 @@
 name: macOS Vulkan backend
 
 on: [push, pull_request]
-
+env:
+  clspv_commit: '88d8ff71000bf995493c8daaed865ec1ac216309'
 jobs:
   build_vulkan:
     name: Vulkan backend macOS
@@ -42,7 +43,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ${{github.workspace}}/clspv/build/install
-        key: 8286ad49be1fa8708f07aa6852e1b84ed4dd0861
+        key: ${{env.clspv_commit}}
 
     - name: checkout clspv
       if: steps.cache-clspv.outputs.cache-hit != 'true'
@@ -50,7 +51,7 @@ jobs:
       with:
         repository: google/clspv
         path: clspv
-        ref: 8286ad49be1fa8708f07aa6852e1b84ed4dd0861
+        ref: ${{env.clspv_commit}}
 
     - name: build clspv
       if: steps.cache-clspv.outputs.cache-hit != 'true'

--- a/.github/workflows/windows-vulkan.yml
+++ b/.github/workflows/windows-vulkan.yml
@@ -11,6 +11,7 @@ jobs:
         clang_version: ['19', '20']
         base_compiler: ['19']
         os: [windows-2022]
+        clspv_commit: ['88d8ff71000bf995493c8daaed865ec1ac216309']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -58,7 +59,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ${{github.workspace}}/clspv/build/install
-        key: 8286ad49be1fa8708f07aa6852e1b84ed4dd0861
+        key: ${{matrix.clspv_commit}}
 
     - name: checkout clspv
       if: steps.cache-clspv.outputs.cache-hit != 'true'
@@ -66,7 +67,7 @@ jobs:
       with:
         repository: google/clspv
         path: clspv
-        ref: 8286ad49be1fa8708f07aa6852e1b84ed4dd0861
+        ref: ${{matrix.clspv_commit}}
 
     - name: build clspv
       if: steps.cache-clspv.outputs.cache-hit != 'true'

--- a/doc/install-vulkan.md
+++ b/doc/install-vulkan.md
@@ -162,19 +162,20 @@ assessment of the status of the benchmarks is as follows on llvmpipe 25.0.7.
 | Benchmark           | Status                                                                                      |
 | ------------------- | ------------------------------------------------------------------------------------------- |
 | HeCbench dslash     | Completes successfully on SYCL and PCUDA                                                    |
-| HeCbench fdtd3d     | SYCL passes on NVIDIA Ada, verification issue on Intel MTL, and crashes on Radv & llvmpipe. |
+| HeCbench fdtd3d     | Completes successfully on SYCL and PCUDA                                                    |
 | HeCbench FFT        | SYCL & PCUDA compiles kernel, but fails verification                                        |
 | HeCbench ising      | Completes successfully on SYCL and PCUDA                                                    |
 | HeCbench mandlebrot | Completes successfully on SYCL and PCUDA                                                    |
 | HeCbench nbody      | Completes successfully on SYCL and PCUDA                                                    |
 | HeCbench rsbench    | Can't compile kernel for SYCL or PCUDA                                                      |
 | HeCbench sph        | Completes successfully on SYCL and PCUDA                                                    |
-| Bude                | SYCL verification fails, PCUDA device not compatible                                        |
-| Cloverleaf          | SYCL verification fails and PCUDA raises an error                                           |
+| Bude                | Completes on SYCL, compilation fail on PCUDA                                                |
+| Cloverleaf          | Verification issues on SYCL, kernel segfault on PCUDA                                       |
 
 Compilation fail investigations:
 
 * Hecbench rsbench - Error processing GEP into alloca array of `type { double, double }` struct.
+* Bude PCUDA - Error processing struct `type { float, float, float, float }`.
 
 #### Benchmark Results
 
@@ -191,6 +192,8 @@ mandlebrot | 22.3 / 21 | 4.6 / 3.3  | 36 /  27  | 2.5 / 0.7  | 42.1 / 2.5    | 2
 ising      | 3.2       | 2.1        | 3.7       | 0.3        | 0.8           | 0.1          | 3.4           |
 dslash     | 2.3       | 2          | 3.9       | 2.2        | 2.3           | 1.4          | 160           |
 sph        | 28.2      | 53         | 36        | 22.7       | 38            | 35.7         | 64.8          |
+fdtd3d     | Error     | 0.04       | 0.4       | 0.004193   | 0.018         | 0.005        | 0.043         |
+bude       | 541       | Error      | 438       | Error      | 45            | 36           | 49            |
 
 SYCL Backends:
 1. OpenMP host device
@@ -207,6 +210,8 @@ Configs:
 * ising - `./sycl-generic -x 5120 -y 5120 -w 10 -n 100`, time is elapsed time in seconds.
 * dslash -  `./sycl-generic 256`, time is total execution time in seconds.
 * sph - `./sycl-generic sph`, time is average execution time of sph kernels in ms.
+* fdtd23 - `./sycl-generic --dimx=376 --dimy=368 --timesteps=40`, time is average kernel execution time in seconds.
+* bude - `./sycl-bude -w 128 -p 1,2,4`, time is average ms.
 
 ### PCUDA
 

--- a/doc/install-vulkan.md
+++ b/doc/install-vulkan.md
@@ -20,7 +20,7 @@ the generic SSCP compilation flow.
   `VK_KHR_buffer_device_address` respectively.
 * The [LunarG Vulkan SDK](https://vulkan.lunarg.com/sdk/home) versions 1.4 or later
   for Vulkan loader, layers, headers, and other tools.
-* A `clspv` executable from commit `8286ad49be1fa8708f07aa6852e1b84ed4dd0861`.
+* A `clspv` executable from commit `88d8ff71000bf995493c8daaed865ec1ac216309`.
 * Linux, macOS, and Windows operating systems are tested in CI. Ubuntu 22.04 and later are the
   tested distributions for Linux. MacOS 15.7.4 is tested CI with MoltenVK. Windows server 2022
   is used with llvmpipe in CI. However on Windows there are sporadic failures in the `group_functions` suite
@@ -159,22 +159,21 @@ The `pcuda` branch of [illuhad/benchmark-scipts](https://github.com/illuhad/benc
 contains benchmarks that work with SYCL and PCUDA. No thorough benchmarking has been done but an initial
 assessment of the status of the benchmarks is as follows on llvmpipe 25.0.7.
 
-| Benchmark           | Status                                               |
-| ------------------- | ---------------------------------------------------- |
-| HeCbench dslash     | Completes successfully on SYCL and PCUDA             |
-| HeCbench fdtd3d     | Can't compile kernel for SYCL or PCUDA               |
-| HeCbench FFT        | SYCL & PCUDA compiles kernel, but fails verification |
-| HeCbench ising      | Completes successfully on SYCL and PCUDA             |
-| HeCbench mandlebrot | Completes successfully on SYCL and PCUDA             |
-| HeCbench nbody      | Completes successfully on SYCL and PCUDA             |
-| HeCbench rsbench    | Can't compile kernel for SYCL or PCUDA               |
-| HeCbench sph        | Completes successfully on SYCL and PCUDA             |
-| Bude                | SYCL verification fails, PCUDA device not compatible |
-| Cloverleaf          | SYCL verification fails and PCUDA raises an error    |
+| Benchmark           | Status                                                                                      |
+| ------------------- | ------------------------------------------------------------------------------------------- |
+| HeCbench dslash     | Completes successfully on SYCL and PCUDA                                                    |
+| HeCbench fdtd3d     | SYCL passes on NVIDIA Ada, verification issue on Intel MTL, and crashes on Radv & llvmpipe. |
+| HeCbench FFT        | SYCL & PCUDA compiles kernel, but fails verification                                        |
+| HeCbench ising      | Completes successfully on SYCL and PCUDA                                                    |
+| HeCbench mandlebrot | Completes successfully on SYCL and PCUDA                                                    |
+| HeCbench nbody      | Completes successfully on SYCL and PCUDA                                                    |
+| HeCbench rsbench    | Can't compile kernel for SYCL or PCUDA                                                      |
+| HeCbench sph        | Completes successfully on SYCL and PCUDA                                                    |
+| Bude                | SYCL verification fails, PCUDA device not compatible                                        |
+| Cloverleaf          | SYCL verification fails and PCUDA raises an error                                           |
 
 Compilation fail investigations:
 
-* HecBench fdtd3d - LLVM-IR contains `llvm.memmove` intrinsic which is not implemented in clspv.
 * Hecbench rsbench - Error processing GEP into alloca array of `type { double, double }` struct.
 
 #### Benchmark Results

--- a/src/compiler/llvm-to-backend/clspv/AddrSpaceCastRemovalPass.cpp
+++ b/src/compiler/llvm-to-backend/clspv/AddrSpaceCastRemovalPass.cpp
@@ -134,6 +134,15 @@ bool fixupMemInstrinsic(llvm::Function &F) {
         newCI->setTailCall(MemSet->isTailCall());
         MemSet->replaceAllUsesWith(newCI);
         InstToDel.push_back(MemSet);
+      } else if (auto MemMove = llvm::dyn_cast<llvm::MemMoveInst>(&I)) {
+        llvm::IRBuilder Builder(MemMove);
+        auto newCI = Builder.CreateMemMove(
+            MemMove->getRawDest(), MemMove->getDestAlign(),
+            MemMove->getRawSource(), MemMove->getSourceAlign(),
+            MemMove->getLength(), MemMove->isVolatile());
+        newCI->setTailCall(MemMove->isTailCall());
+        MemMove->replaceAllUsesWith(newCI);
+        InstToDel.push_back(MemMove);
       }
     }
   }

--- a/tests/compiler/sscp/memmove.cpp
+++ b/tests/compiler/sscp/memmove.cpp
@@ -3,6 +3,9 @@
 // RUN: %acpp %s -o %t --acpp-targets=generic -O3
 // RUN: %t | FileCheck %s
 
+// Fails on CI with AMD EPYC 7763 OpenCL driver
+// UNSUPPORTED: opencl || ocl
+
 #include "common.hpp"
 #include <iostream>
 

--- a/tests/compiler/sscp/memmove.cpp
+++ b/tests/compiler/sscp/memmove.cpp
@@ -22,9 +22,7 @@ void dynamic_size_backward(sycl::queue q) {
 
   q.submit([&](sycl::handler &cgh) {
      cgh.single_task([=]() {
-       for (size_t i = 0; i < size - 1; i++) {
-         device_ptr[i] = device_ptr[i + 1];
-       }
+       __builtin_memmove(device_ptr, &device_ptr[1], (size - 1) * sizeof(int));
      });
    }).wait();
 
@@ -52,9 +50,7 @@ void dynamic_size_forward(sycl::queue q) {
   // Test global address space memmove
   q.submit([&](sycl::handler &cgh) {
      cgh.single_task([=]() {
-       for (size_t i = size - 1; i > 0; i--) {
-         device_ptr[i] = device_ptr[i - 1];
-       }
+       __builtin_memmove(&device_ptr[1], device_ptr, (size - 1) * sizeof(int));
      });
    }).wait();
 
@@ -89,9 +85,7 @@ void static_size_backward(sycl::queue q) {
          arr[i] = input[i];
        }
 
-       for (size_t i = 0; i < size - 1; i++) {
-         arr[i] = arr[i + 1];
-       }
+       __builtin_memmove(arr, &arr[1], (size - 1) * sizeof(int));
 
        for (size_t i = 0; i < size; i++) {
          output[i] = arr[i];
@@ -131,9 +125,7 @@ void static_size_forward(sycl::queue q) {
          arr[i] = input[i];
        }
 
-       for (size_t i = size - 1; i > 0; i--) {
-         arr[i] = arr[i - 1];
-       }
+       __builtin_memmove(&arr[1], arr, (size - 1) * sizeof(int));
 
        for (size_t i = 0; i < size; i++) {
          output[i] = arr[i];

--- a/tests/compiler/sscp/memmove.cpp
+++ b/tests/compiler/sscp/memmove.cpp
@@ -1,0 +1,164 @@
+// RUN: %acpp %s -o %t --acpp-targets=generic
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s -o %t --acpp-targets=generic -O3
+// RUN: %t | FileCheck %s
+
+#include "common.hpp"
+#include <iostream>
+
+// Test compiler can handle lowering llvm.memmove intrinsics with both
+// a compile time known length parameter and a runtime length parameter.
+
+void dynamic_size_backward(sycl::queue q) {
+  int size = 4;
+  int init[4] = {0, 1, 2, 3};
+
+  // Test global address space memmove
+  int *device_ptr = sycl::malloc_device<int>(size, q);
+  q.memcpy(device_ptr, init, sizeof(init)).wait();
+
+  q.submit([&](sycl::handler &cgh) {
+     cgh.single_task([=]() {
+       for (size_t i = 0; i < size - 1; i++) {
+         device_ptr[i] = device_ptr[i + 1];
+       }
+     });
+   }).wait();
+
+  std::vector<int> out_data(size);
+  q.memcpy(out_data.data(), device_ptr, size * sizeof(int)).wait();
+
+  // CHECK: 1
+  // CHECK: 2
+  // CHECK: 3
+  // CHECK: 3
+  for (int i = 0; i < size; ++i) {
+    std::cout << out_data[i] << std::endl;
+  }
+  std::cout << std::endl;
+  sycl::free(device_ptr, q);
+}
+
+void dynamic_size_forward(sycl::queue q) {
+  int size = 4;
+  int init[4] = {0, 1, 2, 3};
+
+  int *device_ptr = sycl::malloc_device<int>(size, q);
+  q.memcpy(device_ptr, init, sizeof(init)).wait();
+
+  // Test global address space memmove
+  q.submit([&](sycl::handler &cgh) {
+     cgh.single_task([=]() {
+       for (size_t i = size - 1; i > 0; i--) {
+         device_ptr[i] = device_ptr[i - 1];
+       }
+     });
+   }).wait();
+
+  std::vector<int> out_data(size);
+  q.memcpy(out_data.data(), device_ptr, size * sizeof(int)).wait();
+
+  // CHECK: 0
+  // CHECK: 0
+  // CHECK: 1
+  // CHECK: 2
+  for (int i = 0; i < size; ++i) {
+    std::cout << out_data[i] << std::endl;
+  }
+  std::cout << std::endl;
+
+  sycl::free(device_ptr, q);
+}
+
+void static_size_backward(sycl::queue q) {
+  constexpr size_t size = 4;
+  int init[4] = {0, 1, 2, 3};
+
+  int *input = sycl::malloc_device<int>(size, q);
+  int *output = sycl::malloc_device<int>(size, q);
+  q.memcpy(input, init, sizeof(init)).wait();
+
+  // Test private address space memmove
+  q.submit([&](sycl::handler &cgh) {
+     cgh.single_task([=]() {
+       int arr[size];
+       for (size_t i = 0; i < size; i++) {
+         arr[i] = input[i];
+       }
+
+       for (size_t i = 0; i < size - 1; i++) {
+         arr[i] = arr[i + 1];
+       }
+
+       for (size_t i = 0; i < size; i++) {
+         output[i] = arr[i];
+       }
+     });
+   }).wait();
+
+  std::vector<int> out_data(size);
+  q.memcpy(out_data.data(), output, size * sizeof(int)).wait();
+
+  // CHECK: 1
+  // CHECK: 2
+  // CHECK: 3
+  // CHECK: 3
+  for (int i = 0; i < size; ++i) {
+    std::cout << out_data[i] << std::endl;
+  }
+  std::cout << std::endl;
+
+  sycl::free(input, q);
+  sycl::free(output, q);
+}
+
+void static_size_forward(sycl::queue q) {
+  constexpr size_t size = 4;
+  int init[4] = {0, 1, 2, 3};
+
+  int *input = sycl::malloc_device<int>(size, q);
+  int *output = sycl::malloc_device<int>(size, q);
+  q.memcpy(input, init, sizeof(init)).wait();
+
+  // Test private address space memmove
+  q.submit([&](sycl::handler &cgh) {
+     cgh.single_task([=]() {
+       float arr[size];
+       for (size_t i = 0; i < size; i++) {
+         arr[i] = input[i];
+       }
+
+       for (size_t i = size - 1; i > 0; i--) {
+         arr[i] = arr[i - 1];
+       }
+
+       for (size_t i = 0; i < size; i++) {
+         output[i] = arr[i];
+       }
+     });
+   }).wait();
+
+  std::vector<int> out_data(size);
+  q.memcpy(out_data.data(), output, size * sizeof(int)).wait();
+
+  // CHECK: 0
+  // CHECK: 0
+  // CHECK: 1
+  // CHECK: 2
+  for (int i = 0; i < size; ++i) {
+    std::cout << out_data[i] << std::endl;
+  }
+  std::cout << std::endl;
+
+  sycl::free(input, q);
+  sycl::free(output, q);
+}
+
+int main() {
+  sycl::queue q = get_queue();
+  dynamic_size_backward(q);
+  dynamic_size_forward(q);
+  static_size_backward(q);
+  static_size_forward(q);
+  return 0;
+}


### PR DESCRIPTION
Brings in the clspv change from PR https://github.com/google/clspv/pull/1613 to add support for the `llvm.memmove` intrinsic.

Includes a test that verifies a compile time known size and runtime known size for the intrinsic. As well as testing global and private pointers to the memmove.

Also update benchmark results based on this commit rebased on tip develop.

Closes https://github.com/AdaptiveCpp/AdaptiveCpp/issues/2110