### PR TITLE
[CI] Use wget to dwonload nvhpc deb packages

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -166,10 +166,9 @@ jobs:
       run: |
         MAJOR_VERSION=$(echo ${{matrix.nvhpc}} | sed 's/\..*//')
         MINOR_VERSION=$(echo ${{matrix.nvhpc}} | sed 's/.*\.//')
-        curl https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg
-        echo 'deb [signed-by=/usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | sudo tee /etc/apt/sources.list.d/nvhpc.list
+        wget https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64/nvhpc-${MAJOR_VERSION}-${MINOR_VERSION}_${MAJOR_VERSION}.${MINOR_VERSION}-0_amd64.deb
         sudo apt-get update -y
-        sudo apt-get install -y nvhpc-${MAJOR_VERSION}-${MINOR_VERSION}
+        sudo apt-get install -y ./nvhpc-${MAJOR_VERSION}-${MINOR_VERSION}_${MAJOR_VERSION}.${MINOR_VERSION}-0_amd64.deb
     - name: build AdaptiveCpp
       run: |
         mkdir build && cd build


### PR DESCRIPTION
it seems that there is currently a bug in the Nvidia HPC sdk apt repo. Using wget, or curl to get the packages work