### PR TITLE
Proof of concept for using clang tooling to expose all amdgcn builtins for the SSCP flow

### DIFF
--- a/include/hipSYCL/compiler/llvm-to-backend/ResolveTargetBuiltinsPass.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/ResolveTargetBuiltinsPass.hpp
@@ -1,0 +1,28 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#ifndef HIPSYCL_RESOLVE_TARGET_BUILTINS_PASS_HPP
+#define HIPSYCL_RESOLVE_TARGET_BUILTINS_PASS_HPP
+
+#include <llvm/IR/PassManager.h>
+
+namespace hipsycl {
+namespace compiler {
+
+class ResolveTargetBuiltinsPass : public llvm::PassInfoMixin<ResolveTargetBuiltinsPass> {
+public:
+  llvm::PreservedAnalyses run(llvm::Module &M,
+                              llvm::ModuleAnalysisManager &MAM);
+};
+
+}
+}
+
+#endif // HIPSYCL_RESOLVE_TARGET_BUILTINS_PASS_HPP

--- a/include/hipSYCL/sycl/libkernel/sscp/builtins/amdgpu_builtins.hpp
+++ b/include/hipSYCL/sycl/libkernel/sscp/builtins/amdgpu_builtins.hpp
@@ -1,0 +1,118 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+
+#ifndef HIPSYCL_SSCP_AMDGPU_BUILTINS_HPP
+#define HIPSYCL_SSCP_AMDGPU_BUILTINS_HPP
+
+#include "builtin_config.hpp"
+#include <hipSYCL/glue/llvm-sscp/jit-reflection/queries.hpp>
+
+// Include our auto-generated Clang wrappers which bypass the need for TargetSpecificIRMapper!
+// This file is generated at build time by src/compiler/builtin_gen/main.cpp
+#include "amdgpu_auto_builtins.hpp"
+
+extern "C" int __acpp_amdgpu_builtin_unsupported_on_non_amd();
+extern "C" float __acpp_amdgpu_fract_unsupported_on_non_amd();
+
+namespace adaptivecpp::amdgpu {
+
+static constexpr int kGfx90aArchId = 0x90a;
+
+
+inline int readfirstlane(int value) {
+  namespace jit = hipsycl::sycl::AdaptiveCpp_jit;
+  return jit::compile_if_else(
+    jit::reflect<jit::reflection_query::target_vendor_id>() == jit::vendor_id::amd,
+    [&]() {
+      return __acpp___builtin_amdgcn_readfirstlane(value);
+    },
+    [&]() {
+      return __acpp_amdgpu_builtin_unsupported_on_non_amd();
+    }
+  );
+}
+
+inline float fract(float value) {
+  namespace jit = hipsycl::sycl::AdaptiveCpp_jit;
+  return jit::compile_if_else(
+    jit::reflect<jit::reflection_query::target_vendor_id>() == jit::vendor_id::amd,
+    [&]() {
+      return __acpp___builtin_amdgcn_fractf(value);
+    },
+    [&]() {
+      return __acpp_amdgpu_fract_unsupported_on_non_amd();
+    }
+  );
+}
+
+extern "C" int __acpp_amdgpu_dpp_unsupported_on_rdna_or_non_amd();
+
+template<int ctrl, int row_mask, int bank_mask, bool bound_ctrl>
+inline int update_dpp(int val) {
+  namespace jit = hipsycl::sycl::AdaptiveCpp_jit;
+  return jit::compile_if_else(
+    jit::reflect<jit::reflection_query::target_vendor_id>() == jit::vendor_id::amd &&
+    jit::reflect<jit::reflection_query::target_arch>() < 0x1000,
+    [&]() {
+      return __acpp___builtin_amdgcn_update_dpp(
+          0, val, ctrl, row_mask, bank_mask, bound_ctrl);
+    },
+    [&]() {
+      return __acpp_amdgpu_dpp_unsupported_on_rdna_or_non_amd();
+    }
+  );
+}
+
+inline float unsafe_atomic_add_f32(float* ptr, float val) {
+  namespace jit = hipsycl::sycl::AdaptiveCpp_jit;
+  return jit::compile_if_else(
+    jit::reflect<jit::reflection_query::target_vendor_id>() == jit::vendor_id::amd,
+    [&]() {
+      return __acpp___builtin_amdgcn_global_atomic_fadd_f32(
+          (float __attribute__((address_space(1)))*)ptr, val);
+    },
+    [&]() {
+      return static_cast<float>(__acpp_amdgpu_builtin_unsupported_on_non_amd());
+    }
+  );
+}
+
+inline double unsafe_atomic_add_f64(double* ptr, double val) {
+  namespace jit = hipsycl::sycl::AdaptiveCpp_jit;
+  return jit::compile_if_else(
+    jit::reflect<jit::reflection_query::target_vendor_id>() == jit::vendor_id::amd,
+    [&]() {
+      return __acpp___builtin_amdgcn_global_atomic_fadd_f64(
+          (double __attribute__((address_space(1)))*)ptr, val);
+    },
+    [&]() {
+      return static_cast<double>(__acpp_amdgpu_builtin_unsupported_on_non_amd());
+    }
+  );
+}
+
+inline float unsafe_atomic_fetch_add(hipsycl::sycl::access::address_space space,
+                                     hipsycl::sycl::memory_order order,
+                                     hipsycl::sycl::memory_scope scope,
+                                     float* ptr, float val) {
+  return unsafe_atomic_add_f32(ptr, val);
+}
+
+inline double unsafe_atomic_fetch_add(hipsycl::sycl::access::address_space space,
+                                     hipsycl::sycl::memory_order order,
+                                     hipsycl::sycl::memory_scope scope,
+                                     double* ptr, double val) {
+  return unsafe_atomic_add_f64(ptr, val);
+}
+
+} // namespace adaptivecpp::amdgpu
+
+#endif // HIPSYCL_SSCP_AMDGPU_BUILTINS_HPP

--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -428,3 +428,4 @@ endif()
 
 
 add_subdirectory(llvm-to-backend)
+add_subdirectory(builtin_gen)

--- a/src/compiler/builtin_gen/CMakeLists.txt
+++ b/src/compiler/builtin_gen/CMakeLists.txt
@@ -1,0 +1,62 @@
+add_executable(acpp-amdgpu-builtin-gen main.cpp)
+
+configure_target(TARGET acpp-amdgpu-builtin-gen)
+
+# Unconditionally disable RTTI and Exceptions for this tool.
+# We don't use them, and if Clang/LLVM were built without them, failing to pass
+# these flags will result in undefined references to typeinfo for ASTFrontendAction.
+target_compile_options(acpp-amdgpu-builtin-gen PRIVATE -fno-exceptions -fno-rtti)
+
+if(NOT WIN32 AND NOT ACPP_LLVM_COMPONENT)
+  # On Unix, we need to explicitly link the clang-cpp and LLVM shared libraries
+  # since configure_target is tailored for plugins and doesn't link them automatically.
+  find_library(CLANG_CPP_LIB NAMES clang-cpp PATHS ${LLVM_LIBRARY_DIR} NO_DEFAULT_PATH)
+  find_library(LLVM_LIB NAMES LLVM PATHS ${LLVM_LIBRARY_DIR} NO_DEFAULT_PATH)
+
+  if (NOT CLANG_CPP_LIB)
+    # If clang-cpp dynamic library is missing, try to find Clang CMake package for static targets
+    find_package(Clang QUIET HINTS "${LLVM_LIBRARY_DIR}/cmake/clang" "${LLVM_DIR}/../clang")
+    if (TARGET clangTooling)
+      set(CLANG_CPP_LIB clangTooling)
+    else()
+      # Manual fallback to static libraries with start/end group for circular deps
+      set(CLANG_CPP_LIB
+        -Wl,--start-group
+        clangTooling clangFrontend clangParse clangSerialization clangSema 
+        clangEdit clangAnalysis clangASTMatchers clangAST clangLex clangBasic clangDriver
+        -Wl,--end-group
+      )
+      target_link_directories(acpp-amdgpu-builtin-gen PRIVATE ${LLVM_LIBRARY_DIR})
+    endif()
+  endif()
+  
+  if (NOT LLVM_LIB)
+    set(LLVM_LIB LLVM)
+  endif()
+
+  target_link_options(acpp-amdgpu-builtin-gen PRIVATE "-Wl,-rpath,${LLVM_LIBRARY_DIR}")
+
+  target_link_libraries(acpp-amdgpu-builtin-gen PRIVATE
+    ${CLANG_CPP_LIB}
+    ${LLVM_LIB}
+  )
+endif()
+
+if(ACPP_LLVM_COMPONENT)
+  # When building in-tree with LLVM, the Clang targets are directly available.
+  target_link_libraries(acpp-amdgpu-builtin-gen PRIVATE
+    clangTooling clangFrontend clangParse clangSerialization clangSema
+    clangEdit clangAnalysis clangASTMatchers clangAST clangLex clangBasic clangDriver
+  )
+
+  # We need to explicitly include the Clang headers
+  # because LLVM_INCLUDE_DIRS only covers LLVM, not Clang.
+  target_include_directories(acpp-amdgpu-builtin-gen PRIVATE
+    ${LLVM_MAIN_SRC_DIR}/../clang/include
+    ${LLVM_BINARY_DIR}/tools/clang/include
+  )
+endif()
+
+# Optional: ensure we compile with C++17 or whatever AdaptiveCpp uses
+set_property(TARGET acpp-amdgpu-builtin-gen PROPERTY CXX_STANDARD 17)
+

--- a/src/compiler/builtin_gen/main.cpp
+++ b/src/compiler/builtin_gen/main.cpp
@@ -1,0 +1,230 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendAction.h"
+#include "clang/Tooling/Tooling.h"
+#include "clang/Basic/Builtins.h"
+#include "clang/Basic/IdentifierTable.h"
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/FileSystem.h"
+
+using namespace clang;
+
+
+
+class BuiltinGenConsumer : public ASTConsumer {
+  std::string HppPath;
+  std::string CppPath;
+public:
+  BuiltinGenConsumer(std::string Hpp, std::string Cpp) : HppPath(Hpp), CppPath(Cpp) {}
+
+  std::string sanitizeType(std::string T) {
+    size_t pos;
+    while ((pos = T.find("_Bool")) != std::string::npos) {
+      T.replace(pos, 5, "bool");
+    }
+    while ((pos = T.find(" __attribute__((ext_vector_type(")) != std::string::npos) {
+      size_t endPos = T.find(")))", pos);
+      if (endPos != std::string::npos) {
+        std::string num = T.substr(pos + 32, endPos - (pos + 32));
+        std::string base = T.substr(0, pos);
+        // clean base type, e.g., "unsigned int" -> "uint"
+        std::string baseName = base;
+        while((pos = baseName.find(" ")) != std::string::npos) {
+           baseName.replace(pos, 1, "_");
+        }
+        std::string newType = "__acpp_vec_" + baseName + "_" + num;
+        T = newType + T.substr(endPos + 3);
+      }
+    }
+    return T;
+  }
+
+  void HandleTranslationUnit(ASTContext &Ctx) override {
+    std::error_code EC1, EC2;
+    llvm::raw_fd_ostream HppFile(HppPath, EC1, llvm::sys::fs::OF_None);
+    llvm::raw_fd_ostream CppFile(CppPath, EC2, llvm::sys::fs::OF_None);
+
+    if (EC1 || EC2) {
+      llvm::errs() << "Error opening output files.\n";
+      return;
+    }
+
+    HppFile << "// Auto-generated AMDGPU Builtins Declarations\n"
+            << "#pragma once\n\n"
+            << "#pragma clang diagnostic push\n"
+            << "#pragma clang diagnostic ignored \"-Wreturn-type-c-linkage\"\n\n"
+            << "typedef float __acpp_vec_float_2 __attribute__((ext_vector_type(2)));\n"
+            << "typedef float __acpp_vec_float_3 __attribute__((ext_vector_type(3)));\n"
+            << "typedef float __acpp_vec_float_4 __attribute__((ext_vector_type(4)));\n"
+            << "typedef float __acpp_vec_float_8 __attribute__((ext_vector_type(8)));\n"
+            << "typedef float __acpp_vec_float_16 __attribute__((ext_vector_type(16)));\n"
+            << "typedef float __acpp_vec_float_32 __attribute__((ext_vector_type(32)));\n"
+            << "typedef double __acpp_vec_double_2 __attribute__((ext_vector_type(2)));\n"
+            << "typedef double __acpp_vec_double_3 __attribute__((ext_vector_type(3)));\n"
+            << "typedef double __acpp_vec_double_4 __attribute__((ext_vector_type(4)));\n"
+            << "typedef double __acpp_vec_double_8 __attribute__((ext_vector_type(8)));\n"
+            << "typedef double __acpp_vec_double_16 __attribute__((ext_vector_type(16)));\n"
+            << "typedef int __acpp_vec_int_2 __attribute__((ext_vector_type(2)));\n"
+            << "typedef int __acpp_vec_int_3 __attribute__((ext_vector_type(3)));\n"
+            << "typedef int __acpp_vec_int_4 __attribute__((ext_vector_type(4)));\n"
+            << "typedef int __acpp_vec_int_8 __attribute__((ext_vector_type(8)));\n"
+            << "typedef int __acpp_vec_int_16 __attribute__((ext_vector_type(16)));\n"
+            << "typedef int __acpp_vec_int_32 __attribute__((ext_vector_type(32)));\n"
+            << "typedef unsigned int __acpp_vec_unsigned_int_2 __attribute__((ext_vector_type(2)));\n"
+            << "typedef unsigned int __acpp_vec_unsigned_int_3 __attribute__((ext_vector_type(3)));\n"
+            << "typedef unsigned int __acpp_vec_unsigned_int_4 __attribute__((ext_vector_type(4)));\n"
+            << "typedef unsigned int __acpp_vec_unsigned_int_8 __attribute__((ext_vector_type(8)));\n"
+            << "typedef unsigned int __acpp_vec_unsigned_int_16 __attribute__((ext_vector_type(16)));\n"
+            << "typedef unsigned int __acpp_vec_unsigned_int_32 __attribute__((ext_vector_type(32)));\n"
+            << "typedef short __acpp_vec_short_2 __attribute__((ext_vector_type(2)));\n"
+            << "typedef short __acpp_vec_short_3 __attribute__((ext_vector_type(3)));\n"
+            << "typedef short __acpp_vec_short_4 __attribute__((ext_vector_type(4)));\n"
+            << "typedef short __acpp_vec_short_8 __attribute__((ext_vector_type(8)));\n"
+            << "typedef short __acpp_vec_short_16 __attribute__((ext_vector_type(16)));\n"
+            << "typedef unsigned short __acpp_vec_unsigned_short_2 __attribute__((ext_vector_type(2)));\n"
+            << "typedef unsigned short __acpp_vec_unsigned_short_3 __attribute__((ext_vector_type(3)));\n"
+            << "typedef unsigned short __acpp_vec_unsigned_short_4 __attribute__((ext_vector_type(4)));\n"
+            << "typedef unsigned short __acpp_vec_unsigned_short_8 __attribute__((ext_vector_type(8)));\n"
+            << "typedef unsigned short __acpp_vec_unsigned_short_16 __attribute__((ext_vector_type(16)));\n"
+            << "typedef __fp16 __acpp_vec___fp16_2 __attribute__((ext_vector_type(2)));\n"
+            << "typedef __fp16 __acpp_vec___fp16_3 __attribute__((ext_vector_type(3)));\n"
+            << "typedef __fp16 __acpp_vec___fp16_4 __attribute__((ext_vector_type(4)));\n"
+            << "typedef __fp16 __acpp_vec___fp16_8 __attribute__((ext_vector_type(8)));\n"
+            << "typedef __fp16 __acpp_vec___fp16_16 __attribute__((ext_vector_type(16)));\n"
+            << "typedef __fp16 __acpp_vec___fp16_32 __attribute__((ext_vector_type(32)));\n"
+            << "typedef long long __acpp_vec_long_long_2 __attribute__((ext_vector_type(2)));\n"
+            << "typedef long long __acpp_vec_long_long_3 __attribute__((ext_vector_type(3)));\n"
+            << "typedef long long __acpp_vec_long_long_4 __attribute__((ext_vector_type(4)));\n"
+            << "typedef long long __acpp_vec_long_long_8 __attribute__((ext_vector_type(8)));\n"
+            << "typedef long long __acpp_vec_long_long_16 __attribute__((ext_vector_type(16)));\n"
+            << "extern \"C\" {\n";
+
+    CppFile << "// Auto-generated AMDGPU Builtins Implementations\n\n"
+            << "#pragma clang diagnostic push\n"
+            << "#pragma clang diagnostic ignored \"-Wreturn-type-c-linkage\"\n\n"
+            << "#include \"hipSYCL/sycl/libkernel/sscp/builtins/amdgpu_auto_builtins.hpp\"\n\n"
+            << "extern \"C\" {\n";
+
+    // Initialize builtins so they populate the IdentifierTable
+    Ctx.BuiltinInfo.initializeBuiltins(Ctx.Idents, Ctx.getLangOpts());
+    
+    std::vector<unsigned> BuiltinIDs;
+    for (auto it = Ctx.Idents.begin(); it != Ctx.Idents.end(); ++it) {
+      unsigned ID = it->getValue()->getBuiltinID();
+      if (ID >= Builtin::FirstTSBuiltin) {
+        std::string Name = it->getKey().str();
+        if (Name.find("amdgcn") != std::string::npos || Name.find("amdgpu") != std::string::npos) {
+          BuiltinIDs.push_back(ID);
+        }
+      }
+    }
+    // Sort to ensure deterministic generation
+    std::sort(BuiltinIDs.begin(), BuiltinIDs.end(), [&](unsigned a, unsigned b) {
+      return Ctx.BuiltinInfo.getName(a) < Ctx.BuiltinInfo.getName(b);
+    });
+
+    for (unsigned ID : BuiltinIDs) {
+      std::string Name(Ctx.BuiltinInfo.getName(ID));
+      const char* Features = Ctx.BuiltinInfo.getRequiredFeatures(ID);
+      
+      if (Name.find("atomic_inc") != std::string::npos ||
+          Name.find("atomic_dec") != std::string::npos ||
+          Name.find("fence") != std::string::npos ||
+          Name.find("div_scale") != std::string::npos ||
+          Name.find("interp") != std::string::npos ||
+          Name.find("buffer_rsrc") != std::string::npos ||
+          Name.find("r600_") != std::string::npos) {
+        continue;
+      }
+
+      ASTContext::GetBuiltinTypeError Error;
+      unsigned IntegerConstantArgs = 0;
+      QualType FuncType = Ctx.GetBuiltinType(ID, Error, &IntegerConstantArgs);
+      
+      if (Error == ASTContext::GE_None && !FuncType.isNull()) {
+        const auto* FPT = FuncType->getAs<FunctionProtoType>();
+        if (!FPT) continue;
+        
+        // Build the parameters string
+        std::string ParamsStr;
+        llvm::raw_string_ostream ParamsOS(ParamsStr);
+        for (unsigned i = 0; i < FPT->getNumParams(); ++i) {
+          if (i > 0) ParamsOS << ", ";
+          ParamsOS << sanitizeType(FPT->getParamType(i).getAsString()) << " arg" << i;
+        }
+
+        std::string Sig = llvm::formatv("{0} __acpp_{1}({2})", 
+            sanitizeType(FPT->getReturnType().getAsString()), Name, ParamsOS.str()).str();
+
+        if (Sig.find("__fp16") != std::string::npos || Sig.find("__amdgpu_buffer_rsrc_t") != std::string::npos) {
+          continue;
+        }
+
+        // Write declaration to .hpp
+        HppFile << Sig << ";\n";
+        
+        // Build the arguments string
+        std::string ArgsStr;
+        llvm::raw_string_ostream ArgsOS(ArgsStr);
+        for (unsigned i = 0; i < FPT->getNumParams(); ++i) {
+          if (i > 0) ArgsOS << ", ";
+          if (IntegerConstantArgs & (1 << i)) {
+            ArgsOS << "1";
+          } else {
+            ArgsOS << "arg" << i;
+          }
+        }
+
+        // Write definition to .cpp
+        CppFile << "__attribute__((always_inline))\n";
+        if (Features && Features[0] != '\0') {
+            CppFile << llvm::formatv("__attribute__((target(\"{0}\")))\n", Features);
+        }
+        
+        CppFile << llvm::formatv("{0} {\n  {1}{2}({3});\n}\n\n",
+            Sig,
+            FPT->getReturnType()->isVoidType() ? "" : "return ",
+            Name,
+            ArgsOS.str());
+      }
+    }
+    
+    HppFile << "}\n#pragma clang diagnostic pop\n";
+    CppFile << "}\n#pragma clang diagnostic pop\n";
+  }
+};
+
+class BuiltinGenAction : public ASTFrontendAction {
+  std::string HppPath;
+  std::string CppPath;
+public:
+  BuiltinGenAction(std::string Hpp, std::string Cpp) : HppPath(Hpp), CppPath(Cpp) {}
+
+  std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI, StringRef file) override {
+    return std::make_unique<BuiltinGenConsumer>(HppPath, CppPath);
+  }
+};
+
+int main(int argc, char** argv) {
+  if (argc != 3) {
+    std::cerr << "Usage: " << argv[0] << " <output_hpp_path> <output_cpp_path>\n";
+    return 1;
+  }
+  
+  std::string HppPath = argv[1];
+  std::string CppPath = argv[2];
+
+  std::vector<std::string> args = {"-target", "amdgcn-amd-amdhsa", "-nogpulib", "-fsyntax-only"};
+  bool success = tooling::runToolOnCodeWithArgs(std::make_unique<BuiltinGenAction>(HppPath, CppPath), "void dummy(){}", args);
+  if (!success) {
+    std::cerr << "runToolOnCodeWithArgs failed!\n";
+    return 1;
+  }
+  std::cerr << "Finished successfully.\n";
+  return 0;
+}

--- a/src/compiler/llvm-to-backend/CMakeLists.txt
+++ b/src/compiler/llvm-to-backend/CMakeLists.txt
@@ -4,7 +4,6 @@ set(LLVM_TO_BACKEND_INCLUDE_DIRS
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${ACPP_BINARY_ROOT}/include)
 
-set(CMAKE_INSTALL_RPATH ${base} ${base}/../../)
 
 function(create_llvm_based_library)
   set(options STATIC)
@@ -65,6 +64,7 @@ function(create_llvm_based_library)
   endif()
 
   set(install_subdir hipSYCL/llvm-to-backend)
+  set_target_properties(${target} PROPERTIES INSTALL_RPATH "${base};${base}/../../")
   install(TARGETS ${target}
     RUNTIME DESTINATION bin/${install_subdir}
     LIBRARY DESTINATION lib/${install_subdir}
@@ -117,6 +117,7 @@ function(create_llvm_to_backend_tool)
     ${LLVM_DEFINITIONS_LIST})
   target_compile_definitions(${target}-tool PRIVATE -DHIPSYCL_TOOL_COMPONENT)
   target_link_libraries(${target}-tool PRIVATE ${target})
+  set_target_properties(${target}-tool PROPERTIES INSTALL_RPATH "${base}/../../../lib/hipSYCL/llvm-to-backend;${base}/../../../lib")
 
   set(install_subdir hipSYCL/llvm-to-backend)
   install(TARGETS ${target}-tool
@@ -162,6 +163,7 @@ if(WITH_SSCP_COMPILER)
       GlobalInliningAttributorPass.cpp
       DeadArgumentEliminationPass.cpp
       ProcessS2ReflectionPass.cpp
+      ResolveTargetBuiltinsPass.cpp
       ../sscp/KernelOutliningPass.cpp
       Utils.cpp
       )

--- a/src/compiler/llvm-to-backend/ResolveTargetBuiltinsPass.cpp
+++ b/src/compiler/llvm-to-backend/ResolveTargetBuiltinsPass.cpp
@@ -1,0 +1,58 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#include "hipSYCL/compiler/llvm-to-backend/ResolveTargetBuiltinsPass.hpp"
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/IRBuilder.h>
+#include "hipSYCL/compiler/utils/LLVMUtils.hpp"
+
+namespace hipsycl {
+namespace compiler {
+
+llvm::PreservedAnalyses ResolveTargetBuiltinsPass::run(llvm::Module &M, llvm::ModuleAnalysisManager &MAM) {
+  bool Changed = false;
+  for (auto &F : M) {
+    if (llvmutils::starts_with(F.getName(), "__acpp___builtin_")) {
+      for (auto &BB : F) {
+        for (auto &I : BB) {
+          if (auto *Call = llvm::dyn_cast<llvm::CallInst>(&I)) {
+            if (llvm::Function *CalledF = Call->getCalledFunction()) {
+              if (llvmutils::starts_with(CalledF->getName(), "llvm.")) {
+                for (unsigned i = 0; i < Call->arg_size(); ++i) {
+                  if (llvm::isa<llvm::Constant>(Call->getArgOperand(i)) && i < F.arg_size()) {
+                    llvm::Argument *WrapperArg = F.getArg(i);
+                    llvm::Value *Replacement = WrapperArg;
+                    if (WrapperArg->getType() != Call->getArgOperand(i)->getType()) {
+                       llvm::IRBuilder<> Builder(Call);
+                       if (WrapperArg->getType()->isIntegerTy() && Call->getArgOperand(i)->getType()->isIntegerTy()) {
+                         Replacement = Builder.CreateIntCast(WrapperArg, Call->getArgOperand(i)->getType(), false);
+                       } else {
+                         Replacement = Builder.CreateBitOrPointerCast(WrapperArg, Call->getArgOperand(i)->getType());
+                       }
+                    }
+                    Call->setArgOperand(i, Replacement);
+                    Changed = true;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return Changed ? llvm::PreservedAnalyses::none() : llvm::PreservedAnalyses::all();
+}
+
+} // namespace compiler
+} // namespace hipsycl

--- a/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
+++ b/src/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.cpp
@@ -10,12 +10,14 @@
 // SPDX-License-Identifier: BSD-2-Clause
 #include "hipSYCL/compiler/llvm-to-backend/amdgpu/LLVMToAmdgpu.hpp"
 #include "hipSYCL/compiler/llvm-to-backend/AddressSpaceInferencePass.hpp"
+#include "hipSYCL/compiler/llvm-to-backend/ResolveTargetBuiltinsPass.hpp"
 #include "hipSYCL/compiler/llvm-to-backend/Utils.hpp"
 #include "hipSYCL/compiler/sscp/IRConstantReplacer.hpp"
 #include "hipSYCL/compiler/utils/LLVMUtils.hpp"
 #include "hipSYCL/glue/llvm-sscp/jit-reflection/queries.hpp"
 #include "hipSYCL/common/filesystem.hpp"
 #include "hipSYCL/common/debug.hpp"
+#include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/DataLayout.h>
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/GlobalVariable.h>
@@ -320,7 +322,10 @@ bool LLVMToAmdgpuTranslator::toBackendFlavor(llvm::Module &M, PassHandler& PH) {
   
   if(!this->linkBitcodeFile(M, BuiltinBitcodeFile))
     return false;
-  
+
+  ResolveTargetBuiltinsPass RTBPass;
+  RTBPass.run(M, *PH.ModuleAnalysisManager);
+
   AddressSpaceInferencePass ASIPass {ASMap};
   ASIPass.run(M, *PH.ModuleAnalysisManager);
   

--- a/src/libkernel/sscp/amdgpu/CMakeLists.txt
+++ b/src/libkernel/sscp/amdgpu/CMakeLists.txt
@@ -6,10 +6,26 @@ if(WITH_LLVM_TO_AMDGPU_AMDHSA)
         -Xclang -fwchar-type=short)
   endif()
 
+  set(GENERATED_HPP "${HIPSYCL_SOURCE_DIR}/include/hipSYCL/sycl/libkernel/sscp/builtins/amdgpu_auto_builtins.hpp")
+  set(GENERATED_CPP "${CMAKE_CURRENT_SOURCE_DIR}/amdgpu_auto_builtins.cpp")
+
+  add_custom_command(
+      OUTPUT ${GENERATED_HPP} ${GENERATED_CPP}
+      COMMAND acpp-amdgpu-builtin-gen ${GENERATED_HPP} ${GENERATED_CPP}
+      DEPENDS acpp-amdgpu-builtin-gen
+      COMMENT "Auto-generating AMDGPU builtin wrappers via LibTooling..."
+  )
+
+  # Create a custom target that forces this generation to happen early
+  add_custom_target(generate_amdgpu_builtins ALL DEPENDS ${GENERATED_HPP} ${GENERATED_CPP})
+
+  set_source_files_properties(${GENERATED_CPP} PROPERTIES GENERATED TRUE)
+
   libkernel_generate_bitcode_target(
       TARGETNAME amdgpu-amdhsa 
       TRIPLE amdgcn-amd-amdhsa
       SOURCES 
+      amdgpu_auto_builtins.cpp
       assert.cpp
       atomic.cpp 
       barrier.cpp 

--- a/src/tools/acpp-hcf-tool/CMakeLists.txt
+++ b/src/tools/acpp-hcf-tool/CMakeLists.txt
@@ -5,4 +5,6 @@ target_include_directories(acpp-hcf-tool PRIVATE
     ${HIPSYCL_SOURCE_DIR}/include
     ${ACPP_BINARY_ROOT}/include)
 
+set_target_properties(acpp-hcf-tool PROPERTIES INSTALL_RPATH ${base}/../lib/)
+
 install(TARGETS acpp-hcf-tool DESTINATION bin)

--- a/tests/compiler/lit.cfg.py
+++ b/tests/compiler/lit.cfg.py
@@ -12,6 +12,18 @@ config.test_exec_root = os.path.join(config.my_obj_root)
 
 config.substitutions.append(('%acpp', config.acpp_compiler))
 
+config.substitutions.append(('%acpp-hcf-tool', os.path.join(os.path.dirname(config.acpp_compiler), 'acpp-hcf-tool')))
+
+llvm_to_amdgpu_tool = os.path.join(os.path.dirname(config.acpp_compiler), 'hipSYCL/llvm-to-backend/llvm-to-amdgpu-tool')
+if os.path.isfile(llvm_to_amdgpu_tool):
+  config.available_features.add('amdgpu-backend-tools')
+  config.substitutions.append(('%llvm-to-amdgpu', llvm_to_amdgpu_tool))
+else:
+  config.substitutions.append(('%llvm-to-amdgpu', 'false # llvm-to-amdgpu-tool not available'))
+
+config.substitutions.append(('%llvm-dis', 'llvm-dis'))
+config.substitutions.append(('%clangxx', 'clang++'))
+
 system = platform.system().lower()
 if system == 'darwin':
   config.available_features.add('system-darwin')
@@ -35,3 +47,10 @@ if "ACPP_VISIBILITY_MASK" in os.environ:
   backends = [ b.split(':')[0] for b in backend_masks]
   for b in backends:
     config.available_features.add(b)
+
+import os
+lib_dir = os.path.join(os.path.dirname(config.acpp_compiler), '../lib')
+lib_dir2 = os.path.join(lib_dir, 'hipSYCL/llvm-to-backend')
+lib_dir = f'{lib_dir}:{lib_dir2}'
+old_ld = os.environ.get('LD_LIBRARY_PATH', '')
+config.environment['LD_LIBRARY_PATH'] = f"{lib_dir}:{old_ld}" if old_ld else lib_dir

--- a/tests/compiler/sscp/amdgpu_builtins_codegen.cpp
+++ b/tests/compiler/sscp/amdgpu_builtins_codegen.cpp
@@ -1,0 +1,106 @@
+// REQUIRES: amdgpu-backend-tools
+// RUN: %acpp %s -c -o %t.o -mllvm -acpp-sscp-emit-hcf
+// RUN: %llvm-to-amdgpu --ir %s.hcf %t.bc llvm-ir.global
+// RUN: rm -f %s.hcf
+// RUN: %llvm-dis %t.bc -o %t.ll
+// RUN: FileCheck --check-prefix=CHECK-IR %s < %t.ll
+// RUN: %clangxx -target amdgcn-amd-amdhsa -mcpu=gfx90a -S %t.ll -o %t.s
+// RUN: FileCheck --check-prefix=CHECK-ASM %s < %t.s
+
+#include <sycl/sycl.hpp>
+#include "hipSYCL/sycl/libkernel/sscp/builtins/amdgpu_builtins.hpp"
+#include "hipSYCL/glue/llvm-sscp/jit-reflection/queries.hpp"
+
+namespace jit = hipsycl::sycl::AdaptiveCpp_jit;
+
+// CHECK-IR: define amdgpu_kernel void @{{.*}}basic_parallel_for{{.*}}
+
+void test_builtins(float *dev_f32, double *dev_f64,
+                   int *dev_dpp_shr, int *dev_dpp_ror, int *dev_dpp_mirror,
+                   int *dev_rfl, float *dev_fract, int *dev_sdot2, int global_idx) {
+  __acpp_if_target_sscp(
+    jit::compile_if(
+      jit::reflect<jit::reflection_query::target_arch>() ==
+        adaptivecpp::amdgpu::kGfx90aArchId,
+      [&]() {
+        // ── Floating-point atomic add ───────────────────────────────────────
+        // CHECK-IR: atomicrmw fadd ptr addrspace(1) %{{[0-9a-zA-Z_]+}}, float 1.500000e+00
+        // CHECK-ASM: global_atomic_add_f32 v{{[0-9]+}}, v{{[0-9]+}}, s[{{[0-9]+}}:{{[0-9]+}}]
+        adaptivecpp::amdgpu::unsafe_atomic_fetch_add(
+          hipsycl::sycl::access::address_space::global_space,
+          sycl::memory_order::relaxed,
+          hipsycl::sycl::memory_scope::device,
+          dev_f32, 1.5f);
+
+        // CHECK-IR: atomicrmw fadd ptr addrspace(1) %{{[0-9a-zA-Z_]+}}, double 2.500000e+00
+        // CHECK-ASM: global_atomic_add_f64 v{{.*}}, v[{{[0-9]+}}:{{[0-9]+}}], s[{{[0-9]+}}:{{[0-9]+}}]
+        adaptivecpp::amdgpu::unsafe_atomic_fetch_add(
+          hipsycl::sycl::access::address_space::global_space,
+          sycl::memory_order::relaxed,
+          hipsycl::sycl::memory_scope::device,
+          dev_f64, 2.5);
+
+        // ── DPP: row_shr:1 (0x111), bound_ctrl=true ────────────────────────
+        // CHECK-IR: call{{.*}} i32 @llvm.amdgcn.update.dpp.i32({{.*}} 0, {{.*}}, {{.*}} 273, {{.*}} 15, {{.*}} 15, {{.*}} true)
+        // CHECK-ASM: v_mov_b32_dpp v{{[0-9]+}}, v{{[0-9]+}} row_shr:1 row_mask:0xf bank_mask:0xf bound_ctrl:1
+        *dev_dpp_shr = adaptivecpp::amdgpu::update_dpp<0x111, 0xf, 0xf, true>(global_idx);
+
+        // ── DPP: row_ror:1 (0x121), bound_ctrl=false ───────────────────────
+        // CHECK-IR: call{{.*}} i32 @llvm.amdgcn.update.dpp.i32({{.*}} 0, {{.*}}, {{.*}} 289, {{.*}} 15, {{.*}} 15, {{.*}} false)
+        // CHECK-ASM: v_mov_b32_dpp v{{[0-9]+}}, v{{[0-9]+}} row_ror:1 row_mask:0xf bank_mask:0xf
+        *dev_dpp_ror = adaptivecpp::amdgpu::update_dpp<0x121, 0xf, 0xf, false>(global_idx);
+
+        // ── DPP: row_mirror (0x140), bound_ctrl=false ──────────────────────
+        // CHECK-IR: call{{.*}} i32 @llvm.amdgcn.update.dpp.i32({{.*}} 0, {{.*}}, {{.*}} 320, {{.*}} 15, {{.*}} 15, {{.*}} false)
+        // CHECK-ASM: v_mov_b32_dpp v{{[0-9]+}}, v{{[0-9]+}} row_mirror row_mask:0xf bank_mask:0xf
+        *dev_dpp_mirror = adaptivecpp::amdgpu::update_dpp<0x140, 0xf, 0xf, false>(global_idx);
+
+        // ── readfirstlane ───────────────────────────────────────────────────
+        // CHECK-IR: call{{.*}} i32 @llvm.amdgcn.readfirstlane.i32(i32
+        // CHECK-ASM: v_readfirstlane_b32 s{{[0-9]+}}, v{{[0-9]+}}
+        *dev_rfl = adaptivecpp::amdgpu::readfirstlane(global_idx);
+
+        // ── fract ───────────────────────────────────────────────────────────
+        // CHECK-IR: call{{.*}} float @llvm.amdgcn.fract.f32(float
+        // CHECK-ASM: v_fract_f32_e64 v{{[0-9]+}}, v{{[0-9]+}}
+        *dev_fract = adaptivecpp::amdgpu::fract(static_cast<float>(global_idx) + 0.456f);
+        
+        // ── sdot2 ───────────────────────────────────────────────────────────
+        // CHECK-IR: call{{.*}} i32 @llvm.amdgcn.sdot2(<2 x i16> {{.*}}, <2 x i16> {{.*}}, i32 {{.*}}, i1 true)
+        // CHECK-ASM: v_dot2_i32_i16
+        __attribute__((__vector_size__(2 * sizeof(short)))) short arg = {static_cast<short>(global_idx), static_cast<short>(global_idx + 1)};
+        *dev_sdot2 = __acpp___builtin_amdgcn_sdot2(arg, arg, global_idx, true);
+      }
+    );
+  );
+}
+
+int main() {
+  sycl::queue q;
+
+  float  *dev_f32        = sycl::malloc_device<float> (1024, q);
+  double *dev_f64        = sycl::malloc_device<double>(1024, q);
+  int    *dev_dpp_shr    = sycl::malloc_device<int>   (1024, q);
+  int    *dev_dpp_ror    = sycl::malloc_device<int>   (1024, q);
+  int    *dev_dpp_mirror = sycl::malloc_device<int>   (1024, q);
+  int    *dev_rfl        = sycl::malloc_device<int>   (1024, q);
+  float  *dev_fract      = sycl::malloc_device<float> (1024, q);
+  int    *dev_sdot2      = sycl::malloc_device<int>   (1024, q);
+
+  q.submit([&](sycl::handler &cgh) {
+    cgh.parallel_for(sycl::range<1>(1024), [=](sycl::id<1> idx) {
+      test_builtins(dev_f32, dev_f64,
+                    dev_dpp_shr, dev_dpp_ror, dev_dpp_mirror,
+                    dev_rfl, dev_fract, dev_sdot2, idx[0]);
+    });
+  }).wait();
+
+  sycl::free(dev_f32,        q);
+  sycl::free(dev_f64,        q);
+  sycl::free(dev_dpp_shr,    q);
+  sycl::free(dev_dpp_ror,    q);
+  sycl::free(dev_dpp_mirror, q);
+  sycl::free(dev_rfl,        q);
+  sycl::free(dev_fract,      q);
+  sycl::free(dev_sdot2,      q);
+}


### PR DESCRIPTION
https://github.com/AdaptiveCpp/AdaptiveCpp/pull/2166 enables the use LLVM intrinsics directly through re-mapping special functions names to LLVM intrinsics via an IR pass. This approach however has some drawbacks:

* It creates a dependency on the LLVM IR which is potentially unstable between releases
* Some builtins are implemented by multiple IR instructions. To replicate the functionality one would need to have a multiple IR instructions emitted using the method proposed in https://github.com/AdaptiveCpp/AdaptiveCpp/pull/2166 

The approach proposed in this MR circumvents this by exposing all of the available amdgcn builtins in the LLVM installation used by AdaptiveCpp. A small application uses the clangtooling interface to query all the builtins available and generates an implementation and interface for each builtin with the necessary target attribute added. 

A second issue, is that some of the builtins require that the parameters are constant expressions. Since they are used to generate intriniscs taking immediates. To work around this during the generation of the builtins library, dummy arguments were used. Later during backend lowering these are then replaced with the actual arguments passed in through the `__acpp__builtins` interface using the ResolveTargetBuiltinsPass.

Draft, because this meant more as a proof of concept than a production ready solution. 
