### PR TITLE
[SSCP] Fix sincos remapping

### DIFF
--- a/src/compiler/sscp/StdBuiltinRemapperPass.cpp
+++ b/src/compiler/sscp/StdBuiltinRemapperPass.cpp
@@ -11,7 +11,9 @@
 #include "hipSYCL/compiler/sscp/StdBuiltinRemapperPass.hpp"
 #include "hipSYCL/common/debug.hpp"
 
+#include <llvm/IR/Constants.h>
 #include <llvm/IR/Function.h>
+#include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Module.h>
 
 #include <unordered_set>
@@ -97,6 +99,98 @@ static constexpr std::array explicitly_mapped_builtins = {
   ACPP_DECLARE_FINITE_BUILTIN_MAPPING(tan)
 };
 
+static bool hasExpectedSincosFloatType(llvm::Type *FloatType, const std::string &Suffix) {
+  return (Suffix == "f32" && FloatType->isFloatTy()) ||
+         (Suffix == "f64" && FloatType->isDoubleTy());
+}
+
+static llvm::Function *getOrCreateSincosAdapter(llvm::Module &M,
+                                                llvm::Function &Original,
+                                                const std::string &ReplacementName) {
+  llvm::FunctionType *FunctionType = Original.getFunctionType();
+  llvm::Function *Adapter = M.getFunction(ReplacementName);
+  if (!Adapter) {
+    Adapter = llvm::Function::Create(FunctionType, llvm::GlobalValue::InternalLinkage,
+                                     ReplacementName, M);
+  } else if (Adapter->getFunctionType() != FunctionType ||
+             !Adapter->hasInternalLinkage() ||
+             Adapter->getCallingConv() != Original.getCallingConv() ||
+             (!Adapter->empty() &&
+              !Adapter->hasFnAttribute(llvm::Attribute::AlwaysInline))) {
+    return nullptr;
+  }
+
+  Adapter->setCallingConv(Original.getCallingConv());
+  Adapter->addFnAttr(llvm::Attribute::AlwaysInline);
+  return Adapter;
+}
+
+static llvm::Function *createLibcSincosAdapter(llvm::Module &M, llvm::Function &Original,
+                                               const std::string &ReplacementName,
+                                               const std::string &Suffix) {
+  llvm::FunctionType *FunctionType = Original.getFunctionType();
+  if (!FunctionType->getReturnType()->isVoidTy() || FunctionType->isVarArg() ||
+      FunctionType->getNumParams() != 3 || !FunctionType->getParamType(1)->isPointerTy() ||
+      !FunctionType->getParamType(2)->isPointerTy())
+    return nullptr;
+
+  llvm::Type *FloatType = FunctionType->getParamType(0);
+  if (!hasExpectedSincosFloatType(FloatType, Suffix))
+    return nullptr;
+
+  llvm::Function *Adapter = getOrCreateSincosAdapter(M, Original, ReplacementName);
+  if (!Adapter || !Adapter->empty())
+    return Adapter;
+
+  llvm::BasicBlock *Entry = llvm::BasicBlock::Create(M.getContext(), "entry", Adapter);
+  llvm::IRBuilder<> Builder{Entry};
+  auto Arg = Adapter->arg_begin();
+  llvm::Value *X = &*Arg++;
+  llvm::Value *SinOut = &*Arg++;
+  llvm::Value *CosOut = &*Arg;
+
+  llvm::FunctionType *UnaryType = llvm::FunctionType::get(FloatType, {FloatType}, false);
+  llvm::FunctionCallee Sin = M.getOrInsertFunction("__acpp_sscp_sin_" + Suffix, UnaryType);
+  llvm::FunctionCallee Cos = M.getOrInsertFunction("__acpp_sscp_cos_" + Suffix, UnaryType);
+
+  Builder.CreateStore(Builder.CreateCall(Sin, {X}), SinOut);
+  Builder.CreateStore(Builder.CreateCall(Cos, {X}), CosOut);
+  Builder.CreateRetVoid();
+  return Adapter;
+}
+
+static llvm::Function *createLlvmSincosAdapter(llvm::Module &M, llvm::Function &Original,
+                                               const std::string &ReplacementName,
+                                               const std::string &Suffix) {
+  llvm::FunctionType *FunctionType = Original.getFunctionType();
+  if (FunctionType->isVarArg() || FunctionType->getNumParams() != 1)
+    return nullptr;
+
+  llvm::Type *FloatType = FunctionType->getParamType(0);
+  auto *ResultType = llvm::dyn_cast<llvm::StructType>(FunctionType->getReturnType());
+  if (!hasExpectedSincosFloatType(FloatType, Suffix) || !ResultType ||
+      ResultType->getNumElements() != 2 || ResultType->getElementType(0) != FloatType ||
+      ResultType->getElementType(1) != FloatType)
+    return nullptr;
+
+  llvm::Function *Adapter = getOrCreateSincosAdapter(M, Original, ReplacementName);
+  if (!Adapter || !Adapter->empty())
+    return Adapter;
+
+  llvm::BasicBlock *Entry = llvm::BasicBlock::Create(M.getContext(), "entry", Adapter);
+  llvm::IRBuilder<> Builder{Entry};
+  llvm::Value *X = &*Adapter->arg_begin();
+  llvm::FunctionType *UnaryType = llvm::FunctionType::get(FloatType, {FloatType}, false);
+  llvm::FunctionCallee Sin = M.getOrInsertFunction("__acpp_sscp_sin_" + Suffix, UnaryType);
+  llvm::FunctionCallee Cos = M.getOrInsertFunction("__acpp_sscp_cos_" + Suffix, UnaryType);
+
+  llvm::Value *Result = llvm::UndefValue::get(ResultType);
+  Result = Builder.CreateInsertValue(Result, Builder.CreateCall(Sin, {X}), 0);
+  Result = Builder.CreateInsertValue(Result, Builder.CreateCall(Cos, {X}), 1);
+  Builder.CreateRet(Result);
+  return Adapter;
+}
+
 llvm::PreservedAnalyses StdBuiltinRemapperPass::run(llvm::Module &M,
                                                     llvm::ModuleAnalysisManager &MAM) {
 
@@ -139,17 +233,34 @@ llvm::PreservedAnalyses StdBuiltinRemapperPass::run(llvm::Module &M,
     Replacements["llvm." + builtin_name + ".f64"] = "__acpp_sscp_" + builtin_name + "_f64";
   }
 
+  // libc sincos uses output pointers, while the LLVM intrinsic returns an
+  // aggregate. AdaptiveCpp has no SSCP sincos ABI, so adapt both forms to the
+  // supported scalar sine and cosine builtins.
+  Replacements["sincosf"] = "__acpp_libc_sincos_adapter_f32";
+  Replacements["sincos"] = "__acpp_libc_sincos_adapter_f64";
+  Replacements["llvm.sincos.f32"] = "__acpp_llvm_sincos_adapter_f32";
+  Replacements["llvm.sincos.f64"] = "__acpp_llvm_sincos_adapter_f64";
+
   for(const auto& B: Replacements) {
     // Find function to replace
     if(llvm::Function* F = M.getFunction(B.first)) {
-      // See if we have replacement declaration
-      llvm::Function* Replacement = M.getFunction(B.second);
-      // If not, create declaration
-      if(!Replacement) {
-        Replacement = llvm::Function::Create(F->getFunctionType(), F->getLinkage(), B.second, M);
-        Replacement->setLinkage(llvm::GlobalValue::ExternalLinkage);
+      llvm::Function* Replacement = nullptr;
+      if(B.first == "sincos" || B.first == "sincosf") {
+        const std::string Suffix = B.first == "sincosf" ? "f32" : "f64";
+        Replacement = createLibcSincosAdapter(M, *F, B.second, Suffix);
+      } else if(B.first == "llvm.sincos.f32" || B.first == "llvm.sincos.f64") {
+        const std::string Suffix = B.first == "llvm.sincos.f32" ? "f32" : "f64";
+        Replacement = createLlvmSincosAdapter(M, *F, B.second, Suffix);
+      } else {
+        // See if we have replacement declaration
+        Replacement = M.getFunction(B.second);
+        // If not, create declaration
+        if(!Replacement) {
+          Replacement = llvm::Function::Create(F->getFunctionType(), F->getLinkage(), B.second, M);
+          Replacement->setLinkage(llvm::GlobalValue::ExternalLinkage);
+        }
       }
-      if(F->getFunctionType() == Replacement->getFunctionType()) {
+      if(Replacement && F->getFunctionType() == Replacement->getFunctionType()) {
         HIPSYCL_DEBUG_INFO << "StdBuiltinRemapper: Remapping calls from " << B.first << " to "
                            << B.second << "\n";
         F->replaceAllUsesWith(Replacement);
@@ -161,4 +272,3 @@ llvm::PreservedAnalyses StdBuiltinRemapperPass::run(llvm::Module &M,
 }
 }
 }
-

--- a/tests/compiler/sscp/builtin_remapping.cpp
+++ b/tests/compiler/sscp/builtin_remapping.cpp
@@ -10,6 +10,7 @@
 
 #include <iostream>
 #include <cmath>
+#include <type_traits>
 #include <sycl/sycl.hpp>
 #include "common.hpp"
 
@@ -19,10 +20,10 @@ bool check_with_tolerance(double a, double b) {
 
 
 template<class T>
-void test() {
+bool test() {
   sycl::queue q = get_queue();
 
-  int num_functions = 10;
+  int num_functions = 12;
 
   T init = static_cast<T>(0.75);
 
@@ -44,6 +45,14 @@ void test() {
     data[7] = std::exp2(data[7]);
     data[8] = std::log(data[8]);
     data[9] = std::asin(data[9]);
+    T sin_value;
+    T cos_value;
+    if constexpr(std::is_same_v<T, float>)
+      __builtin_sincosf(data[10], &sin_value, &cos_value);
+    else
+      __builtin_sincos(data[10], &sin_value, &cos_value);
+    data[10] = sin_value;
+    data[11] = cos_value;
   }).wait();
 
   std::vector<T> host(num_functions, T(0));
@@ -69,12 +78,22 @@ void test() {
   std::cout << check_with_tolerance(host[8], std::log(init)) << std::endl;
   // CHECK: 1
   std::cout << check_with_tolerance(host[9], std::asin(init)) << std::endl;
+  // CHECK: 1
+  const bool sin_correct = check_with_tolerance(host[10], std::sin(init));
+  std::cout << sin_correct << std::endl;
+  // CHECK: 1
+  const bool cos_correct = check_with_tolerance(host[11], std::cos(init));
+  std::cout << cos_correct << std::endl;
 
   sycl::free(data, q);
+  return sin_correct && cos_correct;
 }
 
 int main() {
-  test<float>();
+  bool sincos_correct = test<float>();
   if(get_queue().get_device().has(sycl::aspect::fp64))
-    test<double>();
+    sincos_correct &= test<double>();
+  // CHECK: sincos checks: 1
+  std::cout << "sincos checks: " << sincos_correct << std::endl;
+  return sincos_correct ? 0 : 1;
 }


### PR DESCRIPTION
🤖 _Posted by Codex on behalf of @cbyrohl_

Fixes #2162.

## Summary

Generic SSCP remapping currently sends compiler-emitted `sincos`/`sincosf` calls to `__acpp_sscp_sincos_f64`/`__acpp_sscp_sincos_f32`, but those symbols are not part of the SSCP builtin ABI. This leaves unresolved symbols during JIT/module loading. With newer LLVM versions and fast-math, the frontend may instead emit the aggregate-returning `llvm.sincos.f32`/`llvm.sincos.f64` intrinsic.

This change handles both forms with internal always-inline adapters:

- libc `sincos` ABI: write the sine and cosine results through output pointers;
- LLVM intrinsic ABI: return the `{sin, cos}` aggregate;
- lower both adapters through the existing `__acpp_sscp_sin_*` and `__acpp_sscp_cos_*` builtins.

The adapter ABIs are validated before rewriting, and no new SSCP runtime symbol is introduced.

## Validation

- Focused `builtin_remapping.cpp` lit test passed on the OpenMP backend in all four existing modes: default/O0, O3, O3 with `-ffast-math`, and debug.
- The same four modes passed in FP32 and FP64 on CUDA using an RTX 4060 Ti.
- Final optimized CUDA IR contains neither `sincos` calls nor adapter references.
- `clang-tidy` completed without a new diagnostic in the changed source.