### PR TITLE
[VK] Improve device driver version reporting

### DIFF
--- a/doc/install-vulkan.md
+++ b/doc/install-vulkan.md
@@ -175,18 +175,20 @@ own bugs that need addressed (which may turn out to be not device specific once 
 Devices known to be well supported by the backend include:
 
 | Driver Name  | Driver Version    | Device Type          | Status
-| ------------ | ----------------- | -------------------- | ------------------------------------------------------------------------------------- |
-| llvmpipe     | Mesa 25.0.7       | CPU                  | Well supported                                                                        |
-| RADV Pheonix | Mesa 25.0.7       | AMD Integrated GPU   | Well supported                                                                        |
-| RADV MI100   | Mesa 23.2.1       | AMD Discrete GPU     | Well Supported                                                                        |
-| RADV MI210   | Mesa 23.2.1       | AMD Discrete GPU     | Many [Issues](https://github.com/AdaptiveCpp/AdaptiveCpp/issues/2123)                 |
-| Arc MTL      | Mesa 25.0.7       | Intel Integrated GPU | Issues with sub-groups                                                                |
-| RTX 500      | NVIDIA 580.95.5.0 | NVIDIA Discrete GPU  | Tests pass in isolation, but device stops being detected when running full sycl suite |
-| MoltenVK     | Khronos 1.4.1     | Apple Integrated GPU | CI testing with Macos 15.7.4, [some](#issue-11) tests disabled                        |
-| Swiftshader  | Google 5.0.0      | CPU                  | Poor support, no `Int64` or `VariablePointer` capabilities                            |
-| V3D          | Mesa 25.0.7       | Broadcom iGPU        | Poor support, no `Int64` or `VariablePointer` capabilities                            |
+| ------------ | ----------------- | -------------------- | ----------------------------------------------------------------------------------------------- |
+| llvmpipe     | Mesa 25.0.7       | CPU                  | Well supported                                                                                  |
+| RADV Pheonix | Mesa 25.0.7       | AMD Integrated GPU   | Well supported                                                                                  |
+| RADV MI100   | Mesa 23.2.1       | AMD Discrete GPU     | Well Supported                                                                                  |
+| RADV MI210   | Mesa 23.2.1       | AMD Discrete GPU     | Many [Issues](https://github.com/AdaptiveCpp/AdaptiveCpp/issues/2123)                           |
+| Arc MTL      | Mesa 25.0.7       | Intel Integrated GPU | Issues with sub-groups                                                                          |
+| RTX 500      | NVIDIA 580.95.5.0 | NVIDIA Discrete GPU  | Issues with group functions tests & device stops being detected when running full sycl suite[1] |
+| MoltenVK     | Khronos 1.4.1     | Apple Integrated GPU | CI testing with Macos 15.7.4, [some](#issue-11) tests disabled                                  |
+| Swiftshader  | Google 5.0.0      | CPU                  | Poor support, no `Int64` or `VariablePointer` capabilities                                      |
+| V3D          | Mesa 25.0.7       | Broadcom iGPU        | Poor support, no `Int64` or `VariablePointer` capabilities                                      |
 
 Other devices are untested and support status is unknown.
+
+[1] A workaround to this issue is to set the `ACPP_PERSISTENT_RUNTIME=1` environment variable.
 
 ## Benchmarks
 

--- a/src/runtime/vk/vk_hardware_manager.cpp
+++ b/src/runtime/vk/vk_hardware_manager.cpp
@@ -441,14 +441,17 @@ vk_hardware_context::get_property(device_uint_list_property prop) const {
 }
 
 std::string vk_hardware_context::get_driver_version() const {
-  // TODO - Not all vendors will use driver versions in this form
-  uint32_t version = _properties.driverVersion;
-  uint32_t major = VK_API_VERSION_MAJOR(version);
-  uint32_t minor = VK_API_VERSION_MINOR(version);
-  uint32_t patch = VK_API_VERSION_PATCH(version);
-  return std::to_string(major) + "." + std::to_string(minor) + "." +
-         std::to_string(patch);
+  auto properties2 =
+      _physical_device.getProperties2<vk::PhysicalDeviceProperties2,
+                                      vk::PhysicalDeviceDriverProperties>();
+  vk::PhysicalDeviceDriverProperties const &driver_props =
+      properties2.get<vk::PhysicalDeviceDriverProperties>();
+  std::string driver(std::string(driver_props.driverName));
+  driver.append(", ");
+  driver.append(std::string(driver_props.driverInfo));
+  return driver;
 }
+
 std::string vk_hardware_context::get_profile() const { return "FULL_PROFILE"; }
 
 std::size_t vk_hardware_context::get_platform_index() const { return 0; }
@@ -561,7 +564,6 @@ vk_hardware_manager::vk_hardware_manager()
       static_cast<uint32_t>(enabled_extensions.size()), // enabledExtensionCount
       enabled_extensions.data() // ppEnabledExtensionNames
   };
-  _instance = vk::raii::Instance(_context, create_info);
 
 #ifndef NDEBUG
   vk::DebugUtilsMessageSeverityFlagsEXT severity_flags(
@@ -575,8 +577,13 @@ vk_hardware_manager::vk_hardware_manager()
   vk::DebugUtilsMessengerCreateInfoEXT debug_utils_messenger_create_info{
       {}, severity_flags, message_type_flags, &debugCallback};
 
+  create_info.pNext = &debug_utils_messenger_create_info;
+  _instance = vk::raii::Instance(_context, create_info);
+
   _debug_messenger =
       _instance.createDebugUtilsMessengerEXT(debug_utils_messenger_create_info);
+#else
+  _instance = vk::raii::Instance(_context, create_info);
 #endif
 
   // Iterate over physical devices and find those capable being instantiated


### PR DESCRIPTION
[VkPhysicalDeviceDriverProperties](https://docs.vulkan.org/refpages/latest/refpages/source/VkPhysicalDeviceDriverProperties.html) is available from Vulkan version 1.2, which is our minimum backend version requirement. It provides a `driverInfo` field that contains a version string, this PR updates the code to use that as opposed to the current approach of assembling a driver string from an integer value that may not be correct for all vendors.

For example with `acpp-info` on my Intel MTL Vulkan device:
* Before -  `Driver version: 26.0.3`
* After - `Driver version: Intel open-source Mesa driver, Mesa 26.0.3-1ubuntu1`

This PR also includes a couple of other small fixes:
* Allow valdation layer checking of  Vulkan instance creation
* Document the NVIDIA Ada device workaround reported in https://github.com/AdaptiveCpp/AdaptiveCpp/pull/2009#discussion_r3847010970