### PR TITLE
[CI] Improve the docker infrastructure

### DIFF
--- a/.github/workflows/create-ci-docker/AdaptiveCpp-CI-Linux.dockerfile
+++ b/.github/workflows/create-ci-docker/AdaptiveCpp-CI-Linux.dockerfile
@@ -47,6 +47,7 @@ RUN apt-get -u update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN <<EOF
+    set -e
     # skip if ROCM_VERSION empty (yeah.. Intel not ROCm .. but whatever)
     if [ -z "${ROCM_VERSION}" ]; then exit 0; fi
     wget -q https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.16695.4/intel-igc-core_1.0.16695.4_amd64.deb
@@ -63,6 +64,7 @@ RUN <<EOF
 EOF
 
 RUN <<EOF
+    set -e
     # skip if CUDA_MAJOR_VERSION empty
     if [ -z "${CUDA_MAJOR_VERSION}" ]; then exit 0; fi
     mkdir -p /opt/cuda-${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION}
@@ -73,6 +75,7 @@ RUN <<EOF
 EOF
 
 RUN <<EOF
+    set -e
     # skip if ROCM_VERSION empty
     if [ -z "${ROCM_VERSION}" ]; then exit 0; fi
     wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add -
@@ -84,6 +87,7 @@ RUN <<EOF
 EOF
 
 RUN <<EOF
+    set -e
     wget -q https://apt.llvm.org/llvm.sh
     chmod +x llvm.sh
     ./llvm.sh ${LLVM_VERSION}

--- a/.github/workflows/create-ci-docker/AdaptiveCpp-CI-Linux.dockerfile
+++ b/.github/workflows/create-ci-docker/AdaptiveCpp-CI-Linux.dockerfile
@@ -104,7 +104,7 @@ RUN <<EOF
 EOF
 
 ENV PATH="$PATH:/usr/local/cuda/bin"
-ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:/usr/local/cuda/lib64"
 ENV CC=clang-${LLVM_VERSION}
 ENV CXX=clang++-${LLVM_VERSION}
 

--- a/.github/workflows/create-ci-docker/AdaptiveCpp-CI-Linux.dockerfile
+++ b/.github/workflows/create-ci-docker/AdaptiveCpp-CI-Linux.dockerfile
@@ -90,7 +90,12 @@ RUN <<EOF
     set -e
     wget -q https://apt.llvm.org/llvm.sh
     chmod +x llvm.sh
-    ./llvm.sh ${LLVM_VERSION}
+    # Github runners sometimes have trouble reaching the LLVM repository
+    # We retry multiple times to make the CI more stable
+    for i in 1 2 3 4 5; do 
+        ./llvm.sh ${LLVM_VERSION} && echo "Attempt $i failed, retrying in 15s..."
+        sleep 15 
+    done 
     apt-get install -y libclang-${LLVM_VERSION}-dev clang-tools-${LLVM_VERSION} libomp-${LLVM_VERSION}-dev llvm-${LLVM_VERSION}-dev
     apt-get install -y -o DPkg::options::="--force-overwrite" libclang-rt-${LLVM_VERSION}-dev
     rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/create-ci-docker/action.yml
+++ b/.github/workflows/create-ci-docker/action.yml
@@ -23,8 +23,10 @@ inputs:
     required: true
     default: 'ubuntu-22.04'
   GITHUB_TOKEN:
+    type: boolean
     required: true
   FORCE_BUILD:
+    type: boolean
     default: false
   
 outputs:
@@ -165,7 +167,7 @@ runs:
         fi
         
     - name: Build and push Docker images
-      if: (steps.filter-last-push.outputs.docker == 'true' || steps.tag-exists.outputs.tag == 'not found' || inputs.FORCE_BUILD) && github.event_name != 'pull_request'
+      if: (steps.filter-last-push.outputs.docker == 'true' || steps.tag-exists.outputs.tag == 'not found' || inputs.FORCE_BUILD == 'true') && github.event_name != 'pull_request'
       uses: docker/build-push-action@v6
       id: build
       with:


### PR DESCRIPTION
Currently in the CI some LLVM packages are not always installed successfully. The CI only failes after the images are built while installing AdaptiveCpp even though the apt commands for LLVM also failed in the previous step. https://github.com/AdaptiveCpp/AdaptiveCpp/actions/runs/32279703262/job/96261713479

This PR improves build process by the following:

* Fail docker image build jobs in case some components are not installed successfully
* Re try installing LLVM 5 times to account for higher possible transient network issues
* Remove the defaults from the docker image primer workflow, so that images without cuda can be also built manually
* Changes the type of the `FORCE_BUILD` parameter to boolean, I think this was the reason why the base images got re-generated with every run
* ~~Bumps the version of all used actions due to the deprecation of node20~~
