### PR TITLE
Missing free in empty_kernel_submission SYCL test

### DIFF
--- a/tests/sycl/kernel_invocation.cpp
+++ b/tests/sycl/kernel_invocation.cpp
@@ -85,6 +85,8 @@ BOOST_AUTO_TEST_CASE(empty_kernel_submission) {
   });
 
   e3D.wait_and_throw();
+
+  sycl::free(d_y, q);
 }
 
 BOOST_AUTO_TEST_CASE(basic_parallel_for) {


### PR DESCRIPTION
There's a memory leak where the test mallocs a USM pointer but doesn't free it