### PR TITLE
[VK] Only set portability flag when device reports extension support

### DIFF
--- a/src/runtime/vk/vk_hardware_manager.cpp
+++ b/src/runtime/vk/vk_hardware_manager.cpp
@@ -468,22 +468,23 @@ vk_hardware_manager::vk_hardware_manager()
   }
   enabled_extensions.push_back(required_ext);
 
-  auto optional_ext = VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME;
-  bool optional_ext_supported = std::any_of(
-      std::begin(ext_properties), std::end(ext_properties),
-      [optional_ext](auto const &ext_property) {
-        return strcmp(ext_property.extensionName, optional_ext) == 0;
-      });
-  if (optional_ext_supported) {
-    HIPSYCL_DEBUG_INFO << "vk_hardware_manager: enabling extension "
-                       << optional_ext << std::endl;
-    enabled_extensions.push_back(optional_ext);
-  }
-
   // To layer ontop of moltenVK we need to opt-in to the Vulkan loader showing
   // non-conformant Vulkan implementations
-  const vk::InstanceCreateFlags flags =
-      vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR;
+  auto portability_ext = VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME;
+  bool portability_ext_supported = std::any_of(
+      std::begin(ext_properties), std::end(ext_properties),
+      [portability_ext](auto const &ext_property) {
+        return strcmp(ext_property.extensionName, portability_ext) == 0;
+      });
+
+  vk::InstanceCreateFlags flags{};
+  if (portability_ext_supported) {
+    HIPSYCL_DEBUG_INFO << "vk_hardware_manager: enabling extension "
+                       << portability_ext << std::endl;
+    enabled_extensions.push_back(portability_ext);
+    flags |= vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR;
+  }
+
   vk::InstanceCreateInfo create_info{
       flags,
       &app_info,                                        // pApplicationInfo


### PR DESCRIPTION
To enable the [VK_KHR_portability_enumeration](https://docs.vulkan.org/refpages/latest/refpages/source/VK_KHR_portability_enumeration.html) extension in Vulkan instance creation we need to both pass the extension string, and set a create info flag. Currently we are setting the create info flag regardless of if an Vulkan driver supports the extension, which leads to the following  warning being produced by the validation layer when running on a Vulkan driver that doesn't support `VK_KHR_portability_enumeration`

> VUID-VkInstanceCreateInfo-flags-06559(ERROR / SPEC): msgNum: -155949925 - Validation Error: [ VUID-VkInstanceCreateInfo-flags-06559 ] | MessageID = 0xf6b4649b | vkCreateInstance(): pCreateInfo->flags has VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR set, but ppEnabledExtensionNames does not include VK_KHR_portability_enumeration.
> The Vulkan spec states: If flags has the VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR bit set, the list of enabled extensions in ppEnabledExtensionNames must contain VK_KHR_portability_enumeration (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkInstanceCreateInfo-flags-06559)

Fixed by only conditionally passing the `VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR` bit when a device reports extension support.