### PR TITLE
Minor fix in filepath to enable compilation for llvm22. 

### DIFF
--- a/src/compiler/AdaptiveCppLlvmPasses.cpp
+++ b/src/compiler/AdaptiveCppLlvmPasses.cpp
@@ -39,7 +39,13 @@
 
 #include "llvm/Pass.h"
 #include "llvm/Passes/PassBuilder.h"
+
+#if LLVM_VERSION_MAJOR < 22
 #include "llvm/Passes/PassPlugin.h"
+#else
+#include "llvm/Plugins/PassPlugin.h"
+#endif
+
 #include "llvm/Support/CommandLine.h"
 
 #if LLVM_VERSION_MAJOR < 16

--- a/src/compiler/llvm-to-backend/metal/Emitter.cpp
+++ b/src/compiler/llvm-to-backend/metal/Emitter.cpp
@@ -29,7 +29,11 @@
 #include <llvm/Support/raw_ostream.h>
 
 #include <llvm/Passes/PassBuilder.h>
+#if LLVM_VERSION_MAJOR < 22
 #include <llvm/Passes/PassPlugin.h>
+#else
+#include <llvm/Plugins/PassPlugin.h>
+#endif
 
 #include <llvm/Transforms/InstCombine/InstCombine.h>
 #include <llvm/Transforms/Scalar/EarlyCSE.h>


### PR DESCRIPTION
The executables can run just fine, not sure if there is any further hidden incompatibility.