### PR TITLE
[Metal] Deduplicate residency bindings

### DIFF
--- a/include/hipSYCL/runtime/metal/metal_allocator.hpp
+++ b/include/hipSYCL/runtime/metal/metal_allocator.hpp
@@ -14,13 +14,16 @@
 #include "../allocator.hpp"
 #include "../hints.hpp"
 
+#include <atomic>
 #include <map>
 #include <memory>
+#include <vector>
 
 namespace MTL {
 
 class Device;
 class Buffer;
+class Resource;
 
 } // namespace MTL
 
@@ -72,15 +75,18 @@ public:
 
   size_t get_delta() const { return _delta; }
 
-  template<typename F>
-  void for_each_buffer(F&& f) const {
-    std::lock_guard<std::mutex> lock{_mutex};
-    for (auto& [ptr, block] : _ptr_to_block) {
-      if (block.buffer) {
-        f(block.buffer);
-      }
-    }
+  // Bumped on every allocation/free, so consumers (e.g. residency tracking in
+  // the queue) can tell the allocation set changed without taking the lock.
+  uint64_t generation() const {
+    return _generation.load(std::memory_order_relaxed);
   }
+
+  // Fills `out` with all Metal buffers currently backing USM allocations and
+  // returns the generation the snapshot was taken at. Each buffer is
+  // retain()'d, since the snapshot is meant to be cached and used (e.g. via
+  // useResources()) after this call returns; the caller must release() every
+  // entry once it stops using the snapshot.
+  uint64_t snapshot_buffers(std::vector<const MTL::Resource*>& out) const;
 
 private:
   MTL::Buffer* alloc_buffer(size_t size_bytes);
@@ -97,6 +103,7 @@ private:
   };
   std::map<void*, usm_block> _ptr_to_block;
   mutable std::mutex _mutex;
+  std::atomic<uint64_t> _generation{0};
   std::shared_ptr<metal_mmap_region> _mmap_region;
 };
 

--- a/include/hipSYCL/runtime/metal/metal_queue.hpp
+++ b/include/hipSYCL/runtime/metal/metal_queue.hpp
@@ -24,11 +24,15 @@
 
 #include <mach/mach_time.h>
 
+#include <vector>
+
 namespace MTL {
 
 class Device;
+class Resource;
 class CommandBuffer;
 class CommandQueue;
+class ComputeCommandEncoder;
 class SharedEvent;
 class SharedEventListener;
 
@@ -154,9 +158,18 @@ public:
 
   virtual ~metal_inorder_queue();
 
+  // Makes all known USM allocations resident for `encoder`. Residency is
+  // scoped to the encoder, so this must be called for every one; the
+  // allocation set itself is cached and only rebuilt when it changes.
+  // Public because the free kernel launch helper calls it.
+  void make_allocations_resident(MTL::ComputeCommandEncoder* encoder);
+
 private:
   MTL::CommandBuffer* new_command_buffer();
   void profiling_setup(operation& op, const dag_node_ptr& node);
+
+  // Releases the extra reference held on every entry of _resident_resources.
+  void release_resident_resources();
 
   MTL::Device* _device = nullptr;
   MTL::CommandQueue* _command_queue = nullptr;
@@ -170,6 +183,15 @@ private:
   // by external mutex, so no atomics needed.
   uint64_t _pending_cpu_event{0};
   uint64_t _pending_gpu_event{0};
+
+  // Cached snapshot of the allocations that must be made resident, plus the
+  // allocator generation it was taken at; rebuilt only when that generation
+  // changes. Each entry holds an extra reference taken by
+  // metal_allocator::snapshot_buffers() so a concurrent free() elsewhere
+  // cannot deallocate it while cached here; released when the cache is
+  // replaced or the queue is destroyed.
+  std::vector<const MTL::Resource*> _resident_resources;
+  uint64_t _residency_generation{~static_cast<uint64_t>(0)};
 
   metal_allocator* _allocator = nullptr;
   device_id _device_id;

--- a/src/runtime/metal/metal_allocator.cpp
+++ b/src/runtime/metal/metal_allocator.cpp
@@ -212,6 +212,7 @@ void* metal_allocator::raw_allocate(
   };
   std::lock_guard<std::mutex> lock{_mutex};
   _ptr_to_block[canonical_ptr] = block;
+  ++_generation;
   return canonical_ptr;
 }
 
@@ -230,6 +231,7 @@ void *metal_allocator::raw_allocate_usm(
   };
   std::lock_guard<std::mutex> lock{_mutex};
   _ptr_to_block[host_ptr] = block;
+  ++_generation;
   return host_ptr;
 }
 
@@ -249,6 +251,7 @@ metal_allocator::raw_allocate_optimized_host(
   };
   std::lock_guard<std::mutex> lock{_mutex};
   _ptr_to_block[host_ptr] = block;
+  ++_generation;
   return host_ptr;
 }
 
@@ -266,6 +269,7 @@ void metal_allocator::raw_free(void *mem)
     }
     _ptr_to_block.erase(it);
   }
+  ++_generation;
 }
 
 bool metal_allocator::is_usm_accessible_from(backend_descriptor b) const
@@ -372,6 +376,18 @@ void metal_allocator::calibrate() {
     ^(void*, NS::UInteger) { });
   _delta = buffer->gpuAddress() - reinterpret_cast<uintptr_t>(buffer->contents());
   buffer->release();
+}
+
+uint64_t metal_allocator::snapshot_buffers(std::vector<const MTL::Resource*>& out) const {
+  std::lock_guard<std::mutex> lock{_mutex};
+  out.clear();
+  for (auto& [ptr, block] : _ptr_to_block) {
+    if (block.buffer) {
+      block.buffer->retain();
+      out.push_back(block.buffer);
+    }
+  }
+  return _generation.load(std::memory_order_relaxed);
 }
 
 std::tuple<MTL::Buffer*, size_t, metal_allocator::usm_alloc_type> metal_allocator::get_usm_block(const void* ptr) const {

--- a/src/runtime/metal/metal_queue.cpp
+++ b/src/runtime/metal/metal_queue.cpp
@@ -106,6 +106,7 @@ result launch_kernel_from_library(
   MTL::Library* library,
   MTL::Device* device,
   MTL::CommandBuffer* command_buffer,
+  metal_inorder_queue* queue,
   metal_allocator* allocator,
   std::string_view kernel_name,
   const rt::range<3>& num_groups,
@@ -196,10 +197,10 @@ result launch_kernel_from_library(
       encoder, device, allocator, function.get(), args, arg_sizes, num_args, is_pointer_arg, buffers_out, buf_offset);
   }
 
+  // SSCP kernels may dereference arbitrary USM pointers, so every allocation
+  // must be resident for this encoder.
   // TODO: switch to MTL4 API for O(1) buffer bindings
-  allocator->for_each_buffer([&](MTL::Buffer* buf) {
-    encoder->useResource(buf, MTL::ResourceUsageRead | MTL::ResourceUsageWrite);
-  });
+  queue->make_allocations_resident(encoder);
 
   MTL::Size num_groups_size = MTL::Size::Make(
     num_groups[0],
@@ -311,6 +312,31 @@ MTL::CommandBuffer* metal_inorder_queue::new_command_buffer() {
   }
 
   return cmd_buf;
+}
+
+void metal_inorder_queue::release_resident_resources() {
+  for (const MTL::Resource* r : _resident_resources) {
+    const_cast<MTL::Resource*>(r)->release();
+  }
+}
+
+void metal_inorder_queue::make_allocations_resident(
+  MTL::ComputeCommandEncoder* encoder) {
+  constexpr auto usage = MTL::ResourceUsageRead | MTL::ResourceUsageWrite;
+
+  // The allocation set is only rescanned - under the allocator lock - when
+  // the generation changed since the last scan, turning the per-launch cost
+  // from O(allocations) under that lock into a lock-free generation check
+  // plus one useResources call.
+  if (_allocator->generation() != _residency_generation) {
+    release_resident_resources();
+    _residency_generation = _allocator->snapshot_buffers(_resident_resources);
+  }
+
+  if (!_resident_resources.empty()) {
+    encoder->useResources(_resident_resources.data(),
+                          _resident_resources.size(), usage);
+  }
 }
 
 void metal_inorder_queue::profiling_setup(operation& op, const dag_node_ptr& node) {
@@ -836,7 +862,7 @@ result metal_inorder_queue::submit_sscp_kernel_from_code_object(hcf_object_id hc
   }
 
   return launch_kernel_from_library(
-    library, _device, new_command_buffer(), _allocator, kernel_name,
+    library, _device, new_command_buffer(), this, _allocator, kernel_name,
     num_groups, group_size, local_mem_size,
     _arg_mapper.get_mapped_args(),
     const_cast<std::size_t*>(_arg_mapper.get_mapped_arg_sizes()),
@@ -855,6 +881,7 @@ metal_inorder_queue::~metal_inorder_queue() {
   // Drain pending work before releasing queue-owned Metal objects that may be
   // referenced by completion handlers.
   wait();
+  release_resident_resources();
   _event_listener->release();
   _shared_event->release();
   _command_queue->release();


### PR DESCRIPTION
Split out of #2196 per [review](https://github.com/AdaptiveCpp/AdaptiveCpp/pull/2196#issuecomment-5462113940): this part is independent of the command buffer batching work there, so it's reviewable on its own.

## Background

SSCP kernels may dereference arbitrary USM pointers, so every allocation must be made resident for each dispatch's compute encoder. Previously this was done with `metal_allocator::for_each_buffer`, which took the allocator lock and called `useResource()` once per allocation on every single kernel launch.

## Changes

- `metal_allocator` gains a lock-free monotonic `generation()` counter, bumped on every allocation/free, and a `snapshot_buffers()` method that returns a retained snapshot of all backing buffers together with the generation it was taken at.
- `metal_inorder_queue::make_allocations_resident()` caches that snapshot and only rebuilds it (taking the allocator lock) when the generation has changed since the last check; otherwise it just passes the cached set to `useResources()`. This turns the per-launch residency cost from O(allocations) under the allocator mutex into a single lock-free generation check plus one `useResources()` call in the common case.

## Testing

`sycl_tests`, `pcuda_tests`, `rt_tests` pass on macOS/arm64 (M2 Max, macOS 26).