### PR TITLE
[VK] Handle kernel arguments set via uniform buffers

### DIFF
--- a/.github/workflows/linux-vulkan.yml
+++ b/.github/workflows/linux-vulkan.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         docker: ${{fromJson(needs.prep-container.outputs.docker_matrix)}}
         clang_version: ['19', '21']
-        clspv_commit: ['88d8ff71000bf995493c8daaed865ec1ac216309']
+        clspv_commit: ['3d017c6d751cdabed1a5051b20c6bf5f71e8fd32']
       fail-fast: false
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/macos-vulkan.yml
+++ b/.github/workflows/macos-vulkan.yml
@@ -2,7 +2,7 @@ name: macOS Vulkan backend
 
 on: [push, pull_request]
 env:
-  clspv_commit: '88d8ff71000bf995493c8daaed865ec1ac216309'
+  clspv_commit: '3d017c6d751cdabed1a5051b20c6bf5f71e8fd32'
 jobs:
   build_vulkan:
     name: Vulkan backend macOS

--- a/.github/workflows/windows-vulkan.yml
+++ b/.github/workflows/windows-vulkan.yml
@@ -13,7 +13,7 @@ jobs:
         clang_version: ['19', '20']
         base_compiler: ['19']
         os: [windows-2022]
-        clspv_commit: ['88d8ff71000bf995493c8daaed865ec1ac216309']
+        clspv_commit: ['3d017c6d751cdabed1a5051b20c6bf5f71e8fd32']
     steps:
     - uses: actions/checkout@v7
       with:

--- a/doc/install-vulkan.md
+++ b/doc/install-vulkan.md
@@ -20,7 +20,7 @@ the generic SSCP compilation flow.
   `VK_KHR_buffer_device_address` respectively.
 * The [LunarG Vulkan SDK](https://vulkan.lunarg.com/sdk/home) versions 1.4 or later
   for Vulkan loader, layers, headers, and other tools.
-* A `clspv` executable from commit `88d8ff71000bf995493c8daaed865ec1ac216309`.
+* A `clspv` executable from commit `3d017c6d751cdabed1a5051b20c6bf5f71e8fd32`.
 * Linux, macOS, and Windows operating systems are tested in CI. Ubuntu 22.04 and later are the
   tested distributions for Linux. MacOS 15.7.4 is tested CI with MoltenVK. Windows server 2022
   is used with llvmpipe in CI. However on Windows there are sporadic failures in the `group_functions` suite
@@ -82,6 +82,10 @@ the features used in the kernel:
   instructions to be used in the implementation of SYCL sub-group builtins.
 * `VK_SUBGROUP_FEATURE_SHUFFLE_BIT` - Allows SPIR-V `CapabilityGroupNonUniformShuffle`
   instructions to be used in the implementation of SYCL sub-group builtins.
+* `uniformAndStorageBuffer8BitAccess` - Allows 8-bit arguments to be passed to
+  SPIR-V kernels via uniform buffers.
+* `uniformAndStorageBuffer16BitAccess` - Allows 16-bit arguments to be passed to
+  SPIR-V kernels via uniform buffers.
 
 ## Building
 
@@ -312,11 +316,22 @@ each work-group size variant of a kernel. At adaptivity level 0, a specializatio
 constant is used to set the work-group size on the same `vk_executable_object` object for each
 work-group size variant.
 
-For small numbers of kernel arguments, no buffer descriptors may be required and all
-arguments can be set pushing push constants before the invocation of the Vulkan
-command-buffer containing the kernel. For larger numbers of kernel arguments or struct
-arguments that are decomposed, a single uniform buffer is used with binding 0,
-and each argument is an offset into that uniform buffer.
+#### Kernel Arguments
+
+There are two different mechanisms used for passing arguments to the SPIR-V kernel.
+The preferred was is push constants, which are copied into the command buffer executing
+the kernel and suitable for small numbers of kernel arguments.
+
+For larger numbers of kernel arguments or struct arguments that are decomposed, uniform buffers
+are used. This may be multiple uniform buffers but most likely a single uniform buffer where
+each argument is an offset into that uniform buffer.
+
+In order to use uniform buffers, it's not just the buffers & memory that need to be created
+to hold the arguments for a kernel invocation, it's also the descriptor set which
+defines the binding of buffers to the compute pipeline. In order for multiple invocations
+of the same kernel with different arguments to behave correctly a `vk_kernel_uniform_descriptors`
+class is defined by the backend for containing all information, and a pool of objects
+is created which can be reused as the invocations associated with them complete execution.
 
 #### Queue
 

--- a/doc/install-vulkan.md
+++ b/doc/install-vulkan.md
@@ -319,7 +319,7 @@ work-group size variant.
 #### Kernel Arguments
 
 There are two different mechanisms used for passing arguments to the SPIR-V kernel.
-The preferred was is push constants, which are copied into the command buffer executing
+The preferred is push constants, which are copied into the command buffer executing
 the kernel and suitable for small numbers of kernel arguments.
 
 For larger numbers of kernel arguments or struct arguments that are decomposed, uniform buffers

--- a/include/hipSYCL/compiler/llvm-to-backend/clspv/LLVMToCLSPV.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/clspv/LLVMToCLSPV.hpp
@@ -47,6 +47,7 @@ private:
   unsigned DynamicLocalMemSize = 0;
   std::string MaxPushConstantSize;
   std::string MaxUniformBufferRange;
+  std::string DeviceName;
 };
 
 } // namespace compiler

--- a/include/hipSYCL/compiler/llvm-to-backend/clspv/LLVMToCLSPV.hpp
+++ b/include/hipSYCL/compiler/llvm-to-backend/clspv/LLVMToCLSPV.hpp
@@ -8,7 +8,7 @@
  * See file LICENSE in the project root for full license details.
  */
 // SPDX-License-Identifier: BSD-2-Clause
-#pragma
+#pragma once
 
 #include "../LLVMToBackend.hpp"
 

--- a/include/hipSYCL/runtime/vk/vk_allocator.hpp
+++ b/include/hipSYCL/runtime/vk/vk_allocator.hpp
@@ -59,8 +59,17 @@ public:
 
   vk_alloc_info *find_alloc_info(vk::DeviceAddress ptr);
 
+  // Creates a single buffer backed by allocated device memory, and created with
+  // properties which allow its device address returned
   std::pair<vk::raii::Buffer, vk::raii::DeviceMemory>
-  create_buffer(vk::DeviceSize size, vk::BufferUsageFlags usage_flags);
+  create_device_address_buffer(vk::DeviceSize size);
+
+  // Given a list of uniform buffers sets scraped from SPIR-V reflection
+  // allocates enough memory for all of then, then creates buffers into the
+  // memory which are bound the appropriate offset
+  std::tuple<std::vector<vk::raii::Buffer>, std::vector<vk::DeviceSize>,
+             vk::raii::DeviceMemory>
+  create_uniform_buffers(std::vector<vk::DeviceSize> sizes);
 
 private:
   uint32_t find_memory_type(vk::MemoryPropertyFlags properties,

--- a/include/hipSYCL/runtime/vk/vk_allocator.hpp
+++ b/include/hipSYCL/runtime/vk/vk_allocator.hpp
@@ -65,8 +65,8 @@ public:
   create_device_address_buffer(vk::DeviceSize size);
 
   // Given a list of uniform buffers sets scraped from SPIR-V reflection
-  // allocates enough memory for all of then, then creates buffers into the
-  // memory which are bound the appropriate offset
+  // allocates enough memory for all of them, then creates buffers into the
+  // memory which are bound to the appropriate offset
   std::tuple<std::vector<vk::raii::Buffer>, std::vector<vk::DeviceSize>,
              vk::raii::DeviceMemory>
   create_uniform_buffers(std::vector<vk::DeviceSize> sizes);

--- a/include/hipSYCL/runtime/vk/vk_code_object.hpp
+++ b/include/hipSYCL/runtime/vk/vk_code_object.hpp
@@ -53,30 +53,68 @@ private:
   vk_queue *_queue;
 };
 
+// Wrapper for information related to uniform buffers and descriptors needed
+// to pass kernel arguments, and can be reused for another kernel execution
+// once a previous execution completes with arguments set using an instance.
+class vk_kernel_uniform_descriptors {
+public:
+  // Creates uniform buffers backend by memory, and descriptor sets, but
+  // only if they have not already been created.
+  void init(vk_kernel_object *kern_obj);
+
+  vk::DescriptorSet get_descriptor_set() const { return _desc_set; }
+
+  void set_completion_val(vk::Semaphore semaphore, uint64_t v) {
+    _semaphore = semaphore;
+    _completion_val = v;
+  }
+
+  bool is_available(bool stall);
+
+  void *map_memory(unsigned binding, unsigned offset, unsigned size) {
+    vk::DeviceSize mem_offset = _offsets[binding] + offset;
+    return _dev_mem.mapMemory(mem_offset, size);
+  }
+
+  vk::Buffer get_uniform_buffer(size_t i) { return _uniform_buffers[i]; }
+
+  void unmap_memory() { _dev_mem.unmapMemory(); }
+
+private:
+  void create_uniform_backing_buffers();
+  void create_descriptor_set();
+
+  vk_kernel_object *_kern_obj{nullptr};
+
+  std::vector<vk::raii::Buffer> _uniform_buffers;
+  std::vector<vk::DeviceSize> _offsets;
+  vk::raii::DeviceMemory _dev_mem{nullptr};
+  vk::raii::DescriptorSet _desc_set{nullptr};
+
+  vk::Semaphore _semaphore{nullptr};
+  uint64_t _completion_val{0};
+};
+
+// Wrapper for an kernel instance for a specific workgroup size which can be run
+// once it is bound to a command-buffer and has its arguments set.
 class vk_kernel_pipeline {
 public:
   vk_kernel_pipeline();
   vk_kernel_pipeline(vk_kernel_object *kern_obj,
                      const rt::range<3> &group_size);
 
-  void set_args(vk::CommandBuffer &,
+  void set_args(vk::CommandBuffer &, vk_kernel_uniform_descriptors &,
                 glue::jit::cxx_argument_mapper &arg_mapper);
-  void bind(vk::CommandBuffer &);
+  void bind(vk::CommandBuffer &, vk_kernel_uniform_descriptors &);
 
   const rt::range<3> &get_group_size() const { return _group_size; }
 
 private:
-  void create_uniform_backing_buffers();
-  void create_compute_pipeline();
-
   vk_kernel_object *_kern_obj;
   rt::range<3> _group_size;
 
   vk::raii::Pipeline _compute_pipeline;
   vk::raii::PipelineLayout _compute_pipeline_layout;
-
-  vk::raii::Buffer _uniform_buffer_raii = nullptr;
-  vk::raii::DeviceMemory _uniform_mem_raii = nullptr;
 };
 
 using vk_kernel_pipeline_sp = std::shared_ptr<vk_kernel_pipeline>;
@@ -105,6 +143,9 @@ struct spv_kernel_argument {
                                   const spv_kernel_argument &arg);
 };
 
+// Wrapper holding information about an abstract kernel from an executable
+// object and information about its arguments. In order to run it must be
+// made concrete for a specific workgroup size via `vk_kernel_pipeline`.
 class vk_kernel_object {
 public:
   vk_kernel_object();
@@ -112,24 +153,32 @@ public:
 
   vk_kernel_pipeline_sp create_pipeline(const rt::range<3> &group_size);
   void create_descriptor_pool();
-  void create_descriptor_sets();
+  void create_descriptor_layout();
 
   const std::string &get_name() const { return _name; }
   vk_executable_object *get_exe_obj() const { return _exe_obj; }
 
   void add_spv_arg(spv_kernel_argument);
   const std::vector<spv_kernel_argument> &get_spv_args() const;
-  unsigned get_uniform_arg_size() { return _uniform_arg_size; }
+
+  struct UniformArg {
+    unsigned binding;
+    unsigned size;
+  };
+  const std::vector<UniformArg> &get_uniform_args() const {
+    return _uniform_args;
+  }
+  vk_kernel_uniform_descriptors &create_kernel_descriptors();
 
   size_t get_push_constants_size() const;
   void set_reqd_wg_size(unsigned x, unsigned y, unsigned z);
   bool check_reqd_wg_size(const rt::range<3> &group_size) const;
-  vk::DescriptorSet get_descriptor_set() { return *_desc_sets.front(); }
   vk::DescriptorSetLayout get_descriptor_set_layout() {
     return *_desc_set_layout;
   }
+  vk::DescriptorPool get_descriptor_pool() { return *_desc_pool; }
 
-  // Maximum number of invocations of a kernel
+  // Maximum number of concurrent invocations of a kernel
   static constexpr uint32_t MAX_INSTANCES = 10;
 
 private:
@@ -139,11 +188,11 @@ private:
       _pipelines;
   std::vector<size_t> _reqd_wg_size;
   std::vector<spv_kernel_argument> _args;
-  unsigned _uniform_arg_size;
+  std::vector<UniformArg> _uniform_args;
 
   vk::raii::DescriptorPool _desc_pool;
   vk::raii::DescriptorSetLayout _desc_set_layout;
-  std::vector<vk::raii::DescriptorSet> _desc_sets;
+  std::array<vk_kernel_uniform_descriptors, MAX_INSTANCES> _uniform_descriptors;
 };
 
 struct spv_reflection_data {

--- a/include/hipSYCL/runtime/vk/vk_hardware_manager.hpp
+++ b/include/hipSYCL/runtime/vk/vk_hardware_manager.hpp
@@ -35,6 +35,8 @@ enum feature_bits {
   groupNonUniformShuffle = 1 << 9,
   groupNonUniformVote = 1 << 10,
   shaderFloat64 = 1 << 11,
+  uniformAndStorageBuffer16BitAccess = 1 << 12,
+  uniformAndStorageBuffer8BitAccess = 1 << 13
 };
 }; // namespace vk_device_features
 
@@ -91,6 +93,9 @@ public:
   }
   uint32_t get_max_uniform_buffer_range() const {
     return _limits.maxUniformBufferRange;
+  }
+  uint32_t get_min_uniform_buffer_offset_alignment() const {
+    return _limits.minUniformBufferOffsetAlignment;
   }
   uint32_t get_subgroup_size() const { return _subgroup_size; }
   uint16_t get_phys_dev_features() const { return _physical_dev_features; }

--- a/src/compiler/llvm-to-backend/clspv/LLVMToCLSPV.cpp
+++ b/src/compiler/llvm-to-backend/clspv/LLVMToCLSPV.cpp
@@ -307,6 +307,16 @@ bool LLVMToCLSPVTranslator::translateToBackendFormat(
                                       "--arch=spir64",
                                       "-long-vector",
                                       "-o=" + OutputFileName};
+
+  // Workaround for the Qualcomm Adreno driver on Android that struggles to
+  // consume SPIR-V where the physical pointer arguments are passed in a push
+  // constant with non zero member index. To avoid this pass each argument as
+  // its own uniform buffer.
+  if (DeviceName.find("Adreno") != std::string::npos) {
+    Args.push_back("--pod-ubo");
+    Args.push_back("--cluster-pod-kernel-args=0");
+  }
+
   if (!MaxPushConstantSize.empty()) {
     Args.push_back("-max-pushconstant-size=" + MaxPushConstantSize);
   }
@@ -362,6 +372,10 @@ bool LLVMToCLSPVTranslator::applyBuildOption(const std::string &Option,
 
   if (Option == "-max-ubo-size") {
     this->MaxUniformBufferRange = Value;
+  }
+
+  if (Option == "-device-name") {
+    this->DeviceName = Value;
   }
 
   return false;

--- a/src/compiler/llvm-to-backend/clspv/LLVMToCLSPV.cpp
+++ b/src/compiler/llvm-to-backend/clspv/LLVMToCLSPV.cpp
@@ -372,10 +372,12 @@ bool LLVMToCLSPVTranslator::applyBuildOption(const std::string &Option,
 
   if (Option == "-max-ubo-size") {
     this->MaxUniformBufferRange = Value;
+    return true;
   }
 
   if (Option == "-device-name") {
     this->DeviceName = Value;
+    return true;
   }
 
   return false;

--- a/src/runtime/vk/vk_allocator.cpp
+++ b/src/runtime/vk/vk_allocator.cpp
@@ -47,9 +47,64 @@ std::size_t vk_allocator::get_global_mem_size() const {
   return _mem_properties.memoryHeaps[heap_index].size;
 }
 
+std::tuple<std::vector<vk::raii::Buffer>, std::vector<vk::DeviceSize>,
+           vk::raii::DeviceMemory>
+vk_allocator::create_uniform_buffers(std::vector<vk::DeviceSize> sizes) {
+  const auto &device = _hw_ctx->get_device();
+  std::vector<vk::raii::Buffer> buffers;
+  std::vector<vk::DeviceSize> offsets;
+
+  vk::DeviceSize total_size = 0;
+  vk::DeviceSize max_alignment = 0;
+  uint32_t type_bitmask = UINT32_MAX;
+
+  // First create the buffers and extract requirements for the memory allocation
+  const vk::DeviceSize min_uniform_align =
+      _hw_ctx->get_min_uniform_buffer_offset_alignment();
+  for (size_t i = 0; i < sizes.size(); i++) {
+    vk::BufferCreateInfo buffer_info{{},
+                                     sizes[i],
+                                     vk::BufferUsageFlagBits::eUniformBuffer,
+                                     vk::SharingMode::eExclusive};
+    vk::raii::Buffer buffer(device, buffer_info);
+    vk::MemoryRequirements mem_reqs = buffer.getMemoryRequirements();
+
+    // Find the alignment of this buffer, and add padding
+    vk::DeviceSize align = std::max(mem_reqs.alignment, min_uniform_align);
+    vk::DeviceSize padding = (align - (total_size % align)) % align;
+    total_size += padding;
+    offsets.push_back(total_size);
+
+    total_size += mem_reqs.size;
+    type_bitmask = type_bitmask & mem_reqs.memoryTypeBits;
+
+    buffers.push_back(std::move(buffer));
+  }
+
+  constexpr vk::MemoryPropertyFlags mem_prop_flags =
+      vk::MemoryPropertyFlagBits::eHostVisible |
+      vk::MemoryPropertyFlagBits::eHostCoherent;
+  vk::MemoryAllocateInfo alloc_info{
+      total_size, find_memory_type(mem_prop_flags, type_bitmask)};
+
+  vk::raii::DeviceMemory buffer_mem(device, alloc_info);
+  for (size_t i = 0; i < buffers.size(); i++) {
+    buffers[i].bindMemory(buffer_mem, offsets[i]);
+  }
+
+  HIPSYCL_DEBUG_INFO << "vk_allocator: created " << buffers.size()
+                     << " uniform buffers backed by a " << total_size
+                     << " byte memory allocation" << std::endl;
+
+  return {std::move(buffers), std::move(offsets), std::move(buffer_mem)};
+}
+
 std::pair<vk::raii::Buffer, vk::raii::DeviceMemory>
-vk_allocator::create_buffer(vk::DeviceSize size,
-                            vk::BufferUsageFlags usage_flags) {
+vk_allocator::create_device_address_buffer(vk::DeviceSize size) {
+  constexpr vk::BufferUsageFlags usage_flags =
+      vk::BufferUsageFlagBits::eTransferSrc |
+      vk::BufferUsageFlagBits::eTransferDst |
+      vk::BufferUsageFlagBits::eShaderDeviceAddress;
   constexpr vk::MemoryPropertyFlags mem_prop_flags =
       vk::MemoryPropertyFlagBits::eHostVisible |
       vk::MemoryPropertyFlagBits::eHostCoherent;
@@ -100,11 +155,7 @@ void *vk_allocator::raw_allocate(size_t, size_t size_bytes,
                                  const allocation_hints &) {
   std::lock_guard<std::mutex> lock{_mutex};
 
-  constexpr vk::BufferUsageFlags usage_flags =
-      vk::BufferUsageFlagBits::eTransferSrc |
-      vk::BufferUsageFlagBits::eTransferDst |
-      vk::BufferUsageFlagBits::eShaderDeviceAddress;
-  auto [buffer, device_mem] = create_buffer(size_bytes, usage_flags);
+  auto [buffer, device_mem] = create_device_address_buffer(size_bytes);
 
   vk::BufferDeviceAddressInfo addr_info{buffer};
   vk::DeviceAddress ptr = _hw_ctx->get_device().getBufferAddress(addr_info);

--- a/src/runtime/vk/vk_code_object.cpp
+++ b/src/runtime/vk/vk_code_object.cpp
@@ -36,13 +36,13 @@ result vk_sscp_code_object_invoker::submit_kernel(
 }
 
 vk_kernel_object::vk_kernel_object()
-    : _exe_obj(nullptr), _name(), _uniform_arg_size(0),
-      _desc_set_layout(nullptr), _desc_pool(nullptr) {}
+    : _exe_obj(nullptr), _name(), _desc_set_layout(nullptr),
+      _desc_pool(nullptr) {}
 
 vk_kernel_object::vk_kernel_object(std::string name,
                                    vk_executable_object *exe_obj)
-    : _exe_obj(exe_obj), _name(name), _uniform_arg_size(0),
-      _desc_set_layout(nullptr), _desc_pool(nullptr) {}
+    : _exe_obj(exe_obj), _name(name), _desc_set_layout(nullptr),
+      _desc_pool(nullptr) {}
 
 void vk_kernel_object::add_spv_arg(spv_kernel_argument arg) {
   _args.push_back(arg);
@@ -66,8 +66,30 @@ const std::vector<spv_kernel_argument> &vk_kernel_object::get_spv_args() const {
 }
 
 void vk_kernel_object::create_descriptor_pool() {
-  // All uniform args are condensed into a single buffer
-  constexpr unsigned num_uniform_args = 1;
+  // Find all the uniform buffer arguments which need descriptors
+  for (const auto &spv_arg : _args) {
+    if (spv_arg.is_uniform()) {
+      auto binding = spv_arg._binding;
+      bool found = false;
+      for (auto &arg : _uniform_args) {
+        if (arg.binding == binding) {
+          arg.size += spv_arg._size;
+          found = true;
+        }
+      }
+
+      if (!found) {
+        _uniform_args.push_back({binding, spv_arg._size});
+      }
+    }
+  }
+
+  // If there are no uniform buffer arguments then all arguments can be passed
+  // in push constants and we don't need descriptor pool or sets.
+  const unsigned num_uniform_args = _uniform_args.size();
+  if (num_uniform_args == 0) {
+    return;
+  }
   std::vector<vk::DescriptorPoolSize> pool_sizes = {vk::DescriptorPoolSize(
       vk::DescriptorType::eUniformBuffer, num_uniform_args * MAX_INSTANCES)};
 
@@ -81,32 +103,19 @@ void vk_kernel_object::create_descriptor_pool() {
   _desc_pool = vk::raii::DescriptorPool(device, pool_info);
 }
 
-void vk_kernel_object::create_descriptor_sets() {
-  for (const auto &spv_arg : _args) {
-    if (spv_arg.is_uniform()) {
-      auto binding = spv_arg._binding;
-      assert(binding == 0 && "only one binding currently supported");
-      if (binding == 0) {
-        _uniform_arg_size += spv_arg._size;
-      } else {
-        print_error(
-            __acpp_here(),
-            error_info{"Non zero uniform buffer binding is not supported"});
-      }
-    }
-  }
+void vk_kernel_object::create_descriptor_layout() {
+  std::vector<vk::DescriptorSetLayoutBinding> layout_bindings;
+  for (const auto &arg : _uniform_args) {
+    vk::DescriptorSetLayoutBinding binding(
+        arg.binding, vk::DescriptorType::eUniformBuffer, 1,
+        vk::ShaderStageFlagBits::eCompute, nullptr);
 
-  std::vector<vk::DescriptorSetLayoutBinding> layout_bindings{
-      vk::DescriptorSetLayoutBinding(
-          0 /* binding */, vk::DescriptorType::eUniformBuffer, 1,
-          vk::ShaderStageFlagBits::eCompute, nullptr)};
+    layout_bindings.push_back(binding);
+  }
 
   auto &device = _exe_obj->get_device();
   vk::DescriptorSetLayoutCreateInfo layout_info({}, layout_bindings);
   _desc_set_layout = vk::raii::DescriptorSetLayout(device, layout_info);
-
-  vk::DescriptorSetAllocateInfo alloc_info(_desc_pool, *_desc_set_layout);
-  _desc_sets = device.allocateDescriptorSets(alloc_info);
 }
 
 bool spv_kernel_argument::is_push_constant() const {
@@ -164,6 +173,86 @@ size_t vk_kernel_object::get_push_constants_size() const {
   return max_size;
 }
 
+vk_kernel_uniform_descriptors &vk_kernel_object::create_kernel_descriptors() {
+  for (auto &desc : _uniform_descriptors) {
+    if (desc.is_available(false)) {
+      desc.init(this);
+      return desc;
+    }
+  }
+
+  // If no descriptors are currently free resort to a blocking wait until the
+  // first kernel using them completes
+  _uniform_descriptors[0].is_available(true);
+  return _uniform_descriptors[0];
+}
+
+void vk_kernel_uniform_descriptors::init(vk_kernel_object *kern_obj) {
+  if (_kern_obj != nullptr) {
+    return; // Already initialized
+  }
+  _kern_obj = kern_obj;
+  create_descriptor_set();
+  create_uniform_backing_buffers();
+}
+
+void vk_kernel_uniform_descriptors::create_descriptor_set() {
+  auto pool = _kern_obj->get_descriptor_pool();
+  if (pool == nullptr) {
+    // The kernel may not use buffer descriptors
+    return;
+  }
+
+  std::array<vk::DescriptorSetLayout, 1> layouts{
+      _kern_obj->get_descriptor_set_layout()};
+  vk::DescriptorSetAllocateInfo alloc_info(pool, layouts);
+  _desc_set = std::move(_kern_obj->get_exe_obj()
+                            ->get_hw_ctx()
+                            ->get_device()
+                            .allocateDescriptorSets(alloc_info)
+                            .front());
+}
+
+void vk_kernel_uniform_descriptors::create_uniform_backing_buffers() {
+  std::vector<vk::DeviceSize> sizes;
+  for (const auto &arg : _kern_obj->get_uniform_args()) {
+    sizes.push_back(arg.size);
+  }
+
+  if (sizes.empty()) {
+    // The kernel may not use buffer descriptors
+    return;
+  }
+
+  vk_allocator *allocator =
+      _kern_obj->get_exe_obj()->get_hw_ctx()->get_allocator();
+  auto [uniform_buffers, offsets, dev_mem] =
+      allocator->create_uniform_buffers(sizes);
+  _uniform_buffers = std::move(uniform_buffers);
+  _offsets = std::move(offsets);
+  _dev_mem = std::move(dev_mem);
+}
+
+bool vk_kernel_uniform_descriptors::is_available(bool stall) {
+  if (_completion_val == 0 || _semaphore == nullptr) {
+    return true; // No prior in-flight kernel using this descriptor set
+  }
+
+  // Kernel may not have any uniform buffer descriptors, in which case this
+  // object is always available to be reused
+  if (_dev_mem == nullptr) {
+    return true;
+  }
+
+  // Query semaphore to see if previous execution has completed. Do a blocking
+  // wait here if requested
+  vk::SemaphoreWaitInfo wait_info({}, 1, &_semaphore, &_completion_val);
+  vk::Result wait_ret_code =
+      _kern_obj->get_exe_obj()->get_hw_ctx()->get_device().waitSemaphores(
+          wait_info, stall ? UINT64_MAX : 0);
+  return wait_ret_code == vk::Result::eSuccess;
+}
+
 vk_kernel_pipeline_sp
 vk_kernel_object::create_pipeline(const rt::range<3> &group_size) {
   auto it = _pipelines.find(group_size);
@@ -190,22 +279,6 @@ vk_kernel_pipeline::vk_kernel_pipeline(vk_kernel_object *kern_obj,
                 error_info{"reqd wg size doesn't match enqueued kernel size"});
   }
 
-  create_uniform_backing_buffers();
-  create_compute_pipeline();
-}
-
-void vk_kernel_pipeline::create_uniform_backing_buffers() {
-  if (unsigned bytes = _kern_obj->get_uniform_arg_size(); bytes > 0) {
-    vk_allocator *allocator =
-        _kern_obj->get_exe_obj()->get_hw_ctx()->get_allocator();
-    auto [uniform_buffer_raii, uniform_mem_raii] = allocator->create_buffer(
-        bytes, vk::BufferUsageFlagBits::eUniformBuffer);
-    _uniform_buffer_raii = std::move(uniform_buffer_raii);
-    _uniform_mem_raii = std::move(uniform_mem_raii);
-  }
-}
-
-void vk_kernel_pipeline::create_compute_pipeline() {
   auto &device = _kern_obj->get_exe_obj()->get_device();
   auto desc_set_layout = _kern_obj->get_descriptor_set_layout();
 
@@ -276,6 +349,7 @@ void vk_kernel_pipeline::create_compute_pipeline() {
 }
 
 void vk_kernel_pipeline::set_args(vk::CommandBuffer &cmd_buf,
+                                  vk_kernel_uniform_descriptors &kernel_desc,
                                   glue::jit::cxx_argument_mapper &arg_mapper) {
   void **kernel_args = arg_mapper.get_mapped_args();
 
@@ -288,25 +362,25 @@ void vk_kernel_pipeline::set_args(vk::CommandBuffer &cmd_buf,
       void *dest = push_constants.data() + spv_arg._offset;
       std::memcpy(dest, kernel_arg, spv_arg._size);
     } else if (spv_arg.is_uniform()) {
-      void *vptr = _uniform_mem_raii.mapMemory(spv_arg._offset, spv_arg._size);
+      void *vptr = kernel_desc.map_memory(spv_arg._binding, spv_arg._offset,
+                                          spv_arg._size);
       std::memcpy(vptr, kernel_arg, spv_arg._size);
-      _uniform_mem_raii.unmapMemory();
+      kernel_desc.unmap_memory();
     } else {
       assert(false && "handle unknown arg");
     }
   }
 
-  if (_kern_obj->get_uniform_arg_size() > 0) {
+  for (size_t i = 0; i < _kern_obj->get_uniform_args().size(); i++) {
     std::vector<vk::WriteDescriptorSet> descriptor_writes;
-    vk::DescriptorBufferInfo buffer_info(_uniform_buffer_raii, 0,
+    const auto arg = _kern_obj->get_uniform_args()[i];
+    vk::DescriptorBufferInfo buffer_info(kernel_desc.get_uniform_buffer(i), 0,
                                          VK_WHOLE_SIZE);
 
-    constexpr unsigned binding = 0;
     vk::WriteDescriptorSet write_desc_set(
-        _kern_obj->get_descriptor_set(), binding, 0,
+        kernel_desc.get_descriptor_set(), arg.binding, 0,
         vk::DescriptorType::eUniformBuffer, {}, buffer_info);
     descriptor_writes.push_back(write_desc_set);
-
     auto &device = _kern_obj->get_exe_obj()->get_device();
     device.updateDescriptorSets(descriptor_writes, {});
   }
@@ -318,11 +392,15 @@ void vk_kernel_pipeline::set_args(vk::CommandBuffer &cmd_buf,
   }
 }
 
-void vk_kernel_pipeline::bind(vk::CommandBuffer &cmd_buf) {
+void vk_kernel_pipeline::bind(vk::CommandBuffer &cmd_buf,
+                              vk_kernel_uniform_descriptors &kernel_desc) {
   cmd_buf.bindPipeline(vk::PipelineBindPoint::eCompute, _compute_pipeline);
-  cmd_buf.bindDescriptorSets(vk::PipelineBindPoint::eCompute,
-                             _compute_pipeline_layout, 0,
-                             {_kern_obj->get_descriptor_set()}, {});
+
+  if (auto descriptor_set = kernel_desc.get_descriptor_set()) {
+    cmd_buf.bindDescriptorSets(vk::PipelineBindPoint::eCompute,
+                               _compute_pipeline_layout, 0, {descriptor_set},
+                               {});
+  }
 }
 
 static spv_arg_kind get_spv_arg_kind(uint32_t inst) {
@@ -516,6 +594,16 @@ static void verify_spv_capabilities(const uint16_t phys_dev_features,
       check_support(vk_device_features::storagePushConstant16,
                     "SPIR-V Capability PushConstant16 not supported by device");
       break;
+    case spv::CapabilityUniformAndStorageBuffer8BitAccess:
+      check_support(vk_device_features::storagePushConstant8,
+                    "SPIR-V Capability UniformAndStorageBuffer8 not supported "
+                    "by device");
+      break;
+    case spv::CapabilityUniformAndStorageBuffer16BitAccess:
+      check_support(vk_device_features::storagePushConstant16,
+                    "SPIR-V Capability UniformAndStorageBuffer16 not supported "
+                    "by device");
+      break;
     case spv::CapabilityVariablePointers:
       check_support(
           vk_device_features::variablePointers,
@@ -603,7 +691,7 @@ vk_executable_object::vk_executable_object(vk_hardware_context *hw_ctx,
 
   for (auto &kern : _kernel_handles) {
     kern.second.create_descriptor_pool();
-    kern.second.create_descriptor_sets();
+    kern.second.create_descriptor_layout();
   }
 
   _build_status = make_success();

--- a/src/runtime/vk/vk_code_object.cpp
+++ b/src/runtime/vk/vk_code_object.cpp
@@ -184,6 +184,8 @@ vk_kernel_uniform_descriptors &vk_kernel_object::create_kernel_descriptors() {
   // If no descriptors are currently free resort to a blocking wait until the
   // first kernel using them completes
   _uniform_descriptors[0].is_available(true);
+  // We don't need to reinitialize the descriptor object as if we get here
+  // they have already been used before
   return _uniform_descriptors[0];
 }
 
@@ -595,12 +597,12 @@ static void verify_spv_capabilities(const uint16_t phys_dev_features,
                     "SPIR-V Capability PushConstant16 not supported by device");
       break;
     case spv::CapabilityUniformAndStorageBuffer8BitAccess:
-      check_support(vk_device_features::storagePushConstant8,
+      check_support(vk_device_features::uniformAndStorageBuffer8BitAccess,
                     "SPIR-V Capability UniformAndStorageBuffer8 not supported "
                     "by device");
       break;
     case spv::CapabilityUniformAndStorageBuffer16BitAccess:
-      check_support(vk_device_features::storagePushConstant16,
+      check_support(vk_device_features::uniformAndStorageBuffer16BitAccess,
                     "SPIR-V Capability UniformAndStorageBuffer16 not supported "
                     "by device");
       break;

--- a/src/runtime/vk/vk_hardware_manager.cpp
+++ b/src/runtime/vk/vk_hardware_manager.cpp
@@ -65,6 +65,11 @@ vk_hardware_context::vk_hardware_context(
       (_physical_dev_features & vk_device_features::storagePushConstant8)
           ? VK_TRUE
           : VK_FALSE;
+  phys_dev_12_features.uniformAndStorageBuffer8BitAccess =
+      (_physical_dev_features &
+       vk_device_features::uniformAndStorageBuffer8BitAccess)
+          ? VK_TRUE
+          : VK_FALSE;
 
   vk::PhysicalDeviceVulkan11Features phys_dev_11_features{};
   phys_dev_11_features.variablePointers =
@@ -78,6 +83,11 @@ vk_hardware_context::vk_hardware_context(
           : VK_FALSE;
   phys_dev_11_features.storagePushConstant16 =
       (_physical_dev_features & vk_device_features::storagePushConstant16)
+          ? VK_TRUE
+          : VK_FALSE;
+  phys_dev_11_features.uniformAndStorageBuffer16BitAccess =
+      (_physical_dev_features &
+       vk_device_features::uniformAndStorageBuffer16BitAccess)
           ? VK_TRUE
           : VK_FALSE;
 
@@ -666,6 +676,9 @@ vk_hardware_manager::vk_hardware_manager()
     if (features_12.shaderInt8) {
       backend_features |= vk_device_features::shaderInt8;
     }
+    if (features_12.uniformAndStorageBuffer8BitAccess) {
+      backend_features |= vk_device_features::uniformAndStorageBuffer8BitAccess;
+    }
 
     vk::PhysicalDeviceFeatures const &features =
         supported_features.get<vk::PhysicalDeviceFeatures2>().features;
@@ -691,6 +704,11 @@ vk_hardware_manager::vk_hardware_manager()
 
     if (features_11.storagePushConstant16) {
       backend_features |= vk_device_features::storagePushConstant16;
+    }
+
+    if (features_11.uniformAndStorageBuffer16BitAccess) {
+      backend_features |=
+          vk_device_features::uniformAndStorageBuffer16BitAccess;
     }
 
     auto device_name = phys_dev.getProperties().deviceName;

--- a/src/runtime/vk/vk_queue.cpp
+++ b/src/runtime/vk/vk_queue.cpp
@@ -782,6 +782,7 @@ result vk_queue::submit_sscp_kernel_from_code_object(
     raw_translator->setBuildOption(
         "-max-ubo-size",
         std::to_string(_dev_ctx->get_max_uniform_buffer_range()));
+    raw_translator->setBuildOption("-device-name", _dev_ctx->get_device_name());
 
     // Lower kernels to SPIR-V
     bool enable_dead_arg_elimination = kernel_names.size() == 1;
@@ -841,13 +842,15 @@ result vk_queue::submit_sscp_kernel_from_code_object(
     return res;
 
   auto pipeline = kernel->create_pipeline(group_size);
+  vk_kernel_uniform_descriptors &kernel_descriptors =
+      kernel->create_kernel_descriptors();
 
   vk::CommandBuffer cmd_buf =
       begin_command_buffer(vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
 
   // command-buffer must be in the recording state before we set push constants
-  pipeline->set_args(cmd_buf, _arg_mapper);
-  pipeline->bind(cmd_buf);
+  pipeline->set_args(cmd_buf, kernel_descriptors, _arg_mapper);
+  pipeline->bind(cmd_buf, kernel_descriptors);
 
   HIPSYCL_DEBUG_INFO << "vk_queue: Attempting to submit SSCP kernel"
                      << std::endl;
@@ -855,6 +858,8 @@ result vk_queue::submit_sscp_kernel_from_code_object(
   end_command_buffer(cmd_buf);
 
   submit_command_buffer(cmd_buf);
+
+  kernel_descriptors.set_completion_val(_semaphore, _timeline_value);
   on_kernel_launch_complete(kernel_name, obj);
 
   return make_success();


### PR DESCRIPTION
This patch updates the Vulkan backend to correctly handle when a SPIR-V kernel expects arguments to be passed via uniform buffers instead of push constants. This requires creating uniform buffers and descriptor sets that can be used on a kernel invocation without conflicting with other invocations of the same kernel.

This path is less efficient than pushing constants to set arguments but is used as workaround for the Qualcomm Adreno GPU Vulkan driver on Android which struggles to correctly execute well formed SPIR-V code where ulong device buffer addresses are passed in the push constant struct.

The clspv commit is also bumped to bring in the clspv change from merged PR https://github.com/google/clspv/pull/1623
