### PR TITLE
Don't use external shell for SSCP lit tests

### DIFF
--- a/tests/compiler/lit.cfg.py
+++ b/tests/compiler/lit.cfg.py
@@ -3,7 +3,7 @@ import os
 import platform
 
 config.name = 'AdaptiveCpp Plugin'
-config.test_format = lit.formats.ShTest(True)
+config.test_format = lit.formats.ShTest()
 
 config.suffixes = ['.c', '.cpp', '.cc']
 


### PR DESCRIPTION
LLVM-23 deprecated `lit.formats.ShTest(execute_external=True)`, it now hard-errors at config-parse time, and the option is scheduled for removal in LLVM-24. This is getting picked up in the Vulkan Linux CI job (https://github.com/AdaptiveCpp/AdaptiveCpp/actions/runs/32933966483/job/98072447287), not sure what caused the issue to appear.

```
[1/1] cd /__w/AdaptiveCpp/AdaptiveCpp/build/tests-sscp/compiler && lit /__w/AdaptiveCpp/AdaptiveCpp/build/tests-sscp/compiler/sscp -v
FAILED: compiler/CMakeFiles/check-sscp /__w/AdaptiveCpp/AdaptiveCpp/build/tests-sscp/compiler/CMakeFiles/check-sscp
cd /__w/AdaptiveCpp/AdaptiveCpp/build/tests-sscp/compiler && lit /__w/AdaptiveCpp/AdaptiveCpp/build/tests-sscp/compiler/sscp -v
lit: /usr/local/lib/python3.10/dist-packages/lit/TestingConfig.py:164: fatal: unable to parse config file '/__w/AdaptiveCpp/AdaptiveCpp/AdaptiveCpp/tests/compiler/lit.cfg.py', traceback: Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/lit/TestingConfig.py", line 153, in load_from_path
    exec(compile(data, path, "exec"), cfg_globals, None)
  File "/__w/AdaptiveCpp/AdaptiveCpp/AdaptiveCpp/tests/compiler/lit.cfg.py", line 6, in <module>
    config.test_format = lit.formats.ShTest(True)
  File "/usr/local/lib/python3.10/dist-packages/lit/formats/shtest.py", line 27, in __init__
    raise ValueError(
ValueError: execute_external=True is deprected as of LLVM-23 and the option will be removed in LLVM-24. Please move to using the internal shell (execute_external=False). If you still need to force external execution to allow time for migration, set force_execute_external=True
```

This patch removes the external shell flag from the compiler lit test config, as I don't think it's needed.