### PR TITLE
[SSCP][prototype] Implement sycl_khr_free_function_kernels

### DIFF
--- a/include/hipSYCL/glue/kernel_launcher_data.hpp
+++ b/include/hipSYCL/glue/kernel_launcher_data.hpp
@@ -67,6 +67,13 @@ struct kernel_launcher_data {
   const char* sscp_kernel_id = nullptr;
   const rt::hcf_kernel_info* kernel_info = nullptr;
   invoker_function_t sscp_invoker;
+
+  // Used by the free function kernel launcher (sycl_khr_free_function_kernels):
+  // Unlike lambda/functor kernels - which pass a single closure struct as one
+  // kernel argument - a free function kernel passes each function parameter as
+  // a separate kernel argument. This holds the per-argument sizes; the argument
+  // values themselves are packed contiguously into kernel_args.
+  std::vector<std::size_t> sscp_argument_sizes;
 };
 
 

--- a/include/hipSYCL/glue/llvm-sscp/free_function_kernel_launcher.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/free_function_kernel_launcher.hpp
@@ -1,0 +1,202 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#ifndef HIPSYCL_FREE_FUNCTION_KERNEL_LAUNCHER_HPP
+#define HIPSYCL_FREE_FUNCTION_KERNEL_LAUNCHER_HPP
+
+#include "hipSYCL/glue/kernel_launcher_data.hpp"
+#include "hipSYCL/glue/llvm-sscp/s1_ir_constants.hpp"
+#include "hipSYCL/runtime/kernel_cache.hpp"
+#include "hipSYCL/runtime/code_object_invoker.hpp"
+#include "hipSYCL/runtime/operations.hpp"
+#include "hipSYCL/runtime/dag_node.hpp"
+#include "hipSYCL/runtime/error.hpp"
+#include "hipSYCL/runtime/kernel_type.hpp"
+#include "hipSYCL/sycl/libkernel/range.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+// Name-extraction intrinsic for free function kernels.
+//
+// The SSCP compiler resolves this call (annotation "acpp_sscp_extract_kernel_name",
+// see HostKernelNameExtractionPass) by writing the mangled symbol name of the
+// function passed as the first argument into the global char array pointed to by
+// the second argument.
+//
+// The parameter type is templated on the exact free function kernel signature so
+// that the function pointer is passed *directly*, with no bitcast/indirection --
+// the pass requires operand 0 to be an llvm::Function.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundefined-internal"
+template <class... Params>
+[[clang::annotate("acpp_sscp_extract_kernel_name")]]
+void __acpp_sscp_extract_free_function_kernel_name(void (*Func)(Params...),
+                                                   const char *target);
+#pragma clang diagnostic pop
+
+namespace hipsycl {
+namespace glue {
+namespace free_function_kernels {
+
+// Extract the (compiler-provided) mangled kernel name for the free function
+// kernel Func. The result is cached in a per-Func static buffer whose contents
+// are filled in by the SSCP HostKernelNameExtractionPass.
+template <auto *Func>
+const char *get_kernel_name() {
+  // The compiler will resize this array to the kernel name length and write the
+  // mangled name into it.
+  static char __acpp_sscp_kernel_name[] = "kernel-name-extraction-failed";
+
+  __acpp_sscp_extract_free_function_kernel_name(Func, &__acpp_sscp_kernel_name[0]);
+  return &__acpp_sscp_kernel_name[0];
+}
+
+// Deduce the parameter types of a free function kernel from its type.
+template <class F> struct function_parameter_types;
+template <class... Params>
+struct function_parameter_types<void (*)(Params...)> {
+  using type = std::tuple<Params...>;
+};
+
+template <int Dim>
+rt::range<3> flip_range(const sycl::range<Dim> &r) {
+  rt::range<3> rt_range{1, 1, 1};
+  for (int i = 0; i < Dim; ++i)
+    rt_range[i] = r[Dim - i - 1];
+  return rt_range;
+}
+
+// Append the raw bytes of a value to the contiguous argument blob and record
+// its size.
+inline void append_argument(std::vector<uint8_t> &blob,
+                            std::vector<std::size_t> &sizes, const void *data,
+                            std::size_t size) {
+  const uint8_t *bytes = static_cast<const uint8_t *>(data);
+  blob.insert(blob.end(), bytes, bytes + size);
+  sizes.push_back(size);
+}
+
+// Convert an argument to the corresponding free function kernel parameter type
+// and append its bytes. Converting to the *parameter* type (rather than packing
+// the caller's argument type) guarantees the packed layout matches the kernel
+// ABI even when implicit conversions are involved (e.g. 0 -> float* or int ->
+// float).
+template <class ParamType, class Arg>
+void pack_one(std::vector<uint8_t> &blob, std::vector<std::size_t> &sizes,
+              Arg &&arg) {
+  ParamType converted = static_cast<ParamType>(std::forward<Arg>(arg));
+  append_argument(blob, sizes, &converted, sizeof(ParamType));
+}
+
+template <auto *Func, std::size_t... I, class ArgTuple>
+void pack_arguments(std::vector<uint8_t> &blob, std::vector<std::size_t> &sizes,
+                    std::index_sequence<I...>, ArgTuple &&args) {
+  using param_types = typename function_parameter_types<decltype(Func)>::type;
+  (pack_one<std::tuple_element_t<I, param_types>>(
+       blob, sizes, std::get<I>(std::forward<ArgTuple>(args))),
+   ...);
+}
+
+// Deferred launch: executed by the runtime once the kernel's DAG node is
+// scheduled. Reconstructs the per-argument pointers from the contiguous blob and
+// submits the pre-compiled kernel identified by name from the code object.
+inline rt::result
+invoke(const kernel_launcher_data &cfg, rt::dag_node *node,
+       const rt::kernel_configuration &kernel_config,
+       const rt::backend_kernel_launch_capabilities &launch_capabilities,
+       void *backend_params) {
+  assert(node);
+  auto *kernel_op = static_cast<rt::kernel_operation *>(node->get_operation());
+
+  auto sscp_invoker = launch_capabilities.get_sscp_invoker();
+  if (!sscp_invoker) {
+    return rt::make_error(
+        __acpp_here(),
+        rt::error_info{"free_function_kernel_launcher: backend did not "
+                       "configure the kernel launcher for SSCP."});
+  }
+  auto *invoker = sscp_invoker.value();
+
+  auto selected_group_size = cfg.group_size;
+  if (cfg.group_size.size() == 0)
+    selected_group_size =
+        invoker->select_group_size(cfg.global_size, cfg.group_size);
+
+  rt::range<3> num_groups;
+  for (int i = 0; i < 3; ++i) {
+    num_groups[i] = (cfg.global_size[i] + selected_group_size[i] - 1) /
+                    selected_group_size[i];
+  }
+
+  // Free function kernels forbid non-device-copyable arguments (e.g.
+  // accessors), so there are no embedded pointers to initialize.
+
+  const std::size_t num_args = cfg.sscp_argument_sizes.size();
+  std::vector<void *> arg_pointers(num_args);
+  std::size_t offset = 0;
+  for (std::size_t i = 0; i < num_args; ++i) {
+    arg_pointers[i] = cfg.kernel_args.data() + offset;
+    offset += cfg.sscp_argument_sizes[i];
+  }
+
+  return invoker->submit_kernel(
+      *kernel_op, cfg.sscp_hcf_object_id, num_groups, selected_group_size,
+      cfg.local_mem_size, arg_pointers.data(),
+      const_cast<std::size_t *>(cfg.sscp_argument_sizes.data()), num_args,
+      std::string_view{cfg.sscp_kernel_id}, cfg.kernel_info, kernel_config);
+}
+
+// Populate a kernel_launcher_data for a free function kernel launch.
+template <auto *Func, int Dim, typename... Args>
+void configure(kernel_launcher_data &data, sycl::range<Dim> global_range,
+               sycl::range<Dim> local_range, std::size_t local_mem_size,
+               Args &&...args) {
+  data.type = rt::kernel_type::ndrange_parallel_for;
+  data.sscp_invoker = &invoke;
+
+  data.global_size = flip_range(global_range);
+  data.group_size = flip_range(local_range);
+  data.local_mem_size = static_cast<unsigned>(local_mem_size);
+
+  data.sscp_kernel_id = get_kernel_name<Func>();
+
+  // Resolve the kernel by name. The free function kernel may be defined and
+  // outlined in a different translation unit than this launch, so we cannot
+  // rely on the local HCF object id. We first try the local object (the common
+  // case, cheapest), then fall back to an object-independent lookup.
+  data.sscp_hcf_object_id = __acpp_local_sscp_hcf_object_id;
+  data.kernel_info = rt::hcf_cache::get().get_kernel_info(
+      data.sscp_hcf_object_id, std::string_view{data.sscp_kernel_id});
+  if (!data.kernel_info) {
+    auto resolved = rt::hcf_cache::get().get_kernel_info_by_name(
+        std::string_view{data.sscp_kernel_id});
+    data.sscp_hcf_object_id = resolved.object_id;
+    data.kernel_info = resolved.info;
+  }
+
+  data.kernel_args.clear();
+  data.sscp_argument_sizes.clear();
+  pack_arguments<Func>(data.kernel_args, data.sscp_argument_sizes,
+                       std::make_index_sequence<sizeof...(Args)>{},
+                       std::forward_as_tuple(std::forward<Args>(args)...));
+}
+
+} // namespace free_function_kernels
+} // namespace glue
+} // namespace hipsycl
+
+#endif

--- a/include/hipSYCL/runtime/kernel_cache.hpp
+++ b/include/hipSYCL/runtime/kernel_cache.hpp
@@ -216,6 +216,20 @@ public:
   const hcf_kernel_info *get_kernel_info(hcf_object_id obj,
                                          const std::string &kernel_name) const;
 
+  // Result of a global (object-independent) kernel lookup by name.
+  struct resolved_kernel {
+    hcf_object_id object_id = 0;
+    const hcf_kernel_info *info = nullptr;
+  };
+
+  // Look up a kernel by its (mangled) name across all registered HCF objects,
+  // without knowing which object provides it. This is used by free function
+  // kernels (sycl_khr_free_function_kernels), where the kernel may be defined
+  // and outlined in a different translation unit than the one that launches it,
+  // so the launching TU's local HCF object id cannot be used.
+  // Returns {0, nullptr} if the kernel is not found.
+  resolved_kernel get_kernel_info_by_name(std::string_view kernel_name) const;
+
   const hcf_image_info *get_image_info(hcf_object_id obj,
                                        const std::string &image_name) const;
 
@@ -226,6 +240,9 @@ private:
   std::unordered_map<hcf_object_id, std::unique_ptr<common::hcf_container>>
       _hcf_objects;
   std::unordered_map<std::string, symbol_resolver_list> _exported_symbol_providers;
+  // Maps a kernel's (mangled) name to the HCF object that provides it. Enables
+  // object-independent kernel lookup for free function kernels.
+  std::unordered_map<std::string, hcf_object_id> _kernel_name_providers;
 
   using info_id = std::array<uint64_t, 2>;
 

--- a/include/hipSYCL/sycl/extensions.hpp
+++ b/include/hipSYCL/sycl/extensions.hpp
@@ -88,4 +88,10 @@
 #define SYCL_KHR_QUEUE_EMPTY_QUERY 1
 #define SYCL_KHR_MAX_WORK_GROUP_QUERIES 1
 
+// Only the generic SSCP compiler can outline a free function as a kernel entry
+// point, so the extension is only advertised for that flow.
+#if defined(__ACPP_ENABLE_LLVM_SSCP_TARGET__)
+#define SYCL_KHR_FREE_FUNCTION_KERNELS 1
+#endif
+
 #endif

--- a/include/hipSYCL/sycl/handler.hpp
+++ b/include/hipSYCL/sycl/handler.hpp
@@ -51,6 +51,9 @@
 #include "hipSYCL/glue/kernel_launcher_factory.hpp"
 #include "hipSYCL/glue/kernel_names.hpp"
 #include "hipSYCL/glue/generic/code_object.hpp"
+#if defined(__ACPP_ENABLE_LLVM_SSCP_TARGET__)
+#include "hipSYCL/glue/llvm-sscp/free_function_kernel_launcher.hpp"
+#endif
 
 #include "hipSYCL/algorithms/reduction/reduction_engine.hpp"
 #include "hipSYCL/algorithms/util/memory_streaming.hpp"
@@ -750,6 +753,44 @@ public:
   detail::local_memory_allocator& get_local_memory_allocator()
   {
     return _local_mem_allocator;
+  }
+
+  // Implementation entry point for the sycl_khr_free_function_kernels extension.
+  // Launches the free function kernel identified by the function pointer Func as
+  // an nd-range kernel, passing each element of args as a separate kernel
+  // argument (the kernel's parameters), rather than wrapping it in a lambda.
+  //
+  // This routes the launch through the regular DAG/command-group machinery, so
+  // events, dependencies and command graphs behave as for any other kernel.
+  template <auto *Func, int Dim, typename... Args>
+  void AdaptiveCpp_launch_free_function_kernel(sycl::range<Dim> global_range,
+                                               sycl::range<Dim> local_range,
+                                               Args &&...args) {
+#if defined(__ACPP_ENABLE_LLVM_SSCP_TARGET__)
+    std::size_t local_mem_size = _local_mem_allocator.get_allocation_size();
+
+    glue::kernel_launcher_data launcher_data;
+    glue::free_function_kernels::configure<Func, Dim>(
+        launcher_data, global_range, local_range, local_mem_size,
+        std::forward<Args>(args)...);
+
+    // Free function kernels are only supported by the generic SSCP flow, so we
+    // do not construct any of the SMCP backend launchers here.
+    common::auto_small_vector<std::unique_ptr<rt::backend_kernel_launcher>>
+        backend_launchers;
+    rt::kernel_launcher launcher{launcher_data, std::move(backend_launchers)};
+
+    auto kernel_op = rt::make_operation<rt::kernel_operation>(
+        launcher_data.sscp_kernel_id, std::move(launcher), _requirements);
+
+    rt::dag_node_ptr node =
+        create_task(std::move(kernel_op), _execution_hints, _requirements);
+    _command_group_nodes.push_back(node);
+#else
+    throw exception{make_error_code(errc::feature_not_supported),
+                    "handler: Free function kernels (sycl_khr_free_function_"
+                    "kernels) are only supported by the generic SSCP compiler."};
+#endif
   }
 
 private:

--- a/include/hipSYCL/sycl/khr/free_function_kernels.hpp
+++ b/include/hipSYCL/sycl/khr/free_function_kernels.hpp
@@ -1,0 +1,110 @@
+/*
+ * This file is part of AdaptiveCpp, an implementation of SYCL and C++ standard
+ * parallelism for CPUs and GPUs.
+ *
+ * Copyright The AdaptiveCpp Contributors
+ *
+ * AdaptiveCpp is released under the BSD 2-Clause "Simplified" License.
+ * See file LICENSE in the project root for full license details.
+ */
+// SPDX-License-Identifier: BSD-2-Clause
+#ifndef HIPSYCL_KHR_FREE_FUNCTION_KERNELS_HPP
+#define HIPSYCL_KHR_FREE_FUNCTION_KERNELS_HPP
+
+#include "hipSYCL/sycl/handler.hpp"
+#include "hipSYCL/sycl/queue.hpp"
+#include "hipSYCL/sycl/is_device_copyable.hpp"
+#include "hipSYCL/sycl/libkernel/range.hpp"
+
+#include <type_traits>
+#include <utility>
+
+// Implementation of the sycl_khr_free_function_kernels extension.
+//
+// A free function kernel is an ordinary namespace-scope C++ function decorated
+// with the SYCL_KHR_KERNEL() macro. The function itself becomes the device
+// kernel entry point; its parameters are the kernel arguments (each must be
+// device-copyable), giving them a defined order. The kernel is identified by
+// the function itself and launched via a kernel_function<Func> handle.
+//
+// In AdaptiveCpp the macro maps onto the existing SSCP kernel-entry-point
+// annotations, which cause the generic single-pass compiler to outline the
+// function as a kernel and register it in the HCF under its mangled symbol name.
+// Note that (unlike the AdaptiveCpp PCUDA free kernels) we do NOT add the
+// "acpp_free_kernel" annotation: that would turn an ordinary host call to the
+// function into a kernel launch, whereas this extension launches only through
+// the explicit launch_* functions below.
+
+// Decorate a namespace-scope function declaration to define a free function
+// kernel. The macro takes no arguments.
+#define SYCL_KHR_KERNEL()                                                      \
+  [[clang::annotate("hipsycl_sscp_kernel")]]                                   \
+  [[clang::annotate("hipsycl_sscp_outlining")]]
+
+namespace hipsycl {
+namespace sycl {
+namespace khr {
+
+// Handle identifying the free function kernel to launch. The kernel is
+// identified by the value kernel_function<Func>, not by an explicit template
+// argument on the launch function.
+template <auto *Func> struct kernel_function_s {};
+
+template <auto *Func>
+inline constexpr kernel_function_s<Func> kernel_function{};
+
+namespace detail {
+
+template <auto *Func, typename... Args>
+constexpr void check_launch_constraints() {
+  static_assert(std::is_invocable_v<decltype(Func), Args...>,
+                "The arguments passed to the free function kernel launch are "
+                "not invocable on the kernel function.");
+  static_assert(
+      (is_device_copyable_v<std::decay_t<Args>> && ...),
+      "All free function kernel arguments must be device copyable.");
+}
+
+} // namespace detail
+
+// launch_task ---------------------------------------------------------------
+
+template <auto *Func, typename... Args>
+void launch_task(handler &h, kernel_function_s<Func>, Args &&...args) {
+  detail::check_launch_constraints<Func, Args...>();
+  h.template AdaptiveCpp_launch_free_function_kernel<Func, 1>(
+      range<1>{1}, range<1>{1}, std::forward<Args>(args)...);
+}
+
+template <auto *Func, typename... Args>
+void launch_task(queue &q, kernel_function_s<Func> k, Args &&...args) {
+  detail::check_launch_constraints<Func, Args...>();
+  q.submit([&](handler &h) {
+    launch_task<Func>(h, k, std::forward<Args>(args)...);
+  });
+}
+
+// launch_grouped ------------------------------------------------------------
+
+template <auto *Func, int Dims, typename... Args>
+void launch_grouped(handler &h, range<Dims> global, range<Dims> local,
+                    kernel_function_s<Func>, Args &&...args) {
+  detail::check_launch_constraints<Func, Args...>();
+  h.template AdaptiveCpp_launch_free_function_kernel<Func, Dims>(
+      global, local, std::forward<Args>(args)...);
+}
+
+template <auto *Func, int Dims, typename... Args>
+void launch_grouped(queue &q, range<Dims> global, range<Dims> local,
+                    kernel_function_s<Func> k, Args &&...args) {
+  detail::check_launch_constraints<Func, Args...>();
+  q.submit([&](handler &h) {
+    launch_grouped<Func>(h, global, local, k, std::forward<Args>(args)...);
+  });
+}
+
+} // namespace khr
+} // namespace sycl
+} // namespace hipsycl
+
+#endif

--- a/include/hipSYCL/sycl/sycl.hpp
+++ b/include/hipSYCL/sycl/sycl.hpp
@@ -80,6 +80,7 @@
 #include "specialized.hpp"
 #include "jit.hpp"
 #include "pcuda_interop.hpp"
+#include "khr/free_function_kernels.hpp"
 #include "detail/namespace_compat.hpp"
 
 // Support SYCL_EXTERNAL for SSCP - we cannot have SYCL_EXTERNAL if accelerated CPU

--- a/src/compiler/sscp/KernelOutliningPass.cpp
+++ b/src/compiler/sscp/KernelOutliningPass.cpp
@@ -412,9 +412,16 @@ EntrypointPreparationPass::run(llvm::Module &M, llvm::ModuleAnalysisManager &AM)
         }
       }
       if(Annotation.compare(SSCPKernelMarker) == 0) {
-        HIPSYCL_DEBUG_INFO << "Found SSCP kernel: " << F->getName() << "\n";
-        this->KernelNames.push_back(F->getName().str());
-        Kernels.insert(F->getName().str());
+        // Only functions that are actually defined in this translation unit
+        // become kernel entry points. A decorated declaration without a body
+        // (e.g. a free function kernel declared in a TU that only launches it,
+        // but is defined elsewhere) must not be emitted as a kernel here -
+        // doing so would register a body-less kernel in this TU's HCF object.
+        if(F->size() > 0) {
+          HIPSYCL_DEBUG_INFO << "Found SSCP kernel: " << F->getName() << "\n";
+          this->KernelNames.push_back(F->getName().str());
+          Kernels.insert(F->getName().str());
+        }
       }
 
       if(Annotation.compare(SSCPOutliningMarker) == 0) {

--- a/src/runtime/kernel_cache.cpp
+++ b/src/runtime/kernel_cache.cpp
@@ -442,6 +442,9 @@ hcf_object_id hcf_cache::register_hcf_object(const common::hcf_container &obj) {
           }
           _hcf_kernel_info[generate_info_id(id, kernel_name)] =
               std::move(kernel_info);
+          // Also index by name so that free function kernels can be resolved
+          // without knowing which HCF object provides them.
+          _kernel_name_providers[kernel_name] = id;
         }
       }
     }
@@ -512,9 +515,17 @@ void hcf_cache::unregister_hcf_object(hcf_object_id id) {
                 symbol_providers.end());
           }
         });
+    // Remove this object's kernels from the name->object index.
+    if (auto *kernels_node = it->second->root_node()->get_subnode("kernels")) {
+      for (const auto &kernel_name : kernels_node->get_subnodes()) {
+        auto provider = _kernel_name_providers.find(kernel_name);
+        if (provider != _kernel_name_providers.end() && provider->second == id)
+          _kernel_name_providers.erase(provider);
+      }
+    }
     // Then we can remove the HCF itself.
     // Note: We don't necessarily need to remove the HCF kernel info, since
-    // just maintaining this data won't have any side effects as long as 
+    // just maintaining this data won't have any side effects as long as
     // the HCF object is no longer selected for execution.
     _hcf_objects.erase(id);
   }
@@ -556,6 +567,30 @@ const hcf_kernel_info *
 hcf_cache::get_kernel_info(hcf_object_id obj,
                            const std::string &kernel_name) const {
   return get_kernel_info(obj, std::string_view{kernel_name});
+}
+
+hcf_cache::resolved_kernel
+hcf_cache::get_kernel_info_by_name(std::string_view kernel_name) const {
+  auto query = [&, this]() -> resolved_kernel {
+    std::lock_guard<std::mutex> lock{_mutex};
+    auto it = _kernel_name_providers.find(std::string{kernel_name});
+    if (it == _kernel_name_providers.end())
+      return {};
+    hcf_object_id obj = it->second;
+    auto info_it = _hcf_kernel_info.find(generate_info_id(obj, kernel_name));
+    if (info_it == _hcf_kernel_info.end())
+      return {};
+    return resolved_kernel{obj, info_it->second.get()};
+  };
+
+  if (auto result = query(); result.info) {
+    return result;
+  } else {
+    // The providing HCF object may not have registered yet due to static
+    // initialization order; actively scan the binary and retry.
+    scan_binary_for_hcf();
+    return query();
+  }
 }
 
 const hcf_image_info *


### PR DESCRIPTION
Proof-of-concept implementation of the KHR free function kernels extension ([KhronosGroup/SYCL-Docs#1033](https://github.com/KhronosGroup/SYCL-Docs/pull/1033)) on the generic SSCP flow.

A namespace-scope function decorated with SYCL_KHR_KERNEL() becomes a device kernel entry point whose parameters are the kernel arguments. The kernel is identified by its address via kernel_function<Func> and launched with launch_task / launch_grouped, routed through the normal handler/DAG path (events, dependencies, graphs work as usual).

The macro maps onto the existing SSCP kernel-entry-point annotations (hipsycl_sscp_kernel + hipsycl_sscp_outlining), reusing the same outlining/HCF machinery as PCUDA free kernels, but WITHOUT the acpp_free_kernel host-call rewrite: an ordinary host call to the function is not a launch; only the explicit launch_* functions launch.

Host launch resolves the function address to its mangled HCF kernel name (templated __acpp_sscp_extract_kernel_name variant), packs each argument as a separate kernel parameter, and submits by name. A name->object index in hcf_cache (get_kernel_info_by_name) enables cross-translation-unit launches: define the kernel in one TU, launch from another. EntrypointPreparationPass now only emits a kernel for a function with a body, so a decorated declaration in the launching TU does not register a body-less kernel.

This should be used for illustration purposes only. 

Assisted by Claude@4.8