### PR TITLE
Check for the Clang dev headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,7 +309,7 @@ if(BUILD_CLANG_PLUGIN)
     if(NOT CLANG_AST_HEADER_DIR)
       message(WARNING 
         "AdaptiveCpp requires clang development headers, but they were not found.\n"
-        "You might need to install the clang development package.\n"
+        "You might need to install the clang development package (e.g. libclang-dev or similar).\n"
       )
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,7 +308,7 @@ if(BUILD_CLANG_PLUGIN)
     )
     if(NOT CLANG_AST_HEADER_DIR)
       message(WARNING 
-        "AdaptiveCpp requires Clang AST development headers, but they were not found.\n"
+        "AdaptiveCpp requires clang development headers, but they were not found.\n"
         "You might need to install the clang development package.\n"
       )
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,7 +300,18 @@ if(BUILD_CLANG_PLUGIN)
       message(WARNING "Could not find LLVM in the requested location LLVM_DIR=${LLVM_DIR_OLD}; using ${LLVM_DIR}.")
     endif()
     message(STATUS "Building AdaptiveCpp against LLVM configured from ${LLVM_DIR}")
-    #find_package(Clang REQUIRED)
+    
+    find_path(CLANG_AST_HEADER_DIR
+      NAMES clang/AST/ASTContext.h
+      PATHS ${LLVM_INCLUDE_DIRS}
+      DOC "Path to the Clang AST headers (usually provided by libclang-dev)"
+    )
+    if(NOT CLANG_AST_HEADER_DIR)
+      message(WARNING 
+        "AdaptiveCpp requires Clang AST development headers, but they were not found.\n"
+        "You might need to install the clang development package.\n"
+      )
+    endif()
 
     find_program(CLANG_EXECUTABLE_PATH NAMES clang++-${LLVM_VERSION_MAJOR} clang++-${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR} clang++ HINTS ${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH CACHE STRING)
     if(CLANG_EXECUTABLE_PATH MATCHES "-NOTFOUND")


### PR DESCRIPTION
Currently we only requre the LLVM package to be installed, however the clang development headers are installed as part of a separate package. Since find_package(clang) caused problems in the past, we check if the headers exist and warn the user in case we cannot find them.