### PR TITLE
[CI] Pin MacOS version to avoid compiler-rt build fail

### DIFF
--- a/.github/workflows/macos-acppllvm.yml
+++ b/.github/workflows/macos-acppllvm.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build_2stage_from_appleclang:
     name: AdaptiveCpp LLVM ${{ matrix.clang_version }}
-    runs-on: macos-latest
+    runs-on: macos-15
     strategy:
       matrix:
         clang_version: ['18']

--- a/.github/workflows/macos-acppllvm.yml
+++ b/.github/workflows/macos-acppllvm.yml
@@ -29,8 +29,7 @@ jobs:
       run: |
         set +e
         brew update
-        # force CMake 3.31.6 (CMake 4.0 seems to break compiler-rt build)
-        brew install https://github.com/Homebrew/homebrew-core/raw/b4e46db74e74a8c1650b38b1da222284ce1ec5ce/Formula/cmake.rb
+        brew install cmake
         brew install boost
         brew install ninja
         set -e


### PR DESCRIPTION
In a couple of Vulkan PRs (https://github.com/AdaptiveCpp/AdaptiveCpp/pull/2140 & https://github.com/AdaptiveCpp/AdaptiveCpp/pull/2139) I have observed that the MacOS job not specific to Vulkan have failed to build compiler-rt.

```
2026-07-02T06:58:04.0308840Z FAILED: [code=1] compiler-rt/lib/xray/CMakeFiles/RTXrayFDR.osx.dir/xray_fdr_logging.cpp.o
2026-07-02T06:58:04.0415460Z /Users/runner/work/AdaptiveCpp/AdaptiveCpp/build/bin/clang++ --target=arm64-apple-darwin25.4.0 -DSANITIZER_COMMON_NO_REDEFINE_BUILTINS -DXRAY_HAS_EXCEPTIONS=1 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/Users/runner/work/AdaptiveCpp/AdaptiveCpp/llvm/compiler-rt/lib/xray/.. -I/Users/runner/work/AdaptiveCpp/AdaptiveCpp/llvm/compiler-rt/lib/xray/../../include -fPIC -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -Wall -Wno-unused-parameter -O3 -DNDEBUG -std=c++17 -arch arm64 -isysroot /Applications/Xcode_26.5.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -stdlib=libc++ -mmacosx-version-min=10.10 -isysroot /Applications/Xcode_26.5.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.5.sdk -fPIC -fno-builtin -fno-exceptions -funwind-tables -fno-stack-protector -fno-sanitize=safe-stack -fvisibility=hidden -fno-lto -Wthread-safety -Wthread-safety-reference -Wthread-safety-beta -O3 -g -Wno-gnu -Wno-variadic-macros -Wno-c99-extensions -Wno-format -fno-rtti -MD -MT compiler-rt/lib/xray/CMakeFiles/RTXrayFDR.osx.dir/xray_fdr_logging.cpp.o -MF compiler-rt/lib/xray/CMakeFiles/RTXrayFDR.osx.dir/xray_fdr_logging.cpp.o.d -o compiler-rt/lib/xray/CMakeFiles/RTXrayFDR.osx.dir/xray_fdr_logging.cpp.o -c /Users/runner/work/AdaptiveCpp/AdaptiveCpp/llvm/compiler-rt/lib/xray/xray_fdr_logging.cpp
2026-07-02T06:58:04.0509020Z In file included from /Users/runner/work/AdaptiveCpp/AdaptiveCpp/llvm/compiler-rt/lib/xray/xray_fdr_logging.cpp:21:
2026-07-02T06:58:04.0609610Z In file included from /Applications/Xcode_26.5.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.5.sdk/usr/include/c++/v1/memory:998:
2026-07-02T06:58:04.0711420Z In file included from /Applications/Xcode_26.5.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.5.sdk/usr/include/c++/v1/iterator:693:
2026-07-02T06:58:04.0813710Z In file included from /Applications/Xcode_26.5.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.5.sdk/usr/include/c++/v1/__iterator/istreambuf_iterator.h:19:
2026-07-02T06:58:04.0826800Z In file included from /Applications/Xcode_26.5.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.5.sdk/usr/include/c++/v1/__string/char_traits.h:13:
2026-07-02T06:58:04.0828210Z In file included from /Applications/Xcode_26.5.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.5.sdk/usr/include/c++/v1/__algorithm/find.h:16:
2026-07-02T06:58:04.0829410Z /Applications/Xcode_26.5.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.5.sdk/usr/include/c++/v1/__bit/countr.h:28:10: error: use of undeclared identifier '__builtin_ctzg'
2026-07-02T06:58:04.0830510Z    28 |   return __builtin_ctzg(__t, numeric_limits<_Tp>::digits);
2026-07-02T06:58:04.0830960Z       |          ^
```

This patch fixes this by using `macos-15` as the fixed OS image without the cmake workaround. The failing CI runs seem to be using  `macos-26` which can be picked by `macos-latest` . This label can pick either macos-15 or macos-26, so using a fixed OS gives me stable CI behavior