### PR TITLE
[CI] Reduce rate limiting on Vulkan-SDK downloads

### DIFF
--- a/.github/workflows/linux-vulkan.yml
+++ b/.github/workflows/linux-vulkan.yml
@@ -2,6 +2,8 @@ name: Linux Vulkan
 
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   prep-container:
     name: Prepare CI container clang ${{ matrix.clang }}, ${{ matrix.os }}
@@ -65,6 +67,7 @@ jobs:
         vulkan_version: 1.4.341.1
         cache: true
         stripdown: true
+        github_token: ${{secrets.GITHUB_TOKEN}})
 
     # Install mesa 25.x vulkan driver
     - name: Install LLVMpipe

--- a/.github/workflows/windows-vulkan.yml
+++ b/.github/workflows/windows-vulkan.yml
@@ -2,6 +2,8 @@ name: Windows Vulkan
 
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   test:
     name: clang ${{ matrix.clang_version }}
@@ -45,6 +47,7 @@ jobs:
         install_runtime: true
         cache: true
         stripdown: true
+        github_token: ${{secrets.GITHUB_TOKEN}}
 
     - name: Configure SDK Path
       run: |


### PR DESCRIPTION
In Vulkan jobs we sometimes see errors in the stage for downloading the Vulkan-SDK via the https://github.com/jakoch/install-vulkan-sdk-action action. Example https://github.com/AdaptiveCpp/AdaptiveCpp/actions/runs/34134711168/job/101804537331?pr=2225

```
To avoid hitting GitHub API rate limits, please set github_token as action input or a GITHUB_TOKEN in your environment.
Error: HttpClientError: API rate limit exceeded for 4.155.237.0. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
    at mr.<anonymous> (file:///D:/a/_actions/jakoch/install-vulkan-sdk-action/v1/dist/index.js:63:31542)
    at Generator.next (<anonymous>)
    at a (file:///D:/a/_actions/jakoch/install-vulkan-sdk-action/v1/dist/index.js:63:20903)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
```

This can be mitigate by providing an Github Token API key. This PR does this for the 2 jobs where we use the third party action, but explicitly locks down the job permissions to read-only so that if the third party action is compromised the token can't be abused in the CI job.