### PR TITLE
[Metal] Serialize alloc_buffer delta-convergence loop to fix concurrent allocation races

### DIFF
--- a/src/runtime/metal/metal_allocator.cpp
+++ b/src/runtime/metal/metal_allocator.cpp
@@ -312,6 +312,9 @@ device_id metal_allocator::get_device() const {
 }
 
 MTL::Buffer* metal_allocator::alloc_buffer(size_t size_bytes) {
+  // The delta-convergence loop below only converges if the mmap region layout
+  // is stable across iterations, so it must not run concurrently.
+  std::lock_guard<std::mutex> lock{_mutex};
   const size_t aligned = align_up(size_bytes, _page_size);
   const size_t stride  = metal_gpu_stride(aligned, _page_size);
   void* region_ptr = nullptr;


### PR DESCRIPTION
This fixes https://github.com/AdaptiveCpp/AdaptiveCpp/issues/2132

The delta-convergence loop in alloc_buffer assumes the mmap region layout stays stable between iterations so concurrent allocations perturb each other and the loop fails to converge within 10 iterations

This only fixes correctness. The extra serialization is not great for performance, that will be addressed via a slab-allocator in follow-up PRs