### PR TITLE
[OMP] Allow `numBytes == 0` in memset

### DIFF
--- a/src/runtime/omp/omp_queue.cpp
+++ b/src/runtime/omp/omp_queue.cpp
@@ -668,6 +668,7 @@ result omp_queue::submit_prefetch(prefetch_operation &op, const dag_node_ptr& no
 result omp_queue::submit_memset(memset_operation &op, const dag_node_ptr& node) {
   void *ptr = op.get_pointer();
   std::size_t bytes = op.get_num_bytes();
+  if (bytes == 0) return make_success();
   int pattern = op.get_pattern();
 
   if (!ptr) {

--- a/tests/sycl/usm.cpp
+++ b/tests/sycl/usm.cpp
@@ -507,6 +507,10 @@ BOOST_AUTO_TEST_CASE(memset) {
 
   q.memset(mem, 0, test_size);
   q.memset(mem + 1, 12, test_size - 2);
+
+  // memsets with size==0 shouldn't do anything
+  q.memset(mem, 42, 0);
+
   std::vector<unsigned char> host_mem(test_size);
   q.memcpy(host_mem.data(), mem, test_size);
 


### PR DESCRIPTION
I don't find anything in the SYCL reference that would forbid this. A library that I'm currently trying to make work with AdaptiveCpp uses memsets with size == 0 in several places so I figured fixing this here might be easiest.

Draft because I'm not sure what to do with the instrumentation stuff in `omp_queue::submit_memset`.