### PR TITLE
[Metal] Import native events into SYCL

### DIFF
--- a/include/hipSYCL/glue/metal/metal_interop.hpp
+++ b/include/hipSYCL/glue/metal/metal_interop.hpp
@@ -21,6 +21,7 @@
 #include "hipSYCL/runtime/error.hpp"
 #include "hipSYCL/runtime/inorder_queue_event.hpp"
 #include "hipSYCL/runtime/metal/metal_event.hpp"
+#include "hipSYCL/runtime/operations.hpp"
 #if defined(__APPLE__)
 #include "hipSYCL/runtime/metal/metal_hardware_manager.hpp"
 #endif
@@ -173,6 +174,83 @@ template <> struct backend_interop<sycl::backend::metal> {
 #endif
   }
 
+  static sycl::event make_sycl_event(const native_event_type &native_event,
+                                     const sycl::context &ctx) {
+#if defined(__APPLE__)
+    if (!native_event.event) {
+      rt::register_error(
+          __acpp_here(),
+          rt::error_info{"make_event: invalid native Metal event",
+                         rt::error_type::invalid_parameter_error});
+      return {};
+    }
+
+    rt::runtime *runtime = ctx.AdaptiveCpp_runtime();
+    rt::backend *backend =
+        runtime->backends().get(rt::backend_id::metal);
+    if (!backend) {
+      rt::register_error(
+          __acpp_here(),
+          rt::error_info{"make_event: Metal backend not available",
+                         rt::error_type::runtime_error});
+      return {};
+    }
+
+    rt::device_id event_device;
+    std::shared_ptr<rt::dag_node_event> runtime_event;
+    bool ctx_has_metal_device = false;
+    for (const sycl::device &dev : ctx.get_devices()) {
+      rt::device_id candidate = sycl::detail::extract_rt_device(dev);
+      if (candidate.get_backend() != rt::backend_id::metal)
+        continue;
+      ctx_has_metal_device = true;
+
+      runtime_event = backend->create_event_from_native_handle(
+          &native_event, candidate);
+      if (runtime_event) {
+        event_device = candidate;
+        break;
+      }
+    }
+
+    if (!ctx_has_metal_device) {
+      throw sycl::exception{
+          sycl::make_error_code(sycl::errc::backend_mismatch),
+          "make_event: the supplied context does not contain a Metal device"};
+    }
+
+    if (!runtime_event) {
+      rt::register_error(
+          __acpp_here(),
+          rt::error_info{"make_event: native Metal event does not belong to "
+                         "the supplied context",
+                         rt::error_type::invalid_parameter_error});
+      return {};
+    }
+
+    auto op = std::make_unique<rt::kernel_operation>(
+        "<native Metal event>", rt::kernel_launcher({}, {}),
+        rt::requirements_list{runtime});
+    rt::dag_node_ptr node = std::make_shared<rt::dag_node>(
+        rt::execution_hints{}, rt::node_list_t{}, std::move(op), runtime);
+    node->assign_to_device(event_device);
+    node->assign_to_executor(nullptr);
+    node->assign_to_execution_lane(nullptr);
+    node->assign_execution_index(0);
+    node->get_execution_hints().set_hint(rt::hints::instant_execution{});
+    node->get_operation()->get_instrumentations().mark_set_complete();
+    node->mark_submitted(std::move(runtime_event));
+
+    return sycl::event{node};
+#else
+    rt::register_error(
+        __acpp_here(),
+        rt::error_info{"make_event: Metal backend not supported on this OS",
+                       rt::error_type::runtime_error});
+    return {};
+#endif
+  }
+
   static native_allocation_type get_native_allocation(const void *ptr, const sycl::context &ctx) {
     rt::backend *b =
         ctx.AdaptiveCpp_runtime()->backends().get(rt::backend_id::metal);
@@ -201,7 +279,7 @@ template <> struct backend_interop<sycl::backend::metal> {
   static constexpr bool can_make_device = false;
   static constexpr bool can_make_context = false;
   static constexpr bool can_make_queue = false;
-  static constexpr bool can_make_event = false;
+  static constexpr bool can_make_event = true;
   static constexpr bool can_make_buffer = false;
   static constexpr bool can_make_sampled_image = false;
   static constexpr bool can_make_image_sampler = false;

--- a/include/hipSYCL/glue/metal/metal_interop.hpp
+++ b/include/hipSYCL/glue/metal/metal_interop.hpp
@@ -178,22 +178,18 @@ template <> struct backend_interop<sycl::backend::metal> {
                                      const sycl::context &ctx) {
 #if defined(__APPLE__)
     if (!native_event.event) {
-      rt::register_error(
-          __acpp_here(),
-          rt::error_info{"make_event: invalid native Metal event",
-                         rt::error_type::invalid_parameter_error});
-      return {};
+      throw sycl::exception{
+        sycl::make_error_code(sycl::errc::invalid),
+        "make_event: invalid native Metal event"};
     }
 
     rt::runtime *runtime = ctx.AdaptiveCpp_runtime();
     rt::backend *backend =
         runtime->backends().get(rt::backend_id::metal);
     if (!backend) {
-      rt::register_error(
-          __acpp_here(),
-          rt::error_info{"make_event: Metal backend not available",
-                         rt::error_type::runtime_error});
-      return {};
+      throw sycl::exception{
+        sycl::make_error_code(sycl::errc::backend_mismatch),
+        "make_event: Metal backend not available"};
     }
 
     rt::device_id event_device;
@@ -215,17 +211,15 @@ template <> struct backend_interop<sycl::backend::metal> {
 
     if (!ctx_has_metal_device) {
       throw sycl::exception{
-          sycl::make_error_code(sycl::errc::backend_mismatch),
-          "make_event: the supplied context does not contain a Metal device"};
+        sycl::make_error_code(sycl::errc::backend_mismatch),
+        "make_event: the supplied context does not contain a Metal device"};
     }
 
     if (!runtime_event) {
-      rt::register_error(
-          __acpp_here(),
-          rt::error_info{"make_event: native Metal event does not belong to "
-                         "the supplied context",
-                         rt::error_type::invalid_parameter_error});
-      return {};
+      throw sycl::exception{
+        sycl::make_error_code(sycl::errc::invalid),
+        "make_event: native Metal event does not belong to the supplied "
+        "context"};
     }
 
     auto op = std::make_unique<rt::kernel_operation>(
@@ -243,11 +237,9 @@ template <> struct backend_interop<sycl::backend::metal> {
 
     return sycl::event{node};
 #else
-    rt::register_error(
-        __acpp_here(),
-        rt::error_info{"make_event: Metal backend not supported on this OS",
-                       rt::error_type::runtime_error});
-    return {};
+    throw sycl::exception{
+      sycl::make_error_code(sycl::errc::backend_mismatch),
+      "make_event: Metal backend not supported on this OS"};
 #endif
   }
 

--- a/include/hipSYCL/runtime/backend.hpp
+++ b/include/hipSYCL/runtime/backend.hpp
@@ -28,6 +28,7 @@ class backend_hardware_manager;
 class hw_model;
 class kernel_cache;
 class inorder_queue;
+class dag_node_event;
 
 class backend
 {
@@ -59,6 +60,12 @@ public:
   // priority. It is backend-specific if or how this will affect execution.
   virtual std::unique_ptr<backend_executor>
   create_inorder_executor(device_id dev, int priority) = 0;
+
+  // Optionally imports a native backend event
+  virtual std::shared_ptr<dag_node_event>
+  create_event_from_native_handle(const void *, device_id) {
+    return nullptr;
+  }
 };
 
 class backend_manager
@@ -69,7 +76,7 @@ public:
 
   backend_manager();
   ~backend_manager();
-  
+
   backend* get(backend_id) const;
   hw_model& hardware_model();
   const hw_model& hardware_model() const;

--- a/include/hipSYCL/runtime/metal/metal_backend.hpp
+++ b/include/hipSYCL/runtime/metal/metal_backend.hpp
@@ -38,6 +38,10 @@ public:
 
   std::unique_ptr<backend_executor>
   create_inorder_executor(device_id dev, int priority) override;
+
+  std::shared_ptr<dag_node_event>
+  create_event_from_native_handle(const void *native_handle,
+                                  device_id dev) override;
 private:
   mutable metal_hardware_manager _hw;
   mutable lazily_constructed_executor<multi_queue_executor> _executor;

--- a/src/runtime/inorder_executor.cpp
+++ b/src/runtime/inorder_executor.cpp
@@ -128,6 +128,11 @@ void inorder_executor::submit_directly(const dag_node_ptr& node, operation *op,
           // Nothing to synchronize, the requirement was enqueued on the same
           // inorder queue and will therefore be executed before
           // the new node
+        } else if (!req->get_assigned_execution_lane()) {
+          HIPSYCL_DEBUG_INFO
+              << " --> Synchronizes with imported backend event for node: "
+              << req << std::endl;
+          res = _q->submit_queue_wait_for(req);
         } else {
           assert(req->get_event());
 

--- a/src/runtime/metal/metal_backend.cpp
+++ b/src/runtime/metal/metal_backend.cpp
@@ -11,6 +11,8 @@
 #include "hipSYCL/runtime/backend_loader.hpp"
 #include "hipSYCL/runtime/metal/metal_backend.hpp"
 
+#include <Metal/Metal.hpp>
+
 HIPSYCL_PLUGIN_API_EXPORT
 hipsycl::rt::backend *hipsycl_backend_plugin_create() {
   return new hipsycl::rt::metal_backend();
@@ -84,6 +86,19 @@ std::unique_ptr<backend_executor>
 metal_backend::create_inorder_executor(device_id dev, int priority) {
   std::unique_ptr<inorder_queue> q(_hw.make_queue(dev.get_id()));
   return std::make_unique<inorder_executor>(std::move(q));
+}
+
+std::shared_ptr<dag_node_event>
+metal_backend::create_event_from_native_handle(const void *native_handle,
+                                               device_id dev) {
+  if (!native_handle || dev.get_backend() != backend_id::metal)
+    return nullptr;
+
+  const auto *handle = static_cast<const metal_event_handle *>(native_handle);
+  if (!handle->event)
+    return nullptr;
+
+  return std::make_shared<metal_node_event>(*handle);
 }
 
 metal_backend::~metal_backend() = default;

--- a/tests/sycl/extensions.cpp
+++ b/tests/sycl/extensions.cpp
@@ -1440,6 +1440,36 @@ BOOST_AUTO_TEST_CASE(get_native_metal_event) {
   BOOST_CHECK(native_event.value != 0);
   event.wait();
 }
+
+BOOST_AUTO_TEST_CASE(make_metal_event) {
+  namespace s = sycl;
+
+  const s::property_list props{s::property::queue::in_order{}};
+  s::queue producer{props};
+  if (producer.get_device().get_backend() != s::backend::metal) {
+    BOOST_TEST_MESSAGE("Skipping make_metal_event: not a Metal device");
+    return;
+  }
+
+  s::queue consumer{producer.get_context(), producer.get_device(), props};
+  int *value = s::malloc_shared<int>(1, producer);
+  BOOST_REQUIRE(value != nullptr);
+  *value = 0;
+
+  s::event produced = producer.single_task([=]() { *value = 41; });
+  auto native_event = s::get_native<s::backend::metal>(produced);
+  s::event imported = s::make_event<s::backend::metal>(
+      native_event, producer.get_context());
+
+  s::event consumed = consumer.submit([&](s::handler &cgh) {
+    cgh.depends_on(imported);
+    cgh.single_task([=]() { *value += 1; });
+  });
+  consumed.wait();
+
+  BOOST_CHECK_EQUAL(*value, 42);
+  s::free(value, producer);
+}
 #endif
 #ifdef SYCL_KHR_DEFAULT_CONTEXT
 BOOST_AUTO_TEST_CASE(khr_default_context) {


### PR DESCRIPTION
The Metal backend already exports a `sycl::event` as a native `MTL::SharedEvent` via `sycl::get_native<sycl::backend::metal>()` 
The PR adds the opposite direction: importing a native `MTL::SharedEvent` as a `sycl::event`

This makes it possible to mix SYCL kernels with command buffers submitted directly through the Metal API: on a `MTL::CommandQueue` that AdaptiveCpp does not own 
Without it the only way to order such work against a SYCL kernel is a host round-trip: `waitUntilCompleted()` on the producing command buffer before submitting to the SYCL queue 

With an imported event `handler::depends_on()` lowers to `MTL::CommandBuffer::encodeWait()` on the SYCL queue, so the dependency is resolved on the GPU timeline and the host is not blocked

Snippet:
```
  #include <Metal/Metal.hpp>
  #include <sycl/sycl.hpp>

  MTL::CommandBuffer *cb = my_queue->commandBuffer();
  // ... encode work producing `data` ...
  cb->encodeSignalEvent(my_event, signal_value);
  cb->commit();               // no waitUntilCompleted(): the host does not block

  sycl::queue q{sycl::property::queue::in_order{}};
  sycl::event produced = sycl::make_event<sycl::backend::metal>(
      {my_event, signal_value}, q.get_context());

  q.submit([&](sycl::handler &cgh) {
    cgh.depends_on(produced);
    cgh.parallel_for(N, [=](sycl::id<1> i) { data[i] *= 2.f; });
  });
```

Concrete use-case example: https://github.com/resetius/fdm/blob/master/test/ns_cyl_sycl_demo.cpp#L443