### PR TITLE
Fix division by zero in `memcpy` and `memset` with OMP backend

### DIFF
--- a/src/runtime/omp/omp_queue.cpp
+++ b/src/runtime/omp/omp_queue.cpp
@@ -378,6 +378,9 @@ result omp_queue::submit_memcpy(memcpy_operation &op, const dag_node_ptr& node) 
   std::size_t dest_element_size = op.dest().get_element_size();
 
   std::size_t total_num_bytes = op.get_num_transferred_bytes();
+  if (total_num_bytes == 0) {
+    return make_success();
+  }
 
   bool is_src_contiguous =
       is_contigous(src_offset, transferred_range, src_allocation_shape);
@@ -669,6 +672,10 @@ result omp_queue::submit_memset(memset_operation &op, const dag_node_ptr& node) 
   void *ptr = op.get_pointer();
   std::size_t bytes = op.get_num_bytes();
   int pattern = op.get_pattern();
+
+  if (bytes == 0) {
+    return make_success();
+  }
 
   if (!ptr) {
     return register_error(


### PR DESCRIPTION
#2105 introduces a division by zero error for `memcpy` and `memset` when they are called on 0 elements.

In src/runtime/omp/omp_queue.cpp , line 399, `block_size` appears to be 0 when `queue.memcpy(dest, src, 0);` is called, leading to a divison by zero in line 400. I believe that this is not expected behavior.

Reproducer:

```cpp
#include <sycl/sycl.hpp>

int main() {
	sycl::queue queue{sycl::cpu_selector_v};
	const auto* const src = sycl::malloc_device<int>(10, queue);
	auto* const dest = sycl::malloc_device<int>(10, queue);
	queue.memcpy(dest, src, 0);
	queue.memset(dest, {}, 0);
}
```