### PR TITLE
add default contructor for nd_range

### DIFF
--- a/include/hipSYCL/sycl/libkernel/nd_range.hpp
+++ b/include/hipSYCL/sycl/libkernel/nd_range.hpp
@@ -22,6 +22,14 @@ struct nd_range {
   static constexpr int dimensions = Dimensions;
 
   ACPP_UNIVERSAL_TARGET
+  nd_range()
+    : _global_range{},
+      _local_range{},
+      _num_groups{},
+      _offset{}
+  {}
+
+  ACPP_UNIVERSAL_TARGET
   nd_range(range<Dimensions> globalSize,
            range<Dimensions> localSize,
            id<Dimensions> offset = id<Dimensions>())

--- a/tests/sycl/id_range.cpp
+++ b/tests/sycl/id_range.cpp
@@ -240,4 +240,28 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(id_api, _dimensions, test_dimensions) {
 }
 
 
+BOOST_AUTO_TEST_CASE_TEMPLATE(default_construction, _dimensions, test_dimensions) {
+  namespace s = sycl;
+  constexpr auto d = _dimensions::value;
+
+  {
+    s::range<d> range;
+    for(int i = 0; i < d; ++i) BOOST_TEST(range[i] == 0);
+  }
+  {
+    s::id<d> id;
+    for(int i = 0; i < d; ++i) BOOST_TEST(id[i] == 0);
+  }
+  {
+    s::nd_range<d> nd_range;
+    for(int i = 0; i < d; ++i) {
+      BOOST_TEST(nd_range.get_global_range()[i] == 0);
+      BOOST_TEST(nd_range.get_local_range()[i] == 0);
+      BOOST_TEST(nd_range.get_group_range()[i] == 0);
+      BOOST_TEST(nd_range.get_offset()[i] == 0);
+    }
+  }
+}
+
+
 BOOST_AUTO_TEST_SUITE_END() // NOTE: Make sure not to add anything below this line


### PR DESCRIPTION
Implemented https://github.com/KhronosGroup/SYCL-Docs/pull/1046

And added tests for extra-fancyness, but CTS tests it too, so as you want. I can remove it .