### PR TITLE
[CI] Fix current CI failures

### DIFF
--- a/.github/workflows/create-ci-docker/AdaptiveCpp-CI-Linux.dockerfile
+++ b/.github/workflows/create-ci-docker/AdaptiveCpp-CI-Linux.dockerfile
@@ -90,7 +90,19 @@ RUN <<EOF
     set -e
     wget -q https://apt.llvm.org/llvm.sh
     chmod +x llvm.sh
-    ./llvm.sh ${LLVM_VERSION}
+    success=0
+    for i in 1 2 3 4 5; do
+        if ./llvm.sh ${LLVM_VERSION}; then
+            success=1
+            break
+        fi
+        echo "Attempt $i failed, retrying in 15s..."
+        sleep 15
+    done
+    if [ "$success" -ne 1 ]; then
+        echo "llvm.sh failed after 5 attempts"
+        exit 1
+    fi
     apt-get install -y libclang-${LLVM_VERSION}-dev clang-tools-${LLVM_VERSION} libomp-${LLVM_VERSION}-dev llvm-${LLVM_VERSION}-dev
     apt-get install -y -o DPkg::options::="--force-overwrite" libclang-rt-${LLVM_VERSION}-dev
     rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/create-ci-docker/AdaptiveCpp-CI-Linux.dockerfile
+++ b/.github/workflows/create-ci-docker/AdaptiveCpp-CI-Linux.dockerfile
@@ -90,12 +90,7 @@ RUN <<EOF
     set -e
     wget -q https://apt.llvm.org/llvm.sh
     chmod +x llvm.sh
-    # Github runners sometimes have trouble reaching the LLVM repository
-    # We retry multiple times to make the CI more stable
-    for i in 1 2 3 4 5; do 
-        ./llvm.sh ${LLVM_VERSION} && echo "Attempt $i failed, retrying in 15s..."
-        sleep 15 
-    done 
+    ./llvm.sh ${LLVM_VERSION}
     apt-get install -y libclang-${LLVM_VERSION}-dev clang-tools-${LLVM_VERSION} libomp-${LLVM_VERSION}-dev llvm-${LLVM_VERSION}-dev
     apt-get install -y -o DPkg::options::="--force-overwrite" libclang-rt-${LLVM_VERSION}-dev
     rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/create-ci-docker/AdaptiveCpp-CI-Linux.dockerfile
+++ b/.github/workflows/create-ci-docker/AdaptiveCpp-CI-Linux.dockerfile
@@ -94,7 +94,7 @@ RUN <<EOF
     apt-get install -y libclang-${LLVM_VERSION}-dev clang-tools-${LLVM_VERSION} libomp-${LLVM_VERSION}-dev llvm-${LLVM_VERSION}-dev
     apt-get install -y -o DPkg::options::="--force-overwrite" libclang-rt-${LLVM_VERSION}-dev
     rm -rf /var/lib/apt/lists/*
-    python3 -m pip install lit
+    python3 -m pip install lit==18.1.8
     ln -s /usr/bin/FileCheck-${LLVM_VERSION} /usr/bin/FileCheck
 EOF
 


### PR DESCRIPTION
The logic merged before in #2195 was broken, this PR ~~reverts~~ fixes that. 

Additionally this PR pins the lit version to 18.1.18 to temporally fix the issue reported in #2207  
