### PR TITLE
[CI] Update action versions

### DIFF
--- a/.github/workflows/benchmark-self-hosted.yml
+++ b/.github/workflows/benchmark-self-hosted.yml
@@ -17,7 +17,7 @@ jobs:
         clang_version: ['15']
         cuda: ['11.0']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Build AdaptiveCpp
       run: |
         mkdir build && cd build
@@ -43,7 +43,7 @@ jobs:
         mv output.json ${GITHUB_WORKSPACE}
 
     - name: Download previous benchmark data
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ./cache
         key: ${{ runner.os }}-benchmark

--- a/.github/workflows/create-ci-docker/action.yml
+++ b/.github/workflows/create-ci-docker/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Redact GITHUB_TOKEN
       shell: bash
       run: echo "::add-mask::${{ inputs.GITHUB_TOKEN }}"
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@v4
       id: filter-last-push
       with:
         base: ${{ github.ref }}
@@ -56,16 +56,16 @@ runs:
         REPO_OWNER=${{ github.repository_owner }}
         echo "REPO_OWNER=${REPO_OWNER@L}" >> $GITHUB_OUTPUT
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ inputs.GITHUB_TOKEN }}
     - name: Docker metadata
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       id: metadata
       if: inputs.CUDA_MAJOR_VERSION != '' && inputs.ROCM_VERSION != ''
       with:
@@ -78,7 +78,7 @@ runs:
           latest=false
           prefix=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-rocm-${{ inputs.ROCM_VERSION }}-cuda-${{ inputs.CUDA_MAJOR_VERSION }}.${{ inputs.CUDA_MINOR_VERSION }}.${{ inputs.CUDA_PATCH_VERSION }}-
     - name: Docker metadata no CUDA
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       id: metadata-no-cuda
       if: inputs.CUDA_MAJOR_VERSION == '' && inputs.ROCM_VERSION != ''
       with:
@@ -91,7 +91,7 @@ runs:
           latest=false
           prefix=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-rocm-${{ inputs.ROCM_VERSION }}-
     - name: Docker metadata no ROCm
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       id: metadata-no-rocm
       if: inputs.CUDA_MAJOR_VERSION != '' && inputs.ROCM_VERSION == ''
       with:
@@ -104,7 +104,7 @@ runs:
           latest=false
           prefix=${{ inputs.BASE_TAG }}-llvm-${{ inputs.LLVM_VERSION }}-cuda-${{ inputs.CUDA_MAJOR_VERSION }}.${{ inputs.CUDA_MINOR_VERSION }}.${{ inputs.CUDA_PATCH_VERSION }}-
     - name: Docker metadata no CUDA no ROCm
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       id: metadata-no-cuda-no-rocm
       if: inputs.CUDA_MAJOR_VERSION == '' && inputs.ROCM_VERSION == ''
       with:
@@ -148,7 +148,7 @@ runs:
         ${OUTPUT_EOF}
         EOF
 
-    - uses: tyriis/docker-image-tag-exists@v2.1.0
+    - uses: tyriis/docker-image-tag-exists@v3.0.1
       id: tag-exists
       with:
         registry: ghcr.io
@@ -168,7 +168,7 @@ runs:
         
     - name: Build and push Docker images
       if: (steps.filter-last-push.outputs.docker == 'true' || steps.tag-exists.outputs.tag == 'not found' || inputs.FORCE_BUILD == 'true') && github.event_name != 'pull_request'
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       id: build
       with:
         file: .github/workflows/create-ci-docker/AdaptiveCpp-CI-Linux.dockerfile

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10' 
 
@@ -41,7 +41,7 @@ jobs:
           destination: ./_site
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
 
   deploy_page:
     if: github.ref == 'refs/heads/develop'

--- a/.github/workflows/linux-acppllvm.yml
+++ b/.github/workflows/linux-acppllvm.yml
@@ -22,7 +22,7 @@ jobs:
         rocm_version: ['5.6.1']
         os: [ubuntu-22.04]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 20
@@ -59,12 +59,12 @@ jobs:
         clang_version: ['18', '20']
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
         path: AdaptiveCpp
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@v1.2.21
       with:
         key: ${{ github.job }}-${{matrix.clang_version}}-${{matrix.docker.cuda_or_rocm}}
         restore-keys: |

--- a/.github/workflows/linux-lit.yml
+++ b/.github/workflows/linux-lit.yml
@@ -17,7 +17,7 @@ jobs:
         clang: [15, 16, 17, 18, 19, 20, 21]
         os: [ubuntu-22.04]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 20
@@ -51,11 +51,11 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.21
         with:
           key: ${{ github.job }}-${{matrix.docker.clang}}-${{matrix.docker.os}}-${{matrix.docker.cuda}}-${{matrix.docker.rocm}}-${{ matrix.docker.test_kind }}
       - name: setup build env
@@ -107,11 +107,11 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.21
         with:
           key: ${{ github.job }}-${{matrix.docker.clang}}-${{matrix.docker.os}}-${{matrix.docker.cuda}}-${{matrix.docker.rocm}}-${{ matrix.docker.test_kind }}
       - name: Install OpenCL

--- a/.github/workflows/linux-self-hosted.yml
+++ b/.github/workflows/linux-self-hosted.yml
@@ -12,7 +12,7 @@ jobs:
         cuda: ['11.0']
         nvhpc_version: ['22.11']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: clear JIT cache
       run: |
         rm -rf ~/.acpp
@@ -108,7 +108,7 @@ jobs:
         clang_version: ['18']
         cuda: ['11.0'] # Just to be able to build the backend for explicit multipass
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: clear JIT cache
       run: |
         rm -rf ~/.acpp
@@ -166,7 +166,7 @@ jobs:
       matrix:
         clang_version: ['18']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: clear JIT cache
       run: |
         rm -rf ~/.acpp

--- a/.github/workflows/linux-vulkan.yml
+++ b/.github/workflows/linux-vulkan.yml
@@ -17,7 +17,7 @@ jobs:
         clang: ['17']
         os: [ubuntu-22.04]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 20
@@ -54,7 +54,7 @@ jobs:
         clspv_commit: ['88d8ff71000bf995493c8daaed865ec1ac216309']
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
         path: AdaptiveCpp
@@ -78,7 +78,7 @@ jobs:
         vulkaninfo --summary
 
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@v1.2.21
       with:
         key: ${{ github.job }}-${{matrix.clang_version}}
         restore-keys: |
@@ -86,14 +86,14 @@ jobs:
 
     - name: cache clspv
       id: cache-clspv
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{github.workspace}}/clspv/build/install
         key: ${{matrix.clspv_commit}}
 
     - name: checkout clspv
       if: steps.cache-clspv.outputs.cache-hit != 'true'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: google/clspv
         path: clspv

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,7 +28,7 @@ jobs:
             cuda_patch_version: 2
             rocm: 6.3.1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 20
@@ -67,11 +67,11 @@ jobs:
       run:
         shell: bash
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'    
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@v1.2.21
       with:
         key: ${{ github.job }}-${{matrix.docker.clang}}-${{matrix.docker.os}}-${{matrix.docker.cuda}}-${{matrix.docker.rocm}}-${{ matrix.test_kind }}
     - name: build AdaptiveCpp
@@ -145,7 +145,7 @@ jobs:
         nvhpc: [26.5]
         cuda: [13.2]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
     - name: Free Disk Space (Ubuntu)

--- a/.github/workflows/macos-acppllvm.yml
+++ b/.github/workflows/macos-acppllvm.yml
@@ -12,12 +12,12 @@ jobs:
       matrix:
         clang_version: ['19']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
         path: AdaptiveCpp
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@v1.2.21
       with:
         key: ${{ github.job }}-${{matrix.clang_version}}
         restore-keys: |

--- a/.github/workflows/macos-metal.yml
+++ b/.github/workflows/macos-metal.yml
@@ -14,7 +14,7 @@ jobs:
     # because metal-cpp requires macOS 26 SDK (MTL::LanguageVersion4_0 etc.).
     runs-on: macos-26
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
 

--- a/.github/workflows/macos-vulkan.yml
+++ b/.github/workflows/macos-vulkan.yml
@@ -8,11 +8,11 @@ jobs:
     name: Vulkan backend macOS
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@v1.2.21
       with:
         key: ${{ github.job }}
         restore-keys: |
@@ -40,14 +40,14 @@ jobs:
 
     - name: cache clspv
       id: cache-clspv
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{github.workspace}}/clspv/build/install
         key: ${{env.clspv_commit}}
 
     - name: checkout clspv
       if: steps.cache-clspv.outputs.cache-hit != 'true'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: google/clspv
         path: clspv

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,7 +7,7 @@ jobs:
     name: AppleClang [macOS]
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
     - name: install dependencies

--- a/.github/workflows/prime-docker.yml
+++ b/.github/workflows/prime-docker.yml
@@ -32,7 +32,7 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 20

--- a/.github/workflows/windows-acppllvm.yml
+++ b/.github/workflows/windows-acppllvm.yml
@@ -16,18 +16,20 @@ jobs:
         cuda_or_rocm: ['cuda']
         os: ['windows-2022']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
         path: AdaptiveCpp
     - name: Use MSVC Command prompt
-      uses: ilammy/msvc-dev-cmd@v1
-    - name: Install LLVM and Clang
-      uses: KyleMayes/install-llvm-action@v2.0.7
+      uses: TheMrMilchmann/setup-msvc-dev@v4
       with:
-        version: "${{matrix.base_compiler}}"
+        arch: x64
+    - name: Install LLVM and Clang
+      uses: ZhongRuoyu/setup-llvm@v0.2.0
+      with:
+        llvm-version: "${{matrix.base_compiler}}"
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@v1.2.21
       with:
         variant: sccache
         key: ${{ github.job }}-${{matrix.clang_version}}-${{matrix.cuda_or_rocm}}
@@ -37,7 +39,7 @@ jobs:
       run: |
         git clone --recurse-submodules https://github.com/llvm/llvm-project --depth 1 --single-branch -b release/${{matrix.clang_version}}.x llvm
     - name: cuda-toolkit
-      uses: Jimver/cuda-toolkit@v0.2.19
+      uses: Jimver/cuda-toolkit@v0.2.35
       with:
         method: local
         log-file-suffix: ${{matrix.clang_version}}_${{matrix.os}}.txt
@@ -52,7 +54,7 @@ jobs:
         echo "PATH=$env:GITHUB_WORKSPACE/ninja_install;$env:PATH" >> $env:GITHUB_ENV
     - name: Restore Cache installed Boost
       id: cache-boost-install
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v6
       with:
         path: ${{github.workspace}}/boost/install
         key: ${{runner.os}}-boost1830-install
@@ -81,7 +83,7 @@ jobs:
 
     - name: Save Boost Cache
       if: steps.cache-boost-install.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v6
       with:
         path: ${{github.workspace}}/boost/install
         key: ${{steps.cache-boost-install.outputs.cache-primary-key}}
@@ -157,7 +159,7 @@ jobs:
         cd $env:GITHUB_WORKSPACE/build/tests-sscp
         $env:ACPP_DEBUG_LEVEL=3
         .\sycl_tests.exe
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: github.event_name == 'push'
       with:
         name: AdaptiveCpp-LLVM${{matrix.clang_version}}-Win

--- a/.github/workflows/windows-vulkan.yml
+++ b/.github/workflows/windows-vulkan.yml
@@ -13,19 +13,21 @@ jobs:
         os: [windows-2022]
         clspv_commit: ['88d8ff71000bf995493c8daaed865ec1ac216309']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
         path: AdaptiveCpp
     - name: Use MSVC Command prompt
-      uses: ilammy/msvc-dev-cmd@v1
-    - name: Install LLVM and Clang
-      uses: KyleMayes/install-llvm-action@v2.0.7
+      uses: TheMrMilchmann/setup-msvc-dev@v4
       with:
-        version: "${{matrix.base_compiler}}"
+        arch: x64
+    - name: Install LLVM and Clang
+      uses: ZhongRuoyu/setup-llvm@v0.2.0
+      with:
+        llvm-version: "${{matrix.base_compiler}}"
 
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@v1.2.21
       with:
         variant: sccache
         key: ${{ github.job }}-${{matrix.clang_version}}-${{matrix.docker.os}}
@@ -56,14 +58,14 @@ jobs:
 
     - name: cache clspv
       id: cache-clspv
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{github.workspace}}/clspv/build/install
         key: ${{matrix.clspv_commit}}
 
     - name: checkout clspv
       if: steps.cache-clspv.outputs.cache-hit != 'true'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: google/clspv
         path: clspv
@@ -84,7 +86,7 @@ jobs:
 
     - name: Restore Cache installed Boost
       id: cache-boost-install
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v6
       with:
         path: ${{github.workspace}}/boost/install
         key: ${{runner.os}}-boost1830-install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,20 +11,20 @@ jobs:
         clang: [20]
         os: [windows-2022]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
 
     - name: Cache Boost
       id: cache-boost
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{github.workspace}}/boost_1_87_0
         key: ${{runner.os}}-boost1870
 
     - name: Cache LLVM ${{matrix.clang}}
       id: cache-llvm
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{github.workspace}}/llvm
         key: ${{runner.os}}-llvm-${{matrix.clang}}


### PR DESCRIPTION
Github will deprecate nodejs20 on 23rd of September. We need to switch to actions that support nodjs24 otherwise the CI wail fail after it removed.


For most actions it was fine to bump the version, however there were two that hasn't been updated yet. Here some other alternatives were selected:
KyleMayes/install-llvm-action --> ZhongRuoyu/setup-llvm@v0.2.0
ilammy/msvc-dev-cmd@v1 --> TheMrMilchmann/setup-msvc-dev@v4