### PR TITLE
[VK] Check SDK version in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,7 +242,7 @@ set(WITH_VULKAN_BACKEND OFF CACHE BOOL "Build AdaptiveCpp support for Vulkan") #
 set(WITH_CPU_BACKEND true)
 
 if(WITH_VULKAN_BACKEND)
-  find_package(Vulkan QUIET COMPONENTS SPIRV-Tools REQUIRED)
+  find_package(Vulkan 1.4 QUIET COMPONENTS SPIRV-Tools REQUIRED)
 endif()
 
 if(WITH_CUDA_BACKEND)


### PR DESCRIPTION
Compile-time errors are not particularly cryptic in this case, but configure-time errors are still better.