### PR TITLE
Bump the nvcxx version to 26.5

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -142,8 +142,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        nvhpc: [26.3]
-        cuda: [13.1]
+        nvhpc: [26.5]
+        cuda: [13.2]
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -175,7 +175,10 @@ jobs:
         mkdir build && cd build
         export NV_HPC_SDK_ROOT=/opt/nvidia/hpc_sdk/Linux_x86_64/${{matrix.nvhpc}}
         export NV_HPC_CUDA_ROOT=${NV_HPC_SDK_ROOT}/cuda/${{matrix.cuda}}
-        cmake -DNVCXX_COMPILER=${NV_HPC_SDK_ROOT}/compilers/bin/nvc++ -DWITH_CUDA_BACKEND=ON -DACPP_COMPILER_FEATURE_PROFILE=none -DCMAKE_INSTALL_PREFIX=`pwd`/install -DCUDA_TOOLKIT_ROOT_DIR=${NV_HPC_CUDA_ROOT} ..
+        # nvcxx produces an ICE for some github runners with masked AVX capability
+        # Added -mno-avx512f as a workaround
+        # https://forums.developer.nvidia.com/t/nvc-ice-on-github-runners-zen-4-without-avx512-capability-when-lowering-vector-ldexp/379026/3
+        cmake -DNVCXX_COMPILER=${NV_HPC_SDK_ROOT}/compilers/bin/nvc++ -DWITH_CUDA_BACKEND=ON -DACPP_COMPILER_FEATURE_PROFILE=none -DCMAKE_INSTALL_PREFIX=`pwd`/install -DCUDA_TOOLKIT_ROOT_DIR=${NV_HPC_CUDA_ROOT} -DCUDA_CXX_FLAGS="-U__FLOAT128__ -U__SIZEOF_FLOAT128__ -isystem $ACPP_PATH/include/AdaptiveCpp/hipSYCL/std/hiplike -mno-avx512f" ..
         make -j2 install
         cp ${NV_HPC_CUDA_ROOT}/lib64/stubs/libcuda.so `pwd`/install/lib/libcuda.so
         cp ${NV_HPC_CUDA_ROOT}/lib64/stubs/libcuda.so `pwd`/install/lib/libcuda.so.1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -166,9 +166,10 @@ jobs:
       run: |
         MAJOR_VERSION=$(echo ${{matrix.nvhpc}} | sed 's/\..*//')
         MINOR_VERSION=$(echo ${{matrix.nvhpc}} | sed 's/.*\.//')
-        wget https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64/nvhpc-${MAJOR_VERSION}-${MINOR_VERSION}_${MAJOR_VERSION}.${MINOR_VERSION}-0_amd64.deb
+        curl https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg
+        echo 'deb [signed-by=/usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | sudo tee /etc/apt/sources.list.d/nvhpc.list
         sudo apt-get update -y
-        sudo apt-get install -y ./nvhpc-${MAJOR_VERSION}-${MINOR_VERSION}_${MAJOR_VERSION}.${MINOR_VERSION}-0_amd64.deb
+        sudo apt-get install -y nvhpc-${MAJOR_VERSION}-${MINOR_VERSION}
     - name: build AdaptiveCpp
       run: |
         mkdir build && cd build


### PR DESCRIPTION
This PR reverts the switch the workaround for the Nvidia apt repository issues since these has been [fixed in the meantime](https://forums.developer.nvidia.com/t/hpc-sdk-ubuntu-apt-repository-instructions-fail-with-404/378445/4)

It also moves the CI from nvhpc 26.3 to 26.5 as an attempt to try to fix the sporadic ICE issues. The CI ran with my branch on the runner that used to fail.