### PR TITLE
[stdpar] SyncElision: Fix segfault when function ptr calls are in the sync elision CFG

### DIFF
--- a/src/compiler/stdpar/SyncElision.cpp
+++ b/src/compiler/stdpar/SyncElision.cpp
@@ -221,6 +221,14 @@ void forEachReachableInstructionRequiringSync(
   while(Current) {
     if(auto* CB = llvm::dyn_cast<llvm::CallBase>(Current)) {
       llvm::Function* CalledF = CB->getCalledFunction();
+      // CalledF may be nullptr, e.g. if a function ptr is invoked.
+      // In that case, we have no idea about the CFG and need to insert
+      // a barrier.
+      if(!CalledF) {
+        H(Current);
+        return;
+      }
+
       if(CalledF->getName() == BarrierBuiltinName) {
         // basic block already contains barrier; nothing to do
         return;


### PR DESCRIPTION
Stdpar SyncElision walks the CFG downstream of stdpar calls. If there's a function pointer call there, then the pass might segfault because we don't currently check whether the called function of call/invoke instructions is nullptr. This PR fixes that.