### PR TITLE
[VK] Support event profiling

### DIFF
--- a/doc/install-vulkan.md
+++ b/doc/install-vulkan.md
@@ -343,6 +343,28 @@ command has completed, but before we tell other SYCL commands the DAG node has
 completed. For example, freeing temporary allocations created to implement
 memcopy.
 
+#### Profiling
+
+Support for SYCL event profiling requires device support for the
+[VK_KHR_calibrated_timestamps](https://docs.vulkan.org/refpages/latest/refpages/source/VK_KHR_calibrated_timestamps.html) or
+[VK_EXT_calibrated_timestamps](https://docs.vulkan.org/refpages/latest/refpages/source/VK_EXT_calibrated_timestamps.html)
+extensions to align device and host side counters.
+
+`vkGetCalibratedTimestampsKHR` is used to get the host timestamp for when a command is submitted, and also
+command start and/or end timestamps for when a command is executed asynchronously on host using a worker thread.
+
+For the most common case where commands are executed asynchronously on device in a vkCommandBuffer,
+a single element `vkQueryPool` is created for each instrumentation counter. The command-buffer then
+has extra commands included to bookend it's execution that record the device side timestamps
+into the query pool. When instrumentation counter is queried it reports back the device side
+timestamp converted to a host side timepoint using the calibrated timestamp reference.
+
+A single large query pool that is shared by all event instrumentation counters is
+not used because the choice of static query pool size would have been arbitrary.
+Additionally, the runtime wouldn't frequently free the timestamps to return to the pool,
+as the rt DAG nodes which owns the lifetime of the counters needs to outlive the user
+facing `sycl::event` object.
+
 ### Compiler
 
 #### clspv

--- a/include/hipSYCL/runtime/vk/vk_hardware_manager.hpp
+++ b/include/hipSYCL/runtime/vk/vk_hardware_manager.hpp
@@ -12,7 +12,6 @@
 #pragma once
 
 #include "../hardware.hpp"
-#include "hipSYCL/runtime/vk/vk_allocator.hpp"
 #include <vulkan/vulkan_raii.hpp>
 
 namespace hipsycl {
@@ -39,10 +38,21 @@ enum feature_bits {
 };
 }; // namespace vk_device_features
 
+// Bit for each extension we can enable when creating a logical device,
+// improves extension querying compared to C string comparisons against
+// extension names.
+namespace vk_device_extensions {
+enum extension_bits {
+  khr_portability_subset = 1 << 0,
+  khr_calibrated_timestamps = 1 << 1,
+  ext_calibrated_timestamps = 1 << 2,
+};
+} // namespace vk_device_extensions
+
 class vk_hardware_context : public hardware_context {
 public:
   vk_hardware_context(const vk::raii::PhysicalDevice &, int dev_id,
-                      uint16_t features, bool portability_subset);
+                      uint16_t features);
   vk_hardware_context(vk_hardware_context const &) = delete;
   vk_hardware_context(vk_hardware_context &&) = default;
 
@@ -85,6 +95,10 @@ public:
   uint32_t get_subgroup_size() const { return _subgroup_size; }
   uint16_t get_phys_dev_features() const { return _physical_dev_features; }
 
+  bool are_extensions_enabled(uint16_t bits) const {
+    return (bits & _enabled_extensions) == bits;
+  }
+
 private:
   size_t global_mem_size() const;
 
@@ -100,6 +114,7 @@ private:
 
   int _dev_id;
   uint16_t _physical_dev_features;
+  uint16_t _enabled_extensions;
   std::unique_ptr<vk_allocator> _allocator;
 };
 

--- a/include/hipSYCL/runtime/vk/vk_hardware_manager.hpp
+++ b/include/hipSYCL/runtime/vk/vk_hardware_manager.hpp
@@ -42,7 +42,7 @@ enum feature_bits {
 // improves extension querying compared to C string comparisons against
 // extension names.
 namespace vk_device_extensions {
-enum extension_bits {
+enum extension_bits : uint16_t {
   khr_portability_subset = 1 << 0,
   khr_calibrated_timestamps = 1 << 1,
   ext_calibrated_timestamps = 1 << 2,

--- a/include/hipSYCL/runtime/vk/vk_profiling.hpp
+++ b/include/hipSYCL/runtime/vk/vk_profiling.hpp
@@ -1,0 +1,156 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#pragma once
+
+#include "../instrumentation.hpp"
+#include "hipSYCL/runtime/error.hpp"
+#include <vulkan/vulkan_raii.hpp>
+
+namespace hipsycl {
+namespace rt {
+
+class vk_hardware_context;
+
+// Helper function for vkGetCalibratedTimestampsKHR() with the timestamps
+// needed for profiling
+struct calibrated_timestamps {
+  uint64_t clock_monotonic;
+  uint64_t device;
+};
+calibrated_timestamps vk_get_calibrated_timestamps(const vk::raii::Device &,
+                                                   bool);
+
+// Helper function for calling vkGetQueryPoolResults on a single element
+// query pool
+uint64_t vk_get_query_pool_result(const vk::raii::QueryPool &);
+
+// Helper function for creating a single element query pool
+vk::raii::QueryPool vk_create_query_pool(const vk::raii::Device &);
+
+// Synchronous timestamp used for submission metric
+class vk_sync_timestamp : public instrumentations::submission_timestamp {
+public:
+  vk_sync_timestamp(const vk::raii::Device &dev, bool use_khr) {
+    // Use VK_TIME_DOMAIN_CLOCK_MONOTONIC_KHR value which is already in the
+    // unit of nanoseconds
+    uint64_t now = vk_get_calibrated_timestamps(dev, use_khr).clock_monotonic;
+    _time = profiler_clock::time_point{profiler_clock::duration{now}};
+  }
+
+  profiler_clock::time_point get_time_point() const override { return _time; }
+
+  void wait() const override {}
+
+private:
+  profiler_clock::time_point _time;
+};
+
+// Asynchronous timestamp used for command start/finish metric
+// This needs to support device (via vkCommandBuffer) or
+// host (via host_worker thread)  async execution.
+template <class Base> class vk_async_timestamp : public Base {
+public:
+  vk_async_timestamp(const vk::raii::Device &dev, vk::Semaphore sem,
+                     bool use_khr)
+      : _dev(dev), _use_khr(use_khr), _query_pool(nullptr), _host_timestamp(0),
+        _sem(sem), _sem_wait_val(0) {
+    // Snapshot the current host and device timestamps
+    _ref_timestamps = vk_get_calibrated_timestamps(_dev, _use_khr);
+
+    // Create a single element query pool owned by this instrumentation object
+    _query_pool = vk_create_query_pool(_dev);
+  }
+
+  // Getter allows vkQueue to append command-buffer commands using this
+  // query-pool
+  vk::QueryPool get_query_pool() { return *_query_pool; }
+
+  // Set the value of the timeline semaphore to wait on for command completion
+  void set_semaphore_wait_val(uint64_t wait_val) { _sem_wait_val = wait_val; }
+
+  // Called as part of asynchronous host execution.
+  void take_host_timestamp() {
+    _host_timestamp =
+        vk_get_calibrated_timestamps(_dev, _use_khr).clock_monotonic;
+  }
+
+  profiler_clock::time_point get_time_point() const override {
+    // If command was executed on host, directly convert to time point
+    if (_host_timestamp != 0) {
+      return profiler_clock::time_point{
+          profiler_clock::duration{_host_timestamp}};
+    }
+
+    // If command was executed on device then use the difference between host
+    // and device counters from the reference timestamp to inform how to
+    // convert the device timestamp we captured into a time point.
+    const uint64_t &host_ref = _ref_timestamps.clock_monotonic;
+    const uint64_t &dev_ref = _ref_timestamps.device;
+
+    // Get captured device timestamp from query pool in domain
+    // VK_TIME_DOMAIN_DEVICE_KHR
+    const int64_t device_time = vk_get_query_pool_result(_query_pool);
+
+    // Convert device timestamp to host timepoint
+    int64_t host_time;
+    if (host_ref > dev_ref) {
+      host_time = (host_ref - dev_ref) + device_time;
+    } else {
+      host_time = device_time - (dev_ref - host_ref);
+    }
+    return profiler_clock::time_point{profiler_clock::duration{host_time}};
+  }
+
+  void wait() const override {
+    HIPSYCL_DEBUG_INFO << "vk_async_timestamp: semaphore " << _sem
+                       << " wait on " << _sem_wait_val << std::endl;
+
+    // Wait on completion of semaphore indicating async work has completed
+    vk::SemaphoreWaitInfo wait_info({}, 1, &_sem, &_sem_wait_val);
+    vk::Result wait_ret_code;
+    do {
+      wait_ret_code = _dev.waitSemaphores(wait_info, UINT64_MAX);
+    } while (vk::Result::eTimeout == wait_ret_code);
+
+    if (wait_ret_code != vk::Result::eSuccess) {
+      std::string err_msg("Semaphore wait failed with unexpected return code ");
+      err_msg += std::to_string(static_cast<VkResult>(wait_ret_code));
+      print_error(__acpp_here(), error_info{err_msg});
+    }
+  }
+
+private:
+  // Members below used for device execution
+  const vk::raii::Device &_dev;
+  bool _use_khr;
+  vk::raii::QueryPool _query_pool;
+  calibrated_timestamps _ref_timestamps;
+
+  // Members used to implement wait() method
+  vk::Semaphore _sem;
+  uint64_t _sem_wait_val;
+
+  // Members below used for host execution
+  uint64_t _host_timestamp;
+};
+
+using vk_execution_start_timestamp =
+    vk_async_timestamp<instrumentations::execution_start_timestamp>;
+using vk_execution_finish_timestamp =
+    vk_async_timestamp<instrumentations::execution_finish_timestamp>;
+
+struct vk_async_profiling {
+  std::shared_ptr<vk_execution_start_timestamp> start_time;
+  std::shared_ptr<vk_execution_finish_timestamp> finish_time;
+};
+
+} // namespace rt
+} // namespace hipsycl

--- a/include/hipSYCL/runtime/vk/vk_queue.hpp
+++ b/include/hipSYCL/runtime/vk/vk_queue.hpp
@@ -17,6 +17,7 @@
 #include "hipSYCL/runtime/code_object_invoker.hpp"
 #include "hipSYCL/runtime/generic/async_worker.hpp"
 #include "hipSYCL/runtime/vk/vk_code_object.hpp"
+#include "hipSYCL/runtime/vk/vk_profiling.hpp"
 #include <mutex>
 #include <vulkan/vulkan_raii.hpp>
 
@@ -63,12 +64,16 @@ public:
 
 private:
   // Helper functions
+  vk::CommandBuffer begin_command_buffer(vk::CommandBufferUsageFlagBits);
+  void end_command_buffer(vk::CommandBuffer &cmd_buf);
   vk::CommandBuffer get_command_buffer();
 
   void submit_command_buffer(vk::CommandBuffer &cmd_buf);
 
   std::pair<vk_alloc_info *, bool>
   find_or_create_allocation(vk::DeviceAddress ptr, unsigned size);
+
+  void profile_if_enabled(operation &op, const dag_node_ptr &node);
 
   // Members for tracking backend device
   vk_hardware_manager *_hw_manager;
@@ -104,6 +109,10 @@ private:
     std::unordered_map<uint64_t, ValueType> _alloc_map;
     mutable std::mutex _mutex;
   } _temp_allocs;
+
+  // Members for profiling
+  std::optional<vk_async_profiling> _profiling;
+  bool _dev_has_khr_calibrated_timestamps;
 
   // Members for command synchronization
   uint64_t _timeline_value = 0;

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -248,7 +248,8 @@ if(WITH_VULKAN_BACKEND)
      vk/vk_queue.cpp
      vk/vk_event.cpp
      vk/vk_code_object.cpp
-     vk/vk_hardware_manager.cpp)
+     vk/vk_hardware_manager.cpp
+     vk/vk_profiling.cpp)
   target_include_directories(rt-backend-vk PRIVATE
                              ${HIPSYCL_SOURCE_DIR}/include
                              ${ACPP_BINARY_ROOT}/include/

--- a/src/runtime/vk/vk_allocator.cpp
+++ b/src/runtime/vk/vk_allocator.cpp
@@ -133,6 +133,9 @@ void vk_allocator::raw_free(void *mem) {
   std::lock_guard<std::mutex> lock{_mutex};
   auto dev_ptr = reinterpret_cast<vk::DeviceAddress>(mem);
   assert(_allocs.count(dev_ptr));
+
+  HIPSYCL_DEBUG_INFO << "vk_allocator: freed 0x" << std::hex << mem << std::dec
+                     << std::endl;
   _allocs.erase(dev_ptr);
 }
 

--- a/src/runtime/vk/vk_code_object.cpp
+++ b/src/runtime/vk/vk_code_object.cpp
@@ -9,6 +9,7 @@
  */
 // SPDX-License-Identifier: BSD-2-Clause
 #include "hipSYCL/runtime/vk/vk_code_object.hpp"
+#include "hipSYCL/runtime/vk/vk_allocator.hpp"
 #include "hipSYCL/runtime/vk/vk_hardware_manager.hpp"
 #include "hipSYCL/runtime/vk/vk_queue.hpp"
 

--- a/src/runtime/vk/vk_hardware_manager.cpp
+++ b/src/runtime/vk/vk_hardware_manager.cpp
@@ -12,6 +12,7 @@
 #include "hipSYCL/runtime/vk/vk_hardware_manager.hpp"
 #include "hipSYCL/common/config.hpp"
 #include "hipSYCL/runtime/error.hpp"
+#include "hipSYCL/runtime/vk/vk_allocator.hpp"
 #include <algorithm>
 #include <limits>
 #include <sstream>
@@ -20,10 +21,9 @@ namespace hipsycl {
 namespace rt {
 
 vk_hardware_context::vk_hardware_context(
-    const vk::raii::PhysicalDevice &phys_device, int dev_id, uint16_t features,
-    bool portability_subset)
+    const vk::raii::PhysicalDevice &phys_device, int dev_id, uint16_t features)
     : _physical_device(phys_device), _dev_id(dev_id),
-      _physical_dev_features(features) {
+      _physical_dev_features(features), _enabled_extensions(0) {
   _properties = phys_device.getProperties();
 
   std::vector<vk::QueueFamilyProperties> queue_family_props =
@@ -93,12 +93,38 @@ vk_hardware_context::vk_hardware_context(
                                                                    : VK_FALSE;
 
   vk::DeviceCreateInfo dev_create_info{{}, queue_create_info};
-  // Outside if statement scope so lifetime is valid for raii::Device
-  // initialization
-  const char *portability_ext_name = VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME;
-  if (portability_subset) {
-    dev_create_info.setEnabledExtensionCount(1);
-    dev_create_info.setPpEnabledExtensionNames(&portability_ext_name);
+
+  auto phys_dev_extensions =
+      _physical_device.enumerateDeviceExtensionProperties();
+
+  // Portability subset extensions used to enable MoltenVK.
+  // Calibrated timestamps extension used to enable event profiling.
+  std::array<std::pair<const char *, uint16_t>, 3> optional_exts = {
+      std::make_pair(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME,
+                     vk_device_extensions::khr_portability_subset),
+      std::make_pair(VK_KHR_CALIBRATED_TIMESTAMPS_EXTENSION_NAME,
+                     vk_device_extensions::khr_calibrated_timestamps),
+      std::make_pair(VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME,
+                     vk_device_extensions::ext_calibrated_timestamps)};
+  std::vector<const char *> enable_ext_names;
+  for (auto opt_ext : optional_exts) {
+    bool ext_supported = std::any_of(
+        std::begin(phys_dev_extensions), std::end(phys_dev_extensions),
+        [opt_ext](auto const &ext_property) {
+          return strcmp(ext_property.extensionName, opt_ext.first) == 0;
+        });
+    if (ext_supported) {
+      HIPSYCL_DEBUG_INFO << "vk_hardware_context: enabling extension "
+                         << opt_ext.first << std::endl;
+      _enabled_extensions |= opt_ext.second;
+      enable_ext_names.push_back(opt_ext.first);
+    }
+  }
+
+  if (auto num_dev_extensions = enable_ext_names.size();
+      num_dev_extensions != 0) {
+    dev_create_info.setEnabledExtensionCount(num_dev_extensions);
+    dev_create_info.setPpEnabledExtensionNames(enable_ext_names.data());
   }
 
   vk::StructureChain<vk::DeviceCreateInfo, vk::PhysicalDeviceFeatures2,
@@ -233,8 +259,50 @@ bool vk_hardware_context::has(device_support_aspect aspect) const {
     return false;
   case device_support_aspect::usm_system_allocations:
     return false;
-  case device_support_aspect::execution_timestamps:
-    return false;
+  case device_support_aspect::execution_timestamps: {
+    // Verify that device can create a query pool on the compute queue so
+    // enable capturing asynchronous timestamps during command-buffer execution
+    if (_limits.timestampPeriod == 0) {
+      return false;
+    }
+
+    const vk::QueueFamilyProperties &queue_family_props =
+        _physical_device.getQueueFamilyProperties()[_queue_index];
+    if (!queue_family_props.timestampValidBits) {
+      return false;
+    }
+
+    // Verify that device has either KHR or EXT calibrated timestamps extension
+    // that support both clock monotonic & device domains
+    std::pair<bool, bool> required_domains(false, false);
+
+    // vkTimeDomainKHR is aliased to vkTimeDomainEXT
+    auto check_required_domains =
+        [&required_domains](vk::TimeDomainEXT &time_domain) {
+          if (time_domain == vk::TimeDomainEXT::eClockMonotonic) {
+            required_domains.first = true;
+          }
+
+          if (time_domain == vk::TimeDomainEXT::eDevice) {
+            required_domains.second = true;
+          }
+        };
+
+    // Prefer using KHR entry point rather than EXT if a device supports both
+    if (are_extensions_enabled(
+            vk_device_extensions::khr_calibrated_timestamps)) {
+      auto time_domains = _physical_device.getCalibrateableTimeDomainsKHR();
+      std::for_each(std::begin(time_domains), std::end(time_domains),
+                    check_required_domains);
+    } else if (are_extensions_enabled(
+                   vk_device_extensions::ext_calibrated_timestamps)) {
+      auto time_domains = _physical_device.getCalibrateableTimeDomainsEXT();
+      std::for_each(std::begin(time_domains), std::end(time_domains),
+                    check_required_domains);
+    }
+
+    return required_domains.first && required_domains.second;
+  }
   case device_support_aspect::sscp_kernels:
 #ifdef HIPSYCL_WITH_SSCP_COMPILER
     return true;
@@ -618,19 +686,10 @@ vk_hardware_manager::vk_hardware_manager()
       backend_features |= vk_device_features::storagePushConstant16;
     }
 
-    auto phys_dev_extensions = phys_dev.enumerateDeviceExtensionProperties();
-    bool portability_ext_supported = std::any_of(
-        std::begin(phys_dev_extensions), std::end(phys_dev_extensions),
-        [](auto const &ext_property) {
-          return strcmp(ext_property.extensionName,
-                        VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME) == 0;
-        });
-
     auto device_name = phys_dev.getProperties().deviceName;
     if (device_matches(visibility_mask, backend_id::vk, device_index,
                        device_index, 0, device_name, {})) {
-      _devices.emplace_back(phys_dev, device_index, backend_features,
-                            portability_ext_supported);
+      _devices.emplace_back(phys_dev, device_index, backend_features);
     }
     device_index++;
   }

--- a/src/runtime/vk/vk_profiling.cpp
+++ b/src/runtime/vk/vk_profiling.cpp
@@ -1,0 +1,61 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#include "hipSYCL/runtime/vk/vk_profiling.hpp"
+
+namespace hipsycl {
+namespace rt {
+
+calibrated_timestamps vk_get_calibrated_timestamps(const vk::raii::Device &dev,
+                                                   bool use_khr) {
+  std::array<vk::CalibratedTimestampInfoEXT, 2> timestamp_infos = {
+      vk::CalibratedTimestampInfoEXT(vk::TimeDomainEXT::eClockMonotonic),
+      vk::CalibratedTimestampInfoEXT(vk::TimeDomainEXT::eDevice)};
+
+  auto time_domains = use_khr ? dev.getCalibratedTimestampsKHR(timestamp_infos)
+                              : dev.getCalibratedTimestampsEXT(timestamp_infos);
+  auto &timestamps = time_domains.first; // Drop max deviation
+  return calibrated_timestamps{timestamps[0], timestamps[1]};
+}
+
+uint64_t vk_get_query_pool_result(const vk::raii::QueryPool &query_pool) {
+  std::vector<uint64_t> data;
+  vk::Result result;
+  // Get timestamp data as 64-bit int rather than 32-bit default.
+  std::tie(result, data) = query_pool.getResults<uint64_t>(
+      0, 1, sizeof(uint64_t), 0,
+      vk::QueryResultFlagBits::e64 | vk::QueryResultFlagBits::eWait);
+
+  switch (result) {
+  case vk::Result::eSuccess:
+    break;
+  case vk::Result::eNotReady:
+    print_error(__acpp_here(),
+                error_info{"vkGetQueryPoolResults returned VK_NOT_READY"});
+    break;
+  default:
+    print_error(
+        __acpp_here(),
+        error_info{"vkGetQueryPoolResults returned an unexpected error"});
+    break;
+  }
+
+  return data[0];
+}
+
+vk::raii::QueryPool vk_create_query_pool(const vk::raii::Device &dev) {
+  vk::QueryPoolCreateInfo query_pool_info{};
+  query_pool_info.queryType = vk::QueryType::eTimestamp;
+  query_pool_info.queryCount = 1;
+  return dev.createQueryPool(query_pool_info);
+}
+
+} // namespace rt
+} // namespace hipsycl

--- a/src/runtime/vk/vk_profiling.cpp
+++ b/src/runtime/vk/vk_profiling.cpp
@@ -26,10 +26,8 @@ calibrated_timestamps vk_get_calibrated_timestamps(const vk::raii::Device &dev,
 }
 
 uint64_t vk_get_query_pool_result(const vk::raii::QueryPool &query_pool) {
-  std::vector<uint64_t> data;
-  vk::Result result;
   // Get timestamp data as 64-bit int rather than 32-bit default.
-  std::tie(result, data) = query_pool.getResults<uint64_t>(
+  auto [result, data] = query_pool.getResults<uint64_t>(
       0, 1, sizeof(uint64_t), 0,
       vk::QueryResultFlagBits::e64 | vk::QueryResultFlagBits::eWait);
 

--- a/src/runtime/vk/vk_queue.cpp
+++ b/src/runtime/vk/vk_queue.cpp
@@ -11,6 +11,7 @@
 #include "hipSYCL/runtime/vk/vk_queue.hpp"
 #include "hipSYCL/runtime/device_id.hpp"
 #include "hipSYCL/runtime/queue_completion_event.hpp"
+#include "hipSYCL/runtime/vk/vk_allocator.hpp"
 #include "hipSYCL/runtime/vk/vk_event.hpp"
 #include "hipSYCL/runtime/vk/vk_hardware_manager.hpp"
 
@@ -31,6 +32,9 @@ vk_queue::vk_queue(vk_hardware_manager *hw_manager, std::size_t device_index)
   _dev_ctx =
       static_cast<vk_hardware_context *>(hw_manager->get_device(device_index));
   auto &device = _dev_ctx->get_device();
+
+  _dev_has_khr_calibrated_timestamps = _dev_ctx->are_extensions_enabled(
+      vk_device_extensions::khr_calibrated_timestamps);
 
   _reflection_map = glue::jit::construct_default_reflection_map(_dev_ctx);
 
@@ -83,7 +87,50 @@ vk_queue::find_or_create_allocation(vk::DeviceAddress ptr, unsigned size) {
   return std::make_pair(alloc_info, true);
 }
 
-result vk_queue::submit_memcpy(memcpy_operation &op, const dag_node_ptr &) {
+void vk_queue::profile_if_enabled(operation &op, const dag_node_ptr &node) {
+  if (!node) {
+    return;
+  }
+
+  auto &hints = node->get_execution_hints();
+  if (hints.has_hint<
+          rt::hints::request_instrumentation_submission_timestamp>()) {
+    op.get_instrumentations()
+        .add_instrumentation<instrumentations::submission_timestamp>(
+            std::make_shared<vk_sync_timestamp>(
+                _dev_ctx->get_device(), _dev_has_khr_calibrated_timestamps));
+  }
+
+  vk_async_profiling async_prof;
+  if (hints.has_hint<rt::hints::request_instrumentation_start_timestamp>()) {
+    async_prof.start_time = std::make_shared<vk_execution_start_timestamp>(
+        _dev_ctx->get_device(), *_semaphore,
+        _dev_has_khr_calibrated_timestamps);
+    op.get_instrumentations()
+        .add_instrumentation<instrumentations::execution_start_timestamp>(
+            async_prof.start_time);
+  }
+
+  if (hints.has_hint<rt::hints::request_instrumentation_finish_timestamp>()) {
+    async_prof.finish_time = std::make_shared<vk_execution_finish_timestamp>(
+        _dev_ctx->get_device(), *_semaphore,
+        _dev_has_khr_calibrated_timestamps);
+    op.get_instrumentations()
+        .add_instrumentation<instrumentations::execution_finish_timestamp>(
+            async_prof.finish_time);
+  }
+
+  // Reset this for every new command submission, the underlying
+  // instrumentation object from previous command submissions is kept alive
+  // through the shared pointer attached to `op`.
+  if (async_prof.start_time || async_prof.finish_time) {
+    _profiling = std::move(async_prof);
+  } else {
+    _profiling.reset();
+  }
+}
+
+result vk_queue::submit_memcpy(memcpy_operation &op, const dag_node_ptr &node) {
   id<3> src_offset = op.source().get_access_offset();
   id<3> dest_offset = op.dest().get_access_offset();
   const range<3> transfer_range = op.get_num_transferred_elements();
@@ -112,6 +159,8 @@ result vk_queue::submit_memcpy(memcpy_operation &op, const dag_node_ptr &) {
 
   assert(dimension >= 1 && dimension <= 3);
 
+  profile_if_enabled(op, node);
+
   auto dst_alloc = find_or_create_allocation(dst_ptr, size);
   auto src_alloc = find_or_create_allocation(src_ptr, size);
   std::pair<vk_alloc_info *, vk_alloc_info *> temp_allocs{nullptr, nullptr};
@@ -120,6 +169,7 @@ result vk_queue::submit_memcpy(memcpy_operation &op, const dag_node_ptr &) {
   if (src_alloc.second) {
     const uint64_t wait_value = _timeline_value;
     const uint64_t signal_value = ++_timeline_value;
+
     vk_alloc_info *src_alloc_info = src_alloc.first;
     _host_worker(
         [=]() mutable {
@@ -141,6 +191,12 @@ result vk_queue::submit_memcpy(memcpy_operation &op, const dag_node_ptr &) {
                 "Semaphore wait failed with unexpected return code ");
             err_msg += std::to_string(static_cast<VkResult>(wait_ret_code));
             print_error(__acpp_here(), error_info{err_msg});
+          }
+
+          if (_profiling) {
+            // Since we're dong work before command buffer starts executing,
+            // use an earlier host timestamp
+            _profiling->start_time->take_host_timestamp();
           }
 
           void *vptr = src_alloc_info->_dev_mem.mapMemory(0, size);
@@ -170,9 +226,8 @@ result vk_queue::submit_memcpy(memcpy_operation &op, const dag_node_ptr &) {
   }
 
   // Append a copy-buffer command for every strided copy.
-  vk::CommandBuffer cmd_buf = get_command_buffer();
-  cmd_buf.begin(vk::CommandBufferBeginInfo(
-      vk::CommandBufferUsageFlagBits::eOneTimeSubmit));
+  vk::CommandBuffer cmd_buf =
+      begin_command_buffer(vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
   std::vector<vk::BufferCopy> copy_regions;
   if (dimension == 1) {
     size_t x_src_offset = src_offset[0];
@@ -228,7 +283,7 @@ result vk_queue::submit_memcpy(memcpy_operation &op, const dag_node_ptr &) {
 
   cmd_buf.copyBuffer(src_alloc.first->_buffer, dst_alloc.first->_buffer,
                      copy_regions);
-  cmd_buf.end();
+  end_command_buffer(cmd_buf);
   submit_command_buffer(cmd_buf);
 
   // Cleanup to be wrapped in async call, this is effectively an extra command
@@ -238,6 +293,13 @@ result vk_queue::submit_memcpy(memcpy_operation &op, const dag_node_ptr &) {
   if (temp_allocs.first || temp_allocs.second) {
     const uint64_t wait_value = _timeline_value;
     const uint64_t signal_value = ++_timeline_value;
+
+    if (_profiling) {
+      // Since we need to do work after the command-buffer finishes executing
+      // override semaphore value to wait on
+      _profiling->finish_time->set_semaphore_wait_val(signal_value);
+    }
+
     _host_worker(
         [=]() mutable {
           vk::Semaphore semaphore = *_semaphore;
@@ -276,6 +338,12 @@ result vk_queue::submit_memcpy(memcpy_operation &op, const dag_node_ptr &) {
           }
           _temp_allocs.erase(wait_value);
 
+          if (_profiling) {
+            // Since we're dong work after command buffer starts executing,
+            // use a later host timestamp
+            _profiling->finish_time->take_host_timestamp();
+          }
+
           vk::SemaphoreSignalInfo signal_info(semaphore, signal_value);
           _dev_ctx->get_device().signalSemaphore(signal_info);
 
@@ -287,6 +355,38 @@ result vk_queue::submit_memcpy(memcpy_operation &op, const dag_node_ptr &) {
   }
 
   return make_success();
+}
+
+vk::CommandBuffer
+vk_queue::begin_command_buffer(vk::CommandBufferUsageFlagBits flags) {
+  auto cmd_buf = get_command_buffer();
+  cmd_buf.begin(vk::CommandBufferBeginInfo(
+      vk::CommandBufferUsageFlagBits::eOneTimeSubmit));
+
+  if (_profiling) {
+    // When profiling, start the command buffer with commands to reset and
+    // write a query pool timestamp. This gives the device side timestamp
+    // for when the command begins execution.
+    auto query_pool = _profiling->start_time->get_query_pool();
+
+    cmd_buf.resetQueryPool(query_pool, 0, 1);
+    cmd_buf.writeTimestamp(vk::PipelineStageFlagBits::eComputeShader,
+                           query_pool, 0);
+  }
+  return cmd_buf;
+}
+
+void vk_queue::end_command_buffer(vk::CommandBuffer &cmd_buf) {
+  if (_profiling) {
+    // When profiling, end the command buffer with commands to reset and
+    // write a query pool timestamp. This gives the device side timestamp
+    // for when the command finishes execution.
+    auto query_pool = _profiling->finish_time->get_query_pool();
+    cmd_buf.resetQueryPool(query_pool, 0, 1);
+    cmd_buf.writeTimestamp(vk::PipelineStageFlagBits::eComputeShader,
+                           query_pool, 0);
+  }
+  cmd_buf.end();
 }
 
 vk::CommandBuffer vk_queue::get_command_buffer() {
@@ -384,6 +484,12 @@ void vk_queue::submit_command_buffer(vk::CommandBuffer &cmd_buf) {
   const uint64_t wait_value = _timeline_value;
   const uint64_t signal_value = ++_timeline_value;
 
+  if (_profiling) {
+    // Only let a user read the timestamps after the signal semaphore has fired
+    _profiling->start_time->set_semaphore_wait_val(signal_value);
+    _profiling->finish_time->set_semaphore_wait_val(signal_value);
+  }
+
   HIPSYCL_DEBUG_INFO << "vk_queue: submit command-buffer with "
                      << "semaphore " << *_semaphore << " wait value "
                      << wait_value << " & signal value " << signal_value
@@ -428,22 +534,24 @@ void vk_queue::submit_command_buffer(vk::CommandBuffer &cmd_buf) {
 result vk_queue::submit_kernel(kernel_operation &op, const dag_node_ptr &node) {
   rt::backend_kernel_launch_capabilities cap;
   cap.provide_sscp_invoker(&_sscp_invoker);
+  profile_if_enabled(op, node);
   return op.get_launcher().invoke(backend_id::vk, this, cap, node.get());
 }
 
-result vk_queue::submit_prefetch(prefetch_operation &, const dag_node_ptr &) {
-  vk::CommandBuffer cmd_buf = get_command_buffer();
-  cmd_buf.begin(vk::CommandBufferBeginInfo(
-      vk::CommandBufferUsageFlagBits::eOneTimeSubmit));
+result vk_queue::submit_prefetch(prefetch_operation &op,
+                                 const dag_node_ptr &node) {
+  profile_if_enabled(op, node);
+  vk::CommandBuffer cmd_buf =
+      begin_command_buffer(vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
   // Empty command buffer, ignore perf hint as no-op
-  cmd_buf.end();
+  end_command_buffer(cmd_buf);
 
   submit_command_buffer(cmd_buf);
 
   return make_success();
 }
 
-result vk_queue::submit_memset(memset_operation &op, const dag_node_ptr &) {
+result vk_queue::submit_memset(memset_operation &op, const dag_node_ptr &node) {
   // In order to deal with sizes not divisible by 4 we implement memset on host
   // rather than using a command-buffer command.
   int pattern = op.get_pattern();
@@ -453,10 +561,18 @@ result vk_queue::submit_memset(memset_operation &op, const dag_node_ptr &) {
   // assert we're only dealing with user created allocations
   assert(!ptr_alloc.second);
 
+  profile_if_enabled(op, node);
+
   // Need to snapshot these values now, as _timeline_value may changed
   // by the time the async function is invoked.
   const uint64_t wait_value = _timeline_value;
   const uint64_t signal_value = ++_timeline_value;
+
+  if (_profiling) {
+    // Only let a user read the timestamps after the signal semaphore has fired
+    _profiling->start_time->set_semaphore_wait_val(signal_value);
+    _profiling->finish_time->set_semaphore_wait_val(signal_value);
+  }
 
   _host_worker([=]() mutable {
     vk::Semaphore semaphore = *_semaphore;
@@ -477,10 +593,18 @@ result vk_queue::submit_memset(memset_operation &op, const dag_node_ptr &) {
       print_error(__acpp_here(), error_info{err_msg});
     }
 
+    if (_profiling) {
+      _profiling->start_time->take_host_timestamp();
+    }
+
     char *vptr = (char *)ptr_alloc.first->_dev_mem.mapMemory(0, size);
     auto offset = ptr - ptr_alloc.first->_base_ptr;
     std::memset(vptr + offset, pattern, size);
     ptr_alloc.first->_dev_mem.unmapMemory();
+
+    if (_profiling) {
+      _profiling->finish_time->take_host_timestamp();
+    }
 
     vk::SemaphoreSignalInfo signal_info(semaphore, signal_value);
     _dev_ctx->get_device().signalSemaphore(signal_info);
@@ -710,9 +834,8 @@ result vk_queue::submit_sscp_kernel_from_code_object(
 
   auto pipeline = kernel->create_pipeline(group_size);
 
-  vk::CommandBuffer cmd_buf = get_command_buffer();
-  cmd_buf.begin(vk::CommandBufferBeginInfo(
-      vk::CommandBufferUsageFlagBits::eOneTimeSubmit));
+  vk::CommandBuffer cmd_buf =
+      begin_command_buffer(vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
 
   // command-buffer must be in the recording state before we set push constants
   pipeline->set_args(cmd_buf, _arg_mapper);
@@ -721,7 +844,7 @@ result vk_queue::submit_sscp_kernel_from_code_object(
   HIPSYCL_DEBUG_INFO << "vk_queue: Attempting to submit SSCP kernel"
                      << std::endl;
   cmd_buf.dispatch(num_groups[0], num_groups[1], num_groups[2]);
-  cmd_buf.end();
+  end_command_buffer(cmd_buf);
 
   submit_command_buffer(cmd_buf);
   on_kernel_launch_complete(kernel_name, obj);

--- a/src/runtime/vk/vk_queue.cpp
+++ b/src/runtime/vk/vk_queue.cpp
@@ -193,7 +193,7 @@ result vk_queue::submit_memcpy(memcpy_operation &op, const dag_node_ptr &node) {
             print_error(__acpp_here(), error_info{err_msg});
           }
 
-          if (_profiling) {
+          if (_profiling && _profiling->start_time) {
             // Since we're dong work before command buffer starts executing,
             // use an earlier host timestamp
             _profiling->start_time->take_host_timestamp();
@@ -294,7 +294,7 @@ result vk_queue::submit_memcpy(memcpy_operation &op, const dag_node_ptr &node) {
     const uint64_t wait_value = _timeline_value;
     const uint64_t signal_value = ++_timeline_value;
 
-    if (_profiling) {
+    if (_profiling && _profiling->finish_time) {
       // Since we need to do work after the command-buffer finishes executing
       // override semaphore value to wait on
       _profiling->finish_time->set_semaphore_wait_val(signal_value);
@@ -338,7 +338,7 @@ result vk_queue::submit_memcpy(memcpy_operation &op, const dag_node_ptr &node) {
           }
           _temp_allocs.erase(wait_value);
 
-          if (_profiling) {
+          if (_profiling && _profiling->finish_time) {
             // Since we're dong work after command buffer starts executing,
             // use a later host timestamp
             _profiling->finish_time->take_host_timestamp();
@@ -363,7 +363,7 @@ vk_queue::begin_command_buffer(vk::CommandBufferUsageFlagBits flags) {
   cmd_buf.begin(vk::CommandBufferBeginInfo(
       vk::CommandBufferUsageFlagBits::eOneTimeSubmit));
 
-  if (_profiling) {
+  if (_profiling && _profiling->start_time) {
     // When profiling, start the command buffer with commands to reset and
     // write a query pool timestamp. This gives the device side timestamp
     // for when the command begins execution.
@@ -377,7 +377,7 @@ vk_queue::begin_command_buffer(vk::CommandBufferUsageFlagBits flags) {
 }
 
 void vk_queue::end_command_buffer(vk::CommandBuffer &cmd_buf) {
-  if (_profiling) {
+  if (_profiling && _profiling->finish_time) {
     // When profiling, end the command buffer with commands to reset and
     // write a query pool timestamp. This gives the device side timestamp
     // for when the command finishes execution.
@@ -486,8 +486,12 @@ void vk_queue::submit_command_buffer(vk::CommandBuffer &cmd_buf) {
 
   if (_profiling) {
     // Only let a user read the timestamps after the signal semaphore has fired
-    _profiling->start_time->set_semaphore_wait_val(signal_value);
-    _profiling->finish_time->set_semaphore_wait_val(signal_value);
+    if (_profiling->start_time) {
+      _profiling->start_time->set_semaphore_wait_val(signal_value);
+    }
+    if (_profiling->finish_time) {
+      _profiling->finish_time->set_semaphore_wait_val(signal_value);
+    }
   }
 
   HIPSYCL_DEBUG_INFO << "vk_queue: submit command-buffer with "
@@ -570,8 +574,12 @@ result vk_queue::submit_memset(memset_operation &op, const dag_node_ptr &node) {
 
   if (_profiling) {
     // Only let a user read the timestamps after the signal semaphore has fired
-    _profiling->start_time->set_semaphore_wait_val(signal_value);
-    _profiling->finish_time->set_semaphore_wait_val(signal_value);
+    if (_profiling->start_time) {
+      _profiling->start_time->set_semaphore_wait_val(signal_value);
+    }
+    if (_profiling->finish_time) {
+      _profiling->finish_time->set_semaphore_wait_val(signal_value);
+    }
   }
 
   _host_worker([=]() mutable {
@@ -593,7 +601,7 @@ result vk_queue::submit_memset(memset_operation &op, const dag_node_ptr &node) {
       print_error(__acpp_here(), error_info{err_msg});
     }
 
-    if (_profiling) {
+    if (_profiling && _profiling->start_time) {
       _profiling->start_time->take_host_timestamp();
     }
 
@@ -602,7 +610,7 @@ result vk_queue::submit_memset(memset_operation &op, const dag_node_ptr &node) {
     std::memset(vptr + offset, pattern, size);
     ptr_alloc.first->_dev_mem.unmapMemory();
 
-    if (_profiling) {
+    if (_profiling && _profiling->finish_time) {
       _profiling->finish_time->take_host_timestamp();
     }
 

--- a/tests/sycl/profiler.cpp
+++ b/tests/sycl/profiler.cpp
@@ -162,8 +162,8 @@ BOOST_AUTO_TEST_CASE(queue_profiling)
     BOOST_CHECK(t41 <= t43 && t42 <= t43);
 
     // usm
-    auto *src = sycl::malloc_shared<int>(n, queue);
-    auto *dest = sycl::malloc_shared<int>(n, queue);
+    auto *src = sycl::malloc_device<int>(n, queue);
+    auto *dest = sycl::malloc_device<int>(n, queue);
     auto evt6 = queue.submit(
         [&](sycl::handler &cgh) { cgh.memset(src, 0, sizeof src); });
 

--- a/tests/sycl/profiler.cpp
+++ b/tests/sycl/profiler.cpp
@@ -162,8 +162,12 @@ BOOST_AUTO_TEST_CASE(queue_profiling)
     BOOST_CHECK(t41 <= t43 && t42 <= t43);
 
     // usm
-    auto *src = sycl::malloc_device<int>(n, queue);
-    auto *dest = sycl::malloc_device<int>(n, queue);
+    const bool use_shared_alloc =
+        queue.get_device().has(sycl::aspect::usm_shared_allocations);
+    auto *src = use_shared_alloc ? sycl::malloc_shared<int>(n, queue)
+                                 : sycl::malloc_device<int>(n, queue);
+    auto *dest = use_shared_alloc ? sycl::malloc_shared<int>(n, queue)
+                                  : sycl::malloc_device<int>(n, queue);
     auto evt6 = queue.submit(
         [&](sycl::handler &cgh) { cgh.memset(src, 0, sizeof src); });
 


### PR DESCRIPTION
Implements Vulkan backend support for profiling SYCL events.

Every command creates a single element query pool object per async instrumentation counter. This query pool element then a timestamp written to it by the device as part of command-buffer execution. Either
[VK_KHR_calibrated_timestamps](https://docs.vulkan.org/refpages/latest/refpages/source/VK_KHR_calibrated_timestamps.html) or [VK_EXT_calibrated_timestamps](https://docs.vulkan.org/refpages/latest/refpages/source/VK_EXT_calibrated_timestamps.html) extension is then used to to align device counter with the host side timepoint expected by SYCL.

I decided against a design with a single large query pool because the choice of query pool size would have been arbitrary, it is not possible to dynamically resize the pool if this limit is exceeded, and we don't free the instrumentation counters that often to allow the timestamps to return to the pool because a rt DAG node needs to outlive the user facing `sycl::event` object.

There is a change to the SYCL profiling test to use device USM rather than shared USM, as shared USM isn't supported by the Vulkan backend and it's semantics over device USM aren't required for the test.

Closes https://github.com/AdaptiveCpp/AdaptiveCpp/issues/2135