### PR TITLE
[OpenCL] Skip empty SVM pointer list in coarse-grained USM provider

### DIFF
--- a/src/runtime/ocl/ocl_usm.cpp
+++ b/src/runtime/ocl/ocl_usm.cpp
@@ -668,6 +668,9 @@ public:
 
   cl_int enable_indirect_usm_access(cl::Kernel& k) override {
     std::lock_guard<std::mutex> lock{_mutex};
+    // nothing to register before the first allocation
+    if(_allocations.empty())
+      return CL_SUCCESS;
     return k.setSVMPointers(_allocations);
   }
 


### PR DESCRIPTION
Fixes item 2 of #2228.

## Problem

`ocl_usm_coarse_grained_svm::enable_indirect_usm_access()` registers all live SVM allocations with `clSetKernelExecInfo(CL_KERNEL_EXEC_INFO_SVM_PTRS)` before every launch. When no allocation exists yet, the list is empty and the call is made with a zero-sized pointer list. Some OpenCL implementations reject that with `CL_INVALID_VALUE` (observed on Arm libmali g24p0, Mali-G610), so the first kernel launch on such devices fails:

```
ocl_queue: Could not set indirect access flags (error code = CL:-30)
```

## Fix

Return `CL_SUCCESS` when the allocation list is empty. There is nothing to register before the first allocation, so the call is unnecessary in that case.

## Testing

On a Mali-G610 (libmali g24p0, coarse-grained SVM provider): the first launch of a kernel with no prior allocation now succeeds, and a set of SYCL tests covering `malloc_device`, `memcpy`, `fill`, nd_range kernels with local memory, atomics and reductions passes. The change only affects the coarse-grained SVM provider of the OpenCL backend.