### PR TITLE
Call `dlerror()` before calling `dlsym()`

### DIFF
--- a/src/common/dylib_loader.cpp
+++ b/src/common/dylib_loader.cpp
@@ -96,6 +96,7 @@ void *load_library(const std::string &filename, std::string &message) {
 void *get_symbol_from_library(void *handle, const std::string &symbolName,
                               std::string &message) {
 #ifndef _WIN32
+  dlerror(); // clear any unchecked errors from `dlsym` calls by other libraries
   void *symbol = dlsym(handle, symbolName.c_str());
   if (const char *err = dlerror()) {
     message = "Could not find symbol name: " + symbolName;


### PR DESCRIPTION
I'm seeing an error with the OpenMP backend when loading the kernel symbol name from the SSCP compiled kernel.

This is happening with linking against the LLVM `libomp.so`, rather than `libgomp.so`, and the error message is that the `llvm_omp_target_unlock_mem` symbol isn't found, which is not unexpected in itself because I don't have LLVM offload/libomptarget available.

`libomp` tries to load this symbol to see if `libomptarget` is available, but it's not essential and can fallback to host execution. However, we see the problem in SYCL because [the libomp source code macro](https://github.com/llvm/llvm-project/blob/main/openmp/runtime/src/kmp_os.h#L1304) for calling `dlsym` doesn't clear the error by calling `dlerror()` afterwards, so we receive it in our call.

I've fixed this issue by using the advise from the [dlsym man page](https://linux.die.net/man/3/dlsym):

> the correct way to test for an error is to call dlerror() to clear any old error conditions, then call dlsym(), and then call dlerror() again, saving its return value into a variable, and check whether this saved value is not NULL.