### PR TITLE
[Metal] Add native event extraction

### DIFF
--- a/include/hipSYCL/glue/metal/metal_interop.hpp
+++ b/include/hipSYCL/glue/metal/metal_interop.hpp
@@ -14,9 +14,13 @@
 #ifdef SYCL_EXT_ACPP_BACKEND_METAL
 #include "hipSYCL/sycl/context.hpp"
 #include "hipSYCL/sycl/device.hpp"
+#include "hipSYCL/sycl/event.hpp"
 #include "hipSYCL/runtime/allocator.hpp"
+#include "hipSYCL/runtime/application.hpp"
 #include "hipSYCL/runtime/backend.hpp"
 #include "hipSYCL/runtime/error.hpp"
+#include "hipSYCL/runtime/inorder_queue_event.hpp"
+#include "hipSYCL/runtime/metal/metal_event.hpp"
 #if defined(__APPLE__)
 #include "hipSYCL/runtime/metal/metal_hardware_manager.hpp"
 #endif
@@ -36,6 +40,7 @@ template <> struct backend_interop<sycl::backend::metal> {
   using native_mem_type = void *;
   using native_device_type = MTL::Device *;
   using native_queue_type = MTL::CommandQueue *;
+  using native_event_type = rt::metal_event_handle;
 
   template <class Accessor_type>
   static native_mem_type get_native_mem(const Accessor_type &a) {
@@ -96,6 +101,78 @@ template <> struct backend_interop<sycl::backend::metal> {
         static_cast<rt::inorder_queue *>(launcher_params)->get_native_type());
   }
 
+  static native_event_type get_native_event(const sycl::event &e) {
+#if defined(__APPLE__)
+    rt::dag_node_ptr node = sycl::detail::extract_rt_event(e);
+    if (!node) {
+      rt::register_error(
+          __acpp_here(),
+          rt::error_info{"get_native_event: invalid event",
+                         rt::error_type::invalid_parameter_error});
+      return {nullptr, 0};
+    }
+
+    if (!node->is_submitted()) {
+      rt::runtime_keep_alive_token{}.get()->dag().flush_and_gc();
+    }
+
+    if (!node->is_submitted()) {
+      rt::register_error(
+          __acpp_here(),
+          rt::error_info{"get_native_event: event has not been submitted",
+                         rt::error_type::runtime_error});
+      return {nullptr, 0};
+    }
+
+    if (node->is_cancelled()) {
+      rt::register_error(
+          __acpp_here(),
+          rt::error_info{"get_native_event: event has been cancelled",
+                         rt::error_type::runtime_error});
+      return {nullptr, 0};
+    }
+
+    if (node->get_assigned_device().get_backend() != rt::backend_id::metal) {
+      rt::register_error(
+          __acpp_here(),
+          rt::error_info{"get_native_event: event does not belong to the "
+                         "Metal backend",
+                         rt::error_type::invalid_parameter_error});
+      return {nullptr, 0};
+    }
+
+    auto event = node->get_event();
+    if (!event) {
+      rt::register_error(
+          __acpp_here(),
+          rt::error_info{"get_native_event: event has not been submitted",
+                         rt::error_type::runtime_error});
+      return {nullptr, 0};
+    }
+
+    auto *metal_event =
+        dynamic_cast<rt::inorder_queue_event<rt::metal_event_handle> *>(
+            event.get());
+    if (!metal_event) {
+      rt::register_error(
+          __acpp_here(),
+          rt::error_info{"get_native_event: event is not backed by a native "
+                         "Metal event",
+                         rt::error_type::feature_not_supported});
+      return {nullptr, 0};
+    }
+
+    return metal_event->request_backend_event();
+#else
+    rt::register_error(
+        __acpp_here(),
+        rt::error_info{"get_native_event: Metal backend not supported on this "
+                       "OS",
+                       rt::error_type::runtime_error});
+    return {nullptr, 0};
+#endif
+  }
+
   static native_allocation_type get_native_allocation(const void *ptr, const sycl::context &ctx) {
     rt::backend *b =
         ctx.AdaptiveCpp_runtime()->backends().get(rt::backend_id::metal);
@@ -137,7 +214,7 @@ template <> struct backend_interop<sycl::backend::metal> {
   static constexpr bool can_extract_native_context = false;
   // sycl::get_native(queue) is not implemented; use interop_handle::get_native_queue()
   static constexpr bool can_extract_native_queue = false;
-  static constexpr bool can_extract_native_event = false;
+  static constexpr bool can_extract_native_event = true;
   static constexpr bool can_extract_native_buffer = false;
   static constexpr bool can_extract_native_sampled_image = false;
   static constexpr bool can_extract_native_image_sampler = false;

--- a/include/hipSYCL/sycl/event.hpp
+++ b/include/hipSYCL/sycl/event.hpp
@@ -27,8 +27,15 @@
 namespace hipsycl {
 namespace sycl {
 
+class event;
+
+namespace detail {
+rt::dag_node_ptr extract_rt_event(const event &e);
+} // namespace detail
+
 class event {
   friend class handler;
+  friend rt::dag_node_ptr detail::extract_rt_event(const event &e);
 public:
   event()
   {}
@@ -238,6 +245,13 @@ HIPSYCL_SPECIALIZE_GET_INFO(event, reference_count)
   return _node.use_count();
 }
 
+namespace detail {
+
+inline rt::dag_node_ptr extract_rt_event(const event &e) {
+  return e._node;
+}
+
+} // namespace detail
 
 } // namespace sycl
 } // namespace hipsycl

--- a/tests/sycl/extensions.cpp
+++ b/tests/sycl/extensions.cpp
@@ -12,6 +12,7 @@
 
 #include "hipSYCL/sycl/access.hpp"
 #include "hipSYCL/sycl/backend.hpp"
+#include "hipSYCL/sycl/backend_interop.hpp"
 #include "hipSYCL/sycl/buffer.hpp"
 #include "hipSYCL/sycl/event.hpp"
 #include "hipSYCL/sycl/info/event.hpp"
@@ -1420,6 +1421,24 @@ BOOST_AUTO_TEST_CASE(device_free_memory)
         dev.get_info<sycl::info::device::AdaptiveCpp_free_memory>(),
         sycl::exception);
   }
+}
+#endif
+#if defined(__APPLE__) && defined(SYCL_EXT_ACPP_BACKEND_METAL)
+BOOST_AUTO_TEST_CASE(get_native_metal_event) {
+  namespace s = sycl;
+
+  s::queue q{s::property::queue::in_order{}};
+  if (q.get_device().get_backend() != s::backend::metal) {
+    BOOST_TEST_MESSAGE("Skipping get_native_metal_event: not a Metal device");
+    return;
+  }
+
+  s::event event = q.single_task([]() {});
+  auto native_event = s::get_native<s::backend::metal>(event);
+
+  BOOST_CHECK(native_event.event != nullptr);
+  BOOST_CHECK(native_event.value != 0);
+  event.wait();
 }
 #endif
 #ifdef SYCL_KHR_DEFAULT_CONTEXT


### PR DESCRIPTION
Introduce sycl::get_native<sycl::backend::metal>(event) 
It returns an MTLSharedEvent so Metal GPU code can wait for compute work without blocking the CPU

use-case
```
sycl::event compute_done = queue.single_task(/* update frame data */);

  auto native =
      sycl::get_native<sycl::backend::metal>(compute_done);

  // In the render loop wait for compute before drawing the frame
  command_buffer->encodeWait(native.event, native.value);
  encode_render_pass(command_buffer);
  command_buffer->presentDrawable(drawable);
  command_buffer->commit();
```