### PR TITLE
[VK] Disable sporadic CI failing test

### DIFF
--- a/.github/workflows/linux-vulkan.yml
+++ b/.github/workflows/linux-vulkan.yml
@@ -153,10 +153,11 @@ jobs:
               -DLLVM_DIR=${GITHUB_WORKSPACE}/install/lib/cmake/llvm
         ninja -j2
 
+    # See https://github.com/AdaptiveCpp/AdaptiveCpp/issues/2163 for disabled test
     - name: run SYCL tests
       run: |
         cd ${GITHUB_WORKSPACE}/build/tests-sscp
-        ACPP_VISIBILITY_MASK="vk" ./sycl_tests
+        ACPP_VISIBILITY_MASK="vk" ./sycl_tests -t \!buffer_tests/buffer_shared_ptr
 
     - name: run lit SSCP tests
       run: |


### PR DESCRIPTION
`buffer_tests/buffer_shared_ptr` is sporadically failing for the Vulkan backend in Linux CI, disable  to keep CI green but track investigating and fixing in https://github.com/AdaptiveCpp/AdaptiveCpp/issues/2163  