### PR TITLE
[CI] Fix Docker image building for PRs and cleanup llvm.sh script

### DIFF
--- a/.github/workflows/create-ci-docker/AdaptiveCpp-CI-Linux.dockerfile
+++ b/.github/workflows/create-ci-docker/AdaptiveCpp-CI-Linux.dockerfile
@@ -95,6 +95,9 @@ RUN <<EOF
         if ./llvm.sh ${LLVM_VERSION}; then
             success=1
             break
+        else
+            # Clean up after a failed download
+            rm -f /etc/apt/trusted.gpg.d/apt.llvm.org.asc
         fi
         echo "Attempt $i failed, retrying in 15s..."
         sleep 15

--- a/.github/workflows/create-ci-docker/action.yml
+++ b/.github/workflows/create-ci-docker/action.yml
@@ -160,14 +160,14 @@ runs:
       shell: bash
       run: |
         # use fallback if no changes were made to docker
-        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+        if [[ "${{ steps.filter-last-push.outputs.docker }}" == "false" ]]; then
           echo "docker_image=${{ steps.select-metadata.outputs.fallback_tag }}" >> $GITHUB_OUTPUT
         else
           echo "docker_image=${{ steps.select-metadata.outputs.docker_image }}" >> $GITHUB_OUTPUT
         fi
         
     - name: Build and push Docker images
-      if: (steps.filter-last-push.outputs.docker == 'true' || steps.tag-exists.outputs.tag == 'not found' || inputs.FORCE_BUILD == 'true') && github.event_name != 'pull_request'
+      if: steps.filter-last-push.outputs.docker == 'true' || steps.tag-exists.outputs.tag == 'not found' || inputs.FORCE_BUILD == 'true'
       uses: docker/build-push-action@v7
       id: build
       with:

--- a/.github/workflows/create-ci-docker/action.yml
+++ b/.github/workflows/create-ci-docker/action.yml
@@ -42,7 +42,7 @@ runs:
     - uses: dorny/paths-filter@v4
       id: filter-last-push
       with:
-        base: ${{ github.ref }}
+        base: develop
         filters: |
           docker:
             - '.github/workflows/create-ci-docker/**'

--- a/.github/workflows/linux-acppllvm.yml
+++ b/.github/workflows/linux-acppllvm.yml
@@ -15,6 +15,7 @@ jobs:
     outputs:
       docker_matrix: ${{ steps.matrix-output.outputs.json }}
     strategy:
+      fail-fast: false
       matrix:
         clang: ['17']
         cuda_or_rocm: ['cuda', 'rocm']

--- a/.github/workflows/linux-lit.yml
+++ b/.github/workflows/linux-lit.yml
@@ -13,6 +13,7 @@ jobs:
     outputs:
       docker_matrix: ${{ steps.matrix-output.outputs.json }}
     strategy:
+      fail-fast: false
       matrix:
         clang: [15, 16, 17, 18, 19, 20, 21]
         os: [ubuntu-22.04]

--- a/.github/workflows/linux-vulkan.yml
+++ b/.github/workflows/linux-vulkan.yml
@@ -15,6 +15,7 @@ jobs:
     outputs:
       docker_matrix: ${{ steps.matrix-output.outputs.json }}
     strategy:
+      fail-fast: false
       matrix:
         clang: ['17']
         os: [ubuntu-22.04]

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,6 +13,7 @@ jobs:
     outputs:
       docker_matrix: ${{ steps.matrix-output.outputs.json }}
     strategy:
+      fail-fast: false
       matrix:
         clang: [15, 16, 17, 18, 19, 20]
         os: [ubuntu-22.04]


### PR DESCRIPTION


* ~~clean up after llvm.sh script. The script leaves the empty gpg key if the download from the server failed. Upon re-try it only checks if the file exists, not the content. This results in repeated failure (see failing pipeline [here](https://github.com/AdaptiveCpp/AdaptiveCpp/actions/runs/33022140206/job/98354850003?pr=2203) )~~

* ~~Even after adding multiple rounds of re-try the `llvm.sh` script still kept failing the CI. Check in the required files and use a modified version of the `llvm.sh` script that does not download files.~~


* Requesting a new image creation in a PR failed, because building new images was explicitly disabled for pull request. Removing this enables adding new LLVM versions for instance in PRs (see previously failing pipeline [here](https://github.com/AdaptiveCpp/AdaptiveCpp/actions/runs/32506473134/job/96869568936) ) Additionally this change also enables building custom images in case the PR modified the related files
* When deciding on building a new image, now we compare to develop. This only affects feature branches. These used to compare against `github.ref` which resolves to the current branch 
* Add the fail-fast: false to allow other jobs in the matrix to continue executing even on failure of a participating job. This should reduce the number of manual re-start in case of network instability makes some of the container building jobs fail
