### PR TITLE
Implement infrastructure to support LLVM intrinsics for the SSCP flow

### DIFF
--- a/include/hipSYCL/compiler/sscp/TargetSpecificIRmapper.hpp
+++ b/include/hipSYCL/compiler/sscp/TargetSpecificIRmapper.hpp
@@ -1,0 +1,31 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#ifndef HIPSYCL_STD_BUILTIN_TARGET_SPECIFIC_IR_MAPPER
+#define HIPSYCL_STD_BUILTIN_TARGET_SPECIFIC_IR_MAPPER
+
+#include <llvm/IR/PassManager.h>
+
+namespace hipsycl {
+namespace compiler {
+
+class TargetSpecificIRMapper : public llvm::PassInfoMixin<TargetSpecificIRMapper> {
+public:
+  llvm::PreservedAnalyses run(llvm::Module &M,
+                              llvm::ModuleAnalysisManager &MAM);
+
+};
+
+}
+}
+
+
+#endif
+

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/amdgpu_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/amdgpu_builtins.hpp
@@ -1,0 +1,56 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+#ifndef HIPSYCL_SSCP_AMDGPU_BUILTINS_HPP
+#define HIPSYCL_SSCP_AMDGPU_BUILTINS_HPP
+
+#include "builtin_config.hpp"
+#include "atomic.hpp"
+
+#include <hipSYCL/glue/llvm-sscp/jit-reflection/queries.hpp>
+extern "C" int __acpp_amdgpu_dpp_unsupported_on_rdna_or_non_amd();
+
+namespace adaptivecpp::amdgpu {
+
+extern "C" int __acpp_sscp_custom_intrinsic__llvm_amdgcn_update_dpp_i32(
+    int old_val, int src, int dpp_ctrl, int row_mask, int bank_mask, bool bound_ctrl);
+
+template<int dpp_ctrl, int row_mask, int bank_mask, bool bound_ctrl>
+inline int update_dpp(int value) {
+  namespace jit = hipsycl::sycl::AdaptiveCpp_jit;
+  return jit::compile_if_else(
+    jit::reflect<jit::reflection_query::target_vendor_id>() == jit::vendor_id::amd &&
+    jit::reflect<jit::reflection_query::target_arch>() < 0x1000,
+    [&]() {
+      return __acpp_sscp_custom_intrinsic__llvm_amdgcn_update_dpp_i32(
+          0, value, dpp_ctrl, row_mask, bank_mask, bound_ctrl);
+    },
+    [&]() {
+      return __acpp_amdgpu_dpp_unsupported_on_rdna_or_non_amd();
+    }
+  );
+}
+
+HIPSYCL_SSCP_BUILTIN int readfirstlane(int value);
+
+HIPSYCL_SSCP_BUILTIN float fract(float value);
+
+HIPSYCL_SSCP_BUILTIN_ATTRIBUTES float unsafe_atomic_fetch_add(
+    __acpp_sscp_address_space as, __acpp_sscp_memory_order order,
+    __acpp_sscp_memory_scope scope, float *ptr, float x);
+
+HIPSYCL_SSCP_BUILTIN_ATTRIBUTES double unsafe_atomic_fetch_add(
+    __acpp_sscp_address_space as, __acpp_sscp_memory_order order,
+    __acpp_sscp_memory_scope scope, double *ptr, double x);
+
+} // namespace adaptivecpp::amdgpu
+
+#endif // HIPSYCL_SSCP_AMDGPU_BUILTINS_HPP

--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -259,6 +259,7 @@ if(WITH_SSCP_COMPILER)
     sscp/HostKernelNameExtractionPass.cpp
     sscp/AggregateArgumentExpansionPass.cpp
     sscp/StdBuiltinRemapperPass.cpp
+    sscp/TargetSpecificIRmapper.cpp
     sscp/StdAtomicRemapperPass.cpp
     sscp/DeviceAssertPass.cpp
     sscp/HcfRegistrationPass.cpp

--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -4,7 +4,6 @@ set(LLVM_TO_BACKEND_INCLUDE_DIRS
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${ACPP_BINARY_ROOT}/include)
 
-set(CMAKE_INSTALL_RPATH ${base} ${base}/../../)
 
 function(create_llvm_based_library)
   set(options STATIC)
@@ -65,6 +64,7 @@ function(create_llvm_based_library)
   endif()
 
   set(install_subdir hipSYCL/llvm-to-backend)
+  set_target_properties(${target} PROPERTIES INSTALL_RPATH "${base};${base}/../../")
   install(TARGETS ${target}
     RUNTIME DESTINATION bin/${install_subdir}
     LIBRARY DESTINATION lib/${install_subdir}
@@ -117,6 +117,7 @@ function(create_llvm_to_backend_tool)
     ${LLVM_DEFINITIONS_LIST})
   target_compile_definitions(${target}-tool PRIVATE -DHIPSYCL_TOOL_COMPONENT)
   target_link_libraries(${target}-tool PRIVATE ${target})
+  set_target_properties(${target}-tool PROPERTIES INSTALL_RPATH "${base}/../../../lib/hipSYCL/llvm-to-backend;${base}/../../../lib")
 
   set(install_subdir hipSYCL/llvm-to-backend)
   install(TARGETS ${target}-tool

--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -164,6 +164,7 @@ if(WITH_SSCP_COMPILER)
       DeadArgumentEliminationPass.cpp
       ProcessS2ReflectionPass.cpp
       ../sscp/KernelOutliningPass.cpp
+      ../sscp/TargetSpecificIRmapper.cpp
       Utils.cpp
       )
 

--- a/src/compiler/llvm-to-backend/LLVMToBackend.cpp
+++ b/src/compiler/llvm-to-backend/LLVMToBackend.cpp
@@ -21,6 +21,7 @@
 #include "hipSYCL/compiler/llvm-to-backend/Utils.hpp"
 #include "hipSYCL/compiler/sscp/IRConstantReplacer.hpp"
 #include "hipSYCL/compiler/sscp/KernelOutliningPass.hpp"
+#include "hipSYCL/compiler/sscp/TargetSpecificIRmapper.hpp"
 #include "hipSYCL/compiler/utils/IndirectAccess.hpp"
 #include "hipSYCL/compiler/utils/ProcessFunctionAnnotationsPass.hpp"
 #include "hipSYCL/compiler/utils/LLVMUtils.hpp"
@@ -397,6 +398,11 @@ bool LLVMToBackendTranslator::prepareIR(llvm::Module &M) {
     }
 
     enableModuleStateDumping(M, "backend_flavoring", getCompilationIdentifier());
+
+    TargetSpecificIRMapper TSIRM;
+    TSIRM.run(M, MAM);
+    enableModuleStateDumping(M, "target_specific_mapping", getCompilationIdentifier());
+
     // Run again to resolve reflection inside builtins
     S2RP.run(M, MAM);
     enableModuleStateDumping(M, "builtin_reflection", getCompilationIdentifier());

--- a/src/compiler/sscp/TargetSeparationPass.cpp
+++ b/src/compiler/sscp/TargetSeparationPass.cpp
@@ -15,6 +15,7 @@
 #include "hipSYCL/compiler/sscp/HostKernelNameExtractionPass.hpp"
 #include "hipSYCL/compiler/sscp/AggregateArgumentExpansionPass.hpp"
 #include "hipSYCL/compiler/sscp/StdBuiltinRemapperPass.hpp"
+#include "hipSYCL/compiler/sscp/TargetSpecificIRmapper.hpp"
 #include "hipSYCL/compiler/sscp/DynamicFunctionSupport.hpp"
 #include "hipSYCL/compiler/sscp/StdAtomicRemapperPass.hpp"
 #include "hipSYCL/compiler/sscp/DeviceAssertPass.hpp"

--- a/src/compiler/sscp/TargetSpecificIRmapper.cpp
+++ b/src/compiler/sscp/TargetSpecificIRmapper.cpp
@@ -1,0 +1,88 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "hipSYCL/compiler/sscp/TargetSpecificIRmapper.hpp"
+#include "hipSYCL/common/debug.hpp"
+
+#include "llvm/IR/IRBuilder.h"
+#include <llvm/Demangle/Demangle.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Module.h>
+
+#include <unordered_map>
+#include <unordered_set>
+
+#define STRINGIFY2(x) #x
+#define STRINGIFY(x) STRINGIFY2(x)
+
+namespace hipsycl::compiler {
+
+// Replace __acpp_sscp_custom_intrinsic_<builtin_name> with llvm IR eqvivalent
+llvm::PreservedAnalyses TargetSpecificIRMapper::run(llvm::Module &M,
+                                                    llvm::ModuleAnalysisManager &MAM) {
+
+  llvm::StringRef prefix = "__acpp_sscp_custom_intrinsic__";
+  bool Changed = false;
+  std::vector<llvm::Function *> FunctionsToRemove;
+  for (llvm::Function &F : M) {
+    if (F.hasName() && F.getName().contains(prefix)) {
+
+      auto builtin_name = F.getName().drop_front(prefix.size()).str();
+      std::replace(builtin_name.begin(), builtin_name.end(), '_', '.');
+      llvm::Function *IntrinsicDecl = M.getFunction(builtin_name);
+
+      // If not, create declaration
+      if (!IntrinsicDecl) {
+        IntrinsicDecl = llvm::Function::Create(
+            F.getFunctionType(), llvm::GlobalValue::ExternalLinkage, builtin_name, &M);
+      }
+      std::vector<llvm::CallInst *> CallSites;
+      for (llvm::User *U : F.users()) {
+        if (auto *CI = llvm::dyn_cast<llvm::CallInst>(U)) {
+          CallSites.push_back(CI);
+        }
+      }
+
+      for (llvm::CallInst *CI : CallSites) {
+        llvm::IRBuilder<> Builder(CI);
+
+        // Collect arguments from the original call
+        std::vector<llvm::Value *> Args;
+        for (unsigned i = 0; i < CI->arg_size(); ++i) {
+          Args.push_back(CI->getArgOperand(i));
+        }
+
+        // Emit the new intrinsic call forwarding the arguments
+        llvm::CallInst *NewCall = Builder.CreateCall(IntrinsicDecl, Args);
+
+        // Perfectly forward any debug info or metadata from the old call
+        NewCall->copyMetadata(*CI);
+
+        // Replace uses and clean up the old call instruction
+        CI->replaceAllUsesWith(NewCall);
+        CI->eraseFromParent();
+
+        Changed = true;
+      }
+
+      // Mark the custom builtin declaration for removal now that all call
+      // sites have been rewritten to use the actual intrinsic name.
+      FunctionsToRemove.push_back(&F);
+    }
+  }
+
+  for (llvm::Function *F : FunctionsToRemove) {
+    F->eraseFromParent();
+  }
+  return Changed ? llvm::PreservedAnalyses::none() : llvm::PreservedAnalyses::all();
+}
+
+} // namespace hipsycl::compiler

--- a/src/libkernel/sscp/amdgpu/CMakeLists.txt
+++ b/src/libkernel/sscp/amdgpu/CMakeLists.txt
@@ -28,5 +28,6 @@ if(WITH_LLVM_TO_AMDGPU_AMDHSA)
       broadcast.cpp
       scan_inclusive.cpp
       scan_exclusive.cpp
+      amdgpu_builtins.cpp
       ADDITIONAL_ARGS ${amdgpu_libkernel_additional_args})
 endif()

--- a/src/libkernel/sscp/amdgpu/amdgpu_builtins.cpp
+++ b/src/libkernel/sscp/amdgpu/amdgpu_builtins.cpp
@@ -1,0 +1,107 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "hipSYCL/sycl/libkernel/sscp/builtins/amdgpu_builtins.hpp"
+#include "hipSYCL/glue/llvm-sscp/jit-reflection/queries.hpp"
+
+extern "C" __acpp_int32 __acpp_sscp_custom_intrinsic__llvm_amdgcn_readfirstlane(
+    __acpp_int32 input);
+
+extern "C" __acpp_f32 __acpp_sscp_custom_intrinsic__llvm_amdgcn_fract_f32(
+    __acpp_f32 input);
+
+extern "C" float __acpp_sscp_custom_intrinsic__llvm_amdgcn_global_atomic_fadd_f32_p1_i32(
+    const __attribute__((address_space(1))) float *, float);
+
+extern "C" float __acpp_sscp_custom_intrinsic__llvm_amdgcn_flat_atomic_fadd_f32_p0_i32(
+    float *, float);
+
+extern "C" double __acpp_sscp_custom_intrinsic__llvm_amdgcn_global_atomic_fadd_f64_p1_i32(
+    const __attribute__((address_space(1))) double *, double);
+
+extern "C" double __acpp_sscp_custom_intrinsic__llvm_amdgcn_flat_atomic_fadd_f64_p0_i32(
+    double *, double);
+
+extern "C" float __acpp_sscp_custom_intrinsic__wrong_address_space_f32();
+extern "C" double __acpp_sscp_custom_intrinsic__wrong_address_space_f64();
+
+namespace adaptivecpp::amdgpu {
+
+HIPSYCL_SSCP_BUILTIN int readfirstlane(int value) {
+  return __acpp_sscp_custom_intrinsic__llvm_amdgcn_readfirstlane(value);
+
+}
+
+HIPSYCL_SSCP_BUILTIN float fract(float value) {
+  return __acpp_sscp_custom_intrinsic__llvm_amdgcn_fract_f32(value);
+}
+
+
+HIPSYCL_SSCP_BUILTIN float unsafe_atomic_fetch_add_f32(
+    __acpp_sscp_address_space as, __acpp_sscp_memory_order order,
+    __acpp_sscp_memory_scope scope, float *ptr, float x) {
+  namespace jit = hipsycl::sycl::AdaptiveCpp_jit;
+  return jit::compile_if_else(
+    jit::reflect<jit::reflection_query::target_arch>() == 0x90a,
+    [&](){
+      if (as == __acpp_sscp_address_space::global_space) {
+        return __acpp_sscp_custom_intrinsic__llvm_amdgcn_global_atomic_fadd_f32_p1_i32(
+            (const __attribute__((address_space(1))) float *)ptr, x);
+      } else if (as == __acpp_sscp_address_space::generic_space) {
+        return __acpp_sscp_custom_intrinsic__llvm_amdgcn_flat_atomic_fadd_f32_p0_i32(ptr, x);
+      } else {
+        return __acpp_sscp_atomic_fetch_add_f32(as, order, scope, ptr, x);
+      }
+    },
+    [&]() {
+      return __acpp_sscp_atomic_fetch_add_f32(as, order, scope, ptr, x);
+    }
+  );
+}
+
+HIPSYCL_SSCP_BUILTIN double unsafe_atomic_fetch_add_f64(
+    __acpp_sscp_address_space as, __acpp_sscp_memory_order order,
+    __acpp_sscp_memory_scope scope, double *ptr, double x) {
+  namespace jit = hipsycl::sycl::AdaptiveCpp_jit;
+  return jit::compile_if_else(
+    jit::reflect<jit::reflection_query::target_arch>() == 0x90a,
+    [&](){
+      if (as == __acpp_sscp_address_space::global_space) {
+        return __acpp_sscp_custom_intrinsic__llvm_amdgcn_global_atomic_fadd_f64_p1_i32(
+            (const __attribute__((address_space(1))) double *)ptr, x);
+      } else if (as == __acpp_sscp_address_space::generic_space) {
+        return __acpp_sscp_custom_intrinsic__llvm_amdgcn_flat_atomic_fadd_f64_p0_i32(ptr, x);
+      } else {
+        return __acpp_sscp_atomic_fetch_add_f64(as, order, scope, ptr, x);
+      }
+    },
+    [&]() {
+      return __acpp_sscp_atomic_fetch_add_f64(as, order, scope, ptr, x);
+    }
+  );
+}
+
+
+HIPSYCL_SSCP_BUILTIN_ATTRIBUTES float unsafe_atomic_fetch_add_impl(
+    __acpp_sscp_address_space as, __acpp_sscp_memory_order order,
+    __acpp_sscp_memory_scope scope, float *ptr, float x) {
+  return unsafe_atomic_fetch_add_f32(as, order, scope, ptr, x);
+}
+
+HIPSYCL_SSCP_BUILTIN_ATTRIBUTES double unsafe_atomic_fetch_add_impl(
+    __acpp_sscp_address_space as, __acpp_sscp_memory_order order,
+    __acpp_sscp_memory_scope scope, double *ptr, double x) {
+  return unsafe_atomic_fetch_add_f64(as, order, scope, ptr, x);
+}
+
+
+
+} // namespace adaptivecpp::amdgpu

--- a/src/libkernel/sscp/amdgpu/broadcast.cpp
+++ b/src/libkernel/sscp/amdgpu/broadcast.cpp
@@ -12,11 +12,33 @@
 #include "hipSYCL/sycl/libkernel/sscp/builtins/broadcast.hpp"
 #include "hipSYCL/sycl/libkernel/sscp/builtins/detail/broadcast.hpp"
 
+// llvm.amdgcn.readlane(src, lane): reads a value from a specific lane index.
+// Note: this is distinct from llvm.amdgcn.readfirstlane (no lane argument),
+// which reads from the first active lane — used in adaptivecpp::amdgpu::__acpp_sscp_amdgcn_readfirstlane.
+extern "C" __acpp_int32 __acpp_sscp_custom_intrinsic__llvm_amdgcn_readlane(
+    __acpp_int32 src, __acpp_int32 lane);
+
+template <typename T>
+T readlane_helper(T x, __acpp_int32 sender) {
+  if constexpr (sizeof(T) <= 4) {
+    return static_cast<T>(__acpp_sscp_custom_intrinsic__llvm_amdgcn_readlane(
+        static_cast<__acpp_int32>(x), sender));
+  } else {
+    __acpp_int32 parts[2];
+    __builtin_memcpy(&parts[0], &x, 8);
+    parts[0] = __acpp_sscp_custom_intrinsic__llvm_amdgcn_readlane(parts[0], sender);
+    parts[1] = __acpp_sscp_custom_intrinsic__llvm_amdgcn_readlane(parts[1], sender);
+    T result;
+    __builtin_memcpy(&result, &parts[0], 8);
+    return result;
+  }
+}
+
 #define ACPP_SUBGROUP_BCAST(fn_suffix, input_type)                                                 \
   HIPSYCL_SSCP_CONVERGENT_BUILTIN                                                                  \
   __acpp_##input_type __acpp_sscp_sub_group_broadcast_##fn_suffix(__acpp_int32 sender,             \
                                                                   __acpp_##input_type x) {         \
-    return __acpp_sscp_sub_group_select_##fn_suffix(x, sender);                                    \
+    return readlane_helper(x, sender);                                                             \
   }
 
 #define ACPP_WORKGROUP_BCAST(fn_suffix, input_type)                                                \

--- a/src/tools/acpp-hcf-tool/CMakeLists.txt
+++ b/src/tools/acpp-hcf-tool/CMakeLists.txt
@@ -5,4 +5,6 @@ target_include_directories(acpp-hcf-tool PRIVATE
     ${HIPSYCL_SOURCE_DIR}/include
     ${ACPP_BINARY_ROOT}/include)
 
+set_target_properties(acpp-hcf-tool PROPERTIES INSTALL_RPATH ${base}/../lib/)
+
 install(TARGETS acpp-hcf-tool DESTINATION bin)

--- a/tests/compiler/lit.cfg.py
+++ b/tests/compiler/lit.cfg.py
@@ -12,6 +12,18 @@ config.test_exec_root = os.path.join(config.my_obj_root)
 
 config.substitutions.append(('%acpp', config.acpp_compiler))
 
+config.substitutions.append(('%acpp-hcf-tool', os.path.join(os.path.dirname(config.acpp_compiler), 'acpp-hcf-tool')))
+
+llvm_to_amdgpu_tool = os.path.join(os.path.dirname(config.acpp_compiler), 'hipSYCL/llvm-to-backend/llvm-to-amdgpu-tool')
+if os.path.isfile(llvm_to_amdgpu_tool):
+  config.available_features.add('amdgpu-backend-tools')
+  config.substitutions.append(('%llvm-to-amdgpu', llvm_to_amdgpu_tool))
+else:
+  config.substitutions.append(('%llvm-to-amdgpu', 'false # llvm-to-amdgpu-tool not available'))
+
+config.substitutions.append(('%llvm-dis', 'llvm-dis'))
+config.substitutions.append(('%clangxx', 'clang++'))
+
 system = platform.system().lower()
 if system == 'darwin':
   config.available_features.add('system-darwin')

--- a/tests/compiler/sscp/amdgpu_builtins_codegen.cpp
+++ b/tests/compiler/sscp/amdgpu_builtins_codegen.cpp
@@ -1,0 +1,98 @@
+// REQUIRES: amdgpu-backend-tools
+// RUN: %acpp %s -c -o %t.o -mllvm -acpp-sscp-emit-hcf
+// RUN: %llvm-to-amdgpu --ir %s.hcf %t.bc llvm-ir.global
+// RUN: rm -f %s.hcf
+// RUN: %llvm-dis %t.bc -o %t.ll
+// RUN: FileCheck --check-prefix=CHECK-IR %s < %t.ll
+// RUN: %clangxx -target amdgcn-amd-amdhsa -mcpu=gfx90a -S %t.ll -o %t.s
+// RUN: FileCheck --check-prefix=CHECK-ASM %s < %t.s
+
+#include <sycl/sycl.hpp>
+#include "hipSYCL/sycl/libkernel/sscp/builtins/amdgpu_builtins.hpp"
+#include "hipSYCL/glue/llvm-sscp/jit-reflection/queries.hpp"
+
+namespace jit = hipsycl::sycl::AdaptiveCpp_jit;
+
+// CHECK-IR: define amdgpu_kernel void @{{.*}}basic_parallel_for{{.*}}
+
+void test_builtins(float *dev_f32, double *dev_f64,
+                   int *dev_dpp_shr, int *dev_dpp_ror, int *dev_dpp_mirror,
+                   int *dev_rfl, float *dev_fract, int global_idx) {
+  __acpp_if_target_sscp(
+    jit::compile_if(
+      jit::reflect<jit::reflection_query::target_arch>() ==
+        adaptivecpp::amdgpu::kGfx90aArchId,
+      [&]() {
+        // ── Floating-point atomic add ───────────────────────────────────────
+        // CHECK-IR: atomicrmw fadd ptr addrspace(1) {{.*}} !amdgpu.no.fine.grained.memory ![[MD:[0-9]+]], !amdgpu.ignore.denormal.mode ![[MD]]
+        // CHECK-ASM: global_atomic_add_f32 v{{[0-9]+}}, v{{[0-9]+}}, s[{{[0-9]+}}:{{[0-9]+}}]
+        adaptivecpp::amdgpu::unsafe_atomic_fetch_add(
+          hipsycl::sycl::access::address_space::global_space,
+          sycl::memory_order::relaxed,
+          hipsycl::sycl::memory_scope::device,
+          dev_f32, 1.5f);
+
+        // CHECK-IR: atomicrmw fadd ptr addrspace(1) {{.*}} !amdgpu.no.fine.grained.memory ![[MD]], !amdgpu.ignore.denormal.mode ![[MD]]
+        // CHECK-ASM: global_atomic_add_f64 v{{.*}}, v[{{[0-9]+}}:{{[0-9]+}}], s[{{[0-9]+}}:{{[0-9]+}}]
+        adaptivecpp::amdgpu::unsafe_atomic_fetch_add(
+          hipsycl::sycl::access::address_space::global_space,
+          sycl::memory_order::relaxed,
+          hipsycl::sycl::memory_scope::device,
+          dev_f64, 2.5);
+
+        // ── DPP: row_shr:1 (0x111), bound_ctrl=true ────────────────────────
+        // CHECK-IR: call i32 @llvm.amdgcn.update.dpp.i32(i32 0, i32 {{.*}}, i32 273, i32 15, i32 15, i1 true)
+        // CHECK-ASM: v_mov_b32_dpp v{{[0-9]+}}, v{{[0-9]+}} row_shr:1 row_mask:0xf bank_mask:0xf bound_ctrl:1
+        *dev_dpp_shr = adaptivecpp::amdgpu::update_dpp<0x111, 0xf, 0xf, true>(global_idx);
+
+        // ── DPP: row_ror:1 (0x121), bound_ctrl=false ───────────────────────
+        // CHECK-IR: call i32 @llvm.amdgcn.update.dpp.i32(i32 0, i32 {{.*}}, i32 289, i32 15, i32 15, i1 false)
+        // CHECK-ASM: v_mov_b32_dpp v{{[0-9]+}}, v{{[0-9]+}} row_ror:1 row_mask:0xf bank_mask:0xf
+        *dev_dpp_ror = adaptivecpp::amdgpu::update_dpp<0x121, 0xf, 0xf, false>(global_idx);
+
+        // ── DPP: row_mirror (0x140), bound_ctrl=false ──────────────────────
+        // CHECK-IR: call i32 @llvm.amdgcn.update.dpp.i32(i32 0, i32 {{.*}}, i32 320, i32 15, i32 15, i1 false)
+        // CHECK-ASM: v_mov_b32_dpp v{{[0-9]+}}, v{{[0-9]+}} row_mirror row_mask:0xf bank_mask:0xf
+        *dev_dpp_mirror = adaptivecpp::amdgpu::update_dpp<0x140, 0xf, 0xf, false>(global_idx);
+
+        // ── readfirstlane ───────────────────────────────────────────────────
+        // CHECK-IR: call i32 @llvm.amdgcn.readfirstlane.i32(i32
+        // CHECK-ASM: v_readfirstlane_b32 s{{[0-9]+}}, v{{[0-9]+}}
+        *dev_rfl = adaptivecpp::amdgpu::readfirstlane(global_idx);
+
+        // ── fract ───────────────────────────────────────────────────────────
+        // CHECK-IR: call float @llvm.amdgcn.fract.f32(float
+        // CHECK-ASM: v_fract_f32_e64 v{{[0-9]+}}, v{{[0-9]+}}
+        *dev_fract = adaptivecpp::amdgpu::fract(static_cast<float>(global_idx) + 0.456f);
+      }
+    );
+  );
+}
+
+int main() {
+  sycl::queue q;
+
+  float  *dev_f32        = sycl::malloc_device<float> (1024, q);
+  double *dev_f64        = sycl::malloc_device<double>(1024, q);
+  int    *dev_dpp_shr    = sycl::malloc_device<int>   (1024, q);
+  int    *dev_dpp_ror    = sycl::malloc_device<int>   (1024, q);
+  int    *dev_dpp_mirror = sycl::malloc_device<int>   (1024, q);
+  int    *dev_rfl        = sycl::malloc_device<int>   (1024, q);
+  float  *dev_fract      = sycl::malloc_device<float> (1024, q);
+
+  q.submit([&](sycl::handler &cgh) {
+    cgh.parallel_for(sycl::range<1>(1024), [=](sycl::id<1> idx) {
+      test_builtins(dev_f32, dev_f64,
+                    dev_dpp_shr, dev_dpp_ror, dev_dpp_mirror,
+                    dev_rfl, dev_fract, idx[0]);
+    });
+  }).wait();
+
+  sycl::free(dev_f32,        q);
+  sycl::free(dev_f64,        q);
+  sycl::free(dev_dpp_shr,    q);
+  sycl::free(dev_dpp_ror,    q);
+  sycl::free(dev_dpp_mirror, q);
+  sycl::free(dev_rfl,        q);
+  sycl::free(dev_fract,      q);
+}


### PR DESCRIPTION
Using builtins can lead to significantly improved performance by forcing the use of specific low level instructions. For instance the use of hardware float atomics on MI2XX GPUs can improve performance by an order of magnitude for some kernels. This functionality is usually exposed through Clang builtins. However, Clang validates builtins based on the targeted architecture. Since during stage 1 compilation we do not have a specific device target available yet, these builtins are rejected. Therefore their functionality is only accessible through inline assembly in the application code. 

This PR introduces an additional LLVM pass during stage 2 compilation that remaps function calls in the form of `__acpp_sscp_custom_intrinsic__<LLVM Intrinisc>` to LLVM intrinsics. For instance the function call `__acpp_sscp_custom_intrinsic__llvm_amdgcn_update_dpp_i32` emits `llvm.amdgcn.update.dpp.i32`. Additionally a small library of important functions are added for easier use in downstream applications, and as a proof of concept for how the newly implemented compiler functionality could be used. 

This supersedes PR #1943 . Contrary to the previous approach it does not require multiple target specific libraries to be compiled.