### PR TITLE
[ze] Initialize stype/pNext of Level Zero property structs before API calls

### DIFF
--- a/src/runtime/ze/ze_allocator.cpp
+++ b/src/runtime/ze/ze_allocator.cpp
@@ -128,6 +128,7 @@ bool ze_allocator::is_usm_accessible_from(backend_descriptor b) const {
 result ze_allocator::query_pointer(const void* ptr, pointer_info& out) const {
 
   ze_memory_allocation_properties_t props;
+  props.stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES;
   props.pNext = nullptr;
 
   ze_device_handle_t dev;

--- a/src/runtime/ze/ze_hardware_manager.cpp
+++ b/src/runtime/ze/ze_hardware_manager.cpp
@@ -162,6 +162,8 @@ ze_hardware_context::ze_hardware_context(ze_driver_handle_t driver,
                                          ze_context_handle_t ctx)
     : _driver{driver}, _device{device}, _ctx{ctx} {
 
+  _props.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
+  _props.pNext = nullptr;
   ze_result_t err = zeDeviceGetProperties(_device, &_props);
 
   if(err != ZE_RESULT_SUCCESS) {
@@ -170,6 +172,8 @@ ze_hardware_context::ze_hardware_context(ze_driver_handle_t driver,
                              error_code{"ze", static_cast<int>(err)}});
   }
 
+  _compute_props.stype = ZE_STRUCTURE_TYPE_DEVICE_COMPUTE_PROPERTIES;
+  _compute_props.pNext = nullptr;
   err = zeDeviceGetComputeProperties(_device, &_compute_props);
 
   if(err != ZE_RESULT_SUCCESS) {
@@ -188,6 +192,10 @@ ze_hardware_context::ze_hardware_context(ze_driver_handle_t driver,
   }
   if(num_memory_properties > 0) {
     _memory_props.resize(num_memory_properties);
+    for(auto &mp : _memory_props) {
+      mp.stype = ZE_STRUCTURE_TYPE_DEVICE_MEMORY_PROPERTIES;
+      mp.pNext = nullptr;
+    }
 
     err = zeDeviceGetMemoryProperties(_device, &num_memory_properties, _memory_props.data());
 
@@ -508,6 +516,8 @@ ze_hardware_context::get_property(device_uint_list_property prop) const {
 
 std::string ze_hardware_context::get_driver_version() const {
   ze_driver_properties_t props;
+  props.stype = ZE_STRUCTURE_TYPE_DRIVER_PROPERTIES;
+  props.pNext = nullptr;
   ze_result_t err = zeDriverGetProperties(_driver, &props);
 
   if(err != ZE_RESULT_SUCCESS) {


### PR DESCRIPTION
## Description

Initialize the `stype` and `pNext` fields of Level Zero property structures
before passing them to the respective `ze*Get*Properties` API calls.

Per the Level Zero specification, the `stype` field must be set to the
appropriate structure type enumeration value and `pNext` must be set to
`nullptr` (unless chaining an extension structure) before any API call
that takes the structure. Missing initialization can lead to undefined
behavior or crashes on some runtimes.

### Changes

- `ze_allocator.cpp`: Initialize `stype` for `ze_memory_allocation_properties_t`
  before `zeMemGetAllocProperties`
- `ze_hardware_manager.cpp`: Initialize `stype`/`pNext` for:
  - `ze_device_properties_t` before `zeDeviceGetProperties`
  - `ze_device_compute_properties_t` before `zeDeviceGetComputeProperties`
  - `ze_device_memory_properties_t` (each element) before `zeDeviceGetMemoryProperties`
  - `ze_driver_properties_t` before `zeDriverGetProperties`