### PR TITLE
Tidy up tests/compiler/sscp/global_constant

### DIFF
--- a/tests/compiler/sscp/global_constant.cpp
+++ b/tests/compiler/sscp/global_constant.cpp
@@ -21,7 +21,7 @@ void test_c_array(sycl::queue& q) {
   }).wait();
 
   std::vector<int> result(1024);
-  q.memcpy(result.data(), data, result.size()).wait();
+  q.memcpy(result.data(), data, result.size() * sizeof(int)).wait();
   for(int i = 0; i < 8; ++i) {
     // CHECK: 10
     // CHECK: 21


### PR DESCRIPTION
Does not really matter, just not nice.