### PR TITLE
Use internal linkage for reflection TU registration

### DIFF
--- a/include/hipSYCL/glue/reflection.hpp
+++ b/include/hipSYCL/glue/reflection.hpp
@@ -75,6 +75,7 @@ extern "C" void __acpp_function_annotation_needs_function_ptr_argument_reflectio
 
 
 struct __acpp_reflection_tu_init_trigger {
+  __attribute__((internal_linkage))
   __acpp_reflection_tu_init_trigger() {
     __acpp_reflection_init_registered_function_pointers();
   }

--- a/src/compiler/reflection/FunctionNameExtractionPass.cpp
+++ b/src/compiler/reflection/FunctionNameExtractionPass.cpp
@@ -99,27 +99,23 @@ llvm::PreservedAnalyses FunctionNameExtractionPass::run(llvm::Module &M, llvm::M
     }
   }
 
-  //declare explicitly __acpp_reflection_associate_function_pointer
   static const char* ReflectionAssociateFunctionPointer = "__acpp_reflection_associate_function_pointer";
-  llvm::SmallVector<llvm::Type*> ParamTs;
-  // function pointer
-  ParamTs.push_back(getVoidPtrType(&M));
-  // function name
-  ParamTs.push_back(getCharPtrType(&M));  
-  // declare if not already declared
-  auto FC = M.getOrInsertFunction(ReflectionAssociateFunctionPointer,
-                                  llvm::FunctionType::get(llvm::Type::getVoidTy(M.getContext()),
-                                                          llvm::ArrayRef<llvm::Type *>{ParamTs},
-                                                          false));
-  llvm::Function *NewDeclaration = llvm::dyn_cast<llvm::Function>(FC.getCallee());
-  std::string NewDeclarationName = NewDeclaration->getName().str();
-  
-  
-  llvm::Function* MapFunc = nullptr;
-  for(auto& F : M)
-    if(F.getName().contains("__acpp_reflection_associate_function_pointer"))
-      MapFunc = &F;
-  
+
+  llvm::Function* MapFunc = M.getFunction(ReflectionAssociateFunctionPointer);
+  if (!MapFunc) {
+    llvm::SmallVector<llvm::Type *> ParamTs;
+    // function pointer
+    ParamTs.push_back(getVoidPtrType(&M));
+    // function name
+    ParamTs.push_back(getCharPtrType(&M));
+    // declare if not already declared
+    auto FC = M.getOrInsertFunction(ReflectionAssociateFunctionPointer,
+                                    llvm::FunctionType::get(llvm::Type::getVoidTy(M.getContext()),
+                                                            llvm::ArrayRef<llvm::Type *>{ParamTs},
+                                                            false));
+    MapFunc = llvm::dyn_cast<llvm::Function>(FC.getCallee());
+  }
+
   if(MapFunc) {
     if(auto* InitFunc = M.getFunction("__acpp_reflection_init_registered_function_pointers")){
       if(InitFunc->isDeclaration() && (MapFunc->getFunctionType()->getNumParams() == 2)) {

--- a/tests/compiler/reflection/multi-tu-registration/lit.local.cfg
+++ b/tests/compiler/reflection/multi-tu-registration/lit.local.cfg
@@ -1,0 +1,1 @@
+config.excludes = ["other.cpp"]

--- a/tests/compiler/reflection/multi-tu-registration/main.cpp
+++ b/tests/compiler/reflection/multi-tu-registration/main.cpp
@@ -1,0 +1,16 @@
+// RUN: %acpp %s %S/other.cpp -o %t --acpp-targets=generic
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s %S/other.cpp -o %t --acpp-targets=generic -O3
+// RUN: %t | FileCheck %s
+// RUN: %acpp %s %S/other.cpp -o %t --acpp-targets=generic -g
+// RUN: %t | FileCheck %s
+
+#include <iostream>
+#include "hipSYCL/glue/reflection.hpp"
+
+bool other_tu_resolves();
+
+int main() {
+  // CHECK: 1
+  std::cout << other_tu_resolves() << std::endl;
+}

--- a/tests/compiler/reflection/multi-tu-registration/other.cpp
+++ b/tests/compiler/reflection/multi-tu-registration/other.cpp
@@ -1,0 +1,10 @@
+#include "hipSYCL/glue/reflection.hpp"
+
+void reflected_from_other_tu() {}
+
+bool other_tu_resolves() {
+  hipsycl::glue::reflection::enable_function_symbol_reflection(
+      &reflected_from_other_tu);
+  return hipsycl::glue::reflection::resolve_function_name(
+             &reflected_from_other_tu) != nullptr;
+}


### PR DESCRIPTION
Fixes #2159 by using internal linkage for reflection TU registration. The current design is a bit hacky in general; in long term we should perhaps consider doing something similar as in PR #2153 (or merge reflection into that infrastructure somehow?).

Also cleans up some logic in the corresponding LLVM pass that I noticed when going through the code.

@cbyrohl I took the liberty to add your reproducer as a test case. Hope that's okay!