### PR TITLE
allocator: Unregister the pointer before freeing it

### DIFF
--- a/src/runtime/allocator.cpp
+++ b/src/runtime/allocator.cpp
@@ -55,8 +55,8 @@ void *allocate_shared(backend_allocator *alloc, size_t bytes,
 }
 
 void deallocate(backend_allocator* alloc, void *mem) {
-  alloc->raw_free(mem);
   application::event_handler_layer().on_deallocation(mem);
+  alloc->raw_free(mem);
 }
 
 }


### PR DESCRIPTION
If one worker thread was deallocating a data region, it
was first freeing the pointer and only then unregistering it.

If the application was allocating something at the same time,
it could just so happen that the just-freed pointer is returned,
inserted into the map over the existing one, and immediately
unregistered by the worker thread, leaving `allocation_map`
in a broken state.

Note: applying this patch masks #2208 a bit since `raw_free` was
delaying the `on_deallocation` call.
