### PR TITLE
[SSCP][OpenCL] Compare-exchange fallback for float atomics on devices without cl_ext_float_atomics

### DIFF
--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -101,6 +101,12 @@ struct target_is_cpu;
 /// Return type: bool
 struct target_is_gpu;
 
+/// Returns whether the SPIR-V consumer accepts native floating point atomic fetch_add, 
+/// fetch_min and fetch_max instructions. Only known on the SPIR-V compiler backend when
+/// the runtime backend provides it (currently only OpenCL provides it from cl_ext_float_atomics).
+/// Return type: bool
+struct spirv_has_native_float_atomics;
+
 /// Returns the AdaptiveCpp runtime backend that is managing the execution of this kernel.
 /// Return type: int (sycl::backend cast to int)
 struct runtime_backend;

--- a/include/hipSYCL/glue/llvm-sscp/jit-reflection/queries.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/jit-reflection/queries.hpp
@@ -46,12 +46,14 @@ extern "C" bool __acpp_sscp_jit_reflect_knows_runtime_backend();
 extern "C" bool __acpp_sscp_jit_reflect_knows_compiler_backend();
 extern "C" bool __acpp_sscp_jit_reflect_knows_target_is_cpu();
 extern "C" bool __acpp_sscp_jit_reflect_knows_target_is_gpu();
+extern "C" bool __acpp_sscp_jit_reflect_knows_spirv_has_native_float_atomics();
 
 extern "C" int __acpp_sscp_jit_reflect_target_vendor_id();
 extern "C" int __acpp_sscp_jit_reflect_target_arch();
 extern "C" bool __acpp_sscp_jit_reflect_target_is_cpu();
 extern "C" bool __acpp_sscp_jit_reflect_target_is_gpu();
 extern "C" bool __acpp_sscp_jit_reflect_target_has_independent_forward_progress();
+extern "C" bool __acpp_sscp_jit_reflect_spirv_has_native_float_atomics();
 extern "C" int __acpp_sscp_jit_reflect_runtime_backend();
 extern "C" hipsycl::sycl::AdaptiveCpp_jit::compiler_backend __acpp_sscp_jit_reflect_compiler_backend();
 

--- a/include/hipSYCL/glue/llvm-sscp/jit-reflection/queries.hpp
+++ b/include/hipSYCL/glue/llvm-sscp/jit-reflection/queries.hpp
@@ -79,6 +79,7 @@ ACPP_DEFINE_REFLECT_QUERY(target_arch)
 ACPP_DEFINE_REFLECT_QUERY(target_has_independent_forward_progress)
 ACPP_DEFINE_REFLECT_QUERY(target_is_cpu)
 ACPP_DEFINE_REFLECT_QUERY(target_is_gpu)
+ACPP_DEFINE_REFLECT_QUERY(spirv_has_native_float_atomics)
 ACPP_DEFINE_REFLECT_QUERY(runtime_backend)
 ACPP_DEFINE_REFLECT_QUERY(compiler_backend)
 

--- a/include/hipSYCL/runtime/ocl/ocl_hardware_manager.hpp
+++ b/include/hipSYCL/runtime/ocl/ocl_hardware_manager.hpp
@@ -69,6 +69,7 @@ public:
 
   bool has_intel_extension_profile() const;
   bool has_cl_khr_priority_hints_extension() const;
+  bool has_cl_ext_float_atomics_extension() const;
 
   void init_allocator(ocl_hardware_manager* mgr);
 private:
@@ -80,6 +81,7 @@ private:
   ocl_allocator _alloc;
   bool _has_intel_extension_profile;
   bool _has_cl_khr_priority_hints_extension;
+  bool _has_cl_ext_float_atomics_extension;
 };
 
 class ocl_hardware_manager : public backend_hardware_manager

--- a/src/libkernel/sscp/spirv/atomic.cpp
+++ b/src/libkernel/sscp/spirv/atomic.cpp
@@ -11,6 +11,7 @@
 #include "hipSYCL/sycl/libkernel/sscp/builtins/atomic.hpp"
 #include "hipSYCL/sycl/libkernel/sscp/builtins/builtin_config.hpp"
 #include "hipSYCL/sycl/libkernel/sscp/builtins/spirv/spirv_common.hpp"
+#include "hipSYCL/glue/llvm-sscp/jit-reflection/queries.hpp"
 
 template<class T>
 __spirv_global T* to_global(T* ptr) { return (__spirv_global T*)ptr; }
@@ -143,6 +144,74 @@ get_atomic_memory_semantics(__acpp_sscp_memory_order order) {
   } else {                                                                     \
     command(ptr);                                                              \
   }
+
+// ****************** float atomics without native support ******************
+
+__attribute__((always_inline)) bool has_native_float_atomics() {
+  if (__acpp_sscp_jit_reflect_knows_spirv_has_native_float_atomics())
+    return __acpp_sscp_jit_reflect_spirv_has_native_float_atomics();
+  return true;
+}
+
+template <class T> struct float_bits;
+template <> struct float_bits<__acpp_f32> { using type = __acpp_int32; };
+template <> struct float_bits<__acpp_f64> { using type = __acpp_int64; };
+
+#define SPIRV_DECLARE_FLOAT_BITS_CAST(AS, T)                                   \
+  __attribute__((always_inline)) AS float_bits<T>::type *float_bits_cast(      \
+      AS T *ptr) {                                                             \
+    return (AS float_bits<T>::type *)ptr;                                      \
+  }
+
+SPIRV_DECLARE_ATOMICS_FOR_FLOAT(SPIRV_DECLARE_FLOAT_BITS_CAST)
+
+__attribute__((always_inline)) __acpp_sscp_memory_order
+get_compare_exchange_failure_order(__acpp_sscp_memory_order order) {
+  if (order == __acpp_sscp_memory_order::release)
+    return __acpp_sscp_memory_order::relaxed;
+  if (order == __acpp_sscp_memory_order::acq_rel)
+    return __acpp_sscp_memory_order::acquire;
+  return order;
+}
+
+template <class IntPtr, class T, class Op>
+__attribute__((always_inline)) T
+float_atomic_compare_exchange_loop(IntPtr ptr, __acpp_sscp_memory_order order,
+                                   __acpp_sscp_memory_scope scope, T x, Op op) {
+  using int_type = typename float_bits<T>::type;
+  auto spirv_scope = get_spirv_scope(scope);
+  auto success = get_atomic_memory_semantics(order);
+  auto failure =
+      get_atomic_memory_semantics(get_compare_exchange_failure_order(order));
+
+  int_type old = __spirv_AtomicLoad(ptr, spirv_scope, failure);
+  for (;;) {
+    T old_value = __builtin_bit_cast(T, old);
+    int_type desired = __builtin_bit_cast(int_type, op(old_value, x));
+    int_type prev = __spirv_AtomicCompareExchange(ptr, spirv_scope, success,
+                                                  failure, desired, old);
+    if (prev == old)
+      return old_value;
+    old = prev;
+  }
+}
+
+__attribute__((always_inline)) __acpp_f32
+float_min(__acpp_f32 a, __acpp_f32 b) {
+  return __builtin_fminf(a, b);
+}
+__attribute__((always_inline)) __acpp_f64
+float_min(__acpp_f64 a, __acpp_f64 b) {
+  return __builtin_fmin(a, b);
+}
+__attribute__((always_inline)) __acpp_f32
+float_max(__acpp_f32 a, __acpp_f32 b) {
+  return __builtin_fmaxf(a, b);
+}
+__attribute__((always_inline)) __acpp_f64
+float_max(__acpp_f64 a, __acpp_f64 b) {
+  return __builtin_fmax(a, b);
+}
 
 // ********************** atomic store ***************************
 
@@ -424,8 +493,12 @@ HIPSYCL_SSCP_BUILTIN __acpp_int64 __acpp_sscp_atomic_fetch_xor_i64(
   return __spirv_AtomicIAdd(ptr, get_spirv_scope(scope),                        \
                            get_atomic_memory_semantics(order), x);
 #define RETURN_ATOMIC_FADD(ptr)                                                \
-  return __spirv_AtomicFAddEXT(ptr, get_spirv_scope(scope),                    \
-                               get_atomic_memory_semantics(order), x);
+  if (has_native_float_atomics())                                              \
+    return __spirv_AtomicFAddEXT(ptr, get_spirv_scope(scope),                  \
+                                 get_atomic_memory_semantics(order), x);       \
+  return float_atomic_compare_exchange_loop(                                   \
+      float_bits_cast(ptr), order, scope, x,                                   \
+      [](auto a, auto b) { return a + b; });
 
 HIPSYCL_SSCP_BUILTIN __acpp_int8 __acpp_sscp_atomic_fetch_add_i8(
     __acpp_sscp_address_space as, __acpp_sscp_memory_order order,
@@ -500,8 +573,12 @@ HIPSYCL_SSCP_BUILTIN __acpp_f64 __acpp_sscp_atomic_fetch_add_f64(
   return __spirv_AtomicISub(ptr, get_spirv_scope(scope),                       \
                            get_atomic_memory_semantics(order), x);
 #define RETURN_ATOMIC_FSUB(ptr)                                                \
-  return __spirv_AtomicFAddEXT(ptr, get_spirv_scope(scope),                    \
-                               get_atomic_memory_semantics(order), -x);
+  if (has_native_float_atomics())                                              \
+    return __spirv_AtomicFAddEXT(ptr, get_spirv_scope(scope),                  \
+                                 get_atomic_memory_semantics(order), -x);      \
+  return float_atomic_compare_exchange_loop(                                   \
+      float_bits_cast(ptr), order, scope, x,                                   \
+      [](auto a, auto b) { return a - b; });
 
 
 HIPSYCL_SSCP_BUILTIN __acpp_int8 __acpp_sscp_atomic_fetch_sub_i8(
@@ -583,8 +660,12 @@ HIPSYCL_SSCP_BUILTIN __acpp_f64 __acpp_sscp_atomic_fetch_sub_f64(
                             get_atomic_memory_semantics(order), x);
 
 #define RETURN_ATOMIC_FMIN(ptr)                                                \
-  return __spirv_AtomicFMinEXT(ptr, get_spirv_scope(scope),                    \
-                               get_atomic_memory_semantics(order), x);
+  if (has_native_float_atomics())                                              \
+    return __spirv_AtomicFMinEXT(ptr, get_spirv_scope(scope),                  \
+                                 get_atomic_memory_semantics(order), x);       \
+  return float_atomic_compare_exchange_loop(                                   \
+      float_bits_cast(ptr), order, scope, x,                                   \
+      [](auto a, auto b) { return float_min(a, b); });
 
 HIPSYCL_SSCP_BUILTIN __acpp_int8 __acpp_sscp_atomic_fetch_min_i8(
     __acpp_sscp_address_space as, __acpp_sscp_memory_order order,
@@ -665,8 +746,12 @@ HIPSYCL_SSCP_BUILTIN __acpp_f64 __acpp_sscp_atomic_fetch_min_f64(
                             get_atomic_memory_semantics(order), x);
 
 #define RETURN_ATOMIC_FMAX(ptr)                                                \
-  return __spirv_AtomicFMaxEXT(ptr, get_spirv_scope(scope),                    \
-                               get_atomic_memory_semantics(order), x);
+  if (has_native_float_atomics())                                              \
+    return __spirv_AtomicFMaxEXT(ptr, get_spirv_scope(scope),                  \
+                                 get_atomic_memory_semantics(order), x);       \
+  return float_atomic_compare_exchange_loop(                                   \
+      float_bits_cast(ptr), order, scope, x,                                   \
+      [](auto a, auto b) { return float_max(a, b); });
 
 HIPSYCL_SSCP_BUILTIN __acpp_int8 __acpp_sscp_atomic_fetch_max_i8(
     __acpp_sscp_address_space as, __acpp_sscp_memory_order order,

--- a/src/runtime/ocl/ocl_hardware_manager.cpp
+++ b/src/runtime/ocl/ocl_hardware_manager.cpp
@@ -182,6 +182,7 @@ ocl_hardware_context::ocl_hardware_context(const cl::Device &dev,
     _has_intel_extension_profile = true;
   std::string extensions = info_query<CL_DEVICE_EXTENSIONS, std::string>(dev);
   _has_cl_khr_priority_hints_extension = (extensions.find("cl_khr_priority_hints") != std::string::npos);
+  _has_cl_ext_float_atomics_extension = (extensions.find("cl_ext_float_atomics") != std::string::npos);
 }
 
 bool ocl_hardware_context::is_cpu() const {
@@ -218,6 +219,10 @@ bool ocl_hardware_context::has_intel_extension_profile() const {
 
 bool ocl_hardware_context::has_cl_khr_priority_hints_extension() const {
   return _has_cl_khr_priority_hints_extension;
+}
+
+bool ocl_hardware_context::has_cl_ext_float_atomics_extension() const {
+  return _has_cl_ext_float_atomics_extension;
 }
 
 

--- a/src/runtime/ocl/ocl_queue.cpp
+++ b/src/runtime/ocl/ocl_queue.cpp
@@ -175,6 +175,8 @@ ocl_queue::ocl_queue(ocl_hardware_manager* hw_manager, std::size_t device_index,
   }
 
   _reflection_map = glue::jit::construct_default_reflection_map(dev_ctx);
+  _reflection_map["spirv_has_native_float_atomics"] =
+      dev_ctx->has_cl_ext_float_atomics_extension() ? 1 : 0;
 }
 
 ocl_queue::~ocl_queue() {}


### PR DESCRIPTION
Fixes item 3 of #2228.

## Problem

The SSCP SPIR-V atomic builtins lower float `fetch_add`, `fetch_sub`, `fetch_min` and `fetch_max` to `__spirv_AtomicFAddEXT`, `__spirv_AtomicFMinEXT` and `__spirv_AtomicFMaxEXT`. The resulting module is rejected by OpenCL devices without `cl_ext_float_atomics` at program creation:

```
ocl_code_object: Construction of CL program failed (error code = CL:-30)
```

## Fix

This PR adds new JIT reflection query `spirv_has_native_float_atomics`. The OpenCL backend sets it from `cl_ext_float_atomics` in `CL_DEVICE_EXTENSIONS`. The float atomic builtins branch on it. The native `__spirv_Atomic*EXT` call when the query is unknown or true, and otherwise a compare and exchange loop on the integer representation of the value. When the optimisation pipeline runs, the unused branch folds away at JIT time.

Details:

- `fetch_min` / `fetch_max` use `fmin` / `fmax` semantics in the fallback, matching `atomic_fetch_min` / `atomic_fetch_max` of `cl_ext_float_atomics` (a NaN operand yields the other operand).
- The failure memory order of the compare-exchange is derived from the requested order (`release` -> `relaxed`, `acq_rel` -> `acquire`), as required by SPIR-V.
- The query is set only by OpenCL backend and I have exposed it in the public API, so kernels can branch on it as well. If you think it should stay internal, we can be drop it.
- The capability bits of `cl_ext_float_atomics` are not consulted, only the presence of the extension is checked. The current devices advertising it would behave similar to how they behaved before.

## Testing

On a Mali-G610 (libmali g24p0, no `cl_ext_float_atomics`):

- A test of `atomic_ref<float>` `fetch_add`, `fetch_sub`, `fetch_min` and `fetch_max` on global and local memory with all five memory orders passes, including the uniqueness of the returned old values under contention.
- The [Kompass GPU test suites](https://github.com/automatika-robotics/kompass-core) pass, whose kernels use float `fetch_add`, `fetch_min` and `fetch_max`.

I don't have a device with `cl_ext_float_atomics` available to test the native path, which is unchanged apart from the folded branch.