### PR TITLE
[Metal] Make USM allocations resident via MTLResidencySet

### DIFF
--- a/include/hipSYCL/runtime/metal/metal_allocator.hpp
+++ b/include/hipSYCL/runtime/metal/metal_allocator.hpp
@@ -73,7 +73,18 @@ public:
 
   size_t get_delta() const { return _delta; }
 
+  // Null if the device does not provide residency sets
   MTL::ResidencySet* get_residency_set() const { return _residency_set; }
+
+  template<typename F>
+  void for_each_buffer(F&& f) const {
+    std::lock_guard<std::mutex> lock{_mutex};
+    for (auto& [ptr, block] : _ptr_to_block) {
+      if (block.buffer) {
+        f(block.buffer);
+      }
+    }
+  }
 
 private:
   MTL::Buffer* alloc_buffer(size_t size_bytes);

--- a/include/hipSYCL/runtime/metal/metal_allocator.hpp
+++ b/include/hipSYCL/runtime/metal/metal_allocator.hpp
@@ -21,6 +21,7 @@ namespace MTL {
 
 class Device;
 class Buffer;
+class ResidencySet;
 
 } // namespace MTL
 
@@ -72,19 +73,13 @@ public:
 
   size_t get_delta() const { return _delta; }
 
-  template<typename F>
-  void for_each_buffer(F&& f) const {
-    std::lock_guard<std::mutex> lock{_mutex};
-    for (auto& [ptr, block] : _ptr_to_block) {
-      if (block.buffer) {
-        f(block.buffer);
-      }
-    }
-  }
+  MTL::ResidencySet* get_residency_set() const { return _residency_set; }
 
 private:
   MTL::Buffer* alloc_buffer(size_t size_bytes);
   void calibrate();
+  void add_to_residency_set(MTL::Buffer* buffer);
+  void remove_from_residency_set(MTL::Buffer* buffer);
 
   MTL::Device* _device = nullptr;
   device_id _device_id;
@@ -97,6 +92,7 @@ private:
   };
   std::map<void*, usm_block> _ptr_to_block;
   mutable std::mutex _mutex;
+  MTL::ResidencySet* _residency_set = nullptr;
   std::shared_ptr<metal_mmap_region> _mmap_region;
 };
 

--- a/include/hipSYCL/runtime/metal/metal_allocator.hpp
+++ b/include/hipSYCL/runtime/metal/metal_allocator.hpp
@@ -90,8 +90,8 @@ public:
 private:
   MTL::Buffer* alloc_buffer(size_t size_bytes);
   void calibrate();
-  void add_to_residency_set(MTL::Buffer* buffer);
-  void remove_from_residency_set(MTL::Buffer* buffer);
+  void add_to_residency_set(const std::lock_guard<std::mutex>&, MTL::Buffer* buffer);
+  void remove_from_residency_set(const std::lock_guard<std::mutex>&, MTL::Buffer* buffer);
 
   MTL::Device* _device = nullptr;
   device_id _device_id;

--- a/include/hipSYCL/runtime/metal/metal_allocator.hpp
+++ b/include/hipSYCL/runtime/metal/metal_allocator.hpp
@@ -75,6 +75,7 @@ public:
 
   // Null if the device does not provide residency sets
   MTL::ResidencySet* get_residency_set() const { return _residency_set; }
+  void commit_residency_set();
 
   template<typename F>
   void for_each_buffer(F&& f) const {
@@ -104,6 +105,7 @@ private:
   std::map<void*, usm_block> _ptr_to_block;
   mutable std::mutex _mutex;
   MTL::ResidencySet* _residency_set = nullptr;
+  bool _residency_set_dirty = false;
   std::shared_ptr<metal_mmap_region> _mmap_region;
 };
 

--- a/include/hipSYCL/runtime/metal/metal_queue.hpp
+++ b/include/hipSYCL/runtime/metal/metal_queue.hpp
@@ -29,6 +29,7 @@ namespace MTL {
 class Device;
 class CommandBuffer;
 class CommandQueue;
+class Fence;
 class SharedEvent;
 class SharedEventListener;
 
@@ -170,6 +171,11 @@ private:
   // by external mutex, so no atomics needed.
   uint64_t _pending_cpu_event{0};
   uint64_t _pending_gpu_event{0};
+
+  // Needed for explicit ordering of resources from MTLResources
+  // It is only used if a kernel with memory indirection was submitted
+  MTL::Fence* _fence = nullptr;
+  bool _fence_chain_active = false;
 
   metal_allocator* _allocator = nullptr;
   device_id _device_id;

--- a/src/runtime/metal/metal_allocator.cpp
+++ b/src/runtime/metal/metal_allocator.cpp
@@ -11,6 +11,8 @@
 
 #include "hipSYCL/runtime/metal/metal_allocator.hpp"
 
+#include "hipSYCL/common/debug.hpp"
+
 #include <Metal/Metal.hpp>
 #include <sys/mman.h>
 #include <sys/sysctl.h>
@@ -189,11 +191,14 @@ metal_allocator::metal_allocator(MTL::Device* device, const device_id &id)
   NS::Error* err = nullptr;
   _residency_set = _device->newResidencySet(desc.get(), &err);
   if (!_residency_set) {
-    std::string msg = "metal_allocator: Could not create residency set";
-    if (err && err->localizedDescription()) {
-      msg += std::string{": "} + err->localizedDescription()->utf8String();
-    }
-    throw std::runtime_error(msg);
+    HIPSYCL_DEBUG_WARNING << "metal_allocator: Device does not provide "
+                             "residency sets, falling back to per-encoder "
+                             "residency"
+                          << (err && err->localizedDescription()
+                                ? std::string{": "} +
+                                    err->localizedDescription()->utf8String()
+                                : std::string{})
+                          << std::endl;
   }
 
   calibrate();
@@ -205,8 +210,10 @@ metal_allocator::~metal_allocator() {
       block.buffer->release();
     }
   }
-  _residency_set->endResidency();
-  _residency_set->release();
+  if (_residency_set) {
+    _residency_set->endResidency();
+    _residency_set->release();
+  }
 }
 
 void* metal_allocator::raw_allocate(
@@ -385,11 +392,17 @@ MTL::Buffer* metal_allocator::alloc_buffer(size_t size_bytes) {
 }
 
 void metal_allocator::add_to_residency_set(MTL::Buffer* buffer) {
+  if (!_residency_set) {
+    return;
+  }
   _residency_set->addAllocation(buffer);
   _residency_set->commit();
 }
 
 void metal_allocator::remove_from_residency_set(MTL::Buffer* buffer) {
+  if (!_residency_set) {
+    return;
+  }
   _residency_set->removeAllocation(buffer);
   _residency_set->commit();
 }

--- a/src/runtime/metal/metal_allocator.cpp
+++ b/src/runtime/metal/metal_allocator.cpp
@@ -185,6 +185,17 @@ metal_allocator::metal_allocator(MTL::Device* device, const device_id &id)
   , _mmap_region(std::make_shared<metal_mmap_region>(
       static_cast<size_t>(get_total_ram() * mmap_region_size_fraction), _page_size))
 {
+  NS::SharedPtr<MTL::ResidencySetDescriptor> desc = NS::TransferPtr(MTL::ResidencySetDescriptor::alloc()->init());
+  NS::Error* err = nullptr;
+  _residency_set = _device->newResidencySet(desc.get(), &err);
+  if (!_residency_set) {
+    std::string msg = "metal_allocator: Could not create residency set";
+    if (err && err->localizedDescription()) {
+      msg += std::string{": "} + err->localizedDescription()->utf8String();
+    }
+    throw std::runtime_error(msg);
+  }
+
   calibrate();
 }
 
@@ -194,6 +205,8 @@ metal_allocator::~metal_allocator() {
       block.buffer->release();
     }
   }
+  _residency_set->endResidency();
+  _residency_set->release();
 }
 
 void* metal_allocator::raw_allocate(
@@ -212,6 +225,7 @@ void* metal_allocator::raw_allocate(
   };
   std::lock_guard<std::mutex> lock{_mutex};
   _ptr_to_block[canonical_ptr] = block;
+  add_to_residency_set(buffer);
   return canonical_ptr;
 }
 
@@ -230,6 +244,7 @@ void *metal_allocator::raw_allocate_usm(
   };
   std::lock_guard<std::mutex> lock{_mutex};
   _ptr_to_block[host_ptr] = block;
+  add_to_residency_set(buffer);
   return host_ptr;
 }
 
@@ -249,6 +264,7 @@ metal_allocator::raw_allocate_optimized_host(
   };
   std::lock_guard<std::mutex> lock{_mutex};
   _ptr_to_block[host_ptr] = block;
+  add_to_residency_set(buffer);
   return host_ptr;
 }
 
@@ -260,6 +276,7 @@ void metal_allocator::raw_free(void *mem)
   auto it = _ptr_to_block.find(mem);
   if (it != _ptr_to_block.end()) {
     if(it->second.buffer) {
+      remove_from_residency_set(it->second.buffer);
       it->second.buffer->release();
     } else {
       std::free(mem);
@@ -365,6 +382,16 @@ MTL::Buffer* metal_allocator::alloc_buffer(size_t size_bytes) {
     }
   }
   return buffer;
+}
+
+void metal_allocator::add_to_residency_set(MTL::Buffer* buffer) {
+  _residency_set->addAllocation(buffer);
+  _residency_set->commit();
+}
+
+void metal_allocator::remove_from_residency_set(MTL::Buffer* buffer) {
+  _residency_set->removeAllocation(buffer);
+  _residency_set->commit();
 }
 
 void metal_allocator::calibrate() {

--- a/src/runtime/metal/metal_allocator.cpp
+++ b/src/runtime/metal/metal_allocator.cpp
@@ -396,15 +396,29 @@ void metal_allocator::add_to_residency_set(MTL::Buffer* buffer) {
     return;
   }
   _residency_set->addAllocation(buffer);
-  _residency_set->commit();
+  _residency_set_dirty = true;
 }
 
 void metal_allocator::remove_from_residency_set(MTL::Buffer* buffer) {
   if (!_residency_set) {
     return;
   }
+  if (_residency_set_dirty) {
+    _residency_set->commit();
+    _residency_set_dirty = false;
+  }
   _residency_set->removeAllocation(buffer);
   _residency_set->commit();
+}
+
+void metal_allocator::commit_residency_set() {
+  std::lock_guard<std::mutex> lock{_mutex};
+  if (!_residency_set || !_residency_set_dirty) {
+    return;
+  }
+  _residency_set->commit();
+  _residency_set->requestResidency();
+  _residency_set_dirty = false;
 }
 
 void metal_allocator::calibrate() {

--- a/src/runtime/metal/metal_allocator.cpp
+++ b/src/runtime/metal/metal_allocator.cpp
@@ -232,7 +232,7 @@ void* metal_allocator::raw_allocate(
   };
   std::lock_guard<std::mutex> lock{_mutex};
   _ptr_to_block[canonical_ptr] = block;
-  add_to_residency_set(buffer);
+  add_to_residency_set(lock, buffer);
   return canonical_ptr;
 }
 
@@ -251,7 +251,7 @@ void *metal_allocator::raw_allocate_usm(
   };
   std::lock_guard<std::mutex> lock{_mutex};
   _ptr_to_block[host_ptr] = block;
-  add_to_residency_set(buffer);
+  add_to_residency_set(lock, buffer);
   return host_ptr;
 }
 
@@ -271,7 +271,7 @@ metal_allocator::raw_allocate_optimized_host(
   };
   std::lock_guard<std::mutex> lock{_mutex};
   _ptr_to_block[host_ptr] = block;
-  add_to_residency_set(buffer);
+  add_to_residency_set(lock, buffer);
   return host_ptr;
 }
 
@@ -283,7 +283,7 @@ void metal_allocator::raw_free(void *mem)
   auto it = _ptr_to_block.find(mem);
   if (it != _ptr_to_block.end()) {
     if(it->second.buffer) {
-      remove_from_residency_set(it->second.buffer);
+      remove_from_residency_set(lock, it->second.buffer);
       it->second.buffer->release();
     } else {
       std::free(mem);
@@ -391,7 +391,7 @@ MTL::Buffer* metal_allocator::alloc_buffer(size_t size_bytes) {
   return buffer;
 }
 
-void metal_allocator::add_to_residency_set(MTL::Buffer* buffer) {
+void metal_allocator::add_to_residency_set(const std::lock_guard<std::mutex>&, MTL::Buffer* buffer) {
   if (!_residency_set) {
     return;
   }
@@ -399,7 +399,7 @@ void metal_allocator::add_to_residency_set(MTL::Buffer* buffer) {
   _residency_set_dirty = true;
 }
 
-void metal_allocator::remove_from_residency_set(MTL::Buffer* buffer) {
+void metal_allocator::remove_from_residency_set(const std::lock_guard<std::mutex>&, MTL::Buffer* buffer) {
   if (!_residency_set) {
     return;
   }

--- a/src/runtime/metal/metal_queue.cpp
+++ b/src/runtime/metal/metal_queue.cpp
@@ -195,6 +195,12 @@ result launch_kernel_from_library(
       encoder, device, allocator, function.get(), args, arg_sizes, num_args, is_pointer_arg, buffers_out, buf_offset);
   }
 
+  if (!allocator->get_residency_set()) {
+    allocator->for_each_buffer([&](MTL::Buffer* buf) {
+      encoder->useResource(buf, MTL::ResourceUsageRead | MTL::ResourceUsageWrite);
+    });
+  }
+
   MTL::Size num_groups_size = MTL::Size::Make(
     num_groups[0],
     num_groups[1],
@@ -284,7 +290,9 @@ metal_inorder_queue::metal_inorder_queue(MTL::Device* device, metal_allocator* a
   , _sscp_code_object_invoker(this)
   , _kernel_cache{kernel_cache::get()}
 {
-  _command_queue->addResidencySet(allocator->get_residency_set());
+  if (auto* residency_set = allocator->get_residency_set()) {
+    _command_queue->addResidencySet(residency_set);
+  }
 
   _reflection_map = glue::jit::construct_default_reflection_map(hw_ctx);
 }

--- a/src/runtime/metal/metal_queue.cpp
+++ b/src/runtime/metal/metal_queue.cpp
@@ -87,7 +87,6 @@ void encode_arguments_argbuffer(
       auto [buffer, offset, _] = allocator->get_usm_block(usm_ptr);
       if (buffer) {
         arg_enc->setBuffer(buffer, offset, i);
-        encoder->useResource(buffer, MTL::ResourceUsageRead | MTL::ResourceUsageWrite);
       } else {
         // Argument buffer memory may be reused (e.g. mmap-backed region), so
         // stale pointer slots must be explicitly zeroed rather than left as-is.
@@ -196,11 +195,6 @@ result launch_kernel_from_library(
       encoder, device, allocator, function.get(), args, arg_sizes, num_args, is_pointer_arg, buffers_out, buf_offset);
   }
 
-  // TODO: switch to MTL4 API for O(1) buffer bindings
-  allocator->for_each_buffer([&](MTL::Buffer* buf) {
-    encoder->useResource(buf, MTL::ResourceUsageRead | MTL::ResourceUsageWrite);
-  });
-
   MTL::Size num_groups_size = MTL::Size::Make(
     num_groups[0],
     num_groups[1],
@@ -290,6 +284,8 @@ metal_inorder_queue::metal_inorder_queue(MTL::Device* device, metal_allocator* a
   , _sscp_code_object_invoker(this)
   , _kernel_cache{kernel_cache::get()}
 {
+  _command_queue->addResidencySet(allocator->get_residency_set());
+
   _reflection_map = glue::jit::construct_default_reflection_map(hw_ctx);
 }
 

--- a/src/runtime/metal/metal_queue.cpp
+++ b/src/runtime/metal/metal_queue.cpp
@@ -87,6 +87,7 @@ void encode_arguments_argbuffer(
       auto [buffer, offset, _] = allocator->get_usm_block(usm_ptr);
       if (buffer) {
         arg_enc->setBuffer(buffer, offset, i);
+        encoder->useResource(buffer, MTL::ResourceUsageRead | MTL::ResourceUsageWrite);
       } else {
         // Argument buffer memory may be reused (e.g. mmap-backed region), so
         // stale pointer slots must be explicitly zeroed rather than left as-is.
@@ -114,7 +115,10 @@ result launch_kernel_from_library(
   std::size_t* arg_sizes,
   std::size_t num_args,
   const rt::hcf_kernel_info* kernel_info,
-  const std::optional<std::vector<int>>& retained_indices)
+  const std::optional<std::vector<int>>& retained_indices,
+  bool has_indirect_access,
+  MTL::Fence* fence,
+  bool wait_fence)
 {
   if (!library) {
     return make_error(__acpp_here(),
@@ -165,6 +169,10 @@ result launch_kernel_from_library(
                       error_info{"metal: Failed to create compute encoder"});
   }
 
+  if (wait_fence) {
+    encoder->waitForFence(fence);
+  }
+
   encoder->setComputePipelineState(pipeline_state.get());
   uint32_t user_local_mem_size = local_mem_size;
 
@@ -195,7 +203,7 @@ result launch_kernel_from_library(
       encoder, device, allocator, function.get(), args, arg_sizes, num_args, is_pointer_arg, buffers_out, buf_offset);
   }
 
-  if (!allocator->get_residency_set()) {
+  if (has_indirect_access && !allocator->get_residency_set()) {
     allocator->for_each_buffer([&](MTL::Buffer* buf) {
       encoder->useResource(buf, MTL::ResourceUsageRead | MTL::ResourceUsageWrite);
     });
@@ -220,6 +228,10 @@ result launch_kernel_from_library(
                      << ", " << threadgroup_size.depth << ")" << std::endl;
 
   encoder->dispatchThreadgroups(num_groups_size, threadgroup_size);
+
+  if (fence) {
+    encoder->updateFence(fence);
+  }
 
   encoder->endEncoding();
 
@@ -246,7 +258,8 @@ result memset_device(
   metal_allocator* allocator,
   void* ptr,
   unsigned char pattern,
-  std::size_t num_bytes)
+  std::size_t num_bytes,
+  MTL::Fence* fence)
 {
   auto [buffer, offset, _3] = allocator->get_usm_block(ptr);
   if (!buffer) {
@@ -260,7 +273,13 @@ result memset_device(
       error_info{"metal_queue: Failed to create blit encoder for memset"});
   }
 
+  if (fence) {
+    blit_encoder->waitForFence(fence);
+  }
   blit_encoder->fillBuffer(buffer, NS::Range::Make(offset, num_bytes), pattern);
+  if (fence) {
+    blit_encoder->updateFence(fence);
+  }
   blit_encoder->endEncoding();
 
   command_buffer->addCompletedHandler([](MTL::CommandBuffer* command_buffer) {
@@ -292,12 +311,14 @@ metal_inorder_queue::metal_inorder_queue(MTL::Device* device, metal_allocator* a
 {
   if (auto* residency_set = allocator->get_residency_set()) {
     _command_queue->addResidencySet(residency_set);
+    _fence = device->newFence();
   }
 
   _reflection_map = glue::jit::construct_default_reflection_map(hw_ctx);
 }
 
 MTL::CommandBuffer* metal_inorder_queue::new_command_buffer() {
+  _allocator->commit_residency_set();
   auto* cmd_buf = _command_queue->commandBuffer();
   if (auto prev = std::exchange(_pending_gpu_event, 0)) {
     cmd_buf->encodeWait(_shared_event, prev);
@@ -525,6 +546,10 @@ result metal_inorder_queue::submit_memcpy(memcpy_operation& op, const dag_node_p
       error_info{"metal_queue: Failed to create blit encoder for memcpy"});
   }
 
+  if (_fence_chain_active) {
+    blit_encoder->waitForFence(_fence);
+  }
+
   // copy from src or staging buffer to dst or staging buffer
   for (std::size_t surface = 0; surface < transferred_range[0]; ++surface) {
     for (std::size_t row = 0; row < transferred_range[1]; ++row) {
@@ -541,6 +566,10 @@ result metal_inorder_queue::submit_memcpy(memcpy_operation& op, const dag_node_p
         to_offset + dst_linear_index * dest_element_size,
         transferred_range[2] * src_element_size);
     }
+  }
+
+  if (_fence_chain_active) {
+    blit_encoder->updateFence(_fence);
   }
 
   blit_encoder->endEncoding();
@@ -649,7 +678,8 @@ result metal_inorder_queue::submit_memset(memset_operation& op, const dag_node_p
       error_info{"metal_queue: Failed to create command buffer for memset"});
   }
 
-  return memset_device(command_buffer, _allocator, ptr, pattern, num_bytes);
+  return memset_device(command_buffer, _allocator, ptr, pattern, num_bytes,
+                       _fence_chain_active ? _fence : nullptr);
 }
 
 result metal_inorder_queue::submit_queue_wait_for(const dag_node_ptr& node) {
@@ -681,6 +711,7 @@ result metal_inorder_queue::submit_external_wait_for(const dag_node_ptr& node) {
 result metal_inorder_queue::wait() {
   HIPSYCL_DEBUG_INFO << "metal_queue: Waiting for queue completion..." << std::endl;
   insert_event()->wait();
+  _fence_chain_active = false;
   return make_success();
 }
 
@@ -825,6 +856,12 @@ result metal_inorder_queue::submit_sscp_kernel_from_code_object(hcf_object_id hc
 
   const auto& jit_output_metadata = obj->get_jit_output_metadata();
   const auto& retained_indices = jit_output_metadata.kernel_retained_arguments_indices;
+  const bool has_indirect_access = !jit_output_metadata.is_free_of_indirect_access;
+
+  const bool wait_fence = _fence_chain_active;
+  if (_fence && has_indirect_access) {
+    _fence_chain_active = true;
+  }
   if (retained_indices.has_value()) {
     _arg_mapper.apply_dead_argument_elimination_mask(retained_indices.value());
   }
@@ -846,7 +883,10 @@ result metal_inorder_queue::submit_sscp_kernel_from_code_object(hcf_object_id hc
     const_cast<std::size_t*>(_arg_mapper.get_mapped_arg_sizes()),
     _arg_mapper.get_mapped_num_args(),
     kernel_info,
-    retained_indices);
+    retained_indices,
+    has_indirect_access,
+    _fence_chain_active ? _fence : nullptr,
+    wait_fence);
 
 #else
   return make_error(__acpp_here(),
@@ -861,6 +901,9 @@ metal_inorder_queue::~metal_inorder_queue() {
   wait();
   _event_listener->release();
   _shared_event->release();
+  if (_fence) {
+    _fence->release();
+  }
   _command_queue->release();
 }
 

--- a/tests/sycl/usm.cpp
+++ b/tests/sycl/usm.cpp
@@ -1390,5 +1390,105 @@ BOOST_AUTO_TEST_CASE(usm_shared_ptr_gpu_delta_constant) {
   sycl::free(gpu_addrs, q);
 }
 
+// Tests memory ordering between dispatches with many arguments
+BOOST_AUTO_TEST_CASE(usm_chained_dispatch_many_args_ordering) {
+  sycl::queue q{sycl::property::queue::in_order{}};
+
+  if (!q.get_device().has(sycl::aspect::usm_shared_allocations)) {
+    return;
+  }
+
+  static constexpr std::size_t N = 1 << 20;
+  static constexpr int Iterations = 8;
+  static constexpr int K = 8;
+
+  int* a[K];
+  for (int k = 0; k < K; ++k)
+    a[k] = sycl::malloc_shared<int>(N, q);
+
+  int *p0=a[0], *p1=a[1], *p2=a[2], *p3=a[3],
+      *p4=a[4], *p5=a[5], *p6=a[6], *p7=a[7];
+
+  for (int it = 0; it < Iterations; ++it) {
+    q.parallel_for(sycl::range<1>(N), [=](sycl::id<1> idx) {
+      std::size_t i = idx[0];
+      int v = it * 7;
+      p0[i] = v;     p1[i] = v + 1; p2[i] = v + 2; p3[i] = v + 3;
+      p4[i] = v + 4; p5[i] = v + 5; p6[i] = v + 6;
+    });
+    q.parallel_for(sycl::range<1>(N), [=](sycl::id<1> idx) {
+      std::size_t i = idx[0];
+      p7[i] = p0[i] + p1[i] + p2[i] + p3[i] + p4[i] + p5[i] + p6[i];
+    });
+  }
+  q.wait();
+
+  const int expected = 7 * ((Iterations - 1) * 7) + 21;
+  bool ok = true;
+  for (std::size_t i = 0; i < N; ++i) {
+    if (a[7][i] != expected) {
+      BOOST_TEST_MESSAGE("mismatch at i=" << i << " expected=" << expected
+                                          << " got=" << a[7][i]);
+      ok = false;
+      break;
+    }
+  }
+  BOOST_CHECK(ok);
+
+  for (int k = 0; k < K; ++k)
+    sycl::free(a[k], q);
+}
+
+// Same, but with memory indirection
+BOOST_AUTO_TEST_CASE(shared_indirect_chained_ordering) {
+  sycl::queue q{sycl::property::queue::in_order{}};
+
+  if (!q.get_device().has(sycl::aspect::usm_shared_allocations)) {
+    return;
+  }
+
+  static constexpr std::size_t N = 1 << 20;
+  static constexpr int Iterations = 64;
+
+  int** producer_table = sycl::malloc_shared<int*>(2, q);
+  int** consumer_table = sycl::malloc_shared<int*>(2, q);
+  int* a = sycl::malloc_shared<int>(N, q);
+  int* b = sycl::malloc_shared<int>(N, q);
+  producer_table[0] = a;
+  producer_table[1] = b;
+  consumer_table[0] = a;
+  consumer_table[1] = b;
+  for (std::size_t i = 0; i < N; ++i) {
+    a[i] = 0;
+    b[i] = 0;
+  }
+
+  for (int it = 0; it < Iterations; ++it) {
+    q.parallel_for(sycl::range<1>(N), [=](sycl::id<1> idx) {
+      producer_table[0][idx[0]] = producer_table[1][idx[0]] + 1;
+    });
+    q.parallel_for(sycl::range<1>(N), [=](sycl::id<1> idx) {
+      consumer_table[1][idx[0]] = consumer_table[0][idx[0]];
+    });
+  }
+  q.wait();
+
+  bool ok = true;
+  for (std::size_t i = 0; i < N; ++i) {
+    if (b[i] != Iterations) {
+      BOOST_TEST_MESSAGE("mismatch at i=" << i << " expected=" << Iterations
+                                          << " got=" << b[i]);
+      ok = false;
+      break;
+    }
+  }
+  BOOST_CHECK(ok);
+
+  sycl::free(producer_table, q);
+  sycl::free(consumer_table, q);
+  sycl::free(a, q);
+  sycl::free(b, q);
+}
+
 BOOST_AUTO_TEST_SUITE_END() // NOTE: Make sure not to add anything below this
                             // line


### PR DESCRIPTION
benchmark:

```
#include <sycl/sycl.hpp>

#include <atomic>
#include <chrono>
#include <cstdio>
#include <cstdlib>
#include <random>
#include <thread>
#include <vector>

namespace {

std::atomic<long> g_errors{0};
std::atomic<bool> g_stop{false};

void run_worker(int worker_id, int iterations, int num_blocks, int elements,
                bool use_shared_queue, sycl::queue &shared_queue) {
  sycl::queue own_queue;
  sycl::queue &q = use_shared_queue ? shared_queue : own_queue;

  std::vector<int *> blocks;
  for (int b = 0; b < num_blocks; ++b) {
    int *blk = sycl::malloc_shared<int>(elements, q);
    for (int i = 0; i < elements; ++i)
      blk[i] = worker_id * 100000 + b * 1000 + i;
    blocks.push_back(blk);
  }

  int **ptrs = sycl::malloc_shared<int *>(num_blocks, q);
  for (int b = 0; b < num_blocks; ++b)
    ptrs[b] = blocks[b];

  int *out = sycl::malloc_shared<int>(num_blocks * elements, q);

  std::mt19937 rng(worker_id * 7919 + 13);

  for (int it = 0; it < iterations; ++it) {
    int *pre = sycl::malloc_shared<int>(elements, q);
    for (int i = 0; i < elements; ++i)
      pre[i] = i;

    const int bias = it;
    auto ev = q.parallel_for(sycl::range<2>(num_blocks, elements),
                             [=](sycl::id<2> idx) {
                               int b = idx[0], i = idx[1];
                               int *blk = ptrs[b]; // pointer chasing
                               out[b * elements + i] = blk[i] * 2 + bias;
                             });

    sycl::free(pre, q);
    int *mid = sycl::malloc_device<int>(elements, q);
    int *mid2 = sycl::malloc_shared<int>(elements, q);
    sycl::free(mid, q);

    ev.wait();

    for (int b = 0; b < num_blocks; ++b) {
      for (int i = 0; i < elements; ++i) {
        int want = (worker_id * 100000 + b * 1000 + i) * 2 + bias;
        if (out[b * elements + i] != want) {
          if (g_errors.fetch_add(1) < 5)
            std::printf("worker %d iter %d: out[%d][%d] = %d, want %d\n",
                        worker_id, it, b, i, out[b * elements + i], want);
        }
      }
    }

    sycl::free(mid2, q);

    if ((it % 8) == 3) {
      int b = static_cast<int>(rng() % num_blocks);
      sycl::free(blocks[b], q);
      int *fresh = sycl::malloc_shared<int>(elements, q);
      for (int i = 0; i < elements; ++i)
        fresh[i] = worker_id * 100000 + b * 1000 + i;
      blocks[b] = fresh;
      ptrs[b] = fresh;
    }
  }

  for (int *blk : blocks)
    sycl::free(blk, q);
  sycl::free(ptrs, q);
  sycl::free(out, q);
}

void run_churn(int churn_id, int elements) {
  sycl::queue q;
  std::mt19937 rng(churn_id * 104729 + 7);
  std::vector<void *> live;

  while (!g_stop.load(std::memory_order_relaxed)) {
    if (live.size() < 32 || (rng() % 2)) {
      std::size_t n = elements * (1 + rng() % 8);
      void *p = (rng() % 2) ? static_cast<void *>(sycl::malloc_shared<int>(n, q))
                            : static_cast<void *>(sycl::malloc_device<int>(n, q));
      if (p)
        live.push_back(p);
    } else {
      std::size_t idx = rng() % live.size();
      sycl::free(live[idx], q);
      live[idx] = live.back();
      live.pop_back();
    }
  }

  for (void *p : live)
    sycl::free(p, q);
}

} // namespace

int main(int argc, char **argv) {
  const int num_workers = argc > 1 ? std::atoi(argv[1]) : 4;
  const int num_churn = argc > 2 ? std::atoi(argv[2]) : 2;
  const int iterations = argc > 3 ? std::atoi(argv[3]) : 200;
  const int num_blocks = argc > 4 ? std::atoi(argv[4]) : 8;
  const int elements = argc > 5 ? std::atoi(argv[5]) : 256;

  sycl::queue shared_queue;
  std::printf("device: %s\n",
              shared_queue.get_device().get_info<sycl::info::device::name>().c_str());
  std::printf("workers: %d (half of them sharing one queue), churn threads: %d, "
              "iterations: %d, blocks/worker: %d, elements: %d\n",
              num_workers, num_churn, iterations, num_blocks, elements);

  auto t0 = std::chrono::steady_clock::now();

  std::vector<std::thread> churn;
  for (int c = 0; c < num_churn; ++c)
    churn.emplace_back(run_churn, c, elements);

  std::vector<std::thread> workers;
  for (int w = 0; w < num_workers; ++w)
    workers.emplace_back(run_worker, w, iterations, num_blocks, elements,
                         (w % 2) == 0, std::ref(shared_queue));

  for (auto &t : workers)
    t.join();
  g_stop.store(true);
  for (auto &t : churn)
    t.join();

  auto t1 = std::chrono::steady_clock::now();
  double s = std::chrono::duration<double>(t1 - t0).count();

  long errors = g_errors.load();
  std::printf("%ld launches in %.2f s, %ld mismatching elements: %s\n",
              static_cast<long>(num_workers) * iterations, s, errors,
              errors ? "FAILED" : "PASSED");
  return errors ? 1 : 0;
}
```

results:
```
./metal_residency_mt_test <workers> 8 1000 8 256
16 workers
branch: 16000 launches in 3.81 s
develop: 16000 launches in 6.23 s

32 workers
branch: 32000 launches in 7.50 s
develop: 32000 launches in 11.95 s
```