### PR TITLE
SSCP: simplify functions before force-inlining them into the kernel

### DIFF
--- a/src/compiler/llvm-to-backend/LLVMToBackend.cpp
+++ b/src/compiler/llvm-to-backend/LLVMToBackend.cpp
@@ -29,6 +29,9 @@
 #include <cstdint>
 
 #include <llvm/Transforms/IPO/AlwaysInliner.h>
+#include <llvm/Transforms/Scalar/GVN.h>
+#include <llvm/Transforms/Scalar/SimplifyCFG.h>
+#include <llvm/Transforms/Utils/SimplifyCFGOptions.h>
 #include <llvm/ADT/APFloat.h>
 #include <llvm/IR/Attributes.h>
 #include <llvm/IR/DerivedTypes.h>
@@ -54,6 +57,18 @@ namespace hipsycl {
 namespace compiler {
 
 namespace {
+
+// Simplify each function before it is force-inlined into the kernel, while
+// its parameter attributes (e.g. `dereferenceable` on a `const T&`) still let
+// SimplifyCFG fold short-circuited conditions into selects.
+void runPreInlineSimplification(llvm::Module &M, llvm::ModuleAnalysisManager &MAM) {
+  llvm::FunctionPassManager FPM;
+  FPM.addPass(llvm::GVNPass());
+  FPM.addPass(llvm::SimplifyCFGPass(llvm::SimplifyCFGOptions().hoistCommonInsts(true)));
+  llvm::ModulePassManager MPM;
+  MPM.addPass(llvm::createModuleToFunctionPassAdaptor(std::move(FPM)));
+  MPM.run(M, MAM);
+}
 
 void printModuleToFile(llvm::Module& M, const std::string& File,
                       const std::string& Header){
@@ -351,6 +366,10 @@ bool LLVMToBackendTranslator::prepareIR(llvm::Module &M) {
     GlobalInliningAttributorPass InliningPass{Kernels};
     InliningPass.run(M, MAM);
     MAM.clear();
+
+    runPreInlineSimplification(M, MAM);
+    MAM.clear();
+
     llvm::AlwaysInlinerPass AIP;
     AIP.run(M, MAM);
 

--- a/tests/compiler/sscp/preinline_simplify.cpp
+++ b/tests/compiler/sscp/preinline_simplify.cpp
@@ -1,0 +1,58 @@
+// Functions are simplified before being inlined into the kernel, so the
+// `a && b && c` below must reach the JIT pipeline already folded into
+// branchless code.
+//
+// RUN: %acpp %s -o %t --acpp-targets=generic -O3
+// RUN: rm -f %t.ll
+// RUN: env ACPP_S2_DUMP_IR_JIT_OPTIMIZATIONS=%t.ll %t | FileCheck %s --check-prefix=OUT
+// RUN: FileCheck %s --input-file %t.ll
+
+#include "common.hpp"
+#include <iostream>
+
+struct bounds {
+  int lo;
+};
+
+// A real function, so that its reference parameter carries `dereferenceable`.
+// Every conjunct reads the same field, so each is a single compare once the
+// redundant loads are gone.
+static int classify(const bounds &b, int x, int y, int z) {
+  if (x > b.lo && y > b.lo && z > b.lo)
+    return 1;
+  return 0;
+}
+
+int main() {
+  sycl::queue q = get_queue();
+
+  bounds *b = sycl::malloc_device<bounds>(1, q);
+  int *v = sycl::malloc_device<int>(3, q);
+  int *out = sycl::malloc_device<int>(1, q);
+  const bounds host_b{2};
+  const int host_v[3] = {3, 4, 5};
+  q.memcpy(b, &host_b, sizeof(bounds)).wait();
+  q.memcpy(v, host_v, sizeof(host_v)).wait();
+
+  q.single_task([=]() { *out = classify(*b, v[0], v[1], v[2]); }).wait();
+
+  int result = 0;
+  q.memcpy(&result, out, sizeof(int)).wait();
+
+  // OUT: 1
+  std::cout << result << std::endl;
+
+  sycl::free(b, q);
+  sycl::free(v, q);
+  sycl::free(out, q);
+  return 0;
+}
+
+// The dump taken right after the always-inliner: the conjuncts must have been
+// folded while `b` was still a `dereferenceable` argument, so the kernel is
+// free of conditional branches.
+//
+// CHECK-LABEL: stage: jit_optimizations
+// CHECK-LABEL: define {{.*}}__acpp_sscp_kernel
+// CHECK-NOT: br i1
+// CHECK: ret void


### PR DESCRIPTION
Run GVN + SimplifyCFG on every function before AlwaysInlinerPass, as the -O3 pipeline does before its own always-inliner. Inlining drops the callee's parameter attributes, and `dereferenceable` on a `const T&` parameter is what SimplifyCFG needs to fold a short-circuited condition into selects; once inlined, the proof is gone. Adds a lit test for it.