### PR TITLE
[ze] Fix duplicate event slot allocation when event pool overflows

### DIFF
--- a/src/runtime/ze/ze_hardware_manager.cpp
+++ b/src/runtime/ze/ze_hardware_manager.cpp
@@ -142,17 +142,15 @@ ze_context_handle_t ze_event_pool_manager::get_ze_context() const {
 
 std::shared_ptr<ze_event_pool_handle_t>
 ze_event_pool_manager::allocate_event(uint32_t& event_ordinal) {
-  if(_num_used_events+1 >= _pool_size) {
+  if(_num_used_events >= _pool_size) {
     // If pool is full, spawn a new pool
     spawn_pool();
-    event_ordinal = 0;
-
-  } else {
-    uint32_t ordinal = _num_used_events;
-    ++_num_used_events;
-
-    event_ordinal = ordinal;
   }
+  const uint32_t ordinal = _num_used_events;
+  ++_num_used_events;
+
+  event_ordinal = ordinal;
+
   return _pool;
 }
 

--- a/src/runtime/ze/ze_hardware_manager.cpp
+++ b/src/runtime/ze/ze_hardware_manager.cpp
@@ -146,10 +146,8 @@ ze_event_pool_manager::allocate_event(uint32_t& event_ordinal) {
     // If pool is full, spawn a new pool
     spawn_pool();
   }
-  const uint32_t ordinal = _num_used_events;
+  event_ordinal = _num_used_events;
   ++_num_used_events;
-
-  event_ordinal = ordinal;
 
   return _pool;
 }


### PR DESCRIPTION
When the event pool is full, `spawn_pool()` resets `_num_used_events` to 0, but the caller then unconditionally assigned `event_ordinal = 0`. The next call took the else branch and again computed `ordinal = _num_used_events = 0`, so the freshly created pool's slot 0 was handed out twice. 
Two chained commands then waited on the same event slot, creating a self-dependency that deadlocked on devices with strict synchronization.

Fall through to the common path after `spawn_pool()` so the ordinal is always allocated from _num_used_events.