### PR TITLE
[Metal] Batch command buffers and deduplicate residency bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,9 +52,3 @@ build*/
 
 # clangd cache
 .cache
-
-# macOS
-.DS_Store
-
-# local install prefix
-/install/

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,9 @@ build*/
 
 # clangd cache
 .cache
+
+# macOS
+.DS_Store
+
+# local install prefix
+/install/

--- a/include/hipSYCL/runtime/kernel_launcher.hpp
+++ b/include/hipSYCL/runtime/kernel_launcher.hpp
@@ -121,11 +121,9 @@ public:
                      error_type::invalid_parameter_error});
   }
 
-  /// Returns true if this launcher describes a host-side custom (interop)
-  /// operation. Such operations execute user code synchronously during
-  /// invoke(), and that code is free to submit native work directly against
-  /// native handles (e.g. the native command queue). Backends that batch
-  /// native submissions must take this into account to preserve ordering.
+  /// True for host-side custom (interop) operations, whose invoke() may
+  /// submit native work directly. Backends that batch native submissions
+  /// need to know this to preserve ordering.
   bool is_custom_operation() const {
     return static_cast<bool>(_static_data.custom_op)
            || _static_data.type == rt::kernel_type::custom;

--- a/include/hipSYCL/runtime/kernel_launcher.hpp
+++ b/include/hipSYCL/runtime/kernel_launcher.hpp
@@ -118,7 +118,17 @@ public:
     return make_error(
           __acpp_here(),
           error_info{"No kernel launcher is present for requested backend",
-                    error_type::invalid_parameter_error});
+                     error_type::invalid_parameter_error});
+  }
+
+  /// Returns true if this launcher describes a host-side custom (interop)
+  /// operation. Such operations execute user code synchronously during
+  /// invoke(), and that code is free to submit native work directly against
+  /// native handles (e.g. the native command queue). Backends that batch
+  /// native submissions must take this into account to preserve ordering.
+  bool is_custom_operation() const {
+    return static_cast<bool>(_static_data.custom_op)
+           || _static_data.type == rt::kernel_type::custom;
   }
 
   const kernel_configuration& get_kernel_configuration() const {

--- a/include/hipSYCL/runtime/metal/metal_allocator.hpp
+++ b/include/hipSYCL/runtime/metal/metal_allocator.hpp
@@ -17,12 +17,14 @@
 #include <atomic>
 #include <map>
 #include <memory>
+#include <vector>
 
 namespace MTL {
 
 class Device;
 class Buffer;
 class ResidencySet;
+class Resource;
 
 } // namespace MTL
 
@@ -89,17 +91,17 @@ public:
   // USM allocations, and returns the generation the snapshot corresponds to.
   // Snapshot and generation are taken under the same lock, so the returned
   // pair is always consistent.
-  template<typename Container>
-  uint64_t snapshot_buffers(Container& out) const {
-    std::lock_guard<std::mutex> lock{_mutex};
-    out.clear();
-    for (auto& [ptr, block] : _ptr_to_block) {
-      if (block.buffer) {
-        out.push_back(block.buffer);
-      }
-    }
-    return _generation.load(std::memory_order_relaxed);
-  }
+  //
+  // Each returned buffer is retain()'d before being handed out: the snapshot
+  // may be cached and used by the caller (e.g. passed to useResources())
+  // after this lock has been released, and without an extra reference a
+  // concurrent raw_free() on another thread could release/deallocate the
+  // buffer in that window. The caller owns the extra reference and must
+  // release() every entry once it stops using the snapshot (e.g. when
+  // replacing it with a newer one, or on destruction).
+  // (Not a template: retain() requires MTL::Buffer to be a complete type,
+  // which this header intentionally does not pull in - see metal_allocator.cpp.)
+  uint64_t snapshot_buffers(std::vector<const MTL::Resource*>& out) const;
 
 private:
   MTL::Buffer* alloc_buffer(size_t size_bytes);

--- a/include/hipSYCL/runtime/metal/metal_allocator.hpp
+++ b/include/hipSYCL/runtime/metal/metal_allocator.hpp
@@ -14,17 +14,14 @@
 #include "../allocator.hpp"
 #include "../hints.hpp"
 
-#include <atomic>
 #include <map>
 #include <memory>
-#include <vector>
 
 namespace MTL {
 
 class Device;
 class Buffer;
 class ResidencySet;
-class Resource;
 
 } // namespace MTL
 
@@ -80,28 +77,15 @@ public:
   MTL::ResidencySet* get_residency_set() const { return _residency_set; }
   void commit_residency_set();
 
-  // Monotonic counter bumped on every allocation and free. Allows consumers
-  // (e.g. the queue's residency tracking) to detect allocation changes without
-  // taking the allocator lock.
-  uint64_t generation() const {
-    return _generation.load(std::memory_order_relaxed);
+  template<typename F>
+  void for_each_buffer(F&& f) const {
+    std::lock_guard<std::mutex> lock{_mutex};
+    for (auto& [ptr, block] : _ptr_to_block) {
+      if (block.buffer) {
+        f(block.buffer);
+      }
+    }
   }
-
-  // Replaces the contents of `out` with all Metal buffers currently backing
-  // USM allocations, and returns the generation the snapshot corresponds to.
-  // Snapshot and generation are taken under the same lock, so the returned
-  // pair is always consistent.
-  //
-  // Each returned buffer is retain()'d before being handed out: the snapshot
-  // may be cached and used by the caller (e.g. passed to useResources())
-  // after this lock has been released, and without an extra reference a
-  // concurrent raw_free() on another thread could release/deallocate the
-  // buffer in that window. The caller owns the extra reference and must
-  // release() every entry once it stops using the snapshot (e.g. when
-  // replacing it with a newer one, or on destruction).
-  // (Not a template: retain() requires MTL::Buffer to be a complete type,
-  // which this header intentionally does not pull in - see metal_allocator.cpp.)
-  uint64_t snapshot_buffers(std::vector<const MTL::Resource*>& out) const;
 
 private:
   MTL::Buffer* alloc_buffer(size_t size_bytes);
@@ -122,7 +106,6 @@ private:
   mutable std::mutex _mutex;
   MTL::ResidencySet* _residency_set = nullptr;
   bool _residency_set_dirty = false;
-  std::atomic<uint64_t> _generation{0};
   std::shared_ptr<metal_mmap_region> _mmap_region;
 };
 

--- a/include/hipSYCL/runtime/metal/metal_allocator.hpp
+++ b/include/hipSYCL/runtime/metal/metal_allocator.hpp
@@ -85,14 +85,20 @@ public:
     return _generation.load(std::memory_order_relaxed);
   }
 
-  template<typename F>
-  void for_each_buffer(F&& f) const {
+  // Replaces the contents of `out` with all Metal buffers currently backing
+  // USM allocations, and returns the generation the snapshot corresponds to.
+  // Snapshot and generation are taken under the same lock, so the returned
+  // pair is always consistent.
+  template<typename Container>
+  uint64_t snapshot_buffers(Container& out) const {
     std::lock_guard<std::mutex> lock{_mutex};
+    out.clear();
     for (auto& [ptr, block] : _ptr_to_block) {
       if (block.buffer) {
-        f(block.buffer);
+        out.push_back(block.buffer);
       }
     }
+    return _generation.load(std::memory_order_relaxed);
   }
 
 private:

--- a/include/hipSYCL/runtime/metal/metal_allocator.hpp
+++ b/include/hipSYCL/runtime/metal/metal_allocator.hpp
@@ -14,6 +14,7 @@
 #include "../allocator.hpp"
 #include "../hints.hpp"
 
+#include <atomic>
 #include <map>
 #include <memory>
 
@@ -77,6 +78,13 @@ public:
   MTL::ResidencySet* get_residency_set() const { return _residency_set; }
   void commit_residency_set();
 
+  // Monotonic counter bumped on every allocation and free. Allows consumers
+  // (e.g. the queue's residency tracking) to detect allocation changes without
+  // taking the allocator lock.
+  uint64_t generation() const {
+    return _generation.load(std::memory_order_relaxed);
+  }
+
   template<typename F>
   void for_each_buffer(F&& f) const {
     std::lock_guard<std::mutex> lock{_mutex};
@@ -106,6 +114,7 @@ private:
   mutable std::mutex _mutex;
   MTL::ResidencySet* _residency_set = nullptr;
   bool _residency_set_dirty = false;
+  std::atomic<uint64_t> _generation{0};
   std::shared_ptr<metal_mmap_region> _mmap_region;
 };
 

--- a/include/hipSYCL/runtime/metal/metal_queue.hpp
+++ b/include/hipSYCL/runtime/metal/metal_queue.hpp
@@ -195,6 +195,11 @@ private:
 
   void profiling_setup(operation& op, const dag_node_ptr& node);
 
+  // Releases the extra reference held on every entry of _resident_resources
+  // (see comment on that member). Must be called before replacing the cache
+  // with a new snapshot, and on destruction.
+  void release_resident_resources();
+
   MTL::Device* _device = nullptr;
   MTL::CommandQueue* _command_queue = nullptr;
   MTL::SharedEvent* _shared_event = nullptr;
@@ -230,6 +235,12 @@ private:
   // Cached snapshot of the allocations that must be made resident, together
   // with the allocator generation it was taken at. Rebuilt only when the
   // allocator generation changes; independent of command buffer boundaries.
+  // Each entry holds an extra reference taken by metal_allocator::
+  // snapshot_buffers() (retained manually, not via NS::SharedPtr, for the
+  // same reason as _open_buffer above), so a concurrent free() of one of
+  // these buffers on another thread cannot deallocate it while it is cached
+  // here or being passed to useResources(). That reference is released when
+  // the cache is replaced (generation change) or the queue is destroyed.
   std::vector<const MTL::Resource*> _resident_resources;
   uint64_t _residency_generation{~static_cast<uint64_t>(0)};
 

--- a/include/hipSYCL/runtime/metal/metal_queue.hpp
+++ b/include/hipSYCL/runtime/metal/metal_queue.hpp
@@ -24,12 +24,13 @@
 
 #include <mach/mach_time.h>
 
-#include <unordered_set>
+#include <vector>
 
 namespace MTL {
 
 class Device;
 class Buffer;
+class Resource;
 class CommandBuffer;
 class CommandQueue;
 class Fence;
@@ -160,9 +161,10 @@ public:
   virtual ~metal_inorder_queue();
 
   // Makes all USM allocations known to the allocator resident for the given
-  // encoder. Within one open command buffer, each allocation is only passed
-  // to useResource once, and the scan is skipped entirely if the allocator
-  // state has not changed since the last scan.
+  // encoder. Residency established this way is scoped to the encoder, so this
+  // must be called for every encoder; what is cached across encoders is only
+  // the *set* of allocations, which is rebuilt (taking the allocator lock)
+  // exclusively when the allocator generation changes.
   // Public because it is invoked by the free kernel launch helper.
   void make_allocations_resident(MTL::ComputeCommandEncoder* encoder);
 
@@ -225,10 +227,11 @@ private:
 
   static constexpr int max_ops_per_command_buffer = 32;
 
-  // Residency dedup state, valid for the current open command buffer only.
-  std::unordered_set<MTL::Buffer*> _resident_buffers;
+  // Cached snapshot of the allocations that must be made resident, together
+  // with the allocator generation it was taken at. Rebuilt only when the
+  // allocator generation changes; independent of command buffer boundaries.
+  std::vector<const MTL::Resource*> _resident_resources;
   uint64_t _residency_generation{~static_cast<uint64_t>(0)};
-  bool _residency_pass_done{false};
 
   metal_allocator* _allocator = nullptr;
   device_id _device_id;

--- a/include/hipSYCL/runtime/metal/metal_queue.hpp
+++ b/include/hipSYCL/runtime/metal/metal_queue.hpp
@@ -16,13 +16,13 @@
 #include "../kernel_cache.hpp"
 #include "../queue_completion_event.hpp"
 
-#include "hipSYCL/common/spin_lock.hpp"
 #include "hipSYCL/glue/llvm-sscp/jit.hpp"
 
 #include "metal_allocator.hpp"
 #include "metal_event.hpp"
 
 #include <mach/mach_time.h>
+#include <mutex>
 
 namespace MTL {
 
@@ -189,8 +189,7 @@ private:
   // threads concurrently with submit_*() / insert_event().
   std::atomic<uint64_t> _event_counter{0};
 
-  // Only touched by submit_*() and insert_event(), which are serialized
-  // by external mutex, so no atomics needed.
+  // Protected by _mutex.
   uint64_t _pending_cpu_event{0};
   uint64_t _pending_gpu_event{0};
 
@@ -204,7 +203,6 @@ private:
   // because this header must stay free of Foundation headers (see
   // metal_hardware_manager.cpp, which defines the metal-cpp private impls).
   MTL::CommandBuffer* _open_buffer = nullptr;
-  bool _open_buffer_has_trailing_signal{false};
   int _open_op_count{0};
   bool _flush_after_current_op{false};
 
@@ -223,7 +221,7 @@ private:
 
   kernel_configuration _config;
 
-  common::spin_lock _sscp_submission_spin_lock;
+  mutable std::recursive_mutex _mutex;
 
   std::optional<metal_profiling_setup> _profiling_setup;
 };

--- a/include/hipSYCL/runtime/metal/metal_queue.hpp
+++ b/include/hipSYCL/runtime/metal/metal_queue.hpp
@@ -24,17 +24,12 @@
 
 #include <mach/mach_time.h>
 
-#include <vector>
-
 namespace MTL {
 
 class Device;
-class Buffer;
-class Resource;
 class CommandBuffer;
 class CommandQueue;
 class Fence;
-class ComputeCommandEncoder;
 class SharedEvent;
 class SharedEventListener;
 
@@ -160,45 +155,31 @@ public:
 
   virtual ~metal_inorder_queue();
 
-  // Makes all USM allocations known to the allocator resident for the given
-  // encoder. Residency established this way is scoped to the encoder, so this
-  // must be called for every encoder; what is cached across encoders is only
-  // the *set* of allocations, which is rebuilt (taking the allocator lock)
-  // exclusively when the allocator generation changes.
-  // Public because it is invoked by the free kernel launch helper.
-  void make_allocations_resident(MTL::ComputeCommandEncoder* encoder);
-
 private:
-  // Common setup for freshly created command buffers: encodes the wait on the
-  // previous queue work and attaches pending profiling handlers.
+  // Encodes the wait on prior queue work and attaches pending profiling
+  // handlers; shared by get_open_command_buffer() and
+  // new_dedicated_command_buffer().
   MTL::CommandBuffer* prepare_command_buffer(MTL::CommandBuffer* cmd_buf);
 
-  // Returns the currently open (uncommitted) command buffer of this queue,
-  // creating one if none exists. Operations append their encoders to the open
-  // buffer; it is committed lazily by flush().
+  // Returns the open (uncommitted) command buffer, creating one if needed.
+  // Committed lazily by flush().
   MTL::CommandBuffer* get_open_command_buffer();
 
-  // Batching bookkeeping to be invoked after an operation has been fully
-  // encoded into the open buffer: enforces a bound on ops per command buffer
-  // and closes the window for per-op GPU profiling timestamps.
+  // Bounds the number of ops per command buffer and flushes when profiling
+  // needs the buffer to end with exactly the profiled operation.
   void finish_batched_op();
 
-  // Creates a fresh command buffer that is NOT the open buffer, for operations
-  // that must be committed immediately (e.g. device->host copies with CPU-side
-  // completion logic). Serializes against all prior work on this queue.
+  // A command buffer that is committed immediately instead of joining
+  // _open_buffer, for ops needing immediate CPU-side completion handling
+  // (e.g. host-staged copies).
   MTL::CommandBuffer* new_dedicated_command_buffer();
 
-  // Commits the open command buffer, if any. Synchronization with subsequent
-  // work is expressed exclusively through explicit events and host-visible
-  // copies, matching the semantics of the non-batched submission path.
+  // Commits the open command buffer, if any. No implicit signal/wait is
+  // added: that would serialize command buffers the GPU could otherwise run
+  // concurrently, so synchronization stays explicit (events, host copies).
   result flush();
 
   void profiling_setup(operation& op, const dag_node_ptr& node);
-
-  // Releases the extra reference held on every entry of _resident_resources
-  // (see comment on that member). Must be called before replacing the cache
-  // with a new snapshot, and on destruction.
-  void release_resident_resources();
 
   MTL::Device* _device = nullptr;
   MTL::CommandQueue* _command_queue = nullptr;
@@ -218,31 +199,16 @@ private:
   MTL::Fence* _fence = nullptr;
   bool _fence_chain_active = false;
 
-  // Command buffer batching: operations append encoders to _open_buffer which
-  // is committed lazily (on wait/event/flush boundaries or when
-  // max_ops_per_command_buffer is reached). Encoders within a command buffer
-  // execute in encoding order, so batching preserves in-order semantics.
-  // Retained manually; must not be a NS::SharedPtr because this header must
-  // not include Foundation headers (see metal_hardware_manager.cpp, which
-  // defines the metal-cpp private implementation symbols).
+  // Currently open command buffer that ops append encoders to; committed
+  // lazily by flush(). Retained manually rather than via NS::SharedPtr
+  // because this header must stay free of Foundation headers (see
+  // metal_hardware_manager.cpp, which defines the metal-cpp private impls).
   MTL::CommandBuffer* _open_buffer = nullptr;
   bool _open_buffer_has_trailing_signal{false};
   int _open_op_count{0};
   bool _flush_after_current_op{false};
 
   static constexpr int max_ops_per_command_buffer = 32;
-
-  // Cached snapshot of the allocations that must be made resident, together
-  // with the allocator generation it was taken at. Rebuilt only when the
-  // allocator generation changes; independent of command buffer boundaries.
-  // Each entry holds an extra reference taken by metal_allocator::
-  // snapshot_buffers() (retained manually, not via NS::SharedPtr, for the
-  // same reason as _open_buffer above), so a concurrent free() of one of
-  // these buffers on another thread cannot deallocate it while it is cached
-  // here or being passed to useResources(). That reference is released when
-  // the cache is replaced (generation change) or the queue is destroyed.
-  std::vector<const MTL::Resource*> _resident_resources;
-  uint64_t _residency_generation{~static_cast<uint64_t>(0)};
 
   metal_allocator* _allocator = nullptr;
   device_id _device_id;

--- a/include/hipSYCL/runtime/metal/metal_queue.hpp
+++ b/include/hipSYCL/runtime/metal/metal_queue.hpp
@@ -24,12 +24,16 @@
 
 #include <mach/mach_time.h>
 
+#include <unordered_set>
+
 namespace MTL {
 
 class Device;
+class Buffer;
 class CommandBuffer;
 class CommandQueue;
 class Fence;
+class ComputeCommandEncoder;
 class SharedEvent;
 class SharedEventListener;
 
@@ -155,8 +159,38 @@ public:
 
   virtual ~metal_inorder_queue();
 
+  // Makes all USM allocations known to the allocator resident for the given
+  // encoder. Within one open command buffer, each allocation is only passed
+  // to useResource once, and the scan is skipped entirely if the allocator
+  // state has not changed since the last scan.
+  // Public because it is invoked by the free kernel launch helper.
+  void make_allocations_resident(MTL::ComputeCommandEncoder* encoder);
+
 private:
-  MTL::CommandBuffer* new_command_buffer();
+  // Common setup for freshly created command buffers: encodes the wait on the
+  // previous queue work and attaches pending profiling handlers.
+  MTL::CommandBuffer* prepare_command_buffer(MTL::CommandBuffer* cmd_buf);
+
+  // Returns the currently open (uncommitted) command buffer of this queue,
+  // creating one if none exists. Operations append their encoders to the open
+  // buffer; it is committed lazily by flush().
+  MTL::CommandBuffer* get_open_command_buffer();
+
+  // Batching bookkeeping to be invoked after an operation has been fully
+  // encoded into the open buffer: enforces a bound on ops per command buffer
+  // and closes the window for per-op GPU profiling timestamps.
+  void finish_batched_op();
+
+  // Creates a fresh command buffer that is NOT the open buffer, for operations
+  // that must be committed immediately (e.g. device->host copies with CPU-side
+  // completion logic). Serializes against all prior work on this queue.
+  MTL::CommandBuffer* new_dedicated_command_buffer();
+
+  // Commits the open command buffer, if any. Synchronization with subsequent
+  // work is expressed exclusively through explicit events and host-visible
+  // copies, matching the semantics of the non-batched submission path.
+  result flush();
+
   void profiling_setup(operation& op, const dag_node_ptr& node);
 
   MTL::Device* _device = nullptr;
@@ -176,6 +210,25 @@ private:
   // It is only used if a kernel with memory indirection was submitted
   MTL::Fence* _fence = nullptr;
   bool _fence_chain_active = false;
+
+  // Command buffer batching: operations append encoders to _open_buffer which
+  // is committed lazily (on wait/event/flush boundaries or when
+  // max_ops_per_command_buffer is reached). Encoders within a command buffer
+  // execute in encoding order, so batching preserves in-order semantics.
+  // Retained manually; must not be a NS::SharedPtr because this header must
+  // not include Foundation headers (see metal_hardware_manager.cpp, which
+  // defines the metal-cpp private implementation symbols).
+  MTL::CommandBuffer* _open_buffer = nullptr;
+  bool _open_buffer_has_trailing_signal{false};
+  int _open_op_count{0};
+  bool _flush_after_current_op{false};
+
+  static constexpr int max_ops_per_command_buffer = 32;
+
+  // Residency dedup state, valid for the current open command buffer only.
+  std::unordered_set<MTL::Buffer*> _resident_buffers;
+  uint64_t _residency_generation{~static_cast<uint64_t>(0)};
+  bool _residency_pass_done{false};
 
   metal_allocator* _allocator = nullptr;
   device_id _device_id;

--- a/src/runtime/metal/metal_allocator.cpp
+++ b/src/runtime/metal/metal_allocator.cpp
@@ -233,7 +233,6 @@ void* metal_allocator::raw_allocate(
   std::lock_guard<std::mutex> lock{_mutex};
   _ptr_to_block[canonical_ptr] = block;
   add_to_residency_set(lock, buffer);
-  ++_generation;
   return canonical_ptr;
 }
 
@@ -253,7 +252,6 @@ void *metal_allocator::raw_allocate_usm(
   std::lock_guard<std::mutex> lock{_mutex};
   _ptr_to_block[host_ptr] = block;
   add_to_residency_set(lock, buffer);
-  ++_generation;
   return host_ptr;
 }
 
@@ -274,7 +272,6 @@ metal_allocator::raw_allocate_optimized_host(
   std::lock_guard<std::mutex> lock{_mutex};
   _ptr_to_block[host_ptr] = block;
   add_to_residency_set(lock, buffer);
-  ++_generation;
   return host_ptr;
 }
 
@@ -293,7 +290,6 @@ void metal_allocator::raw_free(void *mem)
     }
     _ptr_to_block.erase(it);
   }
-  ++_generation;
 }
 
 bool metal_allocator::is_usm_accessible_from(backend_descriptor b) const
@@ -430,18 +426,6 @@ void metal_allocator::calibrate() {
     ^(void*, NS::UInteger) { });
   _delta = buffer->gpuAddress() - reinterpret_cast<uintptr_t>(buffer->contents());
   buffer->release();
-}
-
-uint64_t metal_allocator::snapshot_buffers(std::vector<const MTL::Resource*>& out) const {
-  std::lock_guard<std::mutex> lock{_mutex};
-  out.clear();
-  for (auto& [ptr, block] : _ptr_to_block) {
-    if (block.buffer) {
-      block.buffer->retain();
-      out.push_back(block.buffer);
-    }
-  }
-  return _generation.load(std::memory_order_relaxed);
 }
 
 std::tuple<MTL::Buffer*, size_t, metal_allocator::usm_alloc_type> metal_allocator::get_usm_block(const void* ptr) const {

--- a/src/runtime/metal/metal_allocator.cpp
+++ b/src/runtime/metal/metal_allocator.cpp
@@ -233,6 +233,7 @@ void* metal_allocator::raw_allocate(
   std::lock_guard<std::mutex> lock{_mutex};
   _ptr_to_block[canonical_ptr] = block;
   add_to_residency_set(lock, buffer);
+  ++_generation;
   return canonical_ptr;
 }
 
@@ -252,6 +253,7 @@ void *metal_allocator::raw_allocate_usm(
   std::lock_guard<std::mutex> lock{_mutex};
   _ptr_to_block[host_ptr] = block;
   add_to_residency_set(lock, buffer);
+  ++_generation;
   return host_ptr;
 }
 
@@ -272,6 +274,7 @@ metal_allocator::raw_allocate_optimized_host(
   std::lock_guard<std::mutex> lock{_mutex};
   _ptr_to_block[host_ptr] = block;
   add_to_residency_set(lock, buffer);
+  ++_generation;
   return host_ptr;
 }
 
@@ -290,6 +293,7 @@ void metal_allocator::raw_free(void *mem)
     }
     _ptr_to_block.erase(it);
   }
+  ++_generation;
 }
 
 bool metal_allocator::is_usm_accessible_from(backend_descriptor b) const

--- a/src/runtime/metal/metal_allocator.cpp
+++ b/src/runtime/metal/metal_allocator.cpp
@@ -432,6 +432,18 @@ void metal_allocator::calibrate() {
   buffer->release();
 }
 
+uint64_t metal_allocator::snapshot_buffers(std::vector<const MTL::Resource*>& out) const {
+  std::lock_guard<std::mutex> lock{_mutex};
+  out.clear();
+  for (auto& [ptr, block] : _ptr_to_block) {
+    if (block.buffer) {
+      block.buffer->retain();
+      out.push_back(block.buffer);
+    }
+  }
+  return _generation.load(std::memory_order_relaxed);
+}
+
 std::tuple<MTL::Buffer*, size_t, metal_allocator::usm_alloc_type> metal_allocator::get_usm_block(const void* ptr) const {
   std::lock_guard<std::mutex> lock{_mutex};
   if (_ptr_to_block.empty()) {

--- a/src/runtime/metal/metal_queue.cpp
+++ b/src/runtime/metal/metal_queue.cpp
@@ -205,8 +205,8 @@ result launch_kernel_from_library(
   }
 
   if (has_indirect_access && !allocator->get_residency_set()) {
-    // Older devices without residency sets need explicit residency declarations.
-    // Deduplicate the declarations across kernels sharing this command buffer.
+    // Older devices without residency sets need explicit residency declarations
+    // for every encoder. Cache the allocation snapshot between launches.
     queue->make_allocations_resident(encoder);
   }
 
@@ -334,11 +334,6 @@ MTL::CommandBuffer* metal_inorder_queue::get_open_command_buffer() {
   _open_buffer_has_trailing_signal = false;
   _open_op_count = 0;
 
-  // Residency dedup state is only valid for a single command buffer.
-  _resident_buffers.clear();
-  _residency_pass_done = false;
-  _residency_generation = ~static_cast<uint64_t>(0);
-
   return cmd_buf;
 }
 
@@ -386,8 +381,6 @@ result metal_inorder_queue::flush() {
   _open_buffer->release();
   _open_buffer = nullptr;
   _open_op_count = 0;
-  _resident_buffers.clear();
-  _residency_pass_done = false;
 
   return make_success();
 }
@@ -404,26 +397,21 @@ void metal_inorder_queue::make_allocations_resident(
   MTL::ComputeCommandEncoder* encoder) {
   constexpr auto usage = MTL::ResourceUsageRead | MTL::ResourceUsageWrite;
 
-  const uint64_t gen = _allocator->generation();
-  if (_residency_pass_done && gen == _residency_generation) {
-    // No allocation or free since the last full scan of this command buffer,
-    // and every allocation has already been made resident in it.
-    return;
-  }
-  if (gen != _residency_generation) {
-    // Allocation set changed; dedup cache may contain stale entries (a freed
-    // buffer's address can be reused by a new allocation).
-    _resident_buffers.clear();
+  // Residency requested via useResource(s) is scoped to the encoder, and a
+  // fresh compute encoder is created per dispatch, so the full set has to be
+  // passed to every encoder. What is cached is only the construction of that
+  // set: the allocator map is rescanned - and its lock taken - exclusively
+  // when an allocation or free happened since the last scan. This turns the
+  // per-launch cost from O(allocations) under the allocator mutex into a
+  // single lock-free generation check plus one useResources call.
+  if (_allocator->generation() != _residency_generation) {
+    _residency_generation = _allocator->snapshot_buffers(_resident_resources);
   }
 
-  _allocator->for_each_buffer([&](MTL::Buffer* buf) {
-    if (_resident_buffers.insert(buf).second) {
-      encoder->useResource(buf, usage);
-    }
-  });
-
-  _residency_generation = gen;
-  _residency_pass_done = true;
+  if (!_resident_resources.empty()) {
+    encoder->useResources(_resident_resources.data(),
+                          _resident_resources.size(), usage);
+  }
 }
 
 void metal_inorder_queue::profiling_setup(operation& op, const dag_node_ptr& node) {

--- a/src/runtime/metal/metal_queue.cpp
+++ b/src/runtime/metal/metal_queue.cpp
@@ -328,7 +328,6 @@ MTL::CommandBuffer* metal_inorder_queue::get_open_command_buffer() {
 
   _open_buffer = cmd_buf;
   _open_buffer->retain();
-  _open_buffer_has_trailing_signal = false;
   _open_op_count = 0;
 
   return cmd_buf;
@@ -345,14 +344,6 @@ result metal_inorder_queue::flush() {
   }
 
   MTL::CommandBuffer* cb = _open_buffer;
-
-  // No implicit signal/wait is added on commit: that would serialize command
-  // buffers the GPU could otherwise run concurrently. If this buffer already
-  // has an explicit signal (from insert_event()), later buffers must wait on it.
-  if (_open_buffer_has_trailing_signal) {
-    _pending_gpu_event = _event_counter.load();
-    _open_buffer_has_trailing_signal = false;
-  }
 
   cb->addCompletedHandler([](MTL::CommandBuffer* completed) {
     if (NS::Error* err = completed->error()) {
@@ -413,6 +404,7 @@ void metal_inorder_queue::profiling_setup(operation& op, const dag_node_ptr& nod
 }
 
 std::shared_ptr<dag_node_event> metal_inorder_queue::insert_event() {
+  std::lock_guard<std::recursive_mutex> lock{_mutex};
   HIPSYCL_DEBUG_INFO << "metal_queue: Inserting event into queue..." << std::endl;
 
   auto val = ++_event_counter;
@@ -421,7 +413,6 @@ std::shared_ptr<dag_node_event> metal_inorder_queue::insert_event() {
       NS::TransferPtr(NS::AutoreleasePool::alloc()->init());
     auto* cmd_buf = get_open_command_buffer();
     cmd_buf->encodeSignalEvent(_shared_event, val);
-    _open_buffer_has_trailing_signal = true;
   }
   // Commit now: the event must be able to complete for waiters.
   flush();
@@ -434,6 +425,7 @@ std::shared_ptr<dag_node_event> metal_inorder_queue::create_queue_completion_eve
 }
 
 result metal_inorder_queue::submit_memcpy(memcpy_operation& op, const dag_node_ptr& node) {
+  std::lock_guard<std::recursive_mutex> lock{_mutex};
   HIPSYCL_DEBUG_INFO << "metal_queue: Submitting memcpy..." << std::endl;
 
   assert(op.source().get_base_ptr());
@@ -705,6 +697,7 @@ result metal_inorder_queue::submit_memcpy(memcpy_operation& op, const dag_node_p
 }
 
 result metal_inorder_queue::submit_kernel(kernel_operation& op, const dag_node_ptr& node) {
+  std::lock_guard<std::recursive_mutex> lock{_mutex};
   HIPSYCL_DEBUG_INFO << "metal_queue: Submitting kernel..." << std::endl;
 
   rt::backend_kernel_launch_capabilities cap;
@@ -746,6 +739,7 @@ result metal_inorder_queue::submit_prefetch(prefetch_operation& op, const dag_no
 }
 
 result metal_inorder_queue::submit_memset(memset_operation& op, const dag_node_ptr& node) {
+  std::lock_guard<std::recursive_mutex> lock{_mutex};
   HIPSYCL_DEBUG_INFO << "metal_queue: Submitting memset..." << std::endl;
 
   void* ptr = op.get_pointer();
@@ -771,6 +765,7 @@ result metal_inorder_queue::submit_memset(memset_operation& op, const dag_node_p
 }
 
 result metal_inorder_queue::submit_queue_wait_for(const dag_node_ptr& node) {
+  std::lock_guard<std::recursive_mutex> lock{_mutex};
   HIPSYCL_DEBUG_INFO << "metal_queue: Submitting wait for other queue..." << std::endl;
 
   assert(node);
@@ -799,6 +794,7 @@ result metal_inorder_queue::submit_external_wait_for(const dag_node_ptr& node) {
 }
 
 result metal_inorder_queue::wait() {
+  std::lock_guard<std::recursive_mutex> lock{_mutex};
   HIPSYCL_DEBUG_INFO << "metal_queue: Waiting for queue completion..." << std::endl;
   insert_event()->wait();
   _fence_chain_active = false;
@@ -809,9 +805,9 @@ device_id metal_inorder_queue::get_device() const {
   return _device_id;
 }
 void* metal_inorder_queue::get_native_type() const {
+  std::lock_guard<std::recursive_mutex> lock{_mutex};
   // External code may commit its own buffers on this queue, so flush ours
-  // first to keep commit order correct. Safe: batching state is only
-  // touched from submission context.
+  // first to keep commit order correct.
   const_cast<metal_inorder_queue*>(this)->flush();
   return static_cast<void*>(_command_queue);
 }
@@ -832,7 +828,7 @@ result metal_inorder_queue::submit_sscp_kernel_from_code_object(hcf_object_id hc
   HIPSYCL_DEBUG_INFO << "[Metal] submit_sscp_kernel_from_code_object() called for kernel: "
                      << kernel_name << std::endl;
 
-  common::spin_lock_guard lock{_sscp_submission_spin_lock};
+  std::lock_guard<std::recursive_mutex> lock{_mutex};
 
   // Validate kernel info
   if (!kernel_info) {

--- a/src/runtime/metal/metal_queue.cpp
+++ b/src/runtime/metal/metal_queue.cpp
@@ -393,6 +393,12 @@ void metal_inorder_queue::finish_batched_op() {
   }
 }
 
+void metal_inorder_queue::release_resident_resources() {
+  for (const MTL::Resource* r : _resident_resources) {
+    const_cast<MTL::Resource*>(r)->release();
+  }
+}
+
 void metal_inorder_queue::make_allocations_resident(
   MTL::ComputeCommandEncoder* encoder) {
   constexpr auto usage = MTL::ResourceUsageRead | MTL::ResourceUsageWrite;
@@ -405,6 +411,12 @@ void metal_inorder_queue::make_allocations_resident(
   // per-launch cost from O(allocations) under the allocator mutex into a
   // single lock-free generation check plus one useResources call.
   if (_allocator->generation() != _residency_generation) {
+    // snapshot_buffers() retains every buffer it hands back, since the
+    // resulting cache outlives the allocator lock and free() on another
+    // thread must not be able to deallocate a buffer while it is cached
+    // here / passed to useResources() below. Release the previous
+    // snapshot's references before replacing it.
+    release_resident_resources();
     _residency_generation = _allocator->snapshot_buffers(_resident_resources);
   }
 
@@ -1042,6 +1054,7 @@ metal_inorder_queue::~metal_inorder_queue() {
   // Drain pending work before releasing queue-owned Metal objects that may be
   // referenced by completion handlers.
   wait();
+  release_resident_resources();
   _event_listener->release();
   _shared_event->release();
   if (_fence) {

--- a/src/runtime/metal/metal_queue.cpp
+++ b/src/runtime/metal/metal_queue.cpp
@@ -106,6 +106,7 @@ result launch_kernel_from_library(
   MTL::Library* library,
   MTL::Device* device,
   MTL::CommandBuffer* command_buffer,
+  metal_inorder_queue* queue,
   metal_allocator* allocator,
   std::string_view kernel_name,
   const rt::range<3>& num_groups,
@@ -204,9 +205,9 @@ result launch_kernel_from_library(
   }
 
   if (has_indirect_access && !allocator->get_residency_set()) {
-    allocator->for_each_buffer([&](MTL::Buffer* buf) {
-      encoder->useResource(buf, MTL::ResourceUsageRead | MTL::ResourceUsageWrite);
-    });
+    // Older devices without residency sets need explicit residency declarations.
+    // Deduplicate the declarations across kernels sharing this command buffer.
+    queue->make_allocations_resident(encoder);
   }
 
   MTL::Size num_groups_size = MTL::Size::Make(
@@ -235,20 +236,9 @@ result launch_kernel_from_library(
 
   encoder->endEncoding();
 
-  command_buffer->addCompletedHandler([=](MTL::CommandBuffer* command_buffer) {
-    if (NS::Error* err = command_buffer->error()) {
-      std::string msg = "metal: Command buffer failed: ";
-      if (err->localizedDescription()) {
-        msg += err->localizedDescription()->utf8String();
-      }
-      register_error(make_error(__acpp_here(), error_info{msg}));
-    }
-
-    HIPSYCL_DEBUG_INFO << "metal: Kernel '" << kernel_name
-                      << "' executed successfully" << std::endl;
-  });
-
-  command_buffer->commit();
+  // The kernel is now encoded into the (possibly shared) open command buffer.
+  // Committing is the responsibility of the caller via finish_batched_op() /
+  // flush(), so that consecutive operations can share one command buffer.
 
   return make_success();
 }
@@ -282,17 +272,7 @@ result memset_device(
   }
   blit_encoder->endEncoding();
 
-  command_buffer->addCompletedHandler([](MTL::CommandBuffer* command_buffer) {
-    if (NS::Error* err = command_buffer->error()) {
-      std::string msg = "metal_queue: Memset failed: ";
-      if (err->localizedDescription()) {
-        msg += err->localizedDescription()->utf8String();
-      }
-      register_error(make_error(__acpp_here(), error_info{msg}));
-    }
-  });
-
-  command_buffer->commit();
+  // Committing is the responsibility of the caller (batching-aware).
 
   return make_success();
 }
@@ -317,9 +297,9 @@ metal_inorder_queue::metal_inorder_queue(MTL::Device* device, metal_allocator* a
   _reflection_map = glue::jit::construct_default_reflection_map(hw_ctx);
 }
 
-MTL::CommandBuffer* metal_inorder_queue::new_command_buffer() {
+MTL::CommandBuffer*
+metal_inorder_queue::prepare_command_buffer(MTL::CommandBuffer* cmd_buf) {
   _allocator->commit_residency_set();
-  auto* cmd_buf = _command_queue->commandBuffer();
   if (auto prev = std::exchange(_pending_gpu_event, 0)) {
     cmd_buf->encodeWait(_shared_event, prev);
   }
@@ -333,9 +313,117 @@ MTL::CommandBuffer* metal_inorder_queue::new_command_buffer() {
       }
     });
     _profiling_setup.reset();
+    // Close the command buffer right after this operation so that the
+    // recorded GPU timestamps correspond to exactly this operation.
+    _flush_after_current_op = true;
+  }
+  return cmd_buf;
+}
+
+MTL::CommandBuffer* metal_inorder_queue::get_open_command_buffer() {
+  if (_open_buffer) {
+    return _open_buffer;
   }
 
+  NS::SharedPtr<NS::AutoreleasePool> pool =
+    NS::TransferPtr(NS::AutoreleasePool::alloc()->init());
+  auto* cmd_buf = prepare_command_buffer(_command_queue->commandBuffer());
+
+  _open_buffer = cmd_buf;
+  _open_buffer->retain();
+  _open_buffer_has_trailing_signal = false;
+  _open_op_count = 0;
+
+  // Residency dedup state is only valid for a single command buffer.
+  _resident_buffers.clear();
+  _residency_pass_done = false;
+  _residency_generation = ~static_cast<uint64_t>(0);
+
   return cmd_buf;
+}
+
+MTL::CommandBuffer* metal_inorder_queue::new_dedicated_command_buffer() {
+  // Note: no autorelease pool is created here. The returned buffer is
+  // autoreleased and must remain valid until the caller commits it, so it
+  // relies on the caller's pool (same contract as the rest of Metal-cpp).
+  return prepare_command_buffer(_command_queue->commandBuffer());
+}
+
+result metal_inorder_queue::flush() {
+  if (!_open_buffer) {
+    return make_success();
+  }
+
+  MTL::CommandBuffer* cb = _open_buffer;
+
+  // Note: no implicit signal is appended here. Synchronization points are
+  // expressed explicitly through events (insert_event) and host-visible
+  // copies, exactly as in the non-batched submission path. Adding a
+  // signal/wait pair per commit would serialize command buffers that the
+  // GPU could otherwise execute concurrently.
+  if (_open_buffer_has_trailing_signal) {
+    // An event signal was explicitly encoded into this buffer; subsequent
+    // command buffers must observe it.
+    _pending_gpu_event = _event_counter.load();
+    _open_buffer_has_trailing_signal = false;
+  }
+
+  cb->addCompletedHandler([](MTL::CommandBuffer* completed) {
+    if (NS::Error* err = completed->error()) {
+      std::string msg = "metal: Command buffer failed: ";
+      if (err->localizedDescription()) {
+        msg += err->localizedDescription()->utf8String();
+      }
+      register_error(make_error(__acpp_here(), error_info{msg}));
+    }
+  });
+
+  // Allocations may have changed while this command buffer was open. Make
+  // those residency-set updates visible before submitting the batched work.
+  _allocator->commit_residency_set();
+  cb->commit();
+
+  _open_buffer->release();
+  _open_buffer = nullptr;
+  _open_op_count = 0;
+  _resident_buffers.clear();
+  _residency_pass_done = false;
+
+  return make_success();
+}
+
+void metal_inorder_queue::finish_batched_op() {
+  ++_open_op_count;
+  if (_flush_after_current_op || _open_op_count >= max_ops_per_command_buffer) {
+    _flush_after_current_op = false;
+    flush();
+  }
+}
+
+void metal_inorder_queue::make_allocations_resident(
+  MTL::ComputeCommandEncoder* encoder) {
+  constexpr auto usage = MTL::ResourceUsageRead | MTL::ResourceUsageWrite;
+
+  const uint64_t gen = _allocator->generation();
+  if (_residency_pass_done && gen == _residency_generation) {
+    // No allocation or free since the last full scan of this command buffer,
+    // and every allocation has already been made resident in it.
+    return;
+  }
+  if (gen != _residency_generation) {
+    // Allocation set changed; dedup cache may contain stale entries (a freed
+    // buffer's address can be reused by a new allocation).
+    _resident_buffers.clear();
+  }
+
+  _allocator->for_each_buffer([&](MTL::Buffer* buf) {
+    if (_resident_buffers.insert(buf).second) {
+      encoder->useResource(buf, usage);
+    }
+  });
+
+  _residency_generation = gen;
+  _residency_pass_done = true;
 }
 
 void metal_inorder_queue::profiling_setup(operation& op, const dag_node_ptr& node) {
@@ -360,6 +448,10 @@ void metal_inorder_queue::profiling_setup(operation& op, const dag_node_ptr& nod
     op.get_instrumentations().add_instrumentation<instrumentations::execution_finish_timestamp>(setup.finish_time);
   }
   if (setup.start_time || setup.finish_time) {
+    // Close any open command buffer so that the profiled operation starts on
+    // a fresh one; prepare_command_buffer() consumes the setup and arranges
+    // for the buffer to be committed right after the operation.
+    flush();
     _profiling_setup = std::move(setup);
   }
 }
@@ -368,10 +460,17 @@ std::shared_ptr<dag_node_event> metal_inorder_queue::insert_event() {
   HIPSYCL_DEBUG_INFO << "metal_queue: Inserting event into queue..." << std::endl;
 
   auto val = ++_event_counter;
-  NS::SharedPtr<NS::AutoreleasePool> pool = NS::TransferPtr(NS::AutoreleasePool::alloc()->init());
-  auto* cmd_buf = new_command_buffer();
-  cmd_buf->encodeSignalEvent(_shared_event, val);
-  cmd_buf->commit();
+  {
+    NS::SharedPtr<NS::AutoreleasePool> pool =
+      NS::TransferPtr(NS::AutoreleasePool::alloc()->init());
+    auto* cmd_buf = get_open_command_buffer();
+    cmd_buf->encodeSignalEvent(_shared_event, val);
+    _open_buffer_has_trailing_signal = true;
+  }
+  // The event must be able to complete for waiters, so commit now. The
+  // trailing signal also serializes subsequent work against everything
+  // encoded before the event.
+  flush();
 
   return std::make_shared<metal_node_event>(metal_event_handle{_shared_event, val});
 }
@@ -436,7 +535,13 @@ result metal_inorder_queue::submit_memcpy(memcpy_operation& op, const dag_node_p
       do_h2h_copy();
     } else {
       // wait for the prior CPU async work (e.g. device->host copy) to complete
-      // before reading from src_ptr
+      // before reading from src_ptr.
+      // Close any open command buffer first: subsequent operations must be
+      // serialized against the deferred CPU-side copy via the event chain,
+      // which only works for command buffers created after this point.
+      if (result r = flush(); !r.is_success()) {
+        return r;
+      }
       auto val_done = ++_event_counter;
       _shared_event->notifyListener(_event_listener, prev_cpu_event,
         [=](MTL::SharedEvent* evt, uint64_t) {
@@ -451,8 +556,21 @@ result metal_inorder_queue::submit_memcpy(memcpy_operation& op, const dag_node_p
 
   NS::SharedPtr<NS::AutoreleasePool> pool = NS::TransferPtr(NS::AutoreleasePool::alloc()->init());
 
+  // Copies involving unregistered host memory require staging buffers and
+  // CPU-side completion handling, so they always run in their own dedicated,
+  // immediately-committed command buffer. Pure device-to-device copies can
+  // join the currently open command buffer.
+  const bool needs_staging = !src_is_device || !dst_is_device;
+  if (needs_staging) {
+    if (result r = flush(); !r.is_success()) {
+      return r;
+    }
+  }
+
   profiling_setup(op, node);
-  MTL::CommandBuffer* command_buffer = new_command_buffer();
+  MTL::CommandBuffer* command_buffer = needs_staging
+    ? new_dedicated_command_buffer()
+    : get_open_command_buffer();
   if (!command_buffer) {
     return make_error(__acpp_here(),
       error_info{"metal_queue: Failed to create command buffer for memcpy"});
@@ -618,14 +736,19 @@ result metal_inorder_queue::submit_memcpy(memcpy_operation& op, const dag_node_p
       command_buffer->encodeSignalEvent(_shared_event, deferred_h2d_done_event);
       _pending_cpu_event = deferred_h2d_done_event;
     }
-    command_buffer->addCompletedHandler([](MTL::CommandBuffer* cb) {
-      if (NS::Error* err = cb->error()) {
-        std::string msg = "metal_queue: Memcpy failed: ";
-        if (err->localizedDescription()) msg += err->localizedDescription()->utf8String();
-        register_error(make_error(__acpp_here(), error_info{msg}));
-      }
-    });
-    command_buffer->commit();
+    if (needs_staging) {
+      command_buffer->addCompletedHandler([](MTL::CommandBuffer* cb) {
+        if (NS::Error* err = cb->error()) {
+          std::string msg = "metal_queue: Memcpy failed: ";
+          if (err->localizedDescription()) msg += err->localizedDescription()->utf8String();
+          register_error(make_error(__acpp_here(), error_info{msg}));
+        }
+      });
+      command_buffer->commit();
+    } else {
+      // Device-to-device copy joined the open command buffer.
+      finish_batched_op();
+    }
   }
 
   return make_success();
@@ -640,6 +763,18 @@ result metal_inorder_queue::submit_kernel(kernel_operation& op, const dag_node_p
   NS::SharedPtr<NS::AutoreleasePool> pool = NS::TransferPtr(NS::AutoreleasePool::alloc()->init());
   auto *node_ptr = node.get();
   profiling_setup(op, node);
+
+  // Custom (interop) operations run host code synchronously during invoke().
+  // That code may create and commit its own native command buffers on this
+  // queue (e.g. FFT libraries using Metal interop). Because Metal executes
+  // command buffers of a queue in commit order, everything encoded so far
+  // must be committed before the host code runs.
+  if (op.get_launcher().is_custom_operation()) {
+    if (result r = flush(); !r.is_success()) {
+      return r;
+    }
+  }
+
   return op.get_launcher().invoke(backend_id::metal, this, cap, node_ptr);
 }
 
@@ -672,14 +807,19 @@ result metal_inorder_queue::submit_memset(memset_operation& op, const dag_node_p
   NS::SharedPtr<NS::AutoreleasePool> pool = NS::TransferPtr(NS::AutoreleasePool::alloc()->init());
 
   profiling_setup(op, node);
-  MTL::CommandBuffer* command_buffer = new_command_buffer();
+  MTL::CommandBuffer* command_buffer = get_open_command_buffer();
   if (!command_buffer) {
     return make_error(__acpp_here(),
       error_info{"metal_queue: Failed to create command buffer for memset"});
   }
 
-  return memset_device(command_buffer, _allocator, ptr, pattern, num_bytes,
-                       _fence_chain_active ? _fence : nullptr);
+  result r = memset_device(command_buffer, _allocator, ptr, pattern, num_bytes,
+                           _fence_chain_active ? _fence : nullptr);
+  if (!r.is_success()) {
+    return r;
+  }
+  finish_batched_op();
+  return make_success();
 }
 
 result metal_inorder_queue::submit_queue_wait_for(const dag_node_ptr& node) {
@@ -691,9 +831,12 @@ result metal_inorder_queue::submit_queue_wait_for(const dag_node_ptr& node) {
   inorder_queue_event<metal_event_handle>* metal_evt = cast<inorder_queue_event<metal_event_handle>>(evt.get());
   auto handle = metal_evt->request_backend_event();
   NS::SharedPtr<NS::AutoreleasePool> pool = NS::TransferPtr(NS::AutoreleasePool::alloc()->init());
-  auto* cmd_buf = new_command_buffer();
+  // The wait is appended to the open command buffer; encoders within a
+  // command buffer execute in encoding order, so all previously batched work
+  // of this queue precedes the wait.
+  auto* cmd_buf = get_open_command_buffer();
   cmd_buf->encodeWait(handle.event, handle.value);
-  cmd_buf->commit();
+  finish_batched_op();
 
   return make_success();
 }
@@ -719,6 +862,12 @@ device_id metal_inorder_queue::get_device() const {
   return _device_id;
 }
 void* metal_inorder_queue::get_native_type() const {
+  // Handing out the native command queue implies that external code may
+  // commit its own command buffers on it. Metal executes command buffers of
+  // a queue in commit order, so any batched, not yet committed work must be
+  // committed first. (const_cast is safe: batching state is only touched
+  // from submission context.)
+  const_cast<metal_inorder_queue*>(this)->flush();
   return static_cast<void*>(_command_queue);
 }
 
@@ -876,8 +1025,8 @@ result metal_inorder_queue::submit_sscp_kernel_from_code_object(hcf_object_id hc
       error_info{"metal_queue: Metal library is null"});
   }
 
-  return launch_kernel_from_library(
-    library, _device, new_command_buffer(), _allocator, kernel_name,
+  result launch_result = launch_kernel_from_library(
+    library, _device, get_open_command_buffer(), this, _allocator, kernel_name,
     num_groups, group_size, local_mem_size,
     _arg_mapper.get_mapped_args(),
     const_cast<std::size_t*>(_arg_mapper.get_mapped_arg_sizes()),
@@ -887,6 +1036,12 @@ result metal_inorder_queue::submit_sscp_kernel_from_code_object(hcf_object_id hc
     has_indirect_access,
     _fence_chain_active ? _fence : nullptr,
     wait_fence);
+
+  if (launch_result.is_success()) {
+    finish_batched_op();
+  }
+
+  return launch_result;
 
 #else
   return make_error(__acpp_here(),

--- a/src/runtime/metal/metal_queue.cpp
+++ b/src/runtime/metal/metal_queue.cpp
@@ -106,7 +106,6 @@ result launch_kernel_from_library(
   MTL::Library* library,
   MTL::Device* device,
   MTL::CommandBuffer* command_buffer,
-  metal_inorder_queue* queue,
   metal_allocator* allocator,
   std::string_view kernel_name,
   const rt::range<3>& num_groups,
@@ -205,9 +204,10 @@ result launch_kernel_from_library(
   }
 
   if (has_indirect_access && !allocator->get_residency_set()) {
-    // Older devices without residency sets need explicit residency declarations
-    // for every encoder. Cache the allocation snapshot between launches.
-    queue->make_allocations_resident(encoder);
+    // TODO: switch to MTL4 API for O(1) buffer bindings
+    allocator->for_each_buffer([&](MTL::Buffer* buf) {
+      encoder->useResource(buf, MTL::ResourceUsageRead | MTL::ResourceUsageWrite);
+    });
   }
 
   MTL::Size num_groups_size = MTL::Size::Make(
@@ -236,9 +236,7 @@ result launch_kernel_from_library(
 
   encoder->endEncoding();
 
-  // The kernel is now encoded into the (possibly shared) open command buffer.
-  // Committing is the responsibility of the caller via finish_batched_op() /
-  // flush(), so that consecutive operations can share one command buffer.
+  // Caller commits (via finish_batched_op()/flush()) so ops can share a buffer.
 
   return make_success();
 }
@@ -272,7 +270,7 @@ result memset_device(
   }
   blit_encoder->endEncoding();
 
-  // Committing is the responsibility of the caller (batching-aware).
+  // Caller commits so this can join a shared open command buffer.
 
   return make_success();
 }
@@ -313,8 +311,7 @@ metal_inorder_queue::prepare_command_buffer(MTL::CommandBuffer* cmd_buf) {
       }
     });
     _profiling_setup.reset();
-    // Close the command buffer right after this operation so that the
-    // recorded GPU timestamps correspond to exactly this operation.
+    // Flush after this op so its GPU timestamps aren't shared with others.
     _flush_after_current_op = true;
   }
   return cmd_buf;
@@ -338,9 +335,7 @@ MTL::CommandBuffer* metal_inorder_queue::get_open_command_buffer() {
 }
 
 MTL::CommandBuffer* metal_inorder_queue::new_dedicated_command_buffer() {
-  // Note: no autorelease pool is created here. The returned buffer is
-  // autoreleased and must remain valid until the caller commits it, so it
-  // relies on the caller's pool (same contract as the rest of Metal-cpp).
+  // Relies on the caller's autorelease pool, like the rest of Metal-cpp.
   return prepare_command_buffer(_command_queue->commandBuffer());
 }
 
@@ -351,14 +346,10 @@ result metal_inorder_queue::flush() {
 
   MTL::CommandBuffer* cb = _open_buffer;
 
-  // Note: no implicit signal is appended here. Synchronization points are
-  // expressed explicitly through events (insert_event) and host-visible
-  // copies, exactly as in the non-batched submission path. Adding a
-  // signal/wait pair per commit would serialize command buffers that the
-  // GPU could otherwise execute concurrently.
+  // No implicit signal/wait is added on commit: that would serialize command
+  // buffers the GPU could otherwise run concurrently. If this buffer already
+  // has an explicit signal (from insert_event()), later buffers must wait on it.
   if (_open_buffer_has_trailing_signal) {
-    // An event signal was explicitly encoded into this buffer; subsequent
-    // command buffers must observe it.
     _pending_gpu_event = _event_counter.load();
     _open_buffer_has_trailing_signal = false;
   }
@@ -393,39 +384,6 @@ void metal_inorder_queue::finish_batched_op() {
   }
 }
 
-void metal_inorder_queue::release_resident_resources() {
-  for (const MTL::Resource* r : _resident_resources) {
-    const_cast<MTL::Resource*>(r)->release();
-  }
-}
-
-void metal_inorder_queue::make_allocations_resident(
-  MTL::ComputeCommandEncoder* encoder) {
-  constexpr auto usage = MTL::ResourceUsageRead | MTL::ResourceUsageWrite;
-
-  // Residency requested via useResource(s) is scoped to the encoder, and a
-  // fresh compute encoder is created per dispatch, so the full set has to be
-  // passed to every encoder. What is cached is only the construction of that
-  // set: the allocator map is rescanned - and its lock taken - exclusively
-  // when an allocation or free happened since the last scan. This turns the
-  // per-launch cost from O(allocations) under the allocator mutex into a
-  // single lock-free generation check plus one useResources call.
-  if (_allocator->generation() != _residency_generation) {
-    // snapshot_buffers() retains every buffer it hands back, since the
-    // resulting cache outlives the allocator lock and free() on another
-    // thread must not be able to deallocate a buffer while it is cached
-    // here / passed to useResources() below. Release the previous
-    // snapshot's references before replacing it.
-    release_resident_resources();
-    _residency_generation = _allocator->snapshot_buffers(_resident_resources);
-  }
-
-  if (!_resident_resources.empty()) {
-    encoder->useResources(_resident_resources.data(),
-                          _resident_resources.size(), usage);
-  }
-}
-
 void metal_inorder_queue::profiling_setup(operation& op, const dag_node_ptr& node) {
   if (!node) {
     return;
@@ -448,9 +406,7 @@ void metal_inorder_queue::profiling_setup(operation& op, const dag_node_ptr& nod
     op.get_instrumentations().add_instrumentation<instrumentations::execution_finish_timestamp>(setup.finish_time);
   }
   if (setup.start_time || setup.finish_time) {
-    // Close any open command buffer so that the profiled operation starts on
-    // a fresh one; prepare_command_buffer() consumes the setup and arranges
-    // for the buffer to be committed right after the operation.
+    // Flush so the profiled operation starts on its own command buffer.
     flush();
     _profiling_setup = std::move(setup);
   }
@@ -467,9 +423,7 @@ std::shared_ptr<dag_node_event> metal_inorder_queue::insert_event() {
     cmd_buf->encodeSignalEvent(_shared_event, val);
     _open_buffer_has_trailing_signal = true;
   }
-  // The event must be able to complete for waiters, so commit now. The
-  // trailing signal also serializes subsequent work against everything
-  // encoded before the event.
+  // Commit now: the event must be able to complete for waiters.
   flush();
 
   return std::make_shared<metal_node_event>(metal_event_handle{_shared_event, val});
@@ -534,11 +488,9 @@ result metal_inorder_queue::submit_memcpy(memcpy_operation& op, const dag_node_p
     if (prev_cpu_event == 0) {
       do_h2h_copy();
     } else {
-      // wait for the prior CPU async work (e.g. device->host copy) to complete
-      // before reading from src_ptr.
-      // Close any open command buffer first: subsequent operations must be
-      // serialized against the deferred CPU-side copy via the event chain,
-      // which only works for command buffers created after this point.
+      // Wait for the prior CPU async work (e.g. device->host copy) to
+      // complete before reading from src_ptr. Flush first: the event chain
+      // that serializes against it only covers buffers created after this.
       if (result r = flush(); !r.is_success()) {
         return r;
       }
@@ -556,10 +508,8 @@ result metal_inorder_queue::submit_memcpy(memcpy_operation& op, const dag_node_p
 
   NS::SharedPtr<NS::AutoreleasePool> pool = NS::TransferPtr(NS::AutoreleasePool::alloc()->init());
 
-  // Copies involving unregistered host memory require staging buffers and
-  // CPU-side completion handling, so they always run in their own dedicated,
-  // immediately-committed command buffer. Pure device-to-device copies can
-  // join the currently open command buffer.
+  // Host-involving copies need staging buffers and CPU-side completion
+  // handling, so they get their own dedicated, immediately-committed buffer.
   const bool needs_staging = !src_is_device || !dst_is_device;
   if (needs_staging) {
     if (result r = flush(); !r.is_success()) {
@@ -764,11 +714,9 @@ result metal_inorder_queue::submit_kernel(kernel_operation& op, const dag_node_p
   auto *node_ptr = node.get();
   profiling_setup(op, node);
 
-  // Custom (interop) operations run host code synchronously during invoke().
-  // That code may create and commit its own native command buffers on this
-  // queue (e.g. FFT libraries using Metal interop). Because Metal executes
-  // command buffers of a queue in commit order, everything encoded so far
-  // must be committed before the host code runs.
+  // Custom (interop) ops may commit their own command buffers on this queue
+  // during invoke() (e.g. FFT libraries); Metal runs them in commit order,
+  // so everything encoded so far must be committed first.
   if (op.get_launcher().is_custom_operation()) {
     if (result r = flush(); !r.is_success()) {
       return r;
@@ -831,9 +779,8 @@ result metal_inorder_queue::submit_queue_wait_for(const dag_node_ptr& node) {
   inorder_queue_event<metal_event_handle>* metal_evt = cast<inorder_queue_event<metal_event_handle>>(evt.get());
   auto handle = metal_evt->request_backend_event();
   NS::SharedPtr<NS::AutoreleasePool> pool = NS::TransferPtr(NS::AutoreleasePool::alloc()->init());
-  // The wait is appended to the open command buffer; encoders within a
-  // command buffer execute in encoding order, so all previously batched work
-  // of this queue precedes the wait.
+  // Appending to the open buffer preserves order: encoders within a command
+  // buffer run in encoding order, so prior batched work precedes the wait.
   auto* cmd_buf = get_open_command_buffer();
   cmd_buf->encodeWait(handle.event, handle.value);
   finish_batched_op();
@@ -862,11 +809,9 @@ device_id metal_inorder_queue::get_device() const {
   return _device_id;
 }
 void* metal_inorder_queue::get_native_type() const {
-  // Handing out the native command queue implies that external code may
-  // commit its own command buffers on it. Metal executes command buffers of
-  // a queue in commit order, so any batched, not yet committed work must be
-  // committed first. (const_cast is safe: batching state is only touched
-  // from submission context.)
+  // External code may commit its own buffers on this queue, so flush ours
+  // first to keep commit order correct. Safe: batching state is only
+  // touched from submission context.
   const_cast<metal_inorder_queue*>(this)->flush();
   return static_cast<void*>(_command_queue);
 }
@@ -1026,7 +971,7 @@ result metal_inorder_queue::submit_sscp_kernel_from_code_object(hcf_object_id hc
   }
 
   result launch_result = launch_kernel_from_library(
-    library, _device, get_open_command_buffer(), this, _allocator, kernel_name,
+    library, _device, get_open_command_buffer(), _allocator, kernel_name,
     num_groups, group_size, local_mem_size,
     _arg_mapper.get_mapped_args(),
     const_cast<std::size_t*>(_arg_mapper.get_mapped_arg_sizes()),
@@ -1054,7 +999,6 @@ metal_inorder_queue::~metal_inorder_queue() {
   // Drain pending work before releasing queue-owned Metal objects that may be
   // referenced by completion handlers.
   wait();
-  release_resident_resources();
   _event_listener->release();
   _shared_event->release();
   if (_fence) {


### PR DESCRIPTION
Profiling [GROMACS](https://gitlab.com/gromacs/gromacs) (SYCL/SSCP, GPU-resident) on Apple Silicon showed that the Metal backend committed one command buffer per operation (~11 per MD step vs ~3.5 for a native Metal backend), with each launch additionally making *every* USM allocation in the process resident under the allocator mutex (`metal_queue.cpp`, see the existing `// TODO: switch to MTL4 API for O(1) buffer bindings`). The GPU was idle 25-40% of each step, dominated by per-commit submission cost and inter-buffer bubbles.

This PR changes the Metal backend to encode consecutive operations into a single, lazily-committed command buffer, and reduces the per-launch residency work from O(ops x allocations) to O(allocations) per command buffer.

Measured on M2 Max (GROMACS, grappa benchmark, GPU-resident, 3-rep medians): **+71% / +84% (RF/PME) at 96k atoms, +14-47% at 192-384k, +3-8% at 768k atoms**, with bit-identical potential energies. Command buffers per traced window dropped from 50.6k to 15.9k.

## Changes

### Command buffer batching (`metal_queue.cpp`)

- Operations append their encoders to a per-queue *open* command buffer which is committed lazily:
  - on `wait()` / `insert_event()` (event must be able to complete),
  - before device-to-host copies and other host-staged memcpys (which need dedicated buffers with CPU-side completion handling),
  - before custom (interop) operations (see below),
  - after a bounded number of ops (`max_ops_per_command_buffer = 32`) to limit memory use and first-work latency.
- D2D memcpys and memsets join the open buffer; host-staging copies keep dedicated committed buffers with unchanged event/staging logic.
- No implicit signal/wait pair is added at commit boundaries: synchronization is expressed exclusively through explicit events and host-visible copies, exactly as before, so the GPU can still execute independent command buffers concurrently. (An earlier version that signal/wait-chained every flush measurably reduced throughput by serializing independent work.)

### Custom operations and native interop ordering

- Host-side custom (interop) operations execute user code synchronously during `invoke()`. That code may create and commit its own native command buffers on the shared `MTLCommandQueue` (e.g. FFT libraries using `get_native_type()`), and Metal executes same-queue command buffers in *commit* order. Batching therefore breaks ordering unless everything encoded so far is committed first.
- `rt::kernel_launcher::is_custom_operation()` exposes whether a launcher describes such an operation; the Metal queue flushes before invoking it, and also in `get_native_type()`.
- Found via a real-world case: GROMACS' VkFFT-on-Metal path produced wrong step-0 energies under batching until this flush was added.

### Residency deduplication (`make_allocations_resident`)

- SSCP kernels may dereference arbitrary USM pointers, so all allocations must be resident - but within one open command buffer each allocation now only gets a single `useResource` call, and the allocator scan is skipped entirely while the allocator state is unchanged.
- `metal_allocator` gains a lock-free monotonic `generation()` counter, bumped on every allocation/free; consumers detect changes without taking the allocator lock. The dedup cache is invalidated whenever the generation changes (a freed buffer's address can be reused by a new allocation).

## Testing

- `sycl_tests` (792 cases), `pcuda_tests`, `rt_tests`: all pass on macOS/arm64 (M2 Max, macOS 26), repeatedly.
- GROMACS end-to-end: step-0 potential energies bit-identical to the unbatched build across RF/PME flavors and system sizes; throughput gains above.

## Throughput results (GROMACS, grappa, GPU-resident, M2 Max, 3-rep medians)

| case | before (ns/day) | after (ns/day) | gain |
|---|---|---|---|
| rf 96k | 52.65 | 89.83 | +70.6% |
| pme 96k | 38.63 | 70.92 | +83.6% |
| rf 192k | 45.35 | 51.66 | +13.9% |
| pme 192k | 35.48 | 41.07 | +15.8% |
| rf 384k | 18.40 | 26.95 | +46.5% |
| pme 384k | 16.29 | 19.15 | +17.6% |
| rf 768k | 11.42 | 11.75 | +3.0% |
| pme 768k | 9.11 | 9.59 | +5.3% |

## xctrace Metal System Trace (192k rf, 18 s window)

| metric | before | after |
|---|---|---|
| GPU command buffers | 50,596 | 15,908 (-69%) |
| compute encoder intervals | 51,590 | 19,675 (merged encoders) |