### PR TITLE
[CMake] Make SSCP bitcode tools configurable for cross builds

### DIFF
--- a/src/libkernel/sscp/CMakeLists.txt
+++ b/src/libkernel/sscp/CMakeLists.txt
@@ -2,14 +2,25 @@ if(POLICY CMP0116)
   cmake_policy(SET CMP0116 NEW)  # Normalize paths in depfile
 endif()
 
-# SSCP libkernel bitcode is generated while building AdaptiveCpp. Keep these
-# tools independently configurable so cross builds can use executables from the
-# build host while CLANG_EXECUTABLE_PATH and LLVM_TOOLS_BINARY_DIR continue to
-# describe the target LLVM installation used by the installed runtime.
-set(ACPP_BITCODE_CLANG "${CLANG_EXECUTABLE_PATH}" CACHE FILEPATH
-    "Build-host clang++ used to generate SSCP libkernel bitcode")
-set(ACPP_BITCODE_LLVM_LINK "${LLVM_TOOLS_BINARY_DIR}/llvm-link" CACHE FILEPATH
-    "Build-host llvm-link used to link SSCP libkernel bitcode")
+# SSCP libkernel bitcode is generated while building AdaptiveCpp. Cross builds
+# may need build-host executables here while CLANG_EXECUTABLE_PATH and
+# LLVM_TOOLS_BINARY_DIR continue to describe the target LLVM installation used
+# by the installed runtime. Native builds must use that matching LLVM toolchain.
+if(CMAKE_CROSSCOMPILING)
+  set(ACPP_BITCODE_CLANG "${CLANG_EXECUTABLE_PATH}" CACHE FILEPATH
+      "Build-host clang++ matching AdaptiveCpp's LLVM version")
+  set(ACPP_BITCODE_LLVM_LINK "${LLVM_TOOLS_BINARY_DIR}/llvm-link" CACHE FILEPATH
+      "Build-host llvm-link matching AdaptiveCpp's LLVM version")
+else()
+  if(DEFINED ACPP_BITCODE_CLANG OR DEFINED ACPP_BITCODE_LLVM_LINK)
+    message(FATAL_ERROR
+      "ACPP_BITCODE_CLANG and ACPP_BITCODE_LLVM_LINK may only be overridden "
+      "when cross-compiling. Native builds must use the LLVM toolchain "
+      "selected by CLANG_EXECUTABLE_PATH and LLVM_TOOLS_BINARY_DIR.")
+  endif()
+  set(ACPP_BITCODE_CLANG "${CLANG_EXECUTABLE_PATH}")
+  set(ACPP_BITCODE_LLVM_LINK "${LLVM_TOOLS_BINARY_DIR}/llvm-link")
+endif()
 
 function(libkernel_generate_bitcode_library)
   set(options)

--- a/src/libkernel/sscp/CMakeLists.txt
+++ b/src/libkernel/sscp/CMakeLists.txt
@@ -2,6 +2,15 @@ if(POLICY CMP0116)
   cmake_policy(SET CMP0116 NEW)  # Normalize paths in depfile
 endif()
 
+# SSCP libkernel bitcode is generated while building AdaptiveCpp. Keep these
+# tools independently configurable so cross builds can use executables from the
+# build host while CLANG_EXECUTABLE_PATH and LLVM_TOOLS_BINARY_DIR continue to
+# describe the target LLVM installation used by the installed runtime.
+set(ACPP_BITCODE_CLANG "${CLANG_EXECUTABLE_PATH}" CACHE FILEPATH
+    "Build-host clang++ used to generate SSCP libkernel bitcode")
+set(ACPP_BITCODE_LLVM_LINK "${LLVM_TOOLS_BINARY_DIR}/llvm-link" CACHE FILEPATH
+    "Build-host llvm-link used to link SSCP libkernel bitcode")
+
 function(libkernel_generate_bitcode_library)
   set(options)
   set(one_value_keywords OUTPUT TRIPLE SOURCE)
@@ -47,7 +56,7 @@ function(libkernel_generate_bitcode_library)
 
   add_custom_command(
       OUTPUT ${target_output_file}
-      COMMAND ${CLANG_EXECUTABLE_PATH} ${target_flag} -fno-exceptions -fno-rtti -O3 -emit-llvm -std=c++17 -DHIPSYCL_SSCP_LIBKERNEL_LIBRARY
+      COMMAND ${ACPP_BITCODE_CLANG} ${target_flag} -fno-exceptions -fno-rtti -O3 -emit-llvm -std=c++17 -DHIPSYCL_SSCP_LIBKERNEL_LIBRARY
                     -I ${HIPSYCL_SOURCE_DIR}/include ${additional} ${platform_specific}
                     -MMD -MT ${target_output_file} -MF ${target_output_file}.d
                     -o ${target_output_file} -c ${CMAKE_CURRENT_SOURCE_DIR}/${source}
@@ -95,7 +104,7 @@ function(libkernel_generate_bitcode_target)
   set(linked_output ${CMAKE_CURRENT_BINARY_DIR}/libkernel-sscp-${target}-full.bc)
   add_custom_command(
     OUTPUT ${linked_output}
-    COMMAND ${LLVM_TOOLS_BINARY_DIR}/llvm-link -o=${linked_output} ${output_files}
+    COMMAND ${ACPP_BITCODE_LLVM_LINK} -o=${linked_output} ${output_files}
     DEPENDS ${output_files} ${target_depends}
   )
 


### PR DESCRIPTION
## Summary

Allow the Clang and `llvm-link` executables used to generate SSCP libkernel bitcode to be overridden only for CMake cross builds through:

- `ACPP_BITCODE_CLANG`
- `ACPP_BITCODE_LLVM_LINK`

Native builds continue to use `CLANG_EXECUTABLE_PATH` and `${LLVM_TOOLS_BINARY_DIR}/llvm-link`; setting either override in a native build now fails clearly instead of allowing an LLVM mismatch.

## Why

SSCP libkernel bitcode is generated during the build. In a cross build, however, `CLANG_EXECUTABLE_PATH` and `LLVM_TOOLS_BINARY_DIR` may describe the target LLVM installation recorded for the installed AdaptiveCpp runtime. Those target executables cannot necessarily run on the build host.

This surfaced while enabling Linux AArch64 packages from an x86_64 host in conda-forge/adaptivecpp-feedstock#43. Restricting the overrides to `CMAKE_CROSSCOMPILING` keeps the native path tied to the LLVM toolchain selected by AdaptiveCpp while allowing cross builds to use matching build-host tools.

This is also related to #2158, which introduces an Android-specific native `llvm-link` path. The generic cross-build variables here provide the same separation without tying it to one target platform, and also cover Clang.

## Validation

- Verified native configurations use the selected target LLVM tools and reject either override.
- Verified cross configurations retain default tools or accept explicit build-host Clang and `llvm-link`.
- Built and linked the complete host SSCP bitcode library in native and simulated Linux AArch64 cross modes with Clang/LLVM 19; the outputs were byte-identical.
- Confirmed the conda-forge AArch64 build sets `CMAKE_SYSTEM_NAME=Linux` and `CMAKE_SYSTEM_PROCESSOR=aarch64`.
- The equivalent feedstock patch passed all 44 conda-forge checks across Linux x86_64, Linux AArch64, Linux ppc64le, macOS, and Windows, including LLVM 16-19 and AArch64 CPU/CUDA variants: conda-forge/adaptivecpp-feedstock#43.
- The resulting AArch64 CUDA package compiled and ran CPU and CUDA kernels on a Jetson Thor: https://gist.github.com/abrandemuehl-rai/ef901d2e82e5b4bb39a7450e513dfe53
- Current-head upstream CI passed all 72 non-skipped checks, including native and cross-build coverage from Clang/LLVM 15 through 21, CUDA, ROCm, Vulkan, Metal, Windows, and macOS: https://github.com/AdaptiveCpp/AdaptiveCpp/actions/runs/33794560649
