### PR TITLE
Fix Vulkan semaphore wait stage mask

### DIFF
--- a/src/runtime/vk/vk_queue.cpp
+++ b/src/runtime/vk/vk_queue.cpp
@@ -519,7 +519,7 @@ void vk_queue::submit_command_buffer(vk::CommandBuffer &cmd_buf) {
   vk::TimelineSemaphoreSubmitInfo timeline_info{
       num_wait_semaphores, wait_values.data(), 1u, &signal_value};
   std::vector<vk::PipelineStageFlags> wait_stages(
-      num_wait_semaphores, vk::PipelineStageFlagBits::eComputeShader);
+      num_wait_semaphores, vk::PipelineStageFlagBits::eAllCommands);
   vk::SubmitInfo submit_info(num_wait_semaphores, semaphores.data(),
                              wait_stages.data(), 1, &cmd_buf, 1,
                              semaphores.data());


### PR DESCRIPTION
Related to #2217.

I spent quite some time double-checking whether `eAllCommands` is the right fix here, and I believe it is. The semaphore already provides the required memory dependency, but `eComputeShader` does not cover transfer commands such as `copyBuffer()`. Since submitted command buffers may contain different types of commands, `eAllCommands` seems to be the correct and safest choice.

## Summary

Change the Vulkan semaphore wait stage mask in `vk_queue::submit_command_buffer()` from `eComputeShader` to `eAllCommands`.

This ensures that queue dependencies are respected by every command in the submitted command buffer, including transfer operations such as `copyBuffer()`.

## References

[Vulkan semaphore signaling](https://docs.vulkan.org/spec/latest/chapters/synchronization.html#synchronization-semaphores-signaling)
[Vulkan semaphore waiting](https://docs.vulkan.org/spec/latest/chapters/synchronization.html#synchronization-semaphores-waiting)