### PR TITLE
[acpp] Treat headers as source files when determining whether we are in a linking step

### DIFF
--- a/bin/acpp
+++ b/bin/acpp
@@ -1268,7 +1268,7 @@ class acpp_config:
 
   @property
   def source_file_arguments(self):
-    source_file_endings = set([".cpp", ".cxx", ".c++", ".cc", ".c", ".hip", ".cu", ".sycl", ".cppm", ".cxxm", ".ccm", ".c++m", ".ixx"])
+    source_file_endings = set([".cpp", ".cxx", ".c++", ".cc", ".c", ".hip", ".cu", ".sycl", ".cppm", ".cxxm", ".ccm", ".c++m", ".ixx", ".h", ".hpp", ".hxx"])
     source_files = []
     for arg in self.forwarded_compiler_arguments:
       if not arg.startswith("-"):


### PR DESCRIPTION
An invocation operating only on headers (e.g. `*.h`) is currently not recognized as operating on source. Thus, acpp only applies linker flags, but not e.g. the macro definitions to control target selection.
This breaks PCH generation where we operate only on headers.