### PR TITLE
[OpenCL] Fix reversed range check in coarse-grained SVM allocation lookup

### DIFF
--- a/src/runtime/ocl/ocl_usm.cpp
+++ b/src/runtime/ocl/ocl_usm.cpp
@@ -690,7 +690,8 @@ private:
     for(int i = 0; i < _allocations.size(); ++i) {
       intptr_t candidate = reinterpret_cast<intptr_t>(_allocations[i]);
       auto alloc_info = _alloc_infos[i];
-      if(candidate >= ptr_int && candidate < ptr_int + alloc_info.size) {
+      if(ptr_int >= candidate &&
+         ptr_int < candidate + static_cast<intptr_t>(alloc_info.size)) {
         h(i, alloc_info);
         return true;
       }


### PR DESCRIPTION
Fixes item 5 of #2228.

## Problem

`ocl_usm_coarse_grained_svm::find_allocation()` looks up the registered allocation that contains a pointer, but its range test is reversed:

```cpp
if(candidate >= ptr_int && candidate < ptr_int + alloc_info.size)
```

This asks whether the candidate's base lies within `size` bytes above `ptr`, instead of whether `ptr` lies within the candidate. For a base pointer the two coincide only as long as no other registered allocation sits in that window. When a later, smaller allocation is placed just below an earlier live one, `free()` of the smaller allocation matches the larger one's registry entry and erases it. The later `free()` of the larger allocation is then not found and fails with `CL_INVALID_MEM_OBJECT`.

For minimal reproduction on a coarse-grained SVM device, allocate 1 MB, then 64 KB, then free the 64 KB allocation, then free the 1 MB one. With the current check the second free fails with

```
ocl_allocator: USM memory free() failed (error code = CL:-38)
```

## Fix

Test containment the correct way.

## Testing

On a Mali-G610 (libmali g24p0): the reproducer above passes, and the [Kompass DWA planner test](https://github.com/automatika-robotics/kompass-core), which triggered the failure through its free/realloc pattern for growing buffers, passes repeatedly. The change only affects the coarse-grained SVM provider of the OpenCL backend.
